### PR TITLE
Update default Node version to 22.6.0

### DIFF
--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -229,7 +229,7 @@ The Terraform backend supports creating lockfiles which support multiple platfor
 The Node.js runtime now uses version 22.7.0 by default. This is 3 major version upgrades from the 16.x series, which was used before.
 Additionally, the default versions of the various package managers have been updated:
 
-npm: 8.5.5 -> 10.8.1
+npm: 8.5.5 -> 10.8.2
 pnpm: 9.5.0 (9.x)
 yarn: 1.22.22 (1.x)
 

--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -226,7 +226,7 @@ The Terraform backend supports creating lockfiles which support multiple platfor
 
 #### Javascript
 
-The Node.js runtime now uses version 20.15.1 by default. This is 2 major version upgrades from the 16.x series, which was used before.
+The Node.js runtime now uses version 22.7.0 by default. This is 3 major version upgrades from the 16.x series, which was used before.
 Additionally, the default versions of the various package managers have been updated:
 
 npm: 8.5.5 -> 10.8.1

--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -226,7 +226,7 @@ The Terraform backend supports creating lockfiles which support multiple platfor
 
 #### Javascript
 
-The Node.js runtime now uses version 22.7.0 by default. This is 3 major version upgrades from the 16.x series, which was used before.
+The Node.js runtime now uses version 22.6.0 by default. This is 3 major version upgrades from the 16.x series, which was used before.
 Additionally, the default versions of the various package managers have been updated:
 
 npm: 8.5.5 -> 10.8.2

--- a/src/python/pants/backend/javascript/subsystems/nodejs.py
+++ b/src/python/pants/backend/javascript/subsystems/nodejs.py
@@ -138,7 +138,7 @@ class NodeJS(Subsystem, TemplatedExternalToolOptionsMixin):
     )
 
     package_managers = DictOption[str](
-        default={"npm": "10.8.1", "yarn": "1.22.22", "pnpm": "9.5.0"},
+        default={"npm": "10.8.2", "yarn": "1.22.22", "pnpm": "9.5.0"},
         help=help_text(
             """
             A mapping of package manager versions to semver releases.

--- a/src/python/pants/backend/javascript/subsystems/nodejs.py
+++ b/src/python/pants/backend/javascript/subsystems/nodejs.py
@@ -62,12 +62,12 @@ class NodeJS(Subsystem, TemplatedExternalToolOptionsMixin):
     options_scope = "nodejs"
     help = "The Node.js Javascript runtime (including Corepack)."
 
-    default_version = "v20.15.1"
+    default_version = "v22.5.1"
     default_known_versions = [
-        "v20.15.1|macos_arm64|4743bc042f90ba5d9edf09403207290a9cdd2f6061bdccf7caaa0bbfd49f343e|41888895",
-        "v20.15.1|macos_x86_64|f5379772ffae1404cfd1fcc8cf0c6c5971306b8fb2090d348019047306de39dc|43531593",
-        "v20.15.1|linux_arm64|10d47a46ef208b3e4b226e4d595a82659123b22397ed77b7975d989114ec317e|24781292",
-        "v20.15.1|linux_x86_64|26700f8d3e78112ad4a2618a9c8e2816e38a49ecf0213ece80e54c38cb02563f|25627852",
+        "v22.5.1|macos_arm64|7602384855f1e169b60e51c360e5a2c672b89a19ccda0199ce4675d68fefaaf2|45737013",
+        "v22.5.1|macos_x86_64|6acb4533bc0a43a468f90bbd49230aa16c7c57b2a3451efe02175feea346754d|47832563",
+        "v22.5.1|linux_arm64|8b88f7fb681d95f8a2ecb7cf87f2cefa6769d3e74ff7309806bf201816e7c136|27412148",
+        "v22.5.1|linux_x86_64|9d4747dbbc1a91b1324f43c77e13eeddc4d4c54685665540cd7b7ad82e1b2fbc|28512812",
     ]
 
     default_url_template = "https://nodejs.org/dist/{version}/node-{version}-{platform}.tar"

--- a/src/python/pants/backend/javascript/subsystems/nodejs.py
+++ b/src/python/pants/backend/javascript/subsystems/nodejs.py
@@ -62,12 +62,12 @@ class NodeJS(Subsystem, TemplatedExternalToolOptionsMixin):
     options_scope = "nodejs"
     help = "The Node.js Javascript runtime (including Corepack)."
 
-    default_version = "v22.5.1"
+    default_version = "v22.7.0"
     default_known_versions = [
-        "v22.5.1|macos_arm64|7602384855f1e169b60e51c360e5a2c672b89a19ccda0199ce4675d68fefaaf2|45737013",
-        "v22.5.1|macos_x86_64|6acb4533bc0a43a468f90bbd49230aa16c7c57b2a3451efe02175feea346754d|47832563",
-        "v22.5.1|linux_arm64|8b88f7fb681d95f8a2ecb7cf87f2cefa6769d3e74ff7309806bf201816e7c136|27412148",
-        "v22.5.1|linux_x86_64|9d4747dbbc1a91b1324f43c77e13eeddc4d4c54685665540cd7b7ad82e1b2fbc|28512812",
+        "v22.7.0|macos_arm64|5c54b08ec6cab6ef1e4e3302e655794f791132e9148dfc7741c5cba4bba1f27b|46726460",
+        "v22.7.0|macos_x86_64|d8d0c2835bad13427cc5a8e1a9aed536f6dd25f3bb55b1f56b027a18d5aa964f|48829706",
+        "v22.7.0|linux_arm64|180dfe622cf3e15cd72f267f576c04ef29f236515248965e58c458cdce6a3ad4|28106420",
+        "v22.7.0|linux_x86_64|f230a6b7f3eb325e84583a209bbdc7406202d7e4e6b91a16e8b0e6769729029f|29252120",
     ]
 
     default_url_template = "https://nodejs.org/dist/{version}/node-{version}-{platform}.tar"

--- a/src/python/pants/backend/javascript/subsystems/nodejs.py
+++ b/src/python/pants/backend/javascript/subsystems/nodejs.py
@@ -62,12 +62,12 @@ class NodeJS(Subsystem, TemplatedExternalToolOptionsMixin):
     options_scope = "nodejs"
     help = "The Node.js Javascript runtime (including Corepack)."
 
-    default_version = "v22.7.0"
+    default_version = "v22.6.0"
     default_known_versions = [
-        "v22.7.0|macos_arm64|5c54b08ec6cab6ef1e4e3302e655794f791132e9148dfc7741c5cba4bba1f27b|46726460",
-        "v22.7.0|macos_x86_64|d8d0c2835bad13427cc5a8e1a9aed536f6dd25f3bb55b1f56b027a18d5aa964f|48829706",
-        "v22.7.0|linux_arm64|180dfe622cf3e15cd72f267f576c04ef29f236515248965e58c458cdce6a3ad4|28106420",
-        "v22.7.0|linux_x86_64|f230a6b7f3eb325e84583a209bbdc7406202d7e4e6b91a16e8b0e6769729029f|29252120",
+        "v22.6.0|macos_arm64|9ea60766807cd3c3a3ad6ad419f98918d634a60fe8dea5b9c07507ed0f176d4c|47583427",
+        "v22.6.0|macos_x86_64|8766c5968ca22d20fc6237c54c7c5d12ef12e15940d6119a79144ccb163ea737|49688634",
+        "v22.6.0|linux_arm64|0053ee0426c4daaa65c44f2cef87be45135001c3145cfb840aa1d0e6f2619610|28097296",
+        "v22.6.0|linux_x86_64|acbbe539edc33209bb3e1b25f7545b5ca5d70e6256ed8318e1ec1e41e7b35703|29240984",
     ]
 
     default_url_template = "https://nodejs.org/dist/{version}/node-{version}-{platform}.tar"

--- a/src/python/pants/backend/javascript/subsystems/nodejs_tool_test.py
+++ b/src/python/pants/backend/javascript/subsystems/nodejs_tool_test.py
@@ -85,7 +85,7 @@ def test_execute_process_with_package_manager(
     "package_manager, version",
     [
         pytest.param("yarn", "1.22.22", id="yarn"),
-        pytest.param("npm", "10.8.1", id="npm"),
+        pytest.param("npm", "10.8.2", id="npm"),
         pytest.param("pnpm", "9.5.0", id="pnpm"),
     ],
 )
@@ -115,7 +115,7 @@ def test_execute_process_with_package_manager_version_from_configuration(
         pytest.param(Path(__file__).parent / "yarn.lock", "yarn", "1.22.22", id="yarn_resolve"),
         pytest.param(Path(__file__).parent / "pnpm-lock.yaml", "pnpm", "9.5.0", id="pnpm_resolve"),
         pytest.param(
-            Path(__file__).parent / "package-lock.json", "npm", "10.8.1", id="npm_resolve"
+            Path(__file__).parent / "package-lock.json", "npm", "10.8.2", id="npm_resolve"
         ),
     ],
 )


### PR DESCRIPTION
22.7.0 is the latest version of Node; 20.x moves into maintenance mode in October, while 22.x should stay LTS [until the end of 2025](https://nodejs.org/en/about/previous-releases), so hopefully this will be the last one of these PRs for a while :)