### PR TITLE
Upgrade default Node version from 18.20.3 to 20.15.1

### DIFF
--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -102,7 +102,7 @@ Sandboxes for the `experimental-deploy` deployment (the execution of `terraform 
 
 #### Javascript
 
-The Node.js runtime now uses version 18.20.3 by default. This is a major version upgrade from the 16.x series, which was used before.
+The Node.js runtime now uses version 20.15.1 by default. This is 2 major version upgrades from the 16.x series, which was used before.
 Additionally, the default versions of the various package managers have been updated:
 
 npm: 8.5.5 -> 10.8.1

--- a/src/python/pants/backend/javascript/subsystems/nodejs.py
+++ b/src/python/pants/backend/javascript/subsystems/nodejs.py
@@ -61,12 +61,12 @@ class NodeJS(Subsystem, TemplatedExternalToolOptionsMixin):
     options_scope = "nodejs"
     help = "The Node.js Javascript runtime (including Corepack)."
 
-    default_version = "v18.20.3"
+    default_version = "v20.15.1"
     default_known_versions = [
-        "v18.20.3|macos_arm64|99328b985f7336a8fcfb62fda382155d210979fcca928e2dd75b7148d9bba636|40077062",
-        "v18.20.3|macos_x86_64|317a4607390c923610303e8583972e23fb656e9d348d3740bde0f1a94cdb7e0c|41659714",
-        "v18.20.3|linux_arm64|3c497c19ddbf75bab7fecb36ddf1738622f0ba244aa1e0aebc70e46daf1a0794|23242684",
-        "v18.20.3|linux_x86_64|ffd6147c263b81016742dc1e72dc68885a3ca9b441d9744f9b76cad362d0cc5f|23995872",
+        "v20.15.1|macos_arm64|4743bc042f90ba5d9edf09403207290a9cdd2f6061bdccf7caaa0bbfd49f343e|41888895",
+        "v20.15.1|macos_x86_64|f5379772ffae1404cfd1fcc8cf0c6c5971306b8fb2090d348019047306de39dc|43531593",
+        "v20.15.1|linux_arm64|10d47a46ef208b3e4b226e4d595a82659123b22397ed77b7975d989114ec317e|24781292",
+        "v20.15.1|linux_x86_64|26700f8d3e78112ad4a2618a9c8e2816e38a49ecf0213ece80e54c38cb02563f|25627852",
     ]
 
     default_url_template = "https://nodejs.org/dist/{version}/node-{version}-{platform}.tar"


### PR DESCRIPTION
Closes #19131 and closes #20617 - this sets the default Node version to 20.x which is the current LTS release.