### PR TITLE
use a template for computing `output_path` for packageable targets

### DIFF
--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -37,7 +37,7 @@ for inspiration. To opt into the feature set the flag
 
 #### Package
 
-The `output_path` field present on targets which can be packaged by `pants package` is now based on a template so that you can use parts of `output_path`'s default behavior when overriding it on a target. For example, you can use the template replacement `{{normalized_spec_path}}` to obtain the default output directory for the target (i.e., the directory in which the target lives with slashes replaced by dots).
+The `output_path` field present on targets which can be packaged by `pants package` is now based on a template so that you can use parts of `output_path`'s default behavior when overriding it on a target. For example, you can use the template replacement `{{spec_path_normalized}}` to obtain the default output directory for the target (i.e., the directory in which the target lives with slashes replaced by dots).
 
 ### Backends
 

--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -35,6 +35,10 @@ for inspiration. To opt into the feature set the flag
 
 ### Goals
 
+#### Package
+
+The `output_path` field present on targets which can be packaged by `pants package` is now based on a template so that you can use parts of `output_path`'s default behavior when overriding it on a target. For example, you can use the template replacement `{{normalized_spec_path}}` to obtain the default output directory for the target (i.e., the directory in which the target lives with slashes replaced by dots).
+
 ### Backends
 
 #### BUILD

--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -37,7 +37,7 @@ for inspiration. To opt into the feature set the flag
 
 #### Package
 
-The `output_path` field present on targets which can be packaged by `pants package` is now based on a template so that you can use parts of `output_path`'s default behavior when overriding it on a target. For example, you can use the template replacement `{{spec_path_normalized}}` to obtain the default output directory for the target (i.e., the directory in which the target lives with slashes replaced by dots).
+The `output_path` field present on targets which can be packaged by `pants package` is now based on a template so that you can use parts of `output_path`'s default behavior when overriding it on a target. For example, you can use the template replacement `${{spec_path_normalized}}` to obtain the default output directory for the target (i.e., the directory in which the target lives with slashes replaced by dots).
 
 ### Backends
 

--- a/src/python/pants/backend/javascript/package/rules.py
+++ b/src/python/pants/backend/javascript/package/rules.py
@@ -106,7 +106,8 @@ async def pack_node_package_into_tgz_for_publication(
         ),
     )
     if field_set.output_path.value:
-        digest = await Get(Digest, AddPrefix(result.output_digest, field_set.output_path.value))
+        output_path = field_set.output_path.value_or_default(file_ending=None)
+        digest = await Get(Digest, AddPrefix(result.output_digest, output_path))
     else:
         digest = result.output_digest
 

--- a/src/python/pants/backend/javascript/package/rules.py
+++ b/src/python/pants/backend/javascript/package/rules.py
@@ -237,7 +237,8 @@ async def generate_package_artifact_from_node_build_script(
     request = NodeBuildScriptRequest.from_package_request(req)
     result = await Get(NodeBuildScriptResult, NodeBuildScriptRequest, request)
     if req.output_path.value:
-        digest = await Get(Digest, AddPrefix(result.process.output_digest, req.output_path.value))
+        output_path = req.output_path.value_or_default(file_ending=None)
+        digest = await Get(Digest, AddPrefix(result.process.output_digest, output_path))
     else:
         digest = result.process.output_digest
     artifacts = tuple(BuiltPackageArtifact(path) for path in request.get_paths())

--- a/src/python/pants/backend/javascript/package/rules_test.py
+++ b/src/python/pants/backend/javascript/package/rules_test.py
@@ -95,7 +95,9 @@ def test_creates_tar_for_package_json(rule_runner: RuleRunner, package_manager: 
     rule_runner.write_digest(result.digest)
 
     archive_name = "ham-v0.0.1.tgz" if package_manager == "yarn" else "ham-0.0.1.tgz"
-    with tarfile.open(os.path.join(rule_runner.build_root, archive_name)) as tar:
+    with tarfile.open(
+        os.path.join(rule_runner.build_root, "src.js", "ham-dist", archive_name)
+    ) as tar:
         assert {member.name for member in tar.getmembers()}.issuperset(
             {
                 "package/package.json",

--- a/src/python/pants/backend/python/packaging/pyoxidizer/rules.py
+++ b/src/python/pants/backend/python/packaging/pyoxidizer/rules.py
@@ -147,7 +147,7 @@ async def package_pyoxidizer_binary(
         config_template = digest_contents[0].content.decode("utf-8")
 
     config = PyOxidizerConfig(
-        executable_name=field_set.binary_name.value or field_set.address.target_name,
+        executable_name=field_set.binary_name.value_or_default(),
         entry_point=field_set.entry_point.value,
         wheels=wheel_paths,
         template=config_template,

--- a/src/python/pants/backend/python/packaging/pyoxidizer/target_types.py
+++ b/src/python/pants/backend/python/packaging/pyoxidizer/target_types.py
@@ -8,6 +8,7 @@ from pants.core.goals.package import OutputPathField
 from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
+    AsyncFieldMixin,
     Dependencies,
     OptionalSingleSourceField,
     StringField,
@@ -40,7 +41,7 @@ class PyOxidizerOutputPathField(OutputPathField):
     )
 
 
-class PyOxidizerBinaryNameField(OutputPathField):
+class PyOxidizerBinaryNameField(StringField, AsyncFieldMixin):
     alias = "binary_name"
     help = help_text(
         """
@@ -48,6 +49,14 @@ class PyOxidizerBinaryNameField(OutputPathField):
         to the name of this target.
         """
     )
+
+    def value_or_default(self) -> str:
+        if self.value:
+            return self.value
+
+        return (
+            self.address.generated_name if self.address.generated_name else self.address.target_name
+        )
 
 
 class PyOxidizerEntryPointField(StringField):

--- a/src/python/pants/backend/python/packaging/pyoxidizer/target_types.py
+++ b/src/python/pants/backend/python/packaging/pyoxidizer/target_types.py
@@ -42,7 +42,6 @@ class PyOxidizerOutputPathField(OutputPathField):
 
 class PyOxidizerBinaryNameField(OutputPathField):
     alias = "binary_name"
-    default = None
     help = help_text(
         """
         The name of the binary that will be output by PyOxidizer. If not set, this will default

--- a/src/python/pants/core/goals/package.py
+++ b/src/python/pants/core/goals/package.py
@@ -76,8 +76,11 @@ class OutputPathField(StringField, AsyncFieldMixin):
         Where the built asset should be located.
 
         This field supports the following template replacements:
+
         - `{{normalized_spec_path}}`: The path to the target's directory ("spec path") with forward slashes replaced by dots.
-        - `{{normalized_address}}`: The target's name with paramaterizations escaped byreplacing dots with underscores.
+
+        - `{{normalized_address}}`: The target's name with paramaterizations escaped by replacing dots with underscores.
+
         - `{{file_suffix}}`: For target's which produce single file artifacts, this is the file type suffix to use with a leading dot,
           and is empty otherwise when not applicable.
 

--- a/src/python/pants/core/goals/package.py
+++ b/src/python/pants/core/goals/package.py
@@ -95,6 +95,10 @@ class OutputPathField(StringField, AsyncFieldMixin):
     )
 
     def parameters(self, *, file_ending: str | None) -> dict[str, str]:
+        normalized_spec_path = self.address.spec_path.replace(os.sep, ".")
+        if not normalized_spec_path:
+            normalized_spec_path = "."
+
         target_name_part = (
             self.address.generated_name.replace(".", "_")
             if self.address.generated_name
@@ -109,7 +113,7 @@ class OutputPathField(StringField, AsyncFieldMixin):
             file_suffix = f".{file_ending}"
 
         return dict(
-            normalized_spec_path=self.address.spec_path.replace(os.sep, "."),
+            normalized_spec_path=normalized_spec_path,
             normalized_address=normalized_address,
             file_suffix=file_suffix,
         )

--- a/src/python/pants/core/goals/package.py
+++ b/src/python/pants/core/goals/package.py
@@ -122,7 +122,8 @@ class OutputPathField(StringField, AsyncFieldMixin):
         template = self.value
         assert template is not None
         params = self.parameters(file_ending=file_ending)
-        return template.format(**params)
+        result = template.format(**params)
+        return os.path.normpath(result)
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/core/goals/package.py
+++ b/src/python/pants/core/goals/package.py
@@ -66,13 +66,24 @@ class BuiltPackage:
 
 
 class OutputPathField(StringField, AsyncFieldMixin):
+    DEFAULT = "{normalized_spec_path}/{normalized_address}{file_suffix}"
+
     alias = "output_path"
+    default = DEFAULT
+
     help = help_text(
         f"""
         Where the built asset should be located.
 
+        This field supports the following template replacements:
+        - `{{normalized_spec_path}}`: The path to the target's directory ("spec path") with forward slashes replaced by dots.
+        - `{{normalized_address}}`: The target's name with paramaterizations escaped byreplacing dots with underscores.
+        - `{{file_suffix}}`: For target's which produce single file artifacts, this is the file type suffix to use with a leading dot,
+          and is empty otherwise when not applicable.
+
         If undefined, this will use the path to the BUILD file, followed by the target name.
-        For example, `src/python/project:app` would be `src.python.project/app.ext`.
+        For example, `src/python/project:app` would be `src.python.project/app.ext`. This behavior corresponds to
+        the default template: `{DEFAULT}`
 
         When running `{bin_name()} package`, this path will be prefixed by `--distdir` (e.g. `dist/`).
 
@@ -80,23 +91,31 @@ class OutputPathField(StringField, AsyncFieldMixin):
         """
     )
 
-    def value_or_default(self, *, file_ending: str | None) -> str:
-        if self.value:
-            return self.value
+    def parameters(self, *, file_ending: str | None) -> dict[str, str]:
         target_name_part = (
             self.address.generated_name.replace(".", "_")
             if self.address.generated_name
             else self.address.target_name
         )
-        params_sanitized = self.address.parameters_repr.replace(".", "_")
-        file_prefix = f"{target_name_part}{params_sanitized}"
+        target_params_sanitized = self.address.parameters_repr.replace(".", "_")
+        normalized_address = f"{target_name_part}{target_params_sanitized}"
 
-        if file_ending is None:
-            file_name = file_prefix
-        else:
+        file_suffix = ""
+        if file_ending:
             assert not file_ending.startswith("."), "`file_ending` should not start with `.`"
-            file_name = f"{file_prefix}.{file_ending}"
-        return os.path.join(self.address.spec_path.replace(os.sep, "."), file_name)
+            file_suffix = f".{file_ending}"
+
+        return dict(
+            normalized_spec_path=self.address.spec_path.replace(os.sep, "."),
+            normalized_address=normalized_address,
+            file_suffix=file_suffix,
+        )
+
+    def value_or_default(self, *, file_ending: str | None) -> str:
+        template = self.value
+        assert template is not None
+        params = self.parameters(file_ending=file_ending)
+        return template.format(**params)
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/core/goals/package.py
+++ b/src/python/pants/core/goals/package.py
@@ -66,7 +66,7 @@ class BuiltPackage:
 
 
 class OutputPathField(StringField, AsyncFieldMixin):
-    DEFAULT = "{normalized_spec_path}/{normalized_address}{file_suffix}"
+    DEFAULT = "{spec_path_normalized}/{target_name_normalized}{file_suffix}"
 
     alias = "output_path"
     default = DEFAULT
@@ -77,9 +77,9 @@ class OutputPathField(StringField, AsyncFieldMixin):
 
         This field supports the following template replacements:
 
-        - `{{normalized_spec_path}}`: The path to the target's directory ("spec path") with forward slashes replaced by dots.
+        - `{{spec_path_normalized}}`: The path to the target's directory ("spec path") with forward slashes replaced by dots.
 
-        - `{{normalized_address}}`: The target's name with paramaterizations escaped by replacing dots with underscores.
+        - `{{target_name_normalized}}`: The target's name with paramaterizations escaped by replacing dots with underscores.
 
         - `{{file_suffix}}`: For target's which produce single file artifacts, this is the file type suffix to use with a leading dot,
           and is empty otherwise when not applicable.
@@ -95,9 +95,9 @@ class OutputPathField(StringField, AsyncFieldMixin):
     )
 
     def parameters(self, *, file_ending: str | None) -> dict[str, str]:
-        normalized_spec_path = self.address.spec_path.replace(os.sep, ".")
-        if not normalized_spec_path:
-            normalized_spec_path = "."
+        spec_path_normalized = self.address.spec_path.replace(os.sep, ".")
+        if not spec_path_normalized:
+            spec_path_normalized = "."
 
         target_name_part = (
             self.address.generated_name.replace(".", "_")
@@ -105,7 +105,7 @@ class OutputPathField(StringField, AsyncFieldMixin):
             else self.address.target_name
         )
         target_params_sanitized = self.address.parameters_repr.replace(".", "_")
-        normalized_address = f"{target_name_part}{target_params_sanitized}"
+        target_name_normalized = f"{target_name_part}{target_params_sanitized}"
 
         file_suffix = ""
         if file_ending:
@@ -113,8 +113,8 @@ class OutputPathField(StringField, AsyncFieldMixin):
             file_suffix = f".{file_ending}"
 
         return dict(
-            normalized_spec_path=normalized_spec_path,
-            normalized_address=normalized_address,
+            spec_path_normalized=spec_path_normalized,
+            target_name_normalized=target_name_normalized,
             file_suffix=file_suffix,
         )
 

--- a/src/python/pants/core/goals/package_test.py
+++ b/src/python/pants/core/goals/package_test.py
@@ -262,9 +262,9 @@ def test_output_path_template_behavior(rule_runner: RuleRunner) -> None:
                 """\
             mock(name="default")
             mock(name="no-template", output_path="foo/bar")
-            mock(name="with-spec-path", output_path="{normalized_spec_path}/xyzzy")
-            mock(name="with-spec-path-and-ext", output_path="{normalized_spec_path}/xyzzy{file_suffix}")
-            mock(name="with-address-and-ext", output_path="xyzzy/{normalized_address}{file_suffix}")
+            mock(name="with-spec-path", output_path="{spec_path_normalized}/xyzzy")
+            mock(name="with-spec-path-and-ext", output_path="{spec_path_normalized}/xyzzy{file_suffix}")
+            mock(name="with-address-and-ext", output_path="xyzzy/{target_name_normalized}{file_suffix}")
             """
             )
         }

--- a/src/python/pants/core/goals/package_test.py
+++ b/src/python/pants/core/goals/package_test.py
@@ -256,17 +256,19 @@ def test_transitive_targets_without_traversing_packages(rule_runner: RuleRunner)
 
 
 def test_output_path_template_behavior(rule_runner: RuleRunner) -> None:
-    rule_runner.write_files({
-        "src/foo/BUILD": dedent(
-            """\
+    rule_runner.write_files(
+        {
+            "src/foo/BUILD": dedent(
+                """\
             mock(name="default")
             mock(name="no-template", output_path="foo/bar")
             mock(name="with-spec-path", output_path="{normalized_spec_path}/xyzzy")
             mock(name="with-spec-path-and-ext", output_path="{normalized_spec_path}/xyzzy{file_suffix}")
             mock(name="with-address-and-ext", output_path="xyzzy/{normalized_address}{file_suffix}")
             """
-        )
-    })
+            )
+        }
+    )
 
     def get_output_path(target_name: str, *, file_ending: str | None = None) -> str:
         tgt = rule_runner.get_target(Address("src/foo", target_name=target_name))

--- a/src/python/pants/core/goals/package_test.py
+++ b/src/python/pants/core/goals/package_test.py
@@ -262,9 +262,9 @@ def test_output_path_template_behavior(rule_runner: RuleRunner) -> None:
                 """\
             mock(name="default")
             mock(name="no-template", output_path="foo/bar")
-            mock(name="with-spec-path", output_path="{spec_path_normalized}/xyzzy")
-            mock(name="with-spec-path-and-ext", output_path="{spec_path_normalized}/xyzzy{file_suffix}")
-            mock(name="with-address-and-ext", output_path="xyzzy/{target_name_normalized}{file_suffix}")
+            mock(name="with-spec-path", output_path="${spec_path_normalized}/xyzzy")
+            mock(name="with-spec-path-and-ext", output_path="${spec_path_normalized}/xyzzy${file_suffix}")
+            mock(name="with-address-and-ext", output_path="xyzzy/${target_name_normalized}${file_suffix}")
             """
             )
         }


### PR DESCRIPTION
As described in https://github.com/pantsbuild/pants/issues/18659, when a user sets `output_path` on a packageable target, the user gives up the default behavior which uses a normalized version of the target's directory as the directory into which the place the built artifact. While the user could replicate the behavior manually, it would be a better user experience if the user can still have partial access to some of the default behavior.

This PR teaches the `output_path` field how to derive its value from a template instead of  hard-coding its behavior in Python. The `output_path` field learns the following template replacements:

- `spec_path_normalized`: The path to the target's directory ("spec path") with forward slashes replaced by dots.
- `target_name_normalized`: The target's name 
- `file_suffix`: For target's which produce single file artifacts, this is the file type suffix to use. This is empty if not applicable.

The default value for the `output_path` field is now `"${spec_path_normalized}/${target_name_normalized}${file_suffix}"` which replicates the existing behavior.

`string.Template` is used as the template engine.

This PR also fixes some incorrect usages of `output_path` in several backends.