### PR TITLE
deprecate `--export-py-hermetic-scripts` in favor of new `--export-py-non-hermetic-scripts-in-resolve` option

### DIFF
--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -96,7 +96,7 @@ Exported virtualenvs can use Pants-provided Python if a `PythonProvider` backend
 
 The docs for the `check` goal have been updated to state that third-party type stubs must be installed in the same resolve as the code.
 
-Deprecate the `--export-py-hermetic-scripts` option in favor of the new `--export-py-non-hermetic-scripts-in-resolve` which allows configuring the hermetic scripts logic on a per-resolve basis.
+Deprecate the `--export-py-hermetic-scripts` option in favor of the new `--export-py-non-hermetic-scripts-in-resolve` option which allows configuring the hermetic scripts logic on a per-resolve basis.
 
 #### Terraform
 

--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -96,6 +96,8 @@ Exported virtualenvs can use Pants-provided Python if a `PythonProvider` backend
 
 The docs for the `check` goal have been updated to state that third-party type stubs must be installed in the same resolve as the code.
 
+Deprecate the `--export-py-hermetic-scripts` option in favor of the new `--export-py-non-hermetic-scripts-in-resolve` which allows configuring the hermetic scripts logic on a per-resolve basis.
+
 #### Terraform
 
 The default version of terraform has been updated from 1.7.1 to 1.9.0.

--- a/src/python/pants/backend/python/goals/export.py
+++ b/src/python/pants/backend/python/goals/export.py
@@ -284,8 +284,8 @@ async def do_export(
             output_path,
         ]
         if (
-            not export_subsys.options.py_hermetic_scripts
-            or req.resolve_name in export_subsys.options.py_non_hermetic_scripts_in_resolve
+            req.resolve_name in export_subsys.options.py_non_hermetic_scripts_in_resolve
+            or not export_subsys.options.py_hermetic_scripts
         ):
             pex_args.insert(-1, "--non-hermetic-scripts")
 

--- a/src/python/pants/backend/python/goals/export_integration_test.py
+++ b/src/python/pants/backend/python/goals/export_integration_test.py
@@ -54,7 +54,7 @@ def build_config(
         },
         "export": {
             "py_resolve_format": py_resolve_format.value,
-            "py_hermetic_scripts": py_hermetic_scripts,
+            "py_non_hermetic_scripts_in_resolve": [] if py_hermetic_scripts else ["a", "b"],
         },
     }
 

--- a/src/python/pants/backend/python/goals/export_test.py
+++ b/src/python/pants/backend/python/goals/export_test.py
@@ -103,7 +103,9 @@ def test_export_venv_new_codepath(
     )
 
     format_flag = f"--export-py-resolve-format={py_resolve_format.value}"
-    hermetic_flags = [] if py_hermetic_scripts else ["--export-py-hermetic-scripts=false"]
+    hermetic_flags = (
+        [] if py_hermetic_scripts else ["--export-py-non-hermetic-scripts-in-resolve=['a', 'b']"]
+    )
     rule_runner.set_options(
         [
             *pants_args_for_python_lockfiles,


### PR DESCRIPTION
Deprecate the  `--export-py-hermetic-scripts` option in favor of the new `--export-py-non-hermetic-scripts-in-resolve` option so that the hermetic script logic can be configured on a per-resolve basis. The behavior for the new option is inverted in a sense from the old option since if we named the option `--export-py-hermetic-scripts-in-resolve` then the default option value of an empty list would mean that resolve did not use hermetic scripts by default. Thus, the new option acts instead as an opt-in to use non-hermetic scripts.