### PR TITLE
pex-cli: add [pex-cli].args option to pass arguments to the PEX process globally

### DIFF
--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -124,6 +124,10 @@ The default version of the `ruff` tool has been updated from 0.4.4 to 0.4.9.
 
 The default version of the [Pex](https://docs.pex-tool.org/) tool has been updated from 2.3.1 to [2.11.0](https://github.com/pex-tool/pex/releases/tag/v2.11.0).
 
+A new option `[pex-cli].args` has been added to be able to pass arbitrary arguments to the `pex` tool as part 
+of any Pants goal invocation. This should make it a lot easier to modify behavior of `pex` tool without needing 
+to make changes in the Pants codebase.
+
 Fix running python source files that have dashes in them (bug introduced in 2.20). For example: `pants run path/to/some-executable.py`
 
 A new `entry_point_dependencies` field is now available for `python_tests` and `python_test` targets. This allows tests

--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -124,7 +124,7 @@ The default version of the `ruff` tool has been updated from 0.4.4 to 0.4.9.
 
 The default version of the [Pex](https://docs.pex-tool.org/) tool has been updated from 2.3.1 to [2.11.0](https://github.com/pex-tool/pex/releases/tag/v2.11.0).
 
-A new option `[pex-cli].args` has been added to be able to pass arbitrary arguments to the `pex` tool as part 
+[A new option `[pex-cli].args`](https://www.pantsbuild.org/2.23/reference/subsystems/pex-cli#args) has been added to be able to pass arbitrary arguments to the `pex` tool as part 
 of any Pants goal invocation. This should make it a lot easier to modify behavior of `pex` tool without needing 
 to make changes in the Pants codebase.
 

--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -124,9 +124,9 @@ The default version of the `ruff` tool has been updated from 0.4.4 to 0.4.9.
 
 The default version of the [Pex](https://docs.pex-tool.org/) tool has been updated from 2.3.1 to [2.11.0](https://github.com/pex-tool/pex/releases/tag/v2.11.0).
 
-[A new option `[pex-cli].args`](https://www.pantsbuild.org/2.23/reference/subsystems/pex-cli#args) has been added to be able to pass arbitrary arguments to the `pex` tool as part 
-of any Pants goal invocation. This should make it a lot easier to modify behavior of `pex` tool without needing 
-to make changes in the Pants codebase.
+[A new option `[pex-cli].global_args`](https://www.pantsbuild.org/2.23/reference/subsystems/pex-cli#global_args) has been 
+added to be able to pass arbitrary arguments to the `pex` tool as part of any Pants goal invocation. 
+This should make it a lot easier to modify behavior of `pex` tool without needing to make changes in the Pants codebase.
 
 Fix running python source files that have dashes in them (bug introduced in 2.20). For example: `pants run path/to/some-executable.py`
 

--- a/src/python/pants/backend/python/goals/run_pex_binary_integration_test.py
+++ b/src/python/pants/backend/python/goals/run_pex_binary_integration_test.py
@@ -283,8 +283,8 @@ def test_run_script_from_3rdparty_dist_issue_13747() -> None:
         assert SAY in result.stdout.strip()
 
 
-def test_pass_extra_pex_cli_subsystem_args() -> None:
-    """Test that extra args passed to the pex-cli subsystem propagate to the actual pex
+def test_pass_extra_pex_cli_subsystem_global_args() -> None:
+    """Test that extra global args passed to the pex-cli subsystem propagate to the actual pex
     invocation."""
     sources = {
         "src/BUILD": dedent(
@@ -297,7 +297,7 @@ def test_pass_extra_pex_cli_subsystem_args() -> None:
     with setup_tmpdir(sources) as tmpdir:
         args = [
             "--backend-packages=pants.backend.python",
-            "--pex-cli-args='--non-existing-flag-name=some-value'",
+            "--pex-cli-global-args='--non-existing-flag-name=some-value'",
             f"--source-root-patterns=['/{tmpdir}/src']",
             "run",
             f"{tmpdir}/src:test",

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -30,6 +30,7 @@ from pants.option.option_types import ArgsListOption
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.meta import classproperty
+from pants.util.strutil import softwrap
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +46,15 @@ class PexCli(TemplatedExternalTool):
 
     # extra args to be passed to the pex tool; note that they
     # are going to apply to all invocations of the pex tool.
-    global_args = ArgsListOption(example="--check=error --no-compile")
+    global_args = ArgsListOption(
+        example="--check=error --no-compile",
+        extra_help=softwrap(
+            """
+            Note that these apply to all invocations of the pex tool, including building `pex_binary`
+            targets, preparing `python_test` targets to run, and generating lockfiles.
+            """
+        ),
+    )
 
     @classproperty
     def default_known_versions(cls):

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -26,6 +26,7 @@ from pants.engine.platform import Platform
 from pants.engine.process import Process, ProcessCacheScope
 from pants.engine.rules import Get, collect_rules, rule
 from pants.option.global_options import GlobalOptions, ca_certs_path_to_file_content
+from pants.option.option_types import ArgsListOption
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.meta import classproperty
@@ -41,6 +42,10 @@ class PexCli(TemplatedExternalTool):
     default_version = "v2.11.0"
     default_url_template = "https://github.com/pex-tool/pex/releases/download/{version}/pex"
     version_constraints = ">=2.3.0,<3.0"
+
+    # extra args to be passed to the pex tool; note that they
+    # are going to apply to all invocations of the pex tool.
+    args = ArgsListOption(example="--check=error --no-compile")
 
     @classproperty
     def default_known_versions(cls):
@@ -123,6 +128,7 @@ async def setup_pex_cli_process(
     python_native_code: PythonNativeCodeSubsystem.EnvironmentAware,
     global_options: GlobalOptions,
     pex_subsystem: PexSubsystem,
+    pex_cli_subsystem: PexCli,
     python_setup: PythonSetup,
 ) -> Process:
     tmpdir = ".tmp"
@@ -179,6 +185,7 @@ async def setup_pex_cli_process(
         *warnings_args,
         *pip_version_args,
         *resolve_args,
+        *pex_cli_subsystem.args,
         # NB: This comes at the end because it may use `--` passthrough args, # which must come at
         # the end.
         *request.extra_args,

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -45,7 +45,7 @@ class PexCli(TemplatedExternalTool):
 
     # extra args to be passed to the pex tool; note that they
     # are going to apply to all invocations of the pex tool.
-    args = ArgsListOption(example="--check=error --no-compile")
+    global_args = ArgsListOption(example="--check=error --no-compile")
 
     @classproperty
     def default_known_versions(cls):
@@ -185,7 +185,7 @@ async def setup_pex_cli_process(
         *warnings_args,
         *pip_version_args,
         *resolve_args,
-        *pex_cli_subsystem.args,
+        *pex_cli_subsystem.global_args,
         # NB: This comes at the end because it may use `--` passthrough args, # which must come at
         # the end.
         *request.extra_args,

--- a/src/python/pants/backend/python/util_rules/pex_cli_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli_test.py
@@ -44,9 +44,9 @@ def test_custom_ca_certs(tmp_path: Path, rule_runner: RuleRunner) -> None:
     assert b"Some fake cert" == chrooted_certs_file[0].content
 
 
-def test_pass_args_to_pex_cli_subsystem(tmp_path: Path, rule_runner: RuleRunner) -> None:
-    """Test that arbitrary arguments can be passed to the pex tool process."""
-    rule_runner.set_options(["--pex-cli-args='--foo=bar --baz --spam=eggs'"])
+def test_pass_global_args_to_pex_cli_subsystem(tmp_path: Path, rule_runner: RuleRunner) -> None:
+    """Test that arbitrary global arguments can be passed to the pex tool process."""
+    rule_runner.set_options(["--pex-cli-global-args='--foo=bar --baz --spam=eggs'"])
     proc = rule_runner.request(
         Process,
         [PexCliProcess(subcommand=(), extra_args=(), description="")],

--- a/src/python/pants/backend/python/util_rules/pex_cli_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli_test.py
@@ -42,3 +42,13 @@ def test_custom_ca_certs(tmp_path: Path, rule_runner: RuleRunner) -> None:
     chrooted_certs_file = [f for f in files if f.path == "certsfile"]
     assert len(chrooted_certs_file) == 1
     assert b"Some fake cert" == chrooted_certs_file[0].content
+
+
+def test_pass_args_to_pex_cli_subsystem(tmp_path: Path, rule_runner: RuleRunner) -> None:
+    """Test that arbitrary arguments can be passed to the pex tool process."""
+    rule_runner.set_options(["--pex-cli-args='--foo=bar --baz --spam=eggs'"])
+    proc = rule_runner.request(
+        Process,
+        [PexCliProcess(subcommand=(), extra_args=(), description="")],
+    )
+    assert "--foo=bar --baz --spam=eggs" in proc.argv


### PR DESCRIPTION
A new option `[pex-cli].global_args` has been added to be able to pass arbitrary arguments to the `pex` tool as part of any Pants goal invocation. This should make it a lot easier to modify behavior of `pex` tool without needing to make changes in the Pants codebase.

Not having this ability to pass arbitrary arguments to pex makes it really hard to start taking advantage of new features that come with newer versions of pex. For instance, the new `--exclude` flag added recently would require making lots of changes in the codebase to be able to pass those extra arguments. This is because the pex invocations in the Pants codebase are numerous and it's really hard to make sure a particular argument is respected (by keeping the chain of calls correct making sure it does reach the final subprocess spawn). And if it's relevant for multiple goals, this becomes even harder.

We would still need to make changes to pass arguments to individual targets, see https://github.com/pantsbuild/pants/pull/20737 or https://github.com/pantsbuild/pants/pull/20939 - this makes sense as those arguments apply only to those targets. However, some options would need to apply for any `pex` invocation (e.g. ignoring all 3rd party dependencies).

I've looked into having environment variables support for all flags that PEX has (https://github.com/pex-tool/pex/issues/2242) first (so that no changes are needed in Pants, one would just export a bunch of env vars as needed), but this is not going to happen any time soon, so doing it in the Pants codebase instead is the only path forward, I reckon.

Usage in practice:

```
PANTS_SOURCE=../pants pants --pex-cli-global-args="--some-flag=value" package cheeseshop/cli:cheeseshop-query
Pantsd has been turned off via Env.
23:00:24.73 [INFO] Initializing Nailgun pool for 16 processes...
23:00:27.85 [INFO] Starting: Resolving plugins: packaging==21.3
23:00:28.61 [INFO] Completed: Resolving plugins: packaging==21.3
...
    raise ExecutionError(

Exception message: 1 Exception encountered:

ProcessExecutionFailure: Process 'Resolving plugins: packaging==21.3' failed with exit code 2.
stdout:

stderr:
usage: pex [-o OUTPUT.PEX] [options] [-- arg1 arg2 ...]

pex builds a PEX (Python Executable) file based on the given specifications: sources, requirements, their dependencies and other options.
Command-line options can be provided in one or more files by prefixing the filenames with an @ symbol. These files must contain one argument per line.

pex: error: unrecognized arguments: --some-flag=value

Use `--keep-sandboxes=on_failure` to preserve the process chroot for inspection.
NoneType: None
```

With practical usage (could be applied to any target, but showing something that actually can be easily verified to proof the flag value is being used), see below.

With `--pex-cli-args="--no-compile"`:

```
$ PANTS_SOURCE=../pants pants --pex-cli-global-args="--no-compile" package cheeseshop/cli:cheeseshop-query
$ unzip -l dist/cheeseshop.cli/cheeseshop-query.pex | grep ".pyc"        
   268816  01-01-1980 00:00   .deps/charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl/charset_normalizer/md__mypyc.cpython-39-x86_64-linux-gnu.so
```

With `--pex-cli-args="--compile"`:

```
$ PANTS_SOURCE=../pants pants --pex-cli-global-args="--compile" package cheeseshop/cli:cheeseshop-query
$ unzip -l dist/cheeseshop.cli/cheeseshop-query.pex | grep ".pyc" | tail -n 5                   
      824  01-01-1980 00:00   cheeseshop/repository/parsing/exceptions.pyc
      839  01-01-1980 00:00   cheeseshop/repository/properties.pyc
     1901  01-01-1980 00:00   cheeseshop/repository/query.pyc
     1474  01-01-1980 00:00   cheeseshop/repository/repository.pyc
      236  01-01-1980 00:00   cheeseshop/version.pyc

```

