### PR TITLE
Fix minor typo in JS docs link

### DIFF
--- a/docs/docs/javascript/overview/package.mdx
+++ b/docs/docs/javascript/overview/package.mdx
@@ -27,7 +27,7 @@ the experimental "packageManager" feature in `package.json` files.
 this setting will ensure that all scripts invoked for this package.json, and any
 [workspaces managed by this package.json](./workspaces.mdx) will use this particular version of `yarn`.
 It can be more convenient to define a project level
-[package manager](./enable-javascript-support.mdx#setting-up-a-package-manager).
+[package manager](./enabling-javascript-support.mdx#setting-up-a-package-manager).
 
 :::tip Choosing between `pants.toml` or `package.json` for package manager version configuration
 In general, if your team runs all tooling via Pants, using `pants.toml` reduces boilerplate in cases where you maintain


### PR DESCRIPTION
Revealed by warnings in the build of https://github.com/pantsbuild/pantsbuild.org/pull/236