### PR TITLE
Native dockerfile parser

### DIFF
--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -45,6 +45,8 @@ Support for parametrizing grouped parametrizations. (e.g. `**parametrize(resolve
 
 Docker inference is improved. Pants can now make inferences by target address for targets supporting `pants package`, and `file` targets can be included by filename. See the [documentation on Docker dependency inference](https://www.pantsbuild.org/2.23/docs/docker#dependency-inference-support) for details
 
+Experimental support for a rust-based dockerfile parser can be enabled via `[dockerfile-parser].use_rust_parser` option.
+
 #### Scala
 
 Source files no longer produce a dependency on Scala plugins. If you are using a Scala plugin that is also required by the source code (such as acyclic), please add an explicit dependency or set the `packages` field on the artifact.

--- a/src/python/pants/backend/docker/subsystems/dockerfile_parser.py
+++ b/src/python/pants/backend/docker/subsystems/dockerfile_parser.py
@@ -15,6 +15,8 @@ from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
 from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent
+from pants.engine.internals.native_engine import NativeDependenciesRequest
+from pants.engine.intrinsics import parse_dockerfile_info
 from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import (
@@ -24,8 +26,11 @@ from pants.engine.target import (
     WrappedTarget,
     WrappedTargetRequest,
 )
+from pants.option.option_types import BoolOption
+from pants.util.docutil import bin_name
 from pants.util.logging import LogLevel
 from pants.util.resources import read_resource
+from pants.util.strutil import softwrap
 
 _DOCKERFILE_SANDBOX_TOOL = "dockerfile_wrapper_script.py"
 _DOCKERFILE_PACKAGE = "pants.backend.docker.subsystems"
@@ -40,6 +45,23 @@ class DockerfileParser(PythonToolRequirementsBase):
     register_interpreter_constraints = True
 
     default_lockfile_resource = (_DOCKERFILE_PACKAGE, "dockerfile.lock")
+
+    use_rust_parser = BoolOption(
+        default=False,
+        help=softwrap(
+            f"""
+            Use the new Rust-based, multithreaded, in-process dependency parser.
+
+            If you think the new behaviour is causing problems, it is recommended that you run
+            `{bin_name()} peek :: > before.json` and then
+            `{bin_name()} --dockerfile-parser-use-rust-parser=False peek :: > after.json` and compare the
+            two results.
+
+            If you think there is a bug, please file an issue:
+            https://github.com/pantsbuild/pants/issues/new/choose.
+            """
+        ),
+    )
 
 
 @dataclass(frozen=True)
@@ -119,8 +141,59 @@ class DockerfileInfoRequest:
     address: Address
 
 
+async def _natively_parse_dockerfile(address: Address, digest: Digest) -> DockerfileInfo:
+    result = await parse_dockerfile_info(NativeDependenciesRequest(digest))
+    return DockerfileInfo(
+        address=address,
+        digest=digest,
+        source=result.source,
+        build_args=DockerBuildArgs.from_strings(*result.build_args, duplicates_must_match=True),
+        copy_source_paths=tuple(result.copy_source_paths),
+        copy_build_args=DockerBuildArgs.from_strings(
+            *result.copy_build_args, duplicates_must_match=True
+        ),
+        from_image_build_args=DockerBuildArgs.from_strings(
+            *result.from_image_build_args, duplicates_must_match=True
+        ),
+        version_tags=tuple(result.version_tags),
+    )
+
+
+async def _legacy_parse_dockerfile(
+    address: Address, digest: Digest, dockerfiles: tuple[str, ...]
+) -> DockerfileInfo:
+    result = await Get(ProcessResult, DockerfileParseRequest(digest, dockerfiles))
+
+    try:
+        raw_output = result.stdout.decode("utf-8")
+        outputs = json.loads(raw_output)
+        assert len(outputs) == len(dockerfiles)
+    except Exception as e:
+        raise DockerfileInfoError(
+            f"Unexpected failure to parse Dockerfiles: {', '.join(dockerfiles)}, "
+            f"for the {address} target: {e}\nDockerfile parser output:\n{raw_output}"
+        ) from e
+    info = outputs[0]
+    return DockerfileInfo(
+        address=address,
+        digest=digest,
+        source=info["source"],
+        build_args=DockerBuildArgs.from_strings(*info["build_args"], duplicates_must_match=True),
+        copy_source_paths=tuple(info["copy_source_paths"]),
+        copy_build_args=DockerBuildArgs.from_strings(
+            *info["copy_build_args"], duplicates_must_match=True
+        ),
+        from_image_build_args=DockerBuildArgs.from_strings(
+            *info["from_image_build_args"], duplicates_must_match=True
+        ),
+        version_tags=tuple(info["version_tags"]),
+    )
+
+
 @rule
-async def parse_dockerfile(request: DockerfileInfoRequest) -> DockerfileInfo:
+async def parse_dockerfile(
+    request: DockerfileInfoRequest, dockerfile_parser: DockerfileParser
+) -> DockerfileInfo:
     wrapped_target = await Get(
         WrappedTarget, WrappedTargetRequest(request.address, description_of_origin="<infallible>")
     )
@@ -139,46 +212,16 @@ async def parse_dockerfile(request: DockerfileInfoRequest) -> DockerfileInfo:
         f"Internal error: Expected a single source file to Dockerfile parse request {request}, "
         f"got: {dockerfiles}."
     )
-
-    result = await Get(
-        ProcessResult,
-        DockerfileParseRequest(
-            sources.snapshot.digest,
-            dockerfiles,
-        ),
-    )
-
     try:
-        raw_output = result.stdout.decode("utf-8")
-        outputs = json.loads(raw_output)
-        assert len(outputs) == len(dockerfiles)
-    except Exception as e:
-        raise DockerfileInfoError(
-            f"Unexpected failure to parse Dockerfiles: {', '.join(dockerfiles)}, "
-            f"for the {request.address} target: {e}\nDockerfile parser output:\n{raw_output}"
-        ) from e
-
-    info = outputs[0]
-    try:
-        return DockerfileInfo(
-            address=request.address,
-            digest=sources.snapshot.digest,
-            source=info["source"],
-            build_args=DockerBuildArgs.from_strings(
-                *info["build_args"], duplicates_must_match=True
-            ),
-            copy_source_paths=tuple(info["copy_source_paths"]),
-            copy_build_args=DockerBuildArgs.from_strings(
-                *info["copy_build_args"], duplicates_must_match=True
-            ),
-            from_image_build_args=DockerBuildArgs.from_strings(
-                *info["from_image_build_args"], duplicates_must_match=True
-            ),
-            version_tags=tuple(info["version_tags"]),
-        )
+        if dockerfile_parser.use_rust_parser:
+            return await _natively_parse_dockerfile(target.address, sources.snapshot.digest)
+        else:
+            return await _legacy_parse_dockerfile(
+                target.address, sources.snapshot.digest, dockerfiles
+            )
     except ValueError as e:
         raise DockerfileInfoError(
-            f"Error while parsing {info['source']} for the {request.address} target: {e}"
+            f"Error while parsing {dockerfiles[0]} for the {request.address} target: {e}"
         ) from e
 
 

--- a/src/python/pants/backend/docker/subsystems/dockerfile_parser.py
+++ b/src/python/pants/backend/docker/subsystems/dockerfile_parser.py
@@ -53,8 +53,8 @@ class DockerfileParser(PythonToolRequirementsBase):
             Use the new Rust-based, multithreaded, in-process dependency parser.
 
             If you think the new behaviour is causing problems, it is recommended that you run
-            `{bin_name()} peek :: > before.json` and then
-            `{bin_name()} --dockerfile-parser-use-rust-parser=False peek :: > after.json` and compare the
+            `{bin_name()} --dockerfile-parser-use-rust-parser=True peek :: > new-parser.json` and then
+            `{bin_name()} --dockerfile-parser-use-rust-parser=False peek :: > old-parser.json` and compare the
             two results.
 
             If you think there is a bug, please file an issue:

--- a/src/python/pants/backend/docker/subsystems/dockerfile_parser.py
+++ b/src/python/pants/backend/docker/subsystems/dockerfile_parser.py
@@ -50,7 +50,7 @@ class DockerfileParser(PythonToolRequirementsBase):
         default=False,
         help=softwrap(
             f"""
-            Use the new Rust-based, multithreaded, in-process dependency parser.
+            Use the new experimental Rust-based, multithreaded, in-process dependency parser.
 
             If you think the new behaviour is causing problems, it is recommended that you run
             `{bin_name()} --dockerfile-parser-use-rust-parser=True peek :: > new-parser.json` and then

--- a/src/python/pants/engine/internals/native_dep_inference.py
+++ b/src/python/pants/engine/internals/native_dep_inference.py
@@ -26,3 +26,13 @@ class NativeParsedJavascriptDependencies:
     def __init__(self, file_imports: set[str], package_imports: set[str]):
         object.__setattr__(self, "file_imports", file_imports)
         object.__setattr__(self, "package_imports", package_imports)
+
+
+@dataclass(frozen=True)
+class NativeParsedDockerfileInfo:
+    source: str
+    build_args: tuple[str, ...]  # "ARG_NAME=VALUE", ...
+    copy_source_paths: tuple[str, ...]
+    copy_build_args: tuple[str, ...]  # "ARG_NAME=UPSTREAM_TARGET_ADDRESS", ...
+    from_image_build_args: tuple[str, ...]  # "ARG_NAME=UPSTREAM_TARGET_ADDRESS", ...
+    version_tags: tuple[str, ...]  # "STAGE TAG", ...

--- a/src/python/pants/engine/internals/native_engine.pyi
+++ b/src/python/pants/engine/internals/native_engine.pyi
@@ -37,6 +37,7 @@ from pants.engine.fs import (
 )
 from pants.engine.internals.docker import DockerResolveImageRequest, DockerResolveImageResult
 from pants.engine.internals.native_dep_inference import (
+    NativeParsedDockerfileInfo,
     NativeParsedJavascriptDependencies,
     NativeParsedPythonDependencies,
 )
@@ -565,6 +566,9 @@ async def interactive_process(
     process: InteractiveProcess, process_execution_environment: ProcessExecutionEnvironment
 ) -> InteractiveProcessResult: ...
 async def docker_resolve_image(request: DockerResolveImageRequest) -> DockerResolveImageResult: ...
+async def parse_dockerfile_info(
+    deps_request: NativeDependenciesRequest,
+) -> NativeParsedDockerfileInfo: ...
 async def parse_python_deps(
     deps_request: NativeDependenciesRequest,
 ) -> NativeParsedPythonDependencies: ...

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -38,6 +38,7 @@ from pants.engine.goal import CurrentExecutingGoals, Goal
 from pants.engine.internals import native_engine
 from pants.engine.internals.docker import DockerResolveImageRequest, DockerResolveImageResult
 from pants.engine.internals.native_dep_inference import (
+    NativeParsedDockerfileInfo,
     NativeParsedJavascriptDependencies,
     NativeParsedPythonDependencies,
 )
@@ -180,6 +181,7 @@ class Scheduler:
             docker_resolve_image_result=DockerResolveImageResult,
             parsed_python_deps_result=NativeParsedPythonDependencies,
             parsed_javascript_deps_result=NativeParsedJavascriptDependencies,
+            parsed_dockerfile_info_result=NativeParsedDockerfileInfo,
         )
         remoting_options = PyRemotingOptions(
             provider=execution_options.remote_provider.value,

--- a/src/python/pants/engine/intrinsics.py
+++ b/src/python/pants/engine/intrinsics.py
@@ -22,6 +22,7 @@ from pants.engine.fs import (
 from pants.engine.internals import native_engine
 from pants.engine.internals.docker import DockerResolveImageRequest, DockerResolveImageResult
 from pants.engine.internals.native_dep_inference import (
+    NativeParsedDockerfileInfo,
     NativeParsedJavascriptDependencies,
     NativeParsedPythonDependencies,
 )
@@ -129,6 +130,13 @@ async def interactive_process(
 @rule
 async def docker_resolve_image(request: DockerResolveImageRequest) -> DockerResolveImageResult:
     return await native_engine.docker_resolve_image(request)
+
+
+@rule
+async def parse_dockerfile_info(
+    deps_request: NativeDependenciesRequest,
+) -> NativeParsedDockerfileInfo:
+    return await native_engine.parse_dockerfile_info(deps_request)
 
 
 @rule

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -872,12 +872,16 @@ version = "2.18.0"
 dependencies = [
  "fnv",
  "hex",
+ "indexmap 1.9.3",
  "itertools",
+ "lazy_static",
  "protos",
+ "regex",
  "serde",
  "serde_derive",
  "sha2",
  "tree-sitter",
+ "tree-sitter-dockerfile",
  "tree-sitter-javascript",
  "tree-sitter-python",
  "walkdir",
@@ -4156,6 +4160,15 @@ checksum = "e747b1f9b7b931ed39a548c1fae149101497de3c1fc8d9e18c62c1a66c683d3d"
 dependencies = [
  "cc",
  "regex",
+]
+
+[[package]]
+name = "tree-sitter-dockerfile"
+version = "0.2.0"
+source = "git+https://github.com/tobni/tree-sitter-dockerfile.git?rev=ce1cbc3537995f0d968c8bc6315b6a62d6faacde#ce1cbc3537995f0d968c8bc6315b6a62d6faacde"
+dependencies = [
+ "cc",
+ "tree-sitter",
 ]
 
 [[package]]

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -254,7 +254,7 @@ humansize = "1.1"
 hyper = "0.14"
 hyper-rustls = "0.24"
 ignore = { git = "https://github.com/pantsbuild/ripgrep.git", rev = "0f7e0fdd00ae528745a7fea24a320cae98235341" }
-indexmap = "1.9"
+indexmap = { version = "1.9", features = ["std", "serde"] }
 indicatif = "0.17.8"
 internment = "0.6"
 itertools = "0.10"
@@ -335,6 +335,8 @@ whoami = "1.4.1"
 tree-sitter = "0.20.10"
 tree-sitter-javascript = "0.20.1"
 tree-sitter-python = "0.20.4"
+# TODO: Waiting on https://github.com/camdencheek/tree-sitter-dockerfile/pull/58.
+tree-sitter-dockerfile = { git = "https://github.com/tobni/tree-sitter-dockerfile.git", rev = "ce1cbc3537995f0d968c8bc6315b6a62d6faacde" }
 
 # Default lints adopted by most crates in this workspace.
 

--- a/src/rust/engine/dep_inference/Cargo.toml
+++ b/src/rust/engine/dep_inference/Cargo.toml
@@ -21,16 +21,21 @@ walkdir = { workspace = true }
 tree-sitter = { workspace = true }
 tree-sitter-javascript = { workspace = true }
 tree-sitter-python = { workspace = true }
+tree-sitter-dockerfile = { workspace = true }
 
 [dependencies]
 fnv = { workspace = true }
 protos = { path = "../protos" }
+indexmap = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 itertools = { workspace = true }
 tree-sitter = { workspace = true }
 tree-sitter-javascript = { workspace = true }
 tree-sitter-python = { workspace = true }
+tree-sitter-dockerfile = { workspace = true }
+lazy_static = { workspace = true }
+regex = { workspace = true }
 
 [lints]
 workspace = true

--- a/src/rust/engine/dep_inference/build.rs
+++ b/src/rust/engine/dep_inference/build.rs
@@ -218,6 +218,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &source_dir,
         out_dir,
     )?;
+    gen_files_for_language(
+        tree_sitter_dockerfile::language(),
+        "dockerfile",
+        &source_dir,
+        out_dir,
+    )?;
     println!("cargo:rerun-if-env-changed=PANTS_PRINT_IMPL_HASHES");
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=src");

--- a/src/rust/engine/dep_inference/src/code.rs
+++ b/src/rust/engine/dep_inference/src/code.rs
@@ -1,0 +1,11 @@
+// Copyright 2024 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+use tree_sitter::{Node, Range};
+
+pub fn at<'a>(code: &'a str, node: Node) -> &'a str {
+    at_range(code, node.range())
+}
+
+pub fn at_range(code: &str, range: Range) -> &str {
+    &code[range.start_byte..range.end_byte]
+}

--- a/src/rust/engine/dep_inference/src/dockerfile/copy.rs
+++ b/src/rust/engine/dep_inference/src/dockerfile/copy.rs
@@ -1,0 +1,65 @@
+// Copyright 2024 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+use crate::code;
+use crate::dockerfile::{ChildBehavior, Visitor};
+use tree_sitter::Node;
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) enum CopiedFile<'a> {
+    Path(&'a str),
+    Arg(&'a str),
+}
+
+pub(crate) struct CopyFileCollector<'a> {
+    pub files: Vec<CopiedFile<'a>>,
+    is_from: bool,
+    code: &'a str,
+}
+
+impl<'a> CopyFileCollector<'a> {
+    pub fn new(code: &'a str) -> Self {
+        Self {
+            code,
+            is_from: false,
+            files: Vec::default(),
+        }
+    }
+}
+
+impl Visitor for CopyFileCollector<'_> {
+    fn visit_variable(&mut self, node: Node) -> ChildBehavior {
+        if self.is_from {
+            ChildBehavior::Ignore
+        } else if let Some(CopiedFile::Path(_)) = self.files.last() {
+            self.replace_last_path_with_encountered_variable_name(node)
+        } else {
+            ChildBehavior::Visit
+        }
+    }
+
+    fn visit_path(&mut self, node: Node) -> ChildBehavior {
+        if self.is_from {
+            return ChildBehavior::Ignore;
+        }
+        self.files.push(CopiedFile::Path(code::at(self.code, node)));
+        ChildBehavior::Visit
+    }
+
+    fn visit_param(&mut self, node: Node) -> ChildBehavior {
+        if code::at(self.code, node).contains("--from") {
+            self.is_from = true;
+            ChildBehavior::Ignore
+        } else {
+            ChildBehavior::Visit
+        }
+    }
+}
+
+impl CopyFileCollector<'_> {
+    /// Because a variable "ARG" is always wrapped in a path "$ARG".
+    fn replace_last_path_with_encountered_variable_name(&mut self, node: Node) -> ChildBehavior {
+        self.files.pop();
+        self.files.push(CopiedFile::Arg(code::at(self.code, node)));
+        ChildBehavior::Ignore
+    }
+}

--- a/src/rust/engine/dep_inference/src/dockerfile/copy.rs
+++ b/src/rust/engine/dep_inference/src/dockerfile/copy.rs
@@ -56,7 +56,18 @@ impl Visitor for CopyFileCollector<'_> {
 }
 
 impl CopyFileCollector<'_> {
-    /// Because a variable "ARG" is always wrapped in a path "$ARG".
+    /// A variable "VAR" is always wrapped in a path "$VAR".
+    /// This method replaces the latest encountered path
+    /// with the next seen variable, assuming it is the variable inside the path.
+    ///
+    /// E.g.
+    /// ```dockerfile
+    /// ARG VAR
+    /// COPY $VAR to/here
+    ///       |--> variable
+    ///      |---> path
+    ///
+    /// ```
     fn replace_last_path_with_encountered_variable_name(&mut self, node: Node) -> ChildBehavior {
         self.files.pop();
         self.files.push(CopiedFile::Arg(code::at(self.code, node)));

--- a/src/rust/engine/dep_inference/src/dockerfile/from.rs
+++ b/src/rust/engine/dep_inference/src/dockerfile/from.rs
@@ -1,0 +1,92 @@
+// Copyright 2024 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+use tree_sitter::Node;
+
+use crate::code;
+use crate::dockerfile::{ChildBehavior, Visitor};
+
+pub(crate) struct TagCollector<'a> {
+    pub tag: Tag<'a>,
+    is_arg: bool,
+    code: &'a str,
+}
+
+impl<'a> TagCollector<'a> {
+    pub fn new(code: &'a str) -> Self {
+        Self {
+            tag: Tag::None,
+            is_arg: false,
+            code,
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) enum Tag<'a> {
+    Explicit(&'a str),
+    BuildArg(&'a str),
+    Default,
+    None,
+}
+
+impl Visitor for TagCollector<'_> {
+    fn visit_variable(&mut self, node: Node) -> ChildBehavior {
+        if self.is_arg {
+            self.tag = Tag::BuildArg(code::at(self.code, node));
+        }
+        ChildBehavior::Ignore
+    }
+
+    fn visit_image_spec(&mut self, node: Node) -> ChildBehavior {
+        if code::at(self.code, node).trim().starts_with('$') {
+            self.is_arg = true;
+        }
+        ChildBehavior::Visit
+    }
+
+    fn visit_image_name(&mut self, _: Node) -> ChildBehavior {
+        if self.tag == Tag::None {
+            self.tag = Tag::Default
+        }
+        ChildBehavior::Visit
+    }
+
+    fn visit_image_tag(&mut self, node: Node) -> ChildBehavior {
+        self.tag = code::at(self.code, node)
+            .strip_prefix(':')
+            .map(Tag::Explicit)
+            .unwrap_or(Tag::Default);
+        ChildBehavior::Ignore
+    }
+
+    fn visit_image_digest(&mut self, _node: Node) -> ChildBehavior {
+        if self.tag == Tag::Default {
+            self.tag = Tag::None
+        }
+        ChildBehavior::Ignore
+    }
+}
+
+pub(crate) struct StageCollector<'a> {
+    pub stage: Option<&'a str>,
+    code: &'a str,
+}
+
+impl<'a> StageCollector<'a> {
+    pub fn new(code: &'a str) -> StageCollector<'a> {
+        Self { stage: None, code }
+    }
+
+    pub fn get_stage(self, stage_number: usize) -> String {
+        self.stage
+            .map(str::to_string)
+            .unwrap_or_else(|| format!("stage{}", stage_number))
+    }
+}
+
+impl Visitor for StageCollector<'_> {
+    fn visit_image_alias(&mut self, node: Node) -> ChildBehavior {
+        self.stage = Some(code::at(self.code, node));
+        ChildBehavior::Ignore
+    }
+}

--- a/src/rust/engine/dep_inference/src/dockerfile/mod.rs
+++ b/src/rust/engine/dep_inference/src/dockerfile/mod.rs
@@ -1,0 +1,192 @@
+// Copyright 2024 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+use std::path::PathBuf;
+
+use indexmap::IndexMap;
+use lazy_static::lazy_static;
+use regex::Regex;
+use serde_derive::{Deserialize, Serialize};
+use tree_sitter::{Node, Parser};
+
+use crate::code;
+use crate::dockerfile::copy::{CopiedFile, CopyFileCollector};
+use crate::dockerfile::from::{StageCollector, Tag, TagCollector};
+
+mod copy;
+mod from;
+
+include!(concat!(env!("OUT_DIR"), "/dockerfile/constants.rs"));
+include!(concat!(env!("OUT_DIR"), "/dockerfile/visitor.rs"));
+include!(concat!(env!("OUT_DIR"), "/dockerfile_impl_hash.rs"));
+
+/* todo: This looks leaky now that it is implemented in rust.
+Replace with native address parsing? Requires more of address parsing logic
+that is currently python rules to move into rust.
+*/
+lazy_static! {
+    static ref ADDRESS_REGEXP: Regex = Regex::new(
+        r"(?x)
+        ^
+        (?://)?  # Optionally root:ed.
+        # Optional path.
+        [^:\#\s]*
+        # Optional target name.
+        (?::[^:\#!@?/=\s]+)?
+        # Optional generated name.
+        (?:\#[^:\#!@?=\s]+)?
+        # Optional parametrizations.
+        (?:@
+          # key=value
+          [^=:\s]+=[^,:\s]*
+          # Optional additional `,key=value`s
+          (?:,[^=:\s]+=[^,:\s]*)*
+        )?
+        $
+    "
+    )
+    .unwrap();
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct ParsedDockerfileDependencies {
+    pub path: PathBuf,
+    pub build_args: Vec<String>,
+    pub copy_build_args: Vec<String>,
+    pub copy_source_paths: Vec<String>,
+    pub from_image_build_args: Vec<String>,
+    pub version_tags: IndexMap<String, String>,
+}
+
+pub fn get_info(contents: &str, filepath: PathBuf) -> Result<ParsedDockerfileDependencies, String> {
+    let mut collector = DockerFileInfoCollector::new(contents);
+    collector.collect();
+    Ok(ParsedDockerfileDependencies {
+        path: filepath,
+        version_tags: collector.version_tags,
+        build_args: collector.build_args,
+        copy_build_args: collector.copy_build_args,
+        copy_source_paths: collector.copy_source_paths,
+        from_image_build_args: collector.from_image_build_args,
+    })
+}
+
+struct DockerFileInfoCollector<'a> {
+    pub version_tags: IndexMap<String, String>,
+    pub build_args: Vec<String>,
+    pub seen_build_args: IndexMap<String, Option<String>>,
+    pub copy_build_args: Vec<String>,
+    pub copy_source_paths: Vec<String>,
+    pub from_image_build_args: Vec<String>,
+    stage_counter: usize,
+    code: &'a str,
+}
+
+impl DockerFileInfoCollector<'_> {
+    pub fn new(code: &'_ str) -> DockerFileInfoCollector<'_> {
+        DockerFileInfoCollector {
+            version_tags: IndexMap::default(),
+            seen_build_args: IndexMap::default(),
+            build_args: Vec::default(),
+            copy_build_args: Vec::default(),
+            copy_source_paths: Vec::default(),
+            from_image_build_args: Vec::default(),
+            stage_counter: 0,
+            code,
+        }
+    }
+
+    fn get_build_arg_value(&self, key: &str) -> Option<&str> {
+        if let Some(maybe_value) = self.seen_build_args.get(key) {
+            maybe_value
+                .as_deref()
+                .map(|value| value.trim_matches(|c| c == '\'' || c == '"'))
+        } else {
+            None
+        }
+    }
+
+    fn get_build_arg_reference(&self, key: &str) -> Option<&str> {
+        self.get_build_arg_value(key)
+            .filter(|s| ADDRESS_REGEXP.is_match(s))
+    }
+
+    pub fn collect(&mut self) {
+        let mut parser = Parser::new();
+        parser
+            .set_language(tree_sitter_dockerfile::language())
+            .expect("Error loading Dockerfile grammar");
+        let parsed = parser.parse(self.code, None);
+        let tree = parsed.unwrap();
+        let mut cursor = tree.walk();
+
+        self.walk(&mut cursor);
+    }
+}
+
+impl Visitor for DockerFileInfoCollector<'_> {
+    fn visit_from_instruction(&mut self, node: Node) -> ChildBehavior {
+        let mut cursor = node.walk();
+        let mut tag_collector = TagCollector::new(self.code);
+        tag_collector.walk(&mut cursor);
+        let tag = match tag_collector.tag {
+            Tag::Default => Some("latest".to_string()),
+            Tag::BuildArg(arg) => {
+                self.from_image_build_args.extend(
+                    self.get_build_arg_reference(arg)
+                        .map(|val| format!("{arg}={val}")),
+                );
+                Some(format!("build-arg:{arg}"))
+            }
+            Tag::Explicit(e) => Some(e.to_string()),
+            Tag::None => None,
+        };
+        if let Some(tag) = tag {
+            let mut stage_collector = StageCollector::new(self.code);
+            stage_collector.walk(&mut cursor);
+            self.version_tags
+                .insert(stage_collector.get_stage(self.stage_counter), tag);
+        }
+        self.stage_counter += 1;
+        ChildBehavior::Ignore
+    }
+
+    fn visit_copy_instruction(&mut self, node: Node) -> ChildBehavior {
+        let mut file_collector = CopyFileCollector::new(self.code);
+        file_collector.walk(&mut node.walk());
+        let mut files = file_collector.files;
+        if files.is_empty() {
+            return ChildBehavior::Visit;
+        } else {
+            files.pop();
+        }
+        for file in files {
+            match file {
+                CopiedFile::Arg(arg) => self.copy_build_args.extend(
+                    self.get_build_arg_reference(arg)
+                        .map(|val| format!("{arg}={val}")),
+                ),
+                CopiedFile::Path(file) => self.copy_source_paths.push(file.to_string()),
+            }
+        }
+        ChildBehavior::Visit
+    }
+
+    fn visit_arg_instruction(&mut self, node: Node) -> ChildBehavior {
+        if let Some(arg) = code::at(self.code, node).strip_prefix("ARG").map(str::trim) {
+            self.build_args.push(arg.to_string());
+            let mut split = arg.splitn(2, '=');
+            self.seen_build_args.insert(
+                split
+                    .next()
+                    .expect("First value from split is always present.")
+                    .trim()
+                    .to_string(),
+                split.next().map(str::trim).map(str::to_string),
+            );
+        };
+        ChildBehavior::Ignore
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/rust/engine/dep_inference/src/dockerfile/tests.rs
+++ b/src/rust/engine/dep_inference/src/dockerfile/tests.rs
@@ -81,6 +81,28 @@ fn from_instructions() {
 }
 
 #[test]
+fn from_instructions_multiple_stages() {
+    assert_from_tags(
+        r"
+FROM untagged
+FROM tagged:v1.2
+FROM digest@sha256:d1f0463b35135852308ea815c2ae54c1734b876d90288ce35828aeeff9899f9d
+FROM gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/operator:v0.54.0@sha256:d1f0463b35135852308ea815c2ae54c1734b876d90288ce35828aeeff9899f9d
+FROM $PYTHON_VERSION AS python
+FROM python:$VERSION
+",
+        [
+            ("stage0", "latest"),
+            ("stage1", "v1.2"),
+            // Stage 2 is not pinned with a tag.
+            ("stage3", "v0.54.0"),
+            ("python", "build-arg:PYTHON_VERSION"), // Parse tag from build arg.
+            ("stage5", "$VERSION"),
+        ],
+    )
+}
+
+#[test]
 fn arg_instructions() {
     assert_build_args(r#"ARG VAR="value""#, [r#"VAR="value""#]);
     assert_build_args("ARG VAR=value", ["VAR=value"]);

--- a/src/rust/engine/dep_inference/src/dockerfile/tests.rs
+++ b/src/rust/engine/dep_inference/src/dockerfile/tests.rs
@@ -117,6 +117,7 @@ fn copy_source_file_path_instructions() {
     assert_copy_from_source_path("COPY a b c to/here", ["a", "b", "c"]);
     assert_copy_from_source_path("ARG MY_ARG=value\nCOPY $MY_ARG $ARG", []);
     assert_copy_from_source_path("COPY my/file $ARG", ["my/file"]);
+    assert_copy_from_source_path("ARG MY_ARG=value\nCOPY some/dir/$MY_ARG w/e", []);
 }
 
 #[test]
@@ -125,6 +126,10 @@ fn copy_build_args_instructions() {
     assert_copy_build_args("ARG MY_ARG=\'value\'\nCOPY $MY_ARG $ARG", ["MY_ARG=value"]);
     assert_copy_build_args("ARG MY_ARG=\"value\"\nCOPY $MY_ARG $ARG", ["MY_ARG=value"]);
     assert_copy_build_args("ARG MY_ARG\nCOPY $MY_ARG $ARG", []);
+    assert_copy_build_args(
+        "ARG MY_ARG=value\nCOPY some/dir/$MY_ARG w/e",
+        ["MY_ARG=value"],
+    );
 }
 
 #[test]

--- a/src/rust/engine/dep_inference/src/dockerfile/tests.rs
+++ b/src/rust/engine/dep_inference/src/dockerfile/tests.rs
@@ -1,0 +1,133 @@
+// Copyright 2024 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+use std::collections::HashSet;
+
+use crate::dockerfile::DockerFileInfoCollector;
+
+fn assert_from_tags<const N: usize>(code: &str, imports: [(&str, &str); N]) {
+    let mut collector = DockerFileInfoCollector::new(code);
+    collector.collect();
+    assert_eq!(
+        collector.version_tags.into_iter().collect::<HashSet<_>>(),
+        HashSet::from_iter(
+            imports
+                .iter()
+                .map(|(s1, s2)| (s1.to_string(), s2.to_string()))
+        )
+    );
+}
+
+fn assert_build_args<const N: usize>(code: &str, build_args: [&str; N]) {
+    let mut collector = DockerFileInfoCollector::new(code);
+    collector.collect();
+    assert_eq!(
+        collector.build_args.into_iter().collect::<HashSet<_>>(),
+        HashSet::from_iter(build_args.iter().map(|s| s.to_string())),
+    );
+}
+
+fn assert_copy_from_source_path<const N: usize>(code: &str, files: [&str; N]) {
+    let mut collector = DockerFileInfoCollector::new(code);
+    collector.collect();
+    assert_eq!(
+        collector
+            .copy_source_paths
+            .into_iter()
+            .collect::<HashSet<_>>(),
+        HashSet::from_iter(files.into_iter().map(str::to_string)),
+    );
+}
+
+fn assert_copy_build_args<const N: usize>(code: &str, files: [&str; N]) {
+    let mut collector = DockerFileInfoCollector::new(code);
+    collector.collect();
+    assert_eq!(
+        collector
+            .copy_build_args
+            .into_iter()
+            .collect::<HashSet<_>>(),
+        HashSet::from_iter(files.into_iter().map(str::to_string)),
+    );
+}
+
+fn assert_from_image_build_args<const N: usize>(code: &str, files: [&str; N]) {
+    let mut collector = DockerFileInfoCollector::new(code);
+    collector.collect();
+    assert_eq!(
+        collector
+            .from_image_build_args
+            .into_iter()
+            .collect::<HashSet<_>>(),
+        HashSet::from_iter(files.into_iter().map(str::to_string)),
+    );
+}
+
+#[test]
+fn from_instructions() {
+    assert_from_tags("FROM python:3.10", [("stage0", "3.10")]);
+    assert_from_tags("FROM docker.io/python:3.10", [("stage0", "3.10")]);
+    assert_from_tags("FROM ${ARG}", [("stage0", "build-arg:ARG")]);
+    assert_from_tags("FROM $ARG", [("stage0", "build-arg:ARG")]);
+    assert_from_tags("FROM $ARG AS dynamic", [("dynamic", "build-arg:ARG")]);
+    assert_from_tags("FROM python:$VERSION", [("stage0", "$VERSION")]);
+    assert_from_tags(
+        "FROM digest@sha256:d1f0463b35135852308ea815c2ae54c1734b876d90288ce35828aeeff9899f9d",
+        [],
+    );
+    assert_from_tags(
+        "FROM gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/kubernetes/operator:v0.54.0@sha256:d1f0463b35135852308ea815c2ae54c1734b876d90288ce35828aeeff9899f9d",
+        [("stage0", "v0.54.0")],
+    );
+}
+
+#[test]
+fn arg_instructions() {
+    assert_build_args(r#"ARG VAR="value""#, [r#"VAR="value""#]);
+    assert_build_args("ARG VAR=value", ["VAR=value"]);
+    assert_build_args("ARG VAR", ["VAR"]);
+}
+
+#[test]
+fn copy_source_file_path_instructions() {
+    assert_copy_from_source_path("COPY --from=somewhere my/file to/here", []);
+    assert_copy_from_source_path("COPY --from=somewhere my/file b to/here", []);
+    assert_copy_from_source_path("COPY my/file to/here", ["my/file"]);
+    assert_copy_from_source_path("COPY a b c to/here", ["a", "b", "c"]);
+    assert_copy_from_source_path("ARG MY_ARG=value\nCOPY $MY_ARG $ARG", []);
+    assert_copy_from_source_path("COPY my/file $ARG", ["my/file"]);
+}
+
+#[test]
+fn copy_build_args_instructions() {
+    assert_copy_build_args("ARG MY_ARG=value\nCOPY $MY_ARG $ARG", ["MY_ARG=value"]);
+    assert_copy_build_args("ARG MY_ARG=\'value\'\nCOPY $MY_ARG $ARG", ["MY_ARG=value"]);
+    assert_copy_build_args("ARG MY_ARG=\"value\"\nCOPY $MY_ARG $ARG", ["MY_ARG=value"]);
+    assert_copy_build_args("ARG MY_ARG\nCOPY $MY_ARG $ARG", []);
+}
+
+#[test]
+fn from_image_build_args() {
+    assert_from_image_build_args(
+        r#"
+ARG BASE_IMAGE_1=":sibling"
+FROM $BASE_IMAGE_1
+ARG BASE_IMAGE_2=":sibling@a=42,b=c"
+FROM $BASE_IMAGE_2
+ARG BASE_IMAGE_3="else/where:weird#name@with=param"
+FROM $BASE_IMAGE_3
+ARG BASE_IMAGE_4="//src/common:name@parametrized=foo-bar.1"
+FROM $BASE_IMAGE_4
+ARG BASE_IMAGE_5="should/allow/default-target-name"
+FROM $BASE_IMAGE_5
+ARG DECOY="this is not a target address"
+FROM $DECOY
+"#,
+        [
+            "BASE_IMAGE_1=:sibling",
+            "BASE_IMAGE_2=:sibling@a=42,b=c",
+            "BASE_IMAGE_3=else/where:weird#name@with=param",
+            "BASE_IMAGE_4=//src/common:name@parametrized=foo-bar.1",
+            "BASE_IMAGE_5=should/allow/default-target-name",
+        ],
+    );
+}

--- a/src/rust/engine/dep_inference/src/javascript/mod.rs
+++ b/src/rust/engine/dep_inference/src/javascript/mod.rs
@@ -6,10 +6,10 @@ use fnv::FnvHashSet as HashSet;
 use serde_derive::{Deserialize, Serialize};
 use tree_sitter::{Node, Parser};
 
-use protos::gen::pants::cache::JavascriptInferenceMetadata;
-
+use crate::code;
 use crate::javascript::import_pattern::imports_from_patterns;
 use crate::javascript::util::normalize_path;
+use protos::gen::pants::cache::JavascriptInferenceMetadata;
 
 mod import_pattern;
 mod util;
@@ -99,7 +99,7 @@ impl ImportCollector<'_> {
     }
 
     fn code_at(&self, range: tree_sitter::Range) -> &str {
-        &self.code[range.start_byte..range.end_byte]
+        code::at_range(self.code, range)
     }
 
     fn is_pragma_ignored(&self, node: Node) -> bool {

--- a/src/rust/engine/dep_inference/src/lib.rs
+++ b/src/rust/engine/dep_inference/src/lib.rs
@@ -1,5 +1,7 @@
 // Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+mod code;
+pub mod dockerfile;
 pub mod javascript;
 pub mod python;

--- a/src/rust/engine/dep_inference/src/python/mod.rs
+++ b/src/rust/engine/dep_inference/src/python/mod.rs
@@ -2,13 +2,15 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 use std::path::PathBuf;
 
-include!(concat!(env!("OUT_DIR"), "/python/constants.rs"));
-include!(concat!(env!("OUT_DIR"), "/python/visitor.rs"));
-include!(concat!(env!("OUT_DIR"), "/python_impl_hash.rs"));
-
 use fnv::{FnvHashMap as HashMap, FnvHashSet as HashSet};
 use serde_derive::{Deserialize, Serialize};
 use tree_sitter::Parser;
+
+use crate::code;
+
+include!(concat!(env!("OUT_DIR"), "/python/constants.rs"));
+include!(concat!(env!("OUT_DIR"), "/python/visitor.rs"));
+include!(concat!(env!("OUT_DIR"), "/python_impl_hash.rs"));
 
 #[derive(Serialize, Deserialize)]
 pub struct ParsedPythonDependencies {
@@ -97,7 +99,7 @@ impl ImportCollector<'_> {
     }
 
     fn code_at(&self, range: tree_sitter::Range) -> &str {
-        &self.code[range.start_byte..range.end_byte]
+        code::at_range(self.code, range)
     }
 
     fn string_at(&self, range: tree_sitter::Range) -> &str {

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -206,6 +206,7 @@ impl PyTypes {
         docker_resolve_image_result: &PyType,
         parsed_python_deps_result: &PyType,
         parsed_javascript_deps_result: &PyType,
+        parsed_dockerfile_info_result: &PyType,
         py: Python,
     ) -> Self {
         Self(RefCell::new(Some(Types {
@@ -245,6 +246,7 @@ impl PyTypes {
             docker_resolve_image_result: TypeId::new(docker_resolve_image_result),
             parsed_python_deps_result: TypeId::new(parsed_python_deps_result),
             parsed_javascript_deps_result: TypeId::new(parsed_javascript_deps_result),
+            parsed_dockerfile_info_result: TypeId::new(parsed_dockerfile_info_result),
             deps_request: TypeId::new(
                 py.get_type::<externs::dep_inference::PyNativeDependenciesRequest>(),
             ),

--- a/src/rust/engine/src/types.rs
+++ b/src/rust/engine/src/types.rs
@@ -38,5 +38,6 @@ pub struct Types {
     pub docker_resolve_image_result: TypeId,
     pub parsed_python_deps_result: TypeId,
     pub parsed_javascript_deps_result: TypeId,
+    pub parsed_dockerfile_info_result: TypeId,
     pub deps_request: TypeId,
 }


### PR DESCRIPTION
Adds a dockerfile parser that aims to be ~compliant with the pex-python one, but avoids installing the latter tooling.

1. I found that `tree-sitter-dockerfile` did not support value-less options to instructions, so I've opened a fix for this.
2. I focused on being 1:1 with the old parser to the extent that tree-sitter could (see https://github.com/pantsbuild/pants/pull/21160#discussion_r1674400959) without falling back to just parsing strings. Except for ARG, because the python variant kept quotation I opted to mirror this in rust and the tree-sitter traversal was not useful.

2 means that we allocate, duplicate and interpolate strings unnecessarily often. I'd like to create a cleaner more rust-y data structure in the future, but I think keeping the parser outputs similar is more important right now.