### PR TITLE
rename `--export-py-generated-sources` to `--export-py-generated-sources-in-resolve`

### DIFF
--- a/docs/notes/2.22.x.md
+++ b/docs/notes/2.22.x.md
@@ -119,7 +119,7 @@ New field `pex_build_extra_args` is available on FaaS targets [python_aws_lambda
 
 The `runtime` field of [`aws_python_lambda_layer`](https://www.pantsbuild.org/2.22/reference/targets/python_aws_lambda_layer#runtime) or [`aws_python_lambda_function`](https://www.pantsbuild.org/2.22/reference/targets/python_aws_lambda_function#runtime) now has a built-in complete platform configuration for x86-64 Python 3.12. This provides stable support for Python 3.12 lambdas out of the box, allowing deleting manual `complete_platforms` configuration if any.
 
-`pants export` of a Python resolve will now include generated Python sources (for example, from `protobuf_sources` or `thrift_sources` targets) if the option `--export-py-generated-sources` is enabled.
+`pants export` of a Python resolve will now include generated Python sources (for example, from `protobuf_sources` or `thrift_sources` targets) if the resolve is configured in the new `--export-py-generated-sources-in-resolve` option.
 
 #### Semgrep
 

--- a/src/python/pants/backend/python/goals/export.py
+++ b/src/python/pants/backend/python/goals/export.py
@@ -136,15 +136,15 @@ class ExportPluginOptions:
         advanced=True,
     )
 
-    py_generated_sources = BoolOption(
-        default=False,
+    py_generated_sources_in_resolve = StrListOption(
         help=softwrap(
             """
-            When exporting a mutable virtualenv for a resolve, generate any sources
-            which result from code generation (for example, the `protobuf_sources` and `thrift_sources` targets)
-            and place the generated files under the site-packages directory of the virtualenv.
+            When exporting a mutable virtualenv for a resolve listed in this option, generate sources which result from
+            code generation (for example, the `protobuf_sources` and `thrift_sources` target types) into the mutable
+            virtualenv exported for that resolve. Generated sources will be placed in the appropriate location within
+            the site-packages directory of the mutable virtualenv.
             """
-        ),
+        )
     )
 
 
@@ -558,9 +558,9 @@ async def export_virtualenv_for_resolve(
         ),
     )
 
-    # Add generated Python sources from codegen targets to the virtualenv.
+    # Add generated Python sources from codegen targets to the mutable virtualenv.
     if (
-        export_subsys.options.py_generated_sources
+        resolve in export_subsys.options.py_generated_sources_in_resolve
         and export_subsys.options.py_resolve_format == PythonResolveExportFormat.mutable_virtualenv
     ):
         export_result = await add_codegen_to_export_result(

--- a/src/python/pants/backend/python/goals/export_test.py
+++ b/src/python/pants/backend/python/goals/export_test.py
@@ -241,7 +241,7 @@ def test_export_codegen_outputs():
             "--python-resolves={'test-resolve': 'test-resolve.lock'}",
             "--source-root-patterns=src/python",
             "--export-resolve=test-resolve",
-            "--export-py-generated-sources",
+            "--export-py-generated-sources-in-resolve=['test-resolve']",
         ],
         env_inherit=PYTHON_BOOTSTRAP_ENV,
     )


### PR DESCRIPTION
Rename the `--export-py-generated-sources` option to `--export-py-generated-sources-in-resolve` to allow configuring the generated sources logic on a per-resolve basis.

This will be back-ported to the `2.22.x` branch before its final release to avoid a deprecation cycle. Hence, the 2.22.x release notes are updated in this PR to reflect the rename.