### PR TITLE
update Pex to 2.11.0

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -11,7 +11,7 @@ freezegun==1.2.1
 ijson==3.2.3
 libcst==1.4.0
 packaging==21.3
-pex==2.3.3
+pex==2.11.0
 psutil==5.9.8
 # This should be compatible with pytest.py, although it can be looser so that we don't
 # over-constrain pantsbuild.pants.testutil

--- a/3rdparty/python/user_reqs.lock
+++ b/3rdparty/python/user_reqs.lock
@@ -23,7 +23,7 @@
 //     "mypy-typing-asserts==0.1.1",
 //     "node-semver==0.9.0",
 //     "packaging==21.3",
-//     "pex==2.3.3",
+//     "pex==2.11.0",
 //     "psutil==5.9.8",
 //     "pydevd-pycharm==203.5419.8",
 //     "pytest<7.1.0,>=6.2.4",
@@ -56,6 +56,7 @@
   "allow_wheels": true,
   "build_isolation": true,
   "constraints": [],
+  "excluded": [],
   "locked_resolves": [
     {
       "locked_requirements": [
@@ -225,19 +226,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "ddc6c8ce995e6987e7faf5e3f1b02b302836a0e5d98ece18392cb1a36c72ad56",
-              "url": "https://files.pythonhosted.org/packages/5b/11/1e78951465b4a225519b8c3ad29769c49e0d8d157a070f681d5b6d64737f/certifi-2024.6.2-py3-none-any.whl"
+              "hash": "c198e21b1289c2ab85ee4e67bb4b4ef3ead0892059901a8d5b622f24a1101e90",
+              "url": "https://files.pythonhosted.org/packages/1c/d5/c84e1a17bf61d4df64ca866a1c9a913874b4e9bdc131ec689a0ad013fb36/certifi-2024.7.4-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3cd43f1c6fa7dedc5899d69d3ad0398fd018ad1a17fba83ddaf78aa46c747516",
-              "url": "https://files.pythonhosted.org/packages/07/b3/e02f4f397c81077ffc52a538e0aec464016f1860c472ed33bd2a1d220cc5/certifi-2024.6.2.tar.gz"
+              "hash": "5a1e7645bc0ec61a09e26c36f6106dd4cf40c6db3a1fb6352b0244e7fb057c7b",
+              "url": "https://files.pythonhosted.org/packages/c2/02/a95f2b11e207f68bc64d7aae9666fed2e2b3f307748d5123dffb72a1bbea/certifi-2024.7.4.tar.gz"
             }
           ],
           "project_name": "certifi",
           "requires_dists": [],
           "requires_python": ">=3.6",
-          "version": "2024.6.2"
+          "version": "2024.7.4"
         },
         {
           "artifacts": [
@@ -622,13 +623,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "5258b9ed329c5bbdd31a309f53cbfb0b155341807f6ff7606a1e801a891b29ad",
-              "url": "https://files.pythonhosted.org/packages/01/90/79fe92dd413a9cab314ef5c591b5aa9b9ba787ae4cadab75055b0ae00b33/exceptiongroup-1.2.1-py3-none-any.whl"
+              "hash": "3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b",
+              "url": "https://files.pythonhosted.org/packages/02/cc/b7e31358aac6ed1ef2bb790a9746ac2c69bcb3c8588b41616914eb106eaf/exceptiongroup-1.2.2-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a4785e48b045528f5bfe627b6ad554ff32def154f42372786903b7abcfe1aa16",
-              "url": "https://files.pythonhosted.org/packages/a0/65/d66b7fbaef021b3c954b3bbb196d21d8a4b97918ea524f82cfae474215af/exceptiongroup-1.2.1.tar.gz"
+              "hash": "47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc",
+              "url": "https://files.pythonhosted.org/packages/09/35/2495c4ac46b980e4ca1f6ad6db102322ef3ad2410b79fdde159a4b0f3b92/exceptiongroup-1.2.2.tar.gz"
             }
           ],
           "project_name": "exceptiongroup",
@@ -636,7 +637,7 @@
             "pytest>=6; extra == \"test\""
           ],
           "requires_python": ">=3.7",
-          "version": "1.2.1"
+          "version": "1.2.2"
         },
         {
           "artifacts": [
@@ -1062,21 +1063,21 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "774ae9cc8a8b0afbdb5fca2ed855c1c32bbd8a79ce0231ec6719ad64e192d88c",
-              "url": "https://files.pythonhosted.org/packages/b0/5b/00625b22d950529888f660f74cfd82476b9866408465cadb2c049e1834d9/pex-2.3.3-py2.py3-none-any.whl"
+              "hash": "22285310b06dedb45c5ce19d21fa0a5e102caad0030458e53b0cda4975c9a4ef",
+              "url": "https://files.pythonhosted.org/packages/44/cf/fa21a9e47bbe7a14c366ae8298e94bc369c34a17f0fc85303f7a9563b1a1/pex-2.11.0-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2f9f62415e0a5acac54e9a2a3dd20a90c247d063025234c1e0c05ad65cfd6cf6",
-              "url": "https://files.pythonhosted.org/packages/f3/27/4a63a40009046c966dcbc7fec609f39cff08236fe6a07726b94893a3695a/pex-2.3.3.tar.gz"
+              "hash": "9f3394da2c651d4d0adebf0a8e419abf1e37b6302fcbf66de54882281538e29c",
+              "url": "https://files.pythonhosted.org/packages/b8/cd/1d71bf6993ec7e697a89e01c6af75231472cbc25c987ef5f8096941570f5/pex-2.11.0.tar.gz"
             }
           ],
           "project_name": "pex",
           "requires_dists": [
             "subprocess32>=3.2.7; python_version < \"3\" and extra == \"subprocess\""
           ],
-          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.13,>=2.7",
-          "version": "2.3.3"
+          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.14,>=2.7",
+          "version": "2.11.0"
         },
         {
           "artifacts": [
@@ -1180,43 +1181,43 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "aa2774ba5412fd1c5cb890d08e8b0a3bb5765898913ba1f61a65a4810f03cf29",
-              "url": "https://files.pythonhosted.org/packages/b6/85/f23404c7c82ddaa60e83ee0b1ce9c1692a04ed2861c7306ba5d06410608d/pydantic-1.10.16-py3-none-any.whl"
+              "hash": "e41b5b973e5c64f674b3b4720286ded184dcc26a691dd55f34391c62c6934688",
+              "url": "https://files.pythonhosted.org/packages/63/01/2631480d9f2c0dbf27852209f7e6fb58f33e1877e85a025a3d3fb0ae96c6/pydantic-1.10.17-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8bb388f6244809af69ee384900b10b677a69f1980fdc655ea419710cffcb5610",
-              "url": "https://files.pythonhosted.org/packages/11/af/3fbad4c7f9a1c4410b500cd10ba4a9c4fee38ff341428f17d3e6b01636f9/pydantic-1.10.16.tar.gz"
+              "hash": "cafb9c938f61d1b182dfc7d44a7021326547b7b9cf695db5b68ec7b590214773",
+              "url": "https://files.pythonhosted.org/packages/0c/cf/d2b308b90c5b329b68028b5171f933f4991e91916cafee9b70e98d29c948/pydantic-1.10.17-cp39-cp39-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d8d3c71d14c8bd26d2350c081908dbf59d5a6a8f9596d9ef2b09cc1e61c8662b",
-              "url": "https://files.pythonhosted.org/packages/1f/18/c83803430a0f4caa9acae30c862899f53750798dbf4de0b95023d1aea037/pydantic-1.10.16-cp39-cp39-macosx_11_0_arm64.whl"
+              "hash": "f434160fb14b353caf634149baaf847206406471ba70e64657c1e8330277a991",
+              "url": "https://files.pythonhosted.org/packages/22/e6/1ab731db504d13963026a73c15a01d446cb11cf52f3bbec9e44de054dbde/pydantic-1.10.17.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "3895ddb26f22bdddee7e49741486aa7b389258c6f6771943e87fc00eabd79134",
-              "url": "https://files.pythonhosted.org/packages/2a/6a/13542c4ffa7b30dc8fc3a147970d9d31961060fe062228f967d8584df5ce/pydantic-1.10.16-cp39-cp39-musllinux_1_1_i686.whl"
+              "hash": "95ef534e3c22e5abbdbdd6f66b6ea9dac3ca3e34c5c632894f8625d13d084cbe",
+              "url": "https://files.pythonhosted.org/packages/33/e4/2cf3cbb063ba0fa6438ffd923ea37d8e2b4f8ba0bad5a49ca07fac44d621/pydantic-1.10.17-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9d91f6866fd3e303c632207813ef6bc4d86055e21c5e5a0a311983a9ac5f0192",
-              "url": "https://files.pythonhosted.org/packages/58/68/1a0798d394116983a732868592ab6810a369a0165c101200b21b5a451f9b/pydantic-1.10.16-cp39-cp39-macosx_10_9_x86_64.whl"
+              "hash": "7e17c0ee7192e54a10943f245dc79e36d9fe282418ea05b886e1c666063a7b54",
+              "url": "https://files.pythonhosted.org/packages/6b/a2/5f03a2853dfff7e15273378db2c6ec1398595f27239a7694d2f589853a91/pydantic-1.10.17-cp39-cp39-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b73e6386b439b4881d79244e9fc1e32d1e31e8d784673f5d58a000550c94a6c0",
-              "url": "https://files.pythonhosted.org/packages/a1/96/3cd54412c7f423571735224bd7e81e1d40e027bef022055daf0a4f5c8e71/pydantic-1.10.16-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "62d96b8799ae3d782df7ec9615cb59fc32c32e1ed6afa1b231b0595f6516e8ab",
+              "url": "https://files.pythonhosted.org/packages/8e/b3/589540b67291f2cfe3f058311f3b9dd3533a9659748c97d61a2cc1bef795/pydantic-1.10.17-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5f039881fb2ef86f6de6eacce6e71701b47500355738367413ccc1550b2a69cf",
-              "url": "https://files.pythonhosted.org/packages/d1/f6/a9bac5c07e14e82f7ee525ad45bb9d0038efab91729f408c940ed023d54d/pydantic-1.10.16-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "b8ad363330557beac73159acfbeed220d5f1bfcd6b930302a987a375e02f74fd",
+              "url": "https://files.pythonhosted.org/packages/a7/b5/3f223b0718c7c6d7ab1f5682bcf42888f6f279e0a26515529db78eb53441/pydantic-1.10.17-cp39-cp39-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "55b945da2756b5cef93d792521ad0d457fdf2f69fd5a2d10a27513f5281717dd",
-              "url": "https://files.pythonhosted.org/packages/fc/e3/cb85dfd9619f382558f7284c7a93bd669f84782b2c0b810d30c683163223/pydantic-1.10.16-cp39-cp39-musllinux_1_1_x86_64.whl"
+              "hash": "ab2f976336808fd5d539fdc26eb51f9aafc1f4b638e212ef6b6f05e753c8011d",
+              "url": "https://files.pythonhosted.org/packages/f1/9a/80f2a4ead403ddbe26fd9607a5964e362e427770af445651d0a3afe3d51f/pydantic-1.10.17-cp39-cp39-musllinux_1_1_i686.whl"
             }
           ],
           "project_name": "pydantic",
@@ -1226,7 +1227,7 @@
             "typing-extensions>=4.2.0"
           ],
           "requires_python": ">=3.7",
-          "version": "1.10.16"
+          "version": "1.10.17"
         },
         {
           "artifacts": [
@@ -2375,9 +2376,10 @@
   ],
   "only_builds": [],
   "only_wheels": [],
+  "overridden": [],
   "path_mappings": {},
-  "pex_version": "2.3.3",
-  "pip_version": "24.0",
+  "pex_version": "2.11.0",
+  "pip_version": "24.1.2",
   "prefer_older_binary": false,
   "requirements": [
     "PyGithub==2.0.0rc1",
@@ -2394,7 +2396,7 @@
     "mypy-typing-asserts==0.1.1",
     "node-semver==0.9.0",
     "packaging==21.3",
-    "pex==2.3.3",
+    "pex==2.11.0",
     "psutil==5.9.8",
     "pydevd-pycharm==203.5419.8",
     "pytest<7.1.0,>=6.2.4",

--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -91,7 +91,7 @@ The deprecation for the `pants.backend.experimental.python.lint.ruff` backend pa
 
 The default version of the `ruff` tool has been updated from 0.4.4 to 0.4.9.
 
-The default version of the pex tool has been updated from 2.3.1 to 2.3.3.
+The default version of the [Pex](https://docs.pex-tool.org/) tool has been updated from 2.3.1 to [2.11.0](https://github.com/pex-tool/pex/releases/tag/v2.11.0).
 
 Fix running python source files that have dashes in them (bug introduced in 2.20). For example: `pants run path/to/some-executable.py`
 

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -38,7 +38,7 @@ class PexCli(TemplatedExternalTool):
     name = "pex"
     help = "The PEX (Python EXecutable) tool (https://github.com/pex-tool/pex)."
 
-    default_version = "v2.3.3"
+    default_version = "v2.11.0"
     default_url_template = "https://github.com/pex-tool/pex/releases/download/{version}/pex"
     version_constraints = ">=2.3.0,<3.0"
 
@@ -49,8 +49,8 @@ class PexCli(TemplatedExternalTool):
                 (
                     cls.default_version,
                     plat,
-                    "929732cde0b2bc933a5c4819a179cbbefb50186c2f8ecdd8296e4a893feb5432",
-                    "4134920",
+                    "554a3ad5d1662d93d06a7e65bf5444589d1956752df39e2665a4d54e1e05c949",
+                    "4181790",
                 )
             )
             for plat in ["macos_arm64", "macos_x86_64", "linux_x86_64", "linux_arm64"]


### PR DESCRIPTION
Highlighted changelogs:
 * https://github.com/pex-tool/pex/releases/tag/v2.4.0
 * https://github.com/pex-tool/pex/releases/tag/v2.4.1
 * https://github.com/pex-tool/pex/releases/tag/v2.5.0
 * https://github.com/pex-tool/pex/releases/tag/v2.6.0
 * https://github.com/pex-tool/pex/releases/tag/v2.7.0
 * https://github.com/pex-tool/pex/releases/tag/v2.8.0
 * https://github.com/pex-tool/pex/releases/tag/v2.8.1
 * https://github.com/pex-tool/pex/releases/tag/v2.9.0
 * https://github.com/pex-tool/pex/releases/tag/v2.10.0
 * https://github.com/pex-tool/pex/releases/tag/v2.10.1
 * https://github.com/pex-tool/pex/releases/tag/v2.11.0 (!)

```
Lockfile diff: 3rdparty/python/user_reqs.lock [python-default]

==                    Upgraded dependencies                     ==

  certifi                        2024.6.2     -->   2024.7.4
  exceptiongroup                 1.2.1        -->   1.2.2
  pex                            2.3.3        -->   2.11.0
  pydantic                       1.10.16      -->   1.10.17
```

NOTE: This updates the scrupulously backwards compatible Pex, but does not use any new featues yet.  The minimum version is unchanged.

Possibly relevant for: #15704 #21103 #20852 #15454 #21100 #11324 #19256 #19552 #19681
