### PR TITLE
cleanup how adhoc and shell backends process environment variables

### DIFF
--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -158,6 +158,8 @@ Pants will output a more helpful error message if there is no `name` field defin
 
 The `tailor` goal now has independent options for tailoring `shell_sources` and `shunit2_tests` targets. The option was split from `tailor` into [`tailor_sources`](https://www.pantsbuild.org/2.23/reference/subsystems/shell-setup#tailor_sources) and [`tailor_shunit2_tests`](https://www.pantsbuild.org/2.23/reference/subsystems/shell-setup#tailor_shunit2_tests).
 
+Fixed a bug in how the `PATH` environment variable is modified to account for binary shims and dependencies of `adhoc_tool` and `shell_command` targets. The bug was that such paths were overwrite any existing `PATH` variable provided by the user instead of augmenting the `PATH` value.
+
 #### Docker
 
 Fixed a bug where the internal Docker BuildKit parser would return `<unknown> image_id` if the BuildKit output used step durations.

--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -158,7 +158,7 @@ Pants will output a more helpful error message if there is no `name` field defin
 
 The `tailor` goal now has independent options for tailoring `shell_sources` and `shunit2_tests` targets. The option was split from `tailor` into [`tailor_sources`](https://www.pantsbuild.org/2.23/reference/subsystems/shell-setup#tailor_sources) and [`tailor_shunit2_tests`](https://www.pantsbuild.org/2.23/reference/subsystems/shell-setup#tailor_shunit2_tests).
 
-Fixed a bug in how the `PATH` environment variable is modified to account for binary shims and dependencies of `adhoc_tool` and `shell_command` targets. The bug was that such paths were overwrite any existing `PATH` variable provided by the user instead of augmenting the `PATH` value.
+Fixed a bug in how the `PATH` environment variable is modified to account for binary shims and dependencies of `adhoc_tool` and `shell_command` targets. The bug was that such paths overwrote any existing `PATH` variable provided by the user instead of augmenting the `PATH` value.
 
 #### Docker
 

--- a/src/python/pants/backend/adhoc/adhoc_tool.py
+++ b/src/python/pants/backend/adhoc/adhoc_tool.py
@@ -29,6 +29,7 @@ from pants.core.util_rules.adhoc_process_support import (
     AdhocProcessResult,
     ToolRunner,
     ToolRunnerRequest,
+    prepare_env_vars,
 )
 from pants.core.util_rules.adhoc_process_support import rules as adhoc_process_support_rules
 from pants.core.util_rules.environments import EnvironmentNameRequest, EnvironmentTarget
@@ -96,6 +97,14 @@ async def run_in_sandbox_request(
             description_of_origin=f"`{AdhocToolWorkspaceInvalidationSourcesField.alias}` for `adhoc_tool` target at `{target.address}`",
         )
 
+    env_vars: dict[str, str] = dict(tool_runner.extra_env)
+    user_env_vars = await prepare_env_vars(
+        target.get(AdhocToolExtraEnvVarsField).value or (),
+        extra_paths=tool_runner.extra_paths,
+        description_of_origin=f"`{AdhocToolExtraEnvVarsField.alias}` for `adhoc_tool` target at `{target.address}`",
+    )
+    env_vars.update(user_env_vars)
+
     process_request = AdhocProcessRequest(
         description=description,
         address=target.address,
@@ -108,8 +117,7 @@ async def run_in_sandbox_request(
         append_only_caches=FrozenDict(tool_runner.append_only_caches),
         output_files=output_files,
         output_directories=output_directories,
-        fetch_env_vars=target.get(AdhocToolExtraEnvVarsField).value or (),
-        supplied_env_var_values=FrozenDict(tool_runner.extra_env),
+        env_vars=FrozenDict(env_vars),
         log_on_process_errors=None,
         log_output=target[AdhocToolLogOutputField].value,
         capture_stderr_file=target[AdhocToolStderrFilenameField].value,

--- a/src/python/pants/backend/adhoc/adhoc_tool.py
+++ b/src/python/pants/backend/adhoc/adhoc_tool.py
@@ -97,13 +97,12 @@ async def run_in_sandbox_request(
             description_of_origin=f"`{AdhocToolWorkspaceInvalidationSourcesField.alias}` for `adhoc_tool` target at `{target.address}`",
         )
 
-    env_vars: dict[str, str] = dict(tool_runner.extra_env)
-    user_env_vars = await prepare_env_vars(
+    env_vars = await prepare_env_vars(
+        tool_runner.extra_env,
         target.get(AdhocToolExtraEnvVarsField).value or (),
         extra_paths=tool_runner.extra_paths,
         description_of_origin=f"`{AdhocToolExtraEnvVarsField.alias}` for `adhoc_tool` target at `{target.address}`",
     )
-    env_vars.update(user_env_vars)
 
     process_request = AdhocProcessRequest(
         description=description,
@@ -117,7 +116,7 @@ async def run_in_sandbox_request(
         append_only_caches=FrozenDict(tool_runner.append_only_caches),
         output_files=output_files,
         output_directories=output_directories,
-        env_vars=FrozenDict(env_vars),
+        env_vars=env_vars,
         log_on_process_errors=None,
         log_output=target[AdhocToolLogOutputField].value,
         capture_stderr_file=target[AdhocToolStderrFilenameField].value,

--- a/src/python/pants/backend/adhoc/code_quality_tool.py
+++ b/src/python/pants/backend/adhoc/code_quality_tool.py
@@ -205,13 +205,12 @@ async def process_files(batch: CodeQualityToolBatch) -> FallibleProcessResult:
 
     input_digest = await Get(Digest, MergeDigests((runner.digest, batch.sources_snapshot.digest)))
 
-    env_vars: dict[str, str] = dict(runner.extra_env)
-    user_env_vars = await prepare_env_vars(
+    env_vars = await prepare_env_vars(
+        runner.extra_env,
         (),
         extra_paths=runner.extra_paths,
         description_of_origin="code quality tool",
     )
-    env_vars.update(user_env_vars)
 
     result = await Get(
         FallibleProcessResult,
@@ -221,7 +220,7 @@ async def process_files(batch: CodeQualityToolBatch) -> FallibleProcessResult:
             input_digest=input_digest,
             append_only_caches=runner.append_only_caches,
             immutable_input_digests=FrozenDict.frozen(runner.immutable_input_digests),
-            env=FrozenDict(env_vars),
+            env=env_vars,
             output_files=batch.output_files,
         ),
     )

--- a/src/python/pants/backend/shell/util_rules/shell_command.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command.py
@@ -143,13 +143,12 @@ async def _prepare_process_request_from_target(
         ExtraSandboxContents, MergeExtraSandboxContents(tuple(extra_sandbox_contents))
     )
 
-    env_vars: dict[str, str] = dict(merged_extras.extra_env)
-    user_env_vars = await prepare_env_vars(
+    env_vars = await prepare_env_vars(
+        merged_extras.extra_env,
         shell_command.get(ShellCommandExtraEnvVarsField).value or (),
         extra_paths=merged_extras.paths,
         description_of_origin=f"`{ShellCommandExtraEnvVarsField.alias}` for `shell_command` target at `{shell_command.address}`",
     )
-    env_vars.update(user_env_vars)
 
     append_only_caches = {
         **merged_extras.append_only_caches,
@@ -181,7 +180,7 @@ async def _prepare_process_request_from_target(
         output_files=output_files,
         output_directories=output_directories,
         append_only_caches=FrozenDict(append_only_caches),
-        env_vars=FrozenDict(env_vars),
+        env_vars=env_vars,
         immutable_input_digests=FrozenDict.frozen(merged_extras.immutable_input_digests),
         log_on_process_errors=_LOG_ON_PROCESS_ERRORS,
         log_output=shell_command[ShellCommandLogOutputField].value,

--- a/src/python/pants/core/util_rules/adhoc_process_support.py
+++ b/src/python/pants/core/util_rules/adhoc_process_support.py
@@ -615,14 +615,16 @@ async def prepare_adhoc_process(
 
 
 async def prepare_env_vars(
+    existing_env_vars: Mapping[str, str],
     env_vars_templates: tuple[str, ...],
     *,
     extra_paths: tuple[str, ...] = (),
     description_of_origin: str,
 ) -> FrozenDict[str, str]:
+    env_vars: dict[str, str] = dict(existing_env_vars)
+
     to_fetch: set[str] = set()
     duplicate_keys: set[str] = set()
-    env_vars: dict[str, str] = {}
     for env_var in env_vars_templates:
         parts = env_var.split("=", 1)
         if parts[0] in env_vars:

--- a/src/python/pants/core/util_rules/adhoc_process_support.py
+++ b/src/python/pants/core/util_rules/adhoc_process_support.py
@@ -72,8 +72,7 @@ class AdhocProcessRequest:
     append_only_caches: FrozenDict[str, str] | None
     output_files: tuple[str, ...]
     output_directories: tuple[str, ...]
-    fetch_env_vars: tuple[str, ...]
-    supplied_env_var_values: FrozenDict[str, str] | None
+    env_vars: FrozenDict[str, str]
     log_on_process_errors: FrozenDict[int, str] | None
     log_output: bool
     capture_stdout_file: str | None
@@ -124,6 +123,7 @@ class ToolRunner:
     digest: Digest
     args: tuple[str, ...]
     extra_env: FrozenDict[str, str]
+    extra_paths: tuple[str, ...]
     append_only_caches: FrozenDict[str, str]
     immutable_input_digests: FrozenDict[str, Digest]
 
@@ -136,7 +136,7 @@ class ToolRunner:
 @dataclass(frozen=True)
 class ExtraSandboxContents:
     digest: Digest
-    path: str | None
+    paths: tuple[str, ...]
     immutable_input_digests: Mapping[str, Digest]
     append_only_caches: Mapping[str, str]
     extra_env: Mapping[str, str]
@@ -147,66 +147,32 @@ class MergeExtraSandboxContents:
     additions: tuple[ExtraSandboxContents, ...]
 
 
-@dataclass(frozen=True)
-class AddExtraSandboxContentsToProcess:
-    process: Process
-    contents: ExtraSandboxContents
-
-
 @rule
 async def merge_extra_sandbox_contents(request: MergeExtraSandboxContents) -> ExtraSandboxContents:
     additions = request.additions
 
-    digests = []
-    paths = []
+    digests: list[Digest] = []
+    paths: list[str] = []
     immutable_input_digests: dict[str, Digest] = {}
     append_only_caches: dict[str, str] = {}
     extra_env: dict[str, str] = {}
 
     for addition in additions:
         digests.append(addition.digest)
-        if addition.path is not None:
-            paths.append(addition.path)
+        if addition.paths:
+            paths.extend(addition.paths)
         _safe_update(immutable_input_digests, addition.immutable_input_digests)
         _safe_update(append_only_caches, addition.append_only_caches)
         _safe_update(extra_env, addition.extra_env)
 
     digest = await Get(Digest, MergeDigests(digests))
-    path = ":".join(paths) if paths else None
 
     return ExtraSandboxContents(
-        digest,
-        path,
-        FrozenDict(immutable_input_digests),
-        FrozenDict(append_only_caches),
-        FrozenDict(extra_env),
-    )
-
-
-@rule
-async def add_extra_contents_to_process(request: AddExtraSandboxContentsToProcess) -> Process:
-    proc = request.process
-    extras = request.contents
-    new_digest = await Get(
-        Digest, MergeDigests((request.process.input_digest, request.contents.digest))
-    )
-    immutable_input_digests = dict(proc.immutable_input_digests)
-    append_only_caches = dict(proc.append_only_caches)
-    env = dict(proc.env)
-
-    _safe_update(immutable_input_digests, extras.immutable_input_digests)
-    _safe_update(append_only_caches, extras.append_only_caches)
-    _safe_update(env, extras.extra_env)
-    # need to do `PATH` after `env` in case `extra_env` contains a `PATH`.
-    if extras.path:
-        env["PATH"] = extras.path + (":" + env["PATH"]) if "PATH" in env else ""
-
-    return dataclasses.replace(
-        proc,
-        input_digest=new_digest,
+        digest=digest,
+        paths=tuple(paths),
         immutable_input_digests=FrozenDict(immutable_input_digests),
         append_only_caches=FrozenDict(append_only_caches),
-        env=FrozenDict(env),
+        extra_env=FrozenDict(extra_env),
     )
 
 
@@ -259,7 +225,7 @@ async def _resolve_runnable_dependencies(
         extras.append(
             ExtraSandboxContents(
                 digest=runnable.digest,
-                path=None,
+                paths=(),
                 immutable_input_digests=FrozenDict(runnable.immutable_input_digests or {}),
                 append_only_caches=FrozenDict(runnable.append_only_caches or {}),
                 extra_env=FrozenDict(),
@@ -451,22 +417,22 @@ async def create_tool_runner(
 
     extra_sandbox_contents.append(
         ExtraSandboxContents(
-            EMPTY_DIGEST,
-            extra_path,
-            run_request.immutable_input_digests or FrozenDict(),
-            run_request.append_only_caches or FrozenDict(),
-            run_request.extra_env or FrozenDict(),
+            digest=EMPTY_DIGEST,
+            paths=(extra_path,) if extra_path else (),
+            immutable_input_digests=run_request.immutable_input_digests or FrozenDict(),
+            append_only_caches=run_request.append_only_caches or FrozenDict(),
+            extra_env=run_request.extra_env or FrozenDict(),
         )
     )
 
     if runnable_dependencies:
         extra_sandbox_contents.append(
             ExtraSandboxContents(
-                EMPTY_DIGEST,
-                f"{{chroot}}/{runnable_dependencies.path_component}",
-                runnable_dependencies.immutable_input_digests,
-                runnable_dependencies.append_only_caches,
-                runnable_dependencies.extra_env,
+                digest=EMPTY_DIGEST,
+                paths=(f"{{chroot}}/{runnable_dependencies.path_component}",),
+                immutable_input_digests=runnable_dependencies.immutable_input_digests,
+                append_only_caches=runnable_dependencies.append_only_caches,
+                extra_env=runnable_dependencies.extra_env,
             )
         )
 
@@ -476,8 +442,6 @@ async def create_tool_runner(
     )
 
     extra_env = dict(merged_extras.extra_env)
-    if merged_extras.path:
-        extra_env["PATH"] = merged_extras.path
 
     append_only_caches = {
         **merged_extras.append_only_caches,
@@ -488,6 +452,7 @@ async def create_tool_runner(
         digest=main_digest,
         args=run_request.args + tuple(request.args),
         extra_env=FrozenDict(extra_env),
+        extra_paths=merged_extras.paths,
         append_only_caches=FrozenDict(append_only_caches),
         immutable_input_digests=FrozenDict(merged_extras.immutable_input_digests),
     )
@@ -609,18 +574,10 @@ async def prepare_adhoc_process(
     timeout: int | None = request.timeout
     output_files = request.output_files
     output_directories = request.output_directories
-    fetch_env_vars = request.fetch_env_vars
-    supplied_env_vars = request.supplied_env_var_values or FrozenDict()
     append_only_caches = request.append_only_caches or FrozenDict()
     immutable_input_digests = request.immutable_input_digests or FrozenDict()
 
-    command_env: dict[str, str] = {}
-
-    extra_env = await Get(EnvironmentVars, EnvironmentVarsRequest(fetch_env_vars))
-    command_env.update(extra_env)
-
-    if supplied_env_vars:
-        command_env.update(supplied_env_vars)
+    command_env: dict[str, str] = dict(request.env_vars)
 
     # Compute the hash for any workspace invalidation sources and put the hash into the environment as a dummy variable
     # so that the process produced by this rule will be invalidated if any of the referenced files change.
@@ -655,6 +612,57 @@ async def prepare_adhoc_process(
     )
 
     return _output_at_build_root(proc, bash)
+
+
+async def prepare_env_vars(
+    env_vars_templates: tuple[str, ...],
+    *,
+    extra_paths: tuple[str, ...] = (),
+    description_of_origin: str,
+) -> FrozenDict[str, str]:
+    to_fetch: set[str] = set()
+    duplicate_keys: set[str] = set()
+    env_vars: dict[str, str] = {}
+    for env_var in env_vars_templates:
+        parts = env_var.split("=", 1)
+        if parts[0] in env_vars:
+            duplicate_keys.add(parts[0])
+
+        if len(parts) == 2:
+            env_vars[parts[0]] = parts[1]
+        else:
+            to_fetch.add(parts[0])
+
+    if duplicate_keys:
+        dups_as_str = ", ".join(sorted(duplicate_keys))
+        raise ValueError(
+            f"The following environment variables referenced in {description_of_origin} are defined multiple times: {dups_as_str}"
+        )
+
+    if to_fetch:
+        fetched_env_vars = await Get(
+            EnvironmentVars, EnvironmentVarsRequest(tuple(sorted(to_fetch)))
+        )
+        env_vars.update(fetched_env_vars)
+
+    if extra_paths:
+
+        def path_env_join(left: str | None, right: str | None) -> str | None:
+            if not left and not right:
+                return None
+            if left and not right:
+                return left
+            if not left and right:
+                return right
+            return f"{left}:{right}"
+
+        existing_path_env = env_vars.get("PATH")
+        extra_paths_as_str = ":".join(extra_paths)
+        new_path_env = path_env_join(extra_paths_as_str, existing_path_env)
+        if new_path_env:
+            env_vars["PATH"] = new_path_env
+
+    return FrozenDict(env_vars)
 
 
 def _output_at_build_root(process: Process, bash: BashBinary) -> Process:


### PR DESCRIPTION
As described in https://github.com/pantsbuild/pants/issues/21136, Pants currently has a bug where any `PATH` value in the `extra_env_vars` field of the `shell_command` target type is ignored and the `PATH` is set to only the binary shim directory.

This PR is an internal only PR which cleans up how the adhoc and shell backends obtain and process environment variables. The `fetch_env_vars` and `supplied_env_var_values` fields of `AdhocProcessRequest` are replaced with a single `env_vars` field.

Common logic for setting up `env_vars` is extracted to the `prepare_env_vars` helper function including the `PATH` modification logic.

To that end, `ToolRunner` and `ExtraSandboxContents` now contain tuple-typed fields for conveying what extra PATH components need to be added to `PATH` but the related rules do not themselves modify `PATH`; only `prepare_env_vars` does.

The unused `AddExtraSandboxContentsToProcess` and related rules have been deleted.

