### PR TITLE
Create [workunit-logger].logdir if it doesn't already exist

### DIFF
--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -124,6 +124,10 @@ Fixed pulling `helm_artifact`s from OCI repositories.
 
 Added `workspace_invalidation_sources` field to `adhoc_tool` and `shell_command` target types. This new field allows declaring that these targets depend on files without bringing those files into the execution sandbox, but that the target should still be re-executed if those files change. This is intended to work with the `workspace_environment` support where processes are executed in the workspace and not in a separate sandbox.
 
+#### Workunit logger
+
+The `pants.backend.experimental.tools.workunit_logger` backend will now create directory specified by [the `logdir` option](https://www.pantsbuild.org/2.23/reference/subsystems/workunit-logger#logdir) if it doesn't already exist.
+
 ### Plugin API changes
 
 Fixed bug with workspace environment support where Pants used a workspace environment when it was searching for a local environment.

--- a/src/python/pants/backend/tools/workunit_logger/rules.py
+++ b/src/python/pants/backend/tools/workunit_logger/rules.py
@@ -15,6 +15,7 @@ from pants.engine.streaming_workunit_handler import (
 from pants.engine.unions import UnionRule
 from pants.option.option_types import BoolOption, StrOption
 from pants.option.subsystem import Subsystem
+from pants.util.dirutil import safe_open
 
 logger = logging.getLogger(__name__)
 
@@ -66,7 +67,7 @@ class WorkunitLoggerCallback(WorkunitsCallback):
             self._completed_workunits[wu["span_id"]] = wu
         if finished:
             filepath = f"{self.wulogger.logdir}/{context.run_tracker.run_id}.json"
-            with open(filepath, "w") as f:
+            with safe_open(filepath, "w") as f:
                 json.dump(just_dump_map(self._completed_workunits), f)
                 logger.info(f"Wrote log to {filepath}")
 


### PR DESCRIPTION
This adjusts  `pants.backend.experimental.tools.workunit_logger` backend to support writing logs do a directory that doesn't (yet) exist, by creating the directory when first writing a file to it.

Before this PR specifying something `pants --workunit-logger-logdir=/tmp/doesnt-exist ...` would fail to write anything, with an error like:
```
...
  File ".../pants/backend/tools/workunit_logger/rules.py", line 69, in __call__
    with open(filepath, "w") as f:
FileNotFoundError: [Errno 2] No such file or directory: '.pants.d/workunit-logger/pants_run_2024_07_10_13_02_09_746_c7f3742edb1748afb3af8e994bfabd6a.json'
```