### PR TITLE
goals: update update-build-files goal help text

### DIFF
--- a/src/python/pants/core/goals/update_build_files.py
+++ b/src/python/pants/core/goals/update_build_files.py
@@ -120,9 +120,6 @@ class UpdateBuildFilesSubsystem(GoalSubsystem):
         This does not handle the full Pants upgrade. You must still manually change
         `pants_version` in `pants.toml` and you may need to manually address some deprecations.
         See {doc_url('docs/releases/upgrade-tips')} for upgrade tips.
-
-        This goal is run without arguments. It will run over all BUILD files in your
-        project.
         """
     )
 


### PR DESCRIPTION
The help is wrong as you do need to provide arguments for this goal for it to format BUILD files in certain locations:

```
$ pants update-build-files        
23:26:41.70 [WARN] No arguments specified with `pants update-build-files`, so the goal will do nothing.

Instead, you should provide arguments like this:

  * `pants update-build-files ::` to run on everything
  * `pants update-build-files dir::` to run on `dir` and subdirs
  * `pants update-build-files dir` to run on `dir`
  * `pants update-build-files dir/BUILD` to run on that single BUILD file
  * `pants --changed-since=HEAD update-build-files` to run only on changed BUILD files

```