### PR TITLE
[Call-by-name] semgrep/trufflehog/yamllint migration

### DIFF
--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -170,8 +170,11 @@ Pants has a new mechanism for `@rule` invocation in backends. In this release th
 - `cue`
 - `debian`
 - `makeself`
+- `semgrep`
 - `sql`
 - `swift`
+- `trufflehog`
+- `yamllint`
 
 ## Full Changelog
 

--- a/src/python/pants/goal/migrate_call_by_name.py
+++ b/src/python/pants/goal/migrate_call_by_name.py
@@ -604,9 +604,7 @@ def fix_implicitly_usage(call: cst.Call, target_func: cst.FunctionDef) -> cst.Ca
         for a in m.findall(target_func.params, m.Annotation())
     ]
     target_types = [
-        target_type
-        for a in target_annotations
-        if (target_type := h.get_full_name_for_node(a))
+        target_type for a in target_annotations if (target_type := h.get_full_name_for_node(a))
     ]
 
     # Positionally compare the target function's annotations with the call's arguments
@@ -640,9 +638,7 @@ def fix_implicitly_usage(call: cst.Call, target_func: cst.FunctionDef) -> cst.Ca
             return call.with_changes(args=[new_arg])
         else:
             # If arg and target don't match, keep `implicitly` call
-            new_arg = cst.Arg(
-                cst.Call(cst.Name("implicitly"), args=[new_arg]), star="**"
-            )
+            new_arg = cst.Arg(cst.Call(cst.Name("implicitly"), args=[new_arg]), star="**")
             return call.with_changes(args=[new_arg])
 
     # If the target function takes in more arguments than we've passed in, then we need to pass in `implicitly`
@@ -653,9 +649,7 @@ def fix_implicitly_usage(call: cst.Call, target_func: cst.FunctionDef) -> cst.Ca
             return call
         else:
             new_arg = call.args[0].with_changes(comma=cst.MaybeSentinel.DEFAULT)
-            new_arg = cst.Arg(
-                cst.Call(cst.Name("implicitly"), args=[new_arg]), star="**"
-            )
+            new_arg = cst.Arg(cst.Call(cst.Name("implicitly"), args=[new_arg]), star="**")
             return call.with_changes(args=[new_arg])
 
     return call

--- a/src/python/pants/goal/migrate_call_by_name.py
+++ b/src/python/pants/goal/migrate_call_by_name.py
@@ -571,10 +571,12 @@ def fix_implicitly_usage(call: cst.Call, target_func: cst.FunctionDef) -> cst.Ca
     """The CallByNameSyntaxMapper aggressively adds `implicitly` for safety. This function removes
     unnecessary ones, and attempts to cleanup usage.
 
-    The following cases are handled:
-    - The called function takes no arguments
-    - TODO: The called function takes the same number of arguments that are passed to it
-    - TODO: Check the types of the passed in parameters, if they don't match, they need to be implicitly passed
+    Examples:
+        find_all_targets(**implicitly()) -> find_all_targets()
+        create_pex(**implicitly({req: PexRequest})) -> create_pex(req)
+        create_venv_pex(**implicitly({req: PexRequest})) -> create_venv_pex(**implicitly(req))
+
+    Refer to `migrate_call_by_name_test.py` for more examples.
 
     Parameters:
         call: The replaced `Get` which now uses the migrated call-by-name syntax

--- a/src/python/pants/goal/migrate_call_by_name_integration_test.py
+++ b/src/python/pants/goal/migrate_call_by_name_integration_test.py
@@ -61,10 +61,10 @@ MIGRATED_REGISTER_FILE = dedent(
 
     @goal_rule
     async def setup_migrateme(black: Black) -> ContrivedGoal:
-        foo = await variants(**implicitly({black: Black}))
-        bar = await multiline(**implicitly({black: Black}))
-        qux = await shadowed(**implicitly({black: Black}))
-        thud = await multiget(**implicitly({black: Black}))
+        foo = await variants(black)
+        bar = await multiline(black)
+        qux = await shadowed(black)
+        thud = await multiget(black)
 
     def rules():
         return [*collect_rules(), *rules1(), *rules2()]
@@ -195,7 +195,7 @@ MIGRATED_RULES1_FILE = dedent(
     @rule
     async def variants(black: Black, local_env: ChosenLocalEnvironmentName) -> Foo:
         all_targets = await find_all_targets()
-        pex = await create_venv_pex(**implicitly({black.to_pex_request(): PexRequest}))
+        pex = await create_venv_pex(**implicitly(black.to_pex_request()))
         digest = await create_archive(CreateArchive(EMPTY_SNAPSHOT), **implicitly())
         paths = await find_binary(**implicitly({BinaryPathRequest(binary_name='time', search_path=['/usr/bin']): BinaryPathRequest, local_env.val: EnvironmentName}))
         try:
@@ -219,7 +219,7 @@ MIGRATED_RULES1_FILE = dedent(
 
     @rule(desc="Ensure multi-line calls are migrated")
     async def multiline(black: Black) -> Bar:
-        pex = await create_venv_pex(**implicitly({black.to_pex_request(): PexRequest}))
+        pex = await create_venv_pex(**implicitly(black.to_pex_request()))
 
     class Thud:
         pass
@@ -231,12 +231,12 @@ MIGRATED_RULES1_FILE = dedent(
         multigot = await concurrently(
             find_all_targets(),
             all_targets_get,
-            create_venv_pex(**implicitly({black.to_pex_request(): PexRequest})),
+            create_venv_pex(**implicitly(black.to_pex_request())),
             digest_get
         )
         multigot_sameline = await concurrently(
             find_all_targets(), all_targets_get,
-            create_venv_pex(**implicitly({black.to_pex_request(): PexRequest})), digest_get
+            create_venv_pex(**implicitly(black.to_pex_request())), digest_get
         )
         multigot_forloop = await concurrently(
             create_archive(CreateArchive(EMPTY_SNAPSHOT), **implicitly())
@@ -279,7 +279,7 @@ MIGRATED_RULES2_FILE = dedent(
 
     @rule(desc="Ensure assignment name is not shadowed by new syntax")
     async def shadowed(black: Black) -> Qux:
-        create_venv_pex = await create_venv_pex_get(**implicitly({black.to_pex_request(): PexRequest}))
+        create_venv_pex = await create_venv_pex_get(**implicitly(black.to_pex_request()))
 
     def rules():
         return collect_rules()

--- a/src/python/pants/util/cstutil.py
+++ b/src/python/pants/util/cstutil.py
@@ -50,5 +50,7 @@ def extract_functiondef_from_module(module: str, func: str) -> cst.FunctionDef |
     with open(spec.origin) as f:
         source_code = f.read()
         tree = cst.parse_module(source_code)
-        results = m.findall(tree, matcher=m.FunctionDef(m.Name(func), asynchronous=m.Asynchronous()))
+        results = m.findall(
+            tree, matcher=m.FunctionDef(m.Name(func), asynchronous=m.Asynchronous())
+        )
         return cst.ensure_type(results[0], cst.FunctionDef) if results else None

--- a/src/python/pants/util/cstutil.py
+++ b/src/python/pants/util/cstutil.py
@@ -50,5 +50,5 @@ def extract_functiondef_from_module(module: str, func: str) -> cst.FunctionDef |
     with open(spec.origin) as f:
         source_code = f.read()
         tree = cst.parse_module(source_code)
-        results = m.findall(tree, matcher=m.FunctionDef(m.Name(func)))
+        results = m.findall(tree, matcher=m.FunctionDef(m.Name(func), asynchronous=m.Asynchronous()))
         return cst.ensure_type(results[0], cst.FunctionDef) if results else None


### PR DESCRIPTION
This is a PR for the call-by-name migration on multiple, smaller, experimental backends. SemGrep, TruffleHog, YamlLint

Tested on https://github.com/sureshjoshi/pantsanity (as much as reasonably possible) via `pants sanity ::`

See issue https://github.com/pantsbuild/pants/issues/21065 for tracking list.