### PR TITLE
upgrade to Rust v1.80.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -197,7 +197,7 @@ jobs:
       with:
         key: macOS10-15-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain')
           }}-v2
-        path: '~/.rustup/toolchains/1.79.0-*
+        path: '~/.rustup/toolchains/1.80.0-*
 
           ~/.rustup/update-hashes
 
@@ -283,7 +283,7 @@ jobs:
       with:
         key: macOS11-ARM64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain')
           }}-v2
-        path: '~/.rustup/toolchains/1.79.0-*
+        path: '~/.rustup/toolchains/1.80.0-*
 
           ~/.rustup/update-hashes
 
@@ -375,7 +375,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.79.0-*
+        path: '~/.rustup/toolchains/1.80.0-*
 
           ~/.rustup/update-hashes
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,7 +38,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: Linux-ARM64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.79.0-*
+        path: '~/.rustup/toolchains/1.80.0-*
 
           ~/.rustup/update-hashes
 
@@ -131,7 +131,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.79.0-*
+        path: '~/.rustup/toolchains/1.80.0-*
 
           ~/.rustup/update-hashes
 
@@ -234,7 +234,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: macOS12-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.79.0-*
+        path: '~/.rustup/toolchains/1.80.0-*
 
           ~/.rustup/update-hashes
 
@@ -449,7 +449,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: macOS10-15-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.79.0-*
+        path: '~/.rustup/toolchains/1.80.0-*
 
           ~/.rustup/update-hashes
 
@@ -518,7 +518,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: macOS11-ARM64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.79.0-*
+        path: '~/.rustup/toolchains/1.80.0-*
 
           ~/.rustup/update-hashes
 

--- a/src/rust/engine/graph/src/lib.rs
+++ b/src/rust/engine/graph/src/lib.rs
@@ -83,9 +83,9 @@ impl<N: Node> InnerGraph<N> {
     }
 
     ///
-    /// Locates all* cycles in running nodes in the graph, and terminates one Node in each of them.
+    /// Locates all cycles in running nodes in the graph, and terminates one Node in each of them.
     ///
-    /// * Finding "all simple cycles" in a graph is apparently best accomplished with [Johnson's
+    /// Note: Finding "all simple cycles" in a graph is apparently best accomplished with [Johnson's
     /// algorithm](https://www.cs.tufts.edu/comp/150GA/homeworks/hw1/Johnson%2075.PDF), which uses
     /// the strongly connected components, but goes a bit further. Because this method will run
     /// multiple times, we don't worry about that, and just kill one member of each SCC.

--- a/src/rust/engine/rust-toolchain
+++ b/src/rust/engine/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.79.0"
+channel = "1.80.0"
 # NB: We don't list the components (namely `clippy` and `rustfmt`) and instead rely on either the
 #  the profile being "default" (by-and-large the default profile) or the nice error message from
 #  `cargo fmt` and `cargo clippy` if the required component isn't installed

--- a/src/rust/engine/testutil/mock/src/cas.rs
+++ b/src/rust/engine/testutil/mock/src/cas.rs
@@ -27,7 +27,7 @@ use crate::cas_service::StubCASResponder;
 /// * ContentAddressableStorage
 /// * ActionCache
 /// * Capabilities
-/// ...gRPC APIs.
+/// * ...gRPC APIs.
 ///
 /// NB: You might expect that these services could be generically composed, but the
 /// `tonic::{Server, Router}` builder pattern changes its type with each call to `add_service`,


### PR DESCRIPTION
Upgrade to Rust v1.80.0.

Main visible change [as mentioned in the release notes](https://blog.rust-lang.org/2024/07/25/Rust-1.80.0.html) is the stablization of `LazyLock` and `LazyCell`.

Fixes clippy lints related to malformed Markdown in some doc comments.