### PR TITLE
docs/javascript: Add overview of javascript backend and nodejs configuration

### DIFF
--- a/docs/docs/javascript/_category_.json
+++ b/docs/docs/javascript/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Javascript",
+  "position": 13
+}

--- a/docs/docs/javascript/overview/_category_.json
+++ b/docs/docs/javascript/overview/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Javascript overview",
+  "position": 1
+}

--- a/docs/docs/javascript/overview/enabling-javascript-support.mdx
+++ b/docs/docs/javascript/overview/enabling-javascript-support.mdx
@@ -24,7 +24,7 @@ backend_packages = [
 ]
 ```
 
-Pants use [`package_json`](../../../reference/targets/package_json.mdx) targets to model a Nodejs package.
+Pants uses [`package_json`](../../../reference/targets/package_json.mdx) targets to model a NodeJS package.
 Further, [`javascript_source`](../../../reference/targets/javascript_source.mdx) and
 [`javascript_tests`](../../../reference/targets/javascript_test.mdx) targets are used to know which Javascript files to
 run on and to set any metadata.
@@ -46,7 +46,7 @@ Pants will by default download a distribution of `node` according to the
 
 ```toml tab={"label": "pants.toml"}
 [nodejs]
-known_versions = [] # Assign this to the empty list to ensure pants never downloads.
+known_versions = [] # Assign this to the empty list to ensure Pants never downloads.
 version = "v18.0.0"
 search_path = ["<NVM_LOCAL>"]
 
@@ -67,5 +67,5 @@ package_manager = "pnpm" # or yarn, or npm.
 ```
 
 you can instead opt to use the [`package.json#packageManager`](./package.mdx#package-manager) field for this setting.
-Regardless of setting, pants uses the [`corepack`](https://github.com/nodejs/corepack) version distributed with the node
+Regardless of setting, pants uses the [`corepack`](https://github.com/nodejs/corepack) version distributed with the Node
 version you have chosen to install and manage package managers.

--- a/docs/docs/javascript/overview/enabling-javascript-support.mdx
+++ b/docs/docs/javascript/overview/enabling-javascript-support.mdx
@@ -1,0 +1,71 @@
+---
+    title: Enabling Javascript support
+    sidebar_position: 0
+---
+
+How to enable Pants's bundled Javascript backend package.
+
+---
+
+:::note Example Javascript repository
+See [here](https://github.com/pantsbuild/example-javascript) for examples of Pants's Javascript functionality.
+
+:::
+
+### Configuring the repository
+
+Enable the experimental Javascript [backend](../../using-pants/key-concepts/backends.mdx) like this:
+
+```toml title="pants.toml"
+[GLOBAL]
+...
+backend_packages = [
+    "pants.backend.experimental.javascript"
+]
+```
+
+Pants use [`package_json`](../../../reference/targets/package_json.mdx) targets to model a Nodejs package.
+Further, [`javascript_source`](../../../reference/targets/javascript_source.mdx) and
+[`javascript_tests`](../../../reference/targets/javascript_test.mdx) targets are used to know which Javascript files to
+run on and to set any metadata.
+
+You can generate these targets by running [`pants tailor ::`](../../getting-started/initial-configuration.mdx#5-generate-build-files).
+
+```
+❯ pants tailor ::
+Created project/BUILD:
+  - Add javascript_sources target project
+  - Add javascript_tests target tests
+```
+
+
+### Setting up node
+Pants will by default download a distribution of `node` according to the
+[`nodejs` subsystem](../../../reference/subsystems/nodejs) configuration. If you wish to instead use a locally installed
+ version of, for example, 18.0.0 using `nvm` and its `.nvmrc` file, the following will get you there:
+
+```toml tab={"label": "pants.toml"}
+[nodejs]
+known_versions = [] # Assign this to the empty list to ensure pants never downloads.
+version = "v18.0.0"
+search_path = ["<NVM_LOCAL>"]
+
+```
+
+```txt tab={"label": ".nvmrc"}
+v18.0.0
+
+```
+
+### Setting up a package manager
+To set a package manager project wide, do the following:
+
+```toml title="pants.toml"
+[nodejs]
+package_manager = "pnpm" # or yarn, or npm.
+
+```
+
+you can instead opt to use the [`package.json#packageManager`](./package.mdx#package-manager) field for this setting.
+Regardless of setting, pants uses the [`corepack`](https://github.com/nodejs/corepack) version distributed with the node
+version you have chosen to install and manage package managers.

--- a/docs/docs/javascript/overview/index.mdx
+++ b/docs/docs/javascript/overview/index.mdx
@@ -1,0 +1,29 @@
+---
+    title: Javascript overview
+    sidebar_position: 0
+---
+
+Pants's support for Javascript.
+
+:::caution Javascript support is beta stage
+We are done implementing most functionality for Pants's Javascript support
+([tracked here](https://github.com/pantsbuild/pants/labels/backend%3A%20javascript)).
+However, there may be use cases that we aren't yet handling.
+:::
+
+The Javascript and NodeJS ecosystem has a seemingly endless amounts of frameworks and tooling,
+all orchestrated via package managers.
+
+Pants employs a wrapping approach with a thin caching layer applied on top of current supported package managers:
+`npm`, `pnpm` and `yarn`.
+
+Features for Javascript:
+
+- Caching the results of your test scripts and build scripts,
+ making the latter available in your pants workflows as [`resources`](../../reference/targets/resource) and
+ package artifacts.
+- A consistent interface for all languages/tools in your repository,
+ such as being able to run `pants fmt lint check test package`.
+- [Remote execution and remote caching](../../using-pants/remote-caching-and-execution/index.mdx).
+- [Advanced project introspection](../../using-pants/project-introspection.mdx),
+ such as finding all code that transitively depends on a certain package.

--- a/docs/docs/javascript/overview/index.mdx
+++ b/docs/docs/javascript/overview/index.mdx
@@ -11,7 +11,7 @@ We are done implementing most functionality for Pants's Javascript support
 However, there may be use cases that we aren't yet handling.
 :::
 
-The Javascript and NodeJS ecosystem has a seemingly endless amounts of frameworks and tooling,
+The Javascript and NodeJS ecosystem has a seemingly endless amount of frameworks and tooling,
 all orchestrated via package managers.
 
 Pants employs a wrapping approach with a thin caching layer applied on top of current supported package managers:
@@ -20,7 +20,7 @@ Pants employs a wrapping approach with a thin caching layer applied on top of cu
 Features for Javascript:
 
 - Caching the results of your test scripts and build scripts,
- making the latter available in your pants workflows as [`resources`](../../reference/targets/resource) and
+ making the latter available in your Pants workflows as [`resources`](../../reference/targets/resource) and
  package artifacts.
 - A consistent interface for all languages/tools in your repository,
  such as being able to run `pants fmt lint check test package`.

--- a/docs/docs/javascript/overview/lockfiles.mdx
+++ b/docs/docs/javascript/overview/lockfiles.mdx
@@ -37,9 +37,9 @@ $ pants generate-lockfiles
 
 ## Using lockfiles for tools
 
-To ensure that the same version of tooling you have specified in `package.json` is used with a nodejs powered tool,
+To ensure that the same version of tooling you have specified in `package.json` is used with a NodeJS powered tool,
 specify the resolve name for the tool.
-E.g. prettier linter:
+E.g., for the Prettier linter:
 
 ```toml tab={"label": "pants.toml"}
 [GLOBAL]

--- a/docs/docs/javascript/overview/lockfiles.mdx
+++ b/docs/docs/javascript/overview/lockfiles.mdx
@@ -1,0 +1,65 @@
+---
+    title: Lockfiles
+    sidebar_position: 2
+---
+
+Package manager lockfile integration
+
+---
+
+Third-party dependencies are specified in the package.json fields.
+All package managers vendors a lockfile format specific for the package manager you are using. Pants knows of this
+lockfile and models it as a "resolve".
+
+Resolves is the only way to deal with dependencies within pants, and no extra configuration is required.
+
+You can however name your resolves/lockfiles. The resolve name is otherwise auto-generated.
+
+```toml title="pants.toml"
+[GLOBAL]
+backend_packages.add = [
+    "pants.backend.experimental.javascript"
+]
+
+[nodejs.resolves]
+package-lock.json = "my-lock"
+
+```
+
+You generate the lockfile as follows:
+
+```shell title="Bash"
+$ pants generate-lockfiles
+19:00:39.26 [INFO] Completed: Generate lockfile for my-lock
+19:00:39.29 [INFO] Wrote lockfile for the resolve `my-lock` to package-lock.json
+```
+
+
+## Using lockfiles for tools
+
+To ensure that the same version of tooling you have specified in `package.json` is used with a nodejs powered tool,
+specify the resolve name for the tool.
+E.g. prettier linter:
+
+```toml tab={"label": "pants.toml"}
+[GLOBAL]
+backend_packages.add = [
+    "pants.backend.experimental.javascript",
+    "pants.backend.experimental.javascript.lint.prettier",
+]
+
+[prettier]
+install_from_resolve = "nodejs-default"
+
+```
+```json tab={"label": "package.json"}
+{
+    "name": "@my-company/pkg",
+    "devDependencies": {
+        "prettier": "^2.6.2"
+    }
+}
+```
+```python tab={"label": "BUILD"}
+    package_json(name="pkg")
+```

--- a/docs/docs/javascript/overview/package.mdx
+++ b/docs/docs/javascript/overview/package.mdx
@@ -7,14 +7,14 @@ package.json parsing and scripts integration
 
 ---
 
-As mentioned in the [overview introduction](./index.mdx), pants approach to enable support for Javascript is to
+As mentioned in the [overview introduction](./index.mdx), Pants's approach to enable support for Javascript is to
 be a thin caching layer on top of your current tooling.
 
 Refer to the [example repository](https://github.com/pantsbuild/example-javascript) for example usage.
 
 ### Package manager
 
-Pants uses `corepack` to manage package manager versions and installation. Like `corepack`, pants respects
+Pants uses `corepack` to manage package manager versions and installation. Like `corepack`, Pants respects
 the experimental "packageManager" feature in `package.json` files.
 
 ```json title="package.json"
@@ -30,14 +30,14 @@ It can be more convenient to define a project level
 [package manager](./enable-javascript-support.mdx#setting-up-a-package-manager).
 
 :::tip Choosing between `pants.toml` or `package.json` for package manager version configuration
-In general, if your team runs all tooling via pants, using `pants.toml` reduces boilerplate in cases where you maintain
-multiple packages. If your team mixes usage of pants and "bare" package manager invocations, package.json#packageManager
+In general, if your team runs all tooling via Pants, using `pants.toml` reduces boilerplate in cases where you maintain
+multiple packages. If your team mixes usage of Pants and "bare" package manager invocations, package.json#packageManager
 is the safer option.
 :::
 
 ### Testing
 
-By default pants assumes a `package_json` target mapping a `package.json` includes a test script, e.g.
+By default Pants assumes a `package_json` target mapping a `package.json` includes a test script, e.g.
 
 ```json title="package.json"
 {
@@ -60,7 +60,7 @@ contains options for changing the entry point from "test", and to enable coverag
 
 ### Packaging
 
-Similarly, build scripts can be introduced to pants via the
+Similarly, build scripts can be introduced to Pants via the
 [`node_build_script`](../../../reference/build-file-symbols/node_build_script) build symbol. This is intended to be used
 as a way to introduce artifacts generated via bundlers and/or compilers installed and ran via your package manager.
 The result can the be consumed by other targets as either `resource`-targets that can be depended on,

--- a/docs/docs/javascript/overview/package.mdx
+++ b/docs/docs/javascript/overview/package.mdx
@@ -1,0 +1,67 @@
+---
+    title: package.json
+    sidebar_position: 3
+---
+
+package.json parsing and scripts integration
+
+---
+
+As mentioned in the [overview introduction](./index.mdx), pants approach to enable support for Javascript is to
+be a thin caching layer on top of your current tooling.
+
+Refer to the [example repository](https://github.com/pantsbuild/example-javascript) for example usage.
+
+### Package manager
+
+Pants uses `corepack` to manage package manager versions and installation. Like `corepack`, pants respects
+the experimental "packageManager" feature in `package.json` files.
+
+```json title="package.json"
+{
+    "name": "@my-company/pkg",
+    "packageManager": "yarn@1.22.22"
+}
+```
+
+this setting will ensure that all scripts invoked for this package.json, and any
+[workspaces managed by this package.json](./workspaces.mdx) will use this particular version of `yarn`.
+It can be more convenient to define a project level
+[package manager](./enable-javascript-support.mdx#setting-up-a-package-manager).
+
+:::tip Choosing between `pants.toml` or `package.json` for package manager version configuration
+In general, if your team runs all tooling via pants, using `pants.toml` reduces boilerplate in cases where you maintain
+multiple packages. If your team mixes usage of pants and "bare" package manager invocations, package.json#packageManager
+is the safer option.
+:::
+
+### Testing
+
+By default pants assumes a `package_json` target mapping a `package.json` includes a test script, e.g.
+
+```json title="package.json"
+{
+    "name": "@my-company/pkg",
+    "scripts": {
+        "test": "jest"
+    },
+    "devDependencies": {
+        "jest": "^29.5.0"
+    }
+}
+```
+
+and will use this script to execute your tests when running `pants test ::`.
+See [Goal arguments](../../using-pants/key-concepts/goals.mdx#goal-arguments) for the normal techniques for telling Pants what to
+run on.
+
+To enable configurability, the build symbol [`node_test_script`](../../../reference/build-file-symbols/node_test_script)
+contains options for changing the entry point from "test", and to enable coverage reporting.
+
+### Packaging
+
+Similarly, build scripts can be introduced to pants via the
+[`node_build_script`](../../../reference/build-file-symbols/node_build_script) build symbol. This is intended to be used
+as a way to introduce artifacts generated via bundlers and/or compilers installed and ran via your package manager.
+The result can the be consumed by other targets as either `resource`-targets that can be depended on,
+or as a package for the [docker backend](../../docker/index.mdx).

--- a/docs/docs/javascript/overview/workspaces.mdx
+++ b/docs/docs/javascript/overview/workspaces.mdx
@@ -1,0 +1,22 @@
+---
+    title: Monorepo workspaces
+    sidebar_position: 1
+---
+Package manager workspace management
+
+---
+
+Modern versions of package managers introduce similar
+concepts of "workspaces", a list of Nodejs packages all contained within the same code repository.
+
+Pants support all three flavors of package managers and understands the configuration
+settings specific for each tool:
+
+- [pnpm](https://pnpm.io/workspaces) pnpm-workspaces.yaml
+- [yarn](https://yarnpkg.com/features/workspaces) and [npm](https://docs.npmjs.com/cli/v10/using-npm/workspaces)
+    "workspaces" setting in package.json
+
+:::tip Use workspaces!
+It is encouraged by the pants team to utilize this project setup to only have to deal with and maintain
+one [resolve](./lockfiles.mdx). Pants aims to provide full integration with these monorepo settings.
+:::

--- a/docs/docs/javascript/overview/workspaces.mdx
+++ b/docs/docs/javascript/overview/workspaces.mdx
@@ -17,6 +17,6 @@ settings specific for each tool:
     "workspaces" setting in package.json
 
 :::tip Use workspaces!
-It is encouraged by the pants team to utilize this project setup to only have to deal with and maintain
+It is encouraged by the Pants team to utilize this project setup to only have to deal with and maintain
 one [resolve](./lockfiles.mdx). Pants aims to provide full integration with these monorepo settings.
 :::


### PR DESCRIPTION
Adds a summary of the configuration knobs and how to enable a functioning javascript backend.