### PR TITLE
Fix: attach lockfiles to terraform modules

### DIFF
--- a/src/python/pants/backend/terraform/dependencies.py
+++ b/src/python/pants/backend/terraform/dependencies.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from __future__ import annotations
 
+import os.path
 from dataclasses import dataclass
 from typing import Optional
 
@@ -15,7 +16,9 @@ from pants.backend.terraform.target_types import (
 )
 from pants.backend.terraform.tool import TerraformProcess
 from pants.backend.terraform.utils import terraform_arg, terraform_relpath
+from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
+from pants.engine.fs import DigestSubset, PathGlobs
 from pants.engine.internals.native_engine import Address, AddressInput, Digest, MergeDigests
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.process import FallibleProcessResult, ProcessExecutionFailure
@@ -113,8 +116,14 @@ class TerraformInitResponse:
     chdir: str
 
 
-@rule
-async def init_terraform(request: TerraformInitRequest) -> TerraformInitResponse:
+@dataclass(frozen=True)
+class TerraformUpgradeResponse:
+    lockfile: Digest
+    chdir: str
+
+
+async def run_terraform_init(request: TerraformInitRequest):
+    """Just run `terraform init`"""
     this_targets_dependencies = await Get(
         TransitiveTargets, TransitiveTargetsRequest((request.dependencies.address,))
     )
@@ -180,7 +189,7 @@ async def init_terraform(request: TerraformInitRequest) -> TerraformInitResponse
     )
 
     has_lockfile = invocation_files.lockfile is not None
-    third_party_deps = await Get(
+    init_response = await Get(
         TerraformDependenciesResponse,
         TerraformDependenciesRequest(
             chdir,
@@ -192,13 +201,20 @@ async def init_terraform(request: TerraformInitRequest) -> TerraformInitResponse
         ),
     )
 
+    return source_files, dependencies_files, init_response, chdir
+
+
+@rule
+async def terraform_init(request: TerraformInitRequest) -> TerraformInitResponse:
+    source_files, dependencies_files, init_response, chdir = await run_terraform_init(request)
+
     all_terraform_files = await Get(
         Digest,
         MergeDigests(
             [
                 source_files.snapshot.digest,
                 dependencies_files.snapshot.digest,
-                third_party_deps.digest,
+                init_response.digest,
             ]
         ),
     )
@@ -206,6 +222,25 @@ async def init_terraform(request: TerraformInitRequest) -> TerraformInitResponse
     return TerraformInitResponse(
         sources_and_deps=all_terraform_files, terraform_files=source_files, chdir=chdir
     )
+
+
+@rule
+async def terraform_upgrade_lockfile(request: TerraformInitRequest) -> TerraformUpgradeResponse:
+    _, _, init_response, chdir = await run_terraform_init(request)
+
+    lockfile = await Get(
+        Digest,
+        DigestSubset(
+            init_response.digest,
+            PathGlobs(
+                (os.path.join(chdir, ".terraform.lock.hcl"),),
+                glob_match_error_behavior=GlobMatchErrorBehavior.error,
+                description_of_origin="upgrade terraform lockfile with `terraform init`",
+            ),
+        ),
+    )
+
+    return TerraformUpgradeResponse(lockfile, chdir)
 
 
 def rules():

--- a/src/python/pants/backend/terraform/dependency_inference.py
+++ b/src/python/pants/backend/terraform/dependency_inference.py
@@ -302,8 +302,7 @@ async def infer_terraform_deployment_dependencies(
     )
     deps.extend(e.address for e in invocation_files.backend_configs)
     deps.extend(e.address for e in invocation_files.vars_files)
-    if invocation_files.lockfile:
-        deps.append(invocation_files.lockfile.address)
+    # lockfile is attached to the module itself
 
     return InferredDependencies(deps)
 

--- a/src/python/pants/backend/terraform/dependency_inference_test.py
+++ b/src/python/pants/backend/terraform/dependency_inference_test.py
@@ -161,8 +161,7 @@ def test_dependency_inference_autoinfered_files(rule_runner: RuleRunner) -> None
         ],
     )
     assert set(inferred_deps.include) == {
-        Address("src/tf", target_name=tgt)
-        for tgt in ("mod", "tfbackend", "tfvars", ".terraform.lock.hcl")
+        Address("src/tf", target_name=tgt) for tgt in ("mod", "tfbackend", "tfvars")
     }
 
 

--- a/src/python/pants/backend/terraform/goals/lockfiles.py
+++ b/src/python/pants/backend/terraform/goals/lockfiles.py
@@ -106,12 +106,13 @@ async def generate_lockfile_from_sources(
             ),
             lockfile_request.target[TerraformDependenciesField],
             initialise_backend=False,
-            upgrade=True,
         ),
     )
 
     return GenerateLockfileResult(
-        initialised_terraform.lockfile, lockfile_request.resolve_name, lockfile_request.lockfile_dest
+        initialised_terraform.lockfile,
+        lockfile_request.resolve_name,
+        lockfile_request.lockfile_dest,
     )
 
 

--- a/src/python/pants/backend/terraform/goals/lockfiles.py
+++ b/src/python/pants/backend/terraform/goals/lockfiles.py
@@ -4,7 +4,7 @@ import os.path
 from dataclasses import dataclass
 from pathlib import Path
 
-from pants.backend.terraform.dependencies import TerraformInitRequest, TerraformInitResponse
+from pants.backend.terraform.dependencies import TerraformInitRequest, TerraformUpgradeResponse
 from pants.backend.terraform.target_types import (
     TerraformDependenciesField,
     TerraformLockfileTarget,
@@ -12,7 +12,6 @@ from pants.backend.terraform.target_types import (
     TerraformModuleTarget,
     TerraformRootModuleField,
 )
-from pants.backend.terraform.tool import TerraformProcess
 from pants.core.goals.generate_lockfiles import (
     GenerateLockfile,
     GenerateLockfileResult,
@@ -27,7 +26,6 @@ from pants.engine.internals.native_engine import Address, AddressInput, Snapshot
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.internals.synthetic_targets import SyntheticAddressMaps, SyntheticTargetsRequest
 from pants.engine.internals.target_adaptor import TargetAdaptor
-from pants.engine.process import ProcessResult
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import AllTargets, Targets
 from pants.engine.unions import UnionRule
@@ -101,7 +99,7 @@ async def generate_lockfile_from_sources(
 ) -> GenerateLockfileResult:
     """Generate a Terraform lockfile by running `terraform providers lock` on the sources."""
     initialised_terraform = await Get(
-        TerraformInitResponse,
+        TerraformUpgradeResponse,
         TerraformInitRequest(
             TerraformRootModuleField(
                 lockfile_request.target.address.spec, lockfile_request.target.address
@@ -113,7 +111,7 @@ async def generate_lockfile_from_sources(
     )
 
     return GenerateLockfileResult(
-        result.output_digest, lockfile_request.resolve_name, lockfile_request.lockfile_dest
+        initialised_terraform.lockfile, lockfile_request.resolve_name, lockfile_request.lockfile_dest
     )
 
 

--- a/src/python/pants/backend/terraform/goals/lockfiles.py
+++ b/src/python/pants/backend/terraform/goals/lockfiles.py
@@ -111,19 +111,6 @@ async def generate_lockfile_from_sources(
             upgrade=True,
         ),
     )
-    result = await Get(
-        ProcessResult,
-        TerraformProcess(
-            args=(
-                "providers",
-                "lock",
-            ),
-            input_digest=initialised_terraform.sources_and_deps,
-            output_files=(".terraform.lock.hcl",),
-            description=f"Update terraform lockfile for {lockfile_request.resolve_name}",
-            chdir=initialised_terraform.chdir,
-        ),
-    )
 
     return GenerateLockfileResult(
         result.output_digest, lockfile_request.resolve_name, lockfile_request.lockfile_dest


### PR DESCRIPTION
#21099 made synthetic targets for lockfiles. `terraform_deployments` would then pull these in as source files. But `terraform validate` can be run against modules, and these were missing their lockfiles.

This MR attaches the lockfiles to the module. `terraform_deployment` targets still pull in the lockfile, but now transitively through the module.