### PR TITLE
fix type error in default for `--export-py-generated-sources-in-resolve`

### DIFF
--- a/src/python/pants/backend/python/goals/export.py
+++ b/src/python/pants/backend/python/goals/export.py
@@ -143,7 +143,7 @@ class ExportPluginOptions:
     )
 
     py_hermetic_scripts_in_resolve = StrListOption(
-        default=True,
+        default=[],
         help=softwrap(
             """
             When exporting a mutable virtualenv for a resolve listed in this option, by default

--- a/src/python/pants/backend/python/goals/export.py
+++ b/src/python/pants/backend/python/goals/export.py
@@ -134,6 +134,44 @@ class ExportPluginOptions:
             """
         ),
         advanced=True,
+        removal_version="2.24.0.dev0",
+        removal_hint=softwrap(
+            """
+            Use `--export-py-hermetic-in-resolve` instead.
+            """
+        )
+    )
+
+    py_hermetic_scripts_in_resolve = StrListOption(
+        default=True,
+        help=softwrap(
+            """
+            When exporting a mutable virtualenv for a resolve listed in this option, by default
+            modify console script shebang lines to make them "hermetic".
+            The shebang of hermetic console scripts uses the python args: `-sE`:
+
+              - `-s` skips inclusion of the user site-packages directory,
+              - `-E` ignores all `PYTHON*` env vars like `PYTHONPATH`.
+
+            Set this to false if you need non-hermetic scripts with
+            simple python shebangs that respect vars like `PYTHONPATH`,
+            to, for example, allow IDEs like PyCharm to inject its debugger,
+            coverage, or other IDE-specific libs when running a script.
+
+            This only applies when when exporting a `mutable_virtualenv`
+            (`symlinked_immutable_virtualenv` exports are not "full"
+            virtualenvs because they are used internally by pants itself.
+            Pants requires hermetic scripts to provide its reproduciblity
+            guarantee, fine-grained caching, and other features).
+            """
+        ),
+        advanced=True,
+        removal_version="2.24.0.dev0",
+        removal_hint=softwrap(
+            """
+            Use `--export-py-hermetic-in-resolve` instead.
+            """
+        )
     )
 
     py_generated_sources_in_resolve = StrListOption(

--- a/src/python/pants/backend/python/goals/export.py
+++ b/src/python/pants/backend/python/goals/export.py
@@ -139,7 +139,7 @@ class ExportPluginOptions:
             """
             Use `--export-py-hermetic-in-resolve` instead.
             """
-        )
+        ),
     )
 
     py_hermetic_scripts_in_resolve = StrListOption(
@@ -171,7 +171,7 @@ class ExportPluginOptions:
             """
             Use `--export-py-hermetic-in-resolve` instead.
             """
-        )
+        ),
     )
 
     py_generated_sources_in_resolve = StrListOption(


### PR DESCRIPTION
The default for  `--export-py-generated-sources-in-resolve` still has the previous value `True` from when the option was a `BoolOption` and not a `StrListOption`. For whatever reason, the `pants check` run of mypy did not flag this error! (will figure out that issue separately)