### PR TITLE
update-build-files: add support for Buildifier formatter

### DIFF
--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -26,6 +26,16 @@ from the local or remote cache, or be memoized.
 Knowing where the test results come from may be useful when evaluating the efficiency of the caching strategy and 
 the nature of the changes in the source code that may lead to frequent cache invalidations.
 
+### update-build-files goal
+
+`buildifier` was added to the list of supported formatters that can be used to format the BUILD files. 
+It may be helpful if your organization is migrating from Bazel and wants to keep the style of the BUILD files 
+consistent or if for any other reason you may want to adopt the formatting style that is enforced by `buildifier`.  
+
+The `buildifier` can be used on its own, but it can also be used in pair with a Python formatter, such as `black` 
+or `ruff`. For instance, you could first run `buildifier` to sort the target fields alphabetically, 
+and then run `black` to keep the style consistent with the rest of the Python code.
+
 ### Remote caching/execution
 
 The deprecation for the `[GLOBAL].remote_auth_bearer_token_path` option has expired. Use [the `[GLOBAL].remote_auth_bearer_token = "@/path/to/file"` option](https://www.pantsbuild.org/2.23/reference/global-options#remote_oauth_bearer_token) instead.

--- a/src/python/pants/backend/BUILD
+++ b/src/python/pants/backend/BUILD
@@ -36,6 +36,8 @@ __dependents_rules__(
             "[/build_files/fmt/black/register.py]",
             "[/build_files/fmt/ruff/register.py]",
             "[/build_files/fmt/yapf/register.py]",
+            "[/build_files/fmt/buildifier/rules.py]",
+            "[/build_files/fmt/buildifier/subsystem.py]",
             "[/python/lint/black/rules.py]",
             "[/python/lint/black/subsystem.py]",
             "[/python/lint/ruff/format/rules.py]",

--- a/src/python/pants/backend/build_files/fmt/buildifier/rules.py
+++ b/src/python/pants/backend/build_files/fmt/buildifier/rules.py
@@ -22,22 +22,8 @@ class BuildifierRequest(FmtBuildFilesRequest):
 async def buildfier_fmt(
     request: BuildifierRequest.Batch, buildifier: Buildifier, platform: Platform
 ) -> FmtResult:
-    buildifier_tool = await download_external_tool(buildifier.get_request(platform))
-    input_digest = await merge_digests_request_to_digest(
-        MergeDigests((request.snapshot.digest, buildifier_tool.digest))
-    )
-    result = await fallible_to_exec_result_or_raise(
-        **implicitly(
-            Process(
-                argv=[buildifier_tool.exe, "-type=build", *request.files],
-                input_digest=input_digest,
-                output_files=request.files,
-                description=f"Run {Buildifier.options_scope} on {pluralize(len(request.files), 'file')}.",
-                level=LogLevel.DEBUG,
-            )
-        ),
-    )
-    return await FmtResult.create(request, result)
+    result = await _run_buildifier_fmt(request, buildifier, platform)
+    return result
 
 
 # Note - this function is kept separate because it is invoked from update_build_files.py, but

--- a/src/python/pants/backend/build_files/fmt/buildifier/rules.py
+++ b/src/python/pants/backend/build_files/fmt/buildifier/rules.py
@@ -3,7 +3,7 @@
 
 from pants.backend.build_files.fmt.base import FmtBuildFilesRequest
 from pants.backend.build_files.fmt.buildifier.subsystem import Buildifier
-from pants.core.goals.fmt import FmtResult
+from pants.core.goals.fmt import AbstractFmtRequest, FmtResult
 from pants.core.util_rules.external_tool import download_external_tool
 from pants.engine.internals.native_engine import MergeDigests
 from pants.engine.intrinsics import merge_digests_request_to_digest
@@ -32,7 +32,30 @@ async def buildfier_fmt(
                 argv=[buildifier_tool.exe, "-type=build", *request.files],
                 input_digest=input_digest,
                 output_files=request.files,
-                description=f"Run buildifier on {pluralize(len(request.files), 'file')}.",
+                description=f"Run {Buildifier.options_scope} on {pluralize(len(request.files), 'file')}.",
+                level=LogLevel.DEBUG,
+            )
+        ),
+    )
+    return await FmtResult.create(request, result)
+
+
+# Note - this function is kept separate because it is invoked from update_build_files.py, but
+# not as a rule.
+async def _run_buildifier_fmt(
+    request: AbstractFmtRequest.Batch, buildifier: Buildifier, platform: Platform
+) -> FmtResult:
+    buildifier_tool = await download_external_tool(buildifier.get_request(platform))
+    input_digest = await merge_digests_request_to_digest(
+        MergeDigests((request.snapshot.digest, buildifier_tool.digest))
+    )
+    result = await fallible_to_exec_result_or_raise(
+        **implicitly(
+            Process(
+                argv=[buildifier_tool.exe, "-type=build", *request.files],
+                input_digest=input_digest,
+                output_files=request.files,
+                description=f"Run {Buildifier.options_scope} on {pluralize(len(request.files), 'file')}.",
                 level=LogLevel.DEBUG,
             )
         ),

--- a/src/python/pants/backend/build_files/fmt/buildifier/rules.py
+++ b/src/python/pants/backend/build_files/fmt/buildifier/rules.py
@@ -19,15 +19,30 @@ class BuildifierRequest(FmtBuildFilesRequest):
 
 
 @rule(desc="Format with Buildifier", level=LogLevel.DEBUG)
-async def buildfier_fmt(
+async def buildifier_fmt(
     request: BuildifierRequest.Batch, buildifier: Buildifier, platform: Platform
 ) -> FmtResult:
-    result = await _run_buildifier_fmt(request, buildifier, platform)
-    return result
+    buildifier_tool = await download_external_tool(buildifier.get_request(platform))
+    input_digest = await merge_digests_request_to_digest(
+        MergeDigests((request.snapshot.digest, buildifier_tool.digest))
+    )
+    result = await fallible_to_exec_result_or_raise(
+        **implicitly(
+            Process(
+                argv=[buildifier_tool.exe, "-type=build", *request.files],
+                input_digest=input_digest,
+                output_files=request.files,
+                description=f"Run {Buildifier.options_scope} on {pluralize(len(request.files), 'file')}.",
+                level=LogLevel.DEBUG,
+            )
+        ),
+    )
+    return await FmtResult.create(request, result)
 
 
 # Note - this function is kept separate because it is invoked from update_build_files.py, but
-# not as a rule.
+# not as a rule. This function cannot be called from the `buildifier_fmt` rule because other rules
+# invocations will not be detected in the @rule body at rule compile time.
 async def _run_buildifier_fmt(
     request: AbstractFmtRequest.Batch, buildifier: Buildifier, platform: Platform
 ) -> FmtResult:


### PR DESCRIPTION
`buildifier` was added to the list of supported formatters that can be used to format the BUILD files with the `update-build-files` goal.
 
It may be helpful if your organization is migrating from Bazel and wants to keep the style of the BUILD files 
consistent or if for any other reason you may want to adopt the formatting style that is enforced by `buildifier`.  

The addition of the Buildifier support was added in https://github.com/pantsbuild/pants/pull/16573/files; this PR adds a relevant option to actually let users choose it to format their BUILD files.

The `buildifier` can be used on its own, but it can also be used in pair with a Python formatter, such as `black` 
or `ruff`. For instance, you could first run `buildifier` to sort the target fields alphabetically, 
and then run `black` to keep the style consistent with the rest of the Python code.

E.g. running

```
$ pants update-build-files --fmt --formatter=buildifier src/python/pants/backend/python/util_rules/BUILD
$ pants update-build-files --fmt --formatter=black src/python/pants/backend/python/util_rules/BUILD
```

would convert 

```
resource(name="complete_platform_pex_test", source="complete_platform_pex_test.json")

python_sources(
    overrides={
        "local_dists_pep660.py": dict(dependencies=["./scripts/pep660_backend_wrapper.py"]),
        },
    name="foo",
)
```

to

```
# adding a trailing comma, putting one argument per line
resource(
    name="complete_platform_pex_test",
    source="complete_platform_pex_test.json",
)

# reorder the fields, putting the name first
python_sources(
    name="foo",
    overrides={
        "local_dists_pep660.py": dict(dependencies=["./scripts/pep660_backend_wrapper.py"]),
    },
)
```