### PR TITLE
Enable MockGet when using call-by-name

### DIFF
--- a/src/python/pants/backend/javascript/subsystems/nodejs.py
+++ b/src/python/pants/backend/javascript/subsystems/nodejs.py
@@ -41,10 +41,11 @@ from pants.core.util_rules.system_binaries import (
 from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest, PathEnvironmentVariable
 from pants.engine.fs import EMPTY_DIGEST, CreateDigest, Digest, Directory, DownloadFile
 from pants.engine.internals.native_engine import FileDigest, MergeDigests
+from pants.engine.internals.platform_rules import environment_vars_subset
 from pants.engine.internals.selectors import MultiGet
 from pants.engine.platform import Platform
 from pants.engine.process import Process, ProcessResult
-from pants.engine.rules import Get, Rule, collect_rules, rule
+from pants.engine.rules import Get, Rule, collect_rules, implicitly, rule
 from pants.engine.unions import UnionRule
 from pants.option.option_types import DictOption, ShellStrListOption, StrListOption, StrOption
 from pants.option.subsystem import Subsystem
@@ -390,7 +391,11 @@ class NodeJSBootstrap:
 async def _get_nvm_root() -> str | None:
     """See https://github.com/nvm-sh/nvm#installing-and-updating."""
 
-    env = await Get(EnvironmentVars, EnvironmentVarsRequest(("NVM_DIR", "XDG_CONFIG_HOME", "HOME")))
+    env = await environment_vars_subset(
+        **implicitly(
+            {EnvironmentVarsRequest(("NVM_DIR", "XDG_CONFIG_HOME", "HOME")): EnvironmentVarsRequest}
+        )
+    )
     nvm_dir = env.get("NVM_DIR")
     default_dir = env.get("XDG_CONFIG_HOME", env.get("HOME"))
     if nvm_dir:

--- a/src/python/pants/engine/internals/native_engine.pyi
+++ b/src/python/pants/engine/internals/native_engine.pyi
@@ -890,6 +890,10 @@ _Output = TypeVar("_Output")
 _Input = TypeVar("_Input")
 
 class PyGeneratorResponseCall:
+    output_type: type
+    input_types: Sequence[type]
+    inputs: Sequence[Any]
+
     @overload
     def __init__(
         self,

--- a/src/python/pants/engine/internals/selectors.py
+++ b/src/python/pants/engine/internals/selectors.py
@@ -79,10 +79,6 @@ class AwaitableConstraints:
 
 
 class Call(PyGeneratorResponseCall):
-    output_type: type
-    input_types: Sequence[type]
-    inputs: Sequence[Any]
-
     def __await__(
         self,
     ) -> Generator[Any, None, Any]:

--- a/src/python/pants/engine/internals/selectors.py
+++ b/src/python/pants/engine/internals/selectors.py
@@ -79,6 +79,10 @@ class AwaitableConstraints:
 
 
 class Call(PyGeneratorResponseCall):
+    output_type: type
+    input_types: Sequence[type]
+    inputs: Sequence[Any]
+
     def __await__(
         self,
     ) -> Generator[Any, None, Any]:

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -46,7 +46,7 @@ from pants.engine.goal import CurrentExecutingGoals, Goal
 from pants.engine.internals import native_engine
 from pants.engine.internals.native_engine import ProcessExecutionEnvironment, PyExecutor
 from pants.engine.internals.scheduler import ExecutionError, Scheduler, SchedulerSession
-from pants.engine.internals.selectors import Effect, Get, Params
+from pants.engine.internals.selectors import Call, Effect, Get, Params
 from pants.engine.internals.session import SessionValues
 from pants.engine.platform import Platform
 from pants.engine.process import InteractiveProcess, InteractiveProcessResult
@@ -737,7 +737,7 @@ def run_rule_with_mocks(
     if not isinstance(res, (Coroutine, Generator)):
         return res
 
-    def get(res: Get | Effect):
+    def get(res: Get | Effect | Call):
         provider = next(
             (
                 mock_get.mock
@@ -767,7 +767,7 @@ def run_rule_with_mocks(
     while True:
         try:
             res = rule_coroutine.send(rule_input)
-            if isinstance(res, (Get, Effect)):
+            if isinstance(res, (Get, Effect, Call)):
                 rule_input = get(res)
             elif type(res) in (tuple, list):
                 rule_input = [get(g) for g in res]  # type: ignore[union-attr]

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -572,17 +572,11 @@ impl PyGeneratorResponseCall {
         let inner = self.borrow_inner()?;
         let args: Vec<PyObject> = inner.args.as_ref().map_or_else(
             || Ok(Vec::default()),
-            |args| {
-                let pyo: PyObject = args.value.clone().into();
-                pyo.extract(py)
-            },
+            |args| args.to_py_object().extract(py),
         )?;
         Ok(args
             .into_iter()
-            .chain(inner.inputs.iter().map(|k| {
-                let pyo: PyObject = k.value.clone().into();
-                pyo
-            }))
+            .chain(inner.inputs.iter().map(Key::to_py_object))
             .collect())
     }
 }
@@ -681,10 +675,7 @@ impl PyGeneratorResponseGet {
             })?
             .inputs
             .iter()
-            .map(|k| {
-                let pyo: PyObject = k.value.clone().into();
-                pyo
-            })
+            .map(Key::to_py_object)
             .collect())
     }
 

--- a/src/rust/engine/src/python.rs
+++ b/src/rust/engine/src/python.rs
@@ -279,6 +279,10 @@ impl Key {
     pub fn to_value(&self) -> Value {
         self.value.clone()
     }
+
+    pub fn to_py_object(&self) -> PyObject {
+        self.to_value().into()
+    }
 }
 
 // NB: Although `PyObject` (aka `Py<PyAny>`) directly implements `Clone`, it's ~4% faster to wrap


### PR DESCRIPTION
The scaffolding required to use `MockGet` as advertised required `Call` exposing some variables that were kept internal compared to `Get`.

I think this  a good compromise to keep the migration to call-by-name smooth. Especially since plugins out in the wild might utilize `MockGet` more than pants does internally as it is advertized in the [docs](https://www.pantsbuild.org/2.22/docs/tutorials/testing-plugins#unit-testing-for-rules), and plugin authors probably want their plugins to be fast, too.