### PR TITLE
Port JVM tools to use JvmToolBase and ExportableTool

### DIFF
--- a/docs/docs/writing-plugins/common-plugin-tasks/plugin-upgrade-guide.mdx
+++ b/docs/docs/writing-plugins/common-plugin-tasks/plugin-upgrade-guide.mdx
@@ -7,6 +7,72 @@ How to adjust for changes made to the Plugin API.
 
 ---
 
+## 2.23
+
+### Deprecated GenerateToolLockfileSentinel
+
+`GenerateToolLockfileSentinel` was used to generate lockfiles. It is deprecated in favour of `ExportableTool`.
+
+```python title=Before
+class JarJar(JvmToolBase):
+    ...
+
+class JarJarGeneratorLockfileSentinel(GenerateToolLockfileSentinel):
+    resolve_name = JarJar.options_scope
+
+
+@rule
+async def generate_jarjar_lockfile_request(
+    _: JarJarGeneratorLockfileSentinel, jarjar: JarJar
+) -> GenerateJvmLockfileFromTool:
+    return GenerateJvmLockfileFromTool.create(jarjar)
+
+
+def rules():
+    return [..., UnionRule(GenerateToolLockfileSentinel, JarJarGeneratorLockfileSentinel)]
+```
+
+```python title=After
+class JarJar(JvmToolBase):
+    ...
+
+def rules():
+    return [..., UnionRule(ExportableTool, JarJar)]
+```
+
+#### JVM: Deprecated Get(GenerateJvmLockfileFromTool, GenerateToolLockfileSentinel) for lockfiles
+
+As part of the deprecation, `GenerateJvmLockfileFromTool` can be invoked directly on your tool, without a Get. You may need to request your `JvmToolBase`
+
+```python title=Before
+@rule
+async def shade_jar(request: ShadeJarRequest, jdk: InternalJdk, jarjar: JarJar) -> ShadedJar:
+    ...
+    lockfile_request = await Get(GenerateJvmLockfileFromTool, JarJarGeneratorLockfileSentinel())
+
+    tool_classpath = await Get(ToolClasspath, ToolClasspathRequest(lockfile=lockfile_request))
+```
+
+```python title=After
+@rule
+async def shade_jar(request: ShadeJarRequest, jdk: InternalJdk, jarjar: JarJar) -> ShadedJar:
+    ...
+    await Get(
+            ToolClasspath, ToolClasspathRequest(lockfile=GenerateJvmLockfileFromTool.create(jarjar))
+        )
+```
+
+### JVM: Migrating from GenerateJvmLockfileFromTool to JvmToolBase
+
+`JvmToolBase` is the preferred way to define JVM-based tools.
+
+1. set the `options_scope`, usually to the `resolve_name`
+2. set the `help`
+3. `default_artifacts` is the `artifact_inputs` converted to a tuple. A version can be replaced by `{version}` and moved to the `default_version` field
+4. `default_lockfile_resource` is the same
+
+A `GenerateJvmLockfileFromTool` is created from a `JvmToolBase` with `GenerateJvmLockfileFromTool.create`
+
 ## 2.17
 
 ### Deprecated some `Request` types in favor of `Get` with only one arg

--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -71,6 +71,10 @@ The Scala dependency inference now understand usages of the `_root_` package nam
 
 Scala dependency inference now also understands types refered to only by pattern matching cases such as `case MyType() =>`. These used to require manually adding a dependency if the type was defined in a separate file even if it was in the same package. This is now inferred.
 
+#### JVM
+
+All JVM tools have been refactored to use a different configuration mechanism. This includes the internal dependency parsers for Java, Kotlin, and Scala; internal JarTool, StripJarTool, and JarJar; and the OpenAPI code generator. This new mechanism should have parity.
+
 #### NEW: Trufflehog
 
 A new experimental `pants.backend.experimental.tools.trufflehog` backend was added to support

--- a/src/python/pants/backend/java/dependency_inference/java_parser.py
+++ b/src/python/pants/backend/java/dependency_inference/java_parser.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 import pkg_resources
 
 from pants.backend.java.dependency_inference.types import JavaSourceDependencyAnalysis
-from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
+from pants.core.goals.resolves import ExportableTool
 from pants.core.util_rules.source_files import SourceFiles
 from pants.engine.fs import AddPrefix, CreateDigest, Digest, DigestContents, Directory, FileContent
 from pants.engine.internals.native_engine import MergeDigests, RemovePrefix
@@ -20,11 +20,7 @@ from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.jvm.jdk_rules import InternalJdk, JvmProcess
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
-from pants.jvm.resolve.jvm_tool import (
-    GenerateJvmLockfileFromTool,
-    GenerateJvmToolLockfileSentinel,
-    JvmToolBase,
-)
+from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool, JvmToolBase
 from pants.util.logging import LogLevel
 
 logger = logging.getLogger(__name__)
@@ -33,8 +29,19 @@ logger = logging.getLogger(__name__)
 _LAUNCHER_BASENAME = "PantsJavaParserLauncher.java"
 
 
-class JavaParserToolLockfileSentinel(GenerateJvmToolLockfileSentinel):
-    resolve_name = "java-parser"
+class JavaParser(JvmToolBase):
+    options_scope = "java_parser"
+    help = "Internal tool for parsing JVM sources to identify dependencies"
+
+    default_artifacts = (
+        "com.fasterxml.jackson.core:jackson-databind:2.12.4",
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.12.4",
+        "com.github.javaparser:javaparser-symbol-solver-core:3.25.5",
+    )
+    default_lockfile_resource = (
+        "pants.backend.java.dependency_inference",
+        "java_parser.lock",
+    )
 
 
 @dataclass(frozen=True)
@@ -77,6 +84,7 @@ async def make_analysis_request_from_source_files(
 async def analyze_java_source_dependencies(
     processor_classfiles: JavaParserCompiledClassfiles,
     jdk: InternalJdk,
+    tool: JavaParser,
     request: JavaSourceDependencyAnalysisRequest,
 ) -> FallibleJavaSourceDependencyAnalysisResult:
     source_files = request.source_files
@@ -93,13 +101,10 @@ async def analyze_java_source_dependencies(
     processorcp_relpath = "__processorcp"
     toolcp_relpath = "__toolcp"
 
-    parser_lockfile_request = await Get(
-        GenerateJvmLockfileFromTool, JavaParserToolLockfileSentinel()
-    )
     tool_classpath, prefixed_source_files_digest = await MultiGet(
         Get(
             ToolClasspath,
-            ToolClasspathRequest(lockfile=parser_lockfile_request),
+            ToolClasspathRequest(lockfile=(GenerateJvmLockfileFromTool.create(tool))),
         ),
         Get(Digest, AddPrefix(source_files.snapshot.digest, source_prefix)),
     )
@@ -142,15 +147,14 @@ def _load_javaparser_launcher_source() -> bytes:
 
 # TODO(13879): Consolidate compilation of wrapper binaries to common rules.
 @rule
-async def build_processors(jdk: InternalJdk) -> JavaParserCompiledClassfiles:
+async def build_processors(jdk: InternalJdk, tool: JavaParser) -> JavaParserCompiledClassfiles:
     dest_dir = "classfiles"
-    parser_lockfile_request = await Get(
-        GenerateJvmLockfileFromTool, JavaParserToolLockfileSentinel()
-    )
     materialized_classpath, source_digest = await MultiGet(
         Get(
             ToolClasspath,
-            ToolClasspathRequest(prefix="__toolcp", lockfile=parser_lockfile_request),
+            ToolClasspathRequest(
+                prefix="__toolcp", lockfile=GenerateJvmLockfileFromTool.create(tool)
+            ),
         ),
         Get(
             Digest,
@@ -203,30 +207,8 @@ async def build_processors(jdk: InternalJdk) -> JavaParserCompiledClassfiles:
     return JavaParserCompiledClassfiles(digest=stripped_classfiles_digest)
 
 
-class JavaParser(JvmToolBase):
-    options_scope = "java_parser"
-    help = "Internal tool for parsing JVM sources to identify dependencies"
-
-    default_artifacts = (
-        "com.fasterxml.jackson.core:jackson-databind:2.12.4",
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.12.4",
-        "com.github.javaparser:javaparser-symbol-solver-core:3.25.5",
-    )
-    default_lockfile_resource = (
-        "pants.backend.java.dependency_inference",
-        "java_parser.lock",
-    )
-
-
-@rule
-def generate_java_parser_lockfile_request(
-    _: JavaParserToolLockfileSentinel, tool: JavaParser
-) -> GenerateJvmLockfileFromTool:
-    return GenerateJvmLockfileFromTool.create(tool)
-
-
 def rules():
-    return [
+    return (
         *collect_rules(),
-        UnionRule(GenerateToolLockfileSentinel, JavaParserToolLockfileSentinel),
-    ]
+        UnionRule(ExportableTool, JavaParser),
+    )

--- a/src/python/pants/backend/java/dependency_inference/java_parser.py
+++ b/src/python/pants/backend/java/dependency_inference/java_parser.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 import pkg_resources
 
 from pants.backend.java.dependency_inference.types import JavaSourceDependencyAnalysis
-from pants.core.goals.generate_lockfiles import DEFAULT_TOOL_LOCKFILE, GenerateToolLockfileSentinel
+from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.util_rules.source_files import SourceFiles
 from pants.engine.fs import AddPrefix, CreateDigest, Digest, DigestContents, Directory, FileContent
 from pants.engine.internals.native_engine import MergeDigests, RemovePrefix
@@ -20,7 +20,11 @@ from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.jvm.jdk_rules import InternalJdk, JvmProcess
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
-from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool, GenerateJvmToolLockfileSentinel, JvmToolBase
+from pants.jvm.resolve.jvm_tool import (
+    GenerateJvmLockfileFromTool,
+    GenerateJvmToolLockfileSentinel,
+    JvmToolBase,
+)
 from pants.util.logging import LogLevel
 
 logger = logging.getLogger(__name__)
@@ -204,9 +208,9 @@ class JavaParser(JvmToolBase):
     help = "Internal tool for parsing JVM sources to identify dependencies"
 
     default_artifacts = (
-                "com.fasterxml.jackson.core:jackson-databind:2.12.4",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.12.4",
-                "com.github.javaparser:javaparser-symbol-solver-core:3.25.5",
+        "com.fasterxml.jackson.core:jackson-databind:2.12.4",
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.12.4",
+        "com.github.javaparser:javaparser-symbol-solver-core:3.25.5",
     )
     default_lockfile_resource = (
         "pants.backend.java.dependency_inference",

--- a/src/python/pants/backend/java/dependency_inference/java_parser.py
+++ b/src/python/pants/backend/java/dependency_inference/java_parser.py
@@ -30,7 +30,7 @@ _LAUNCHER_BASENAME = "PantsJavaParserLauncher.java"
 
 
 class JavaParser(JvmToolBase):
-    options_scope = "java_parser"
+    options_scope = "java-parser"
     help = "Internal tool for parsing JVM sources to identify dependencies"
 
     default_artifacts = (

--- a/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser.py
+++ b/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser.py
@@ -254,7 +254,7 @@ async def setup_kotlin_parser_classfiles(
                         Coordinate(
                             group="org.jetbrains.kotlin",
                             artifact="kotlin-compiler-embeddable",
-                            version=tool.version
+                            version=tool.version,
                         ),
                     ]
                 ),
@@ -262,7 +262,9 @@ async def setup_kotlin_parser_classfiles(
         ),
         Get(
             ToolClasspath,
-            ToolClasspathRequest(prefix="__parsercp", lockfile=(GenerateJvmLockfileFromTool.create(tool))),
+            ToolClasspathRequest(
+                prefix="__parsercp", lockfile=(GenerateJvmLockfileFromTool.create(tool))
+            ),
         ),
         Get(Digest, CreateDigest([parser_source, Directory(dest_dir)])),
     )

--- a/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser.py
+++ b/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser.py
@@ -7,7 +7,7 @@ import os
 from dataclasses import dataclass
 from typing import Any, Iterator
 
-from pants.core.goals.generate_lockfiles import DEFAULT_TOOL_LOCKFILE, GenerateToolLockfileSentinel
+from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.util_rules.source_files import SourceFiles
 from pants.engine.fs import CreateDigest, DigestContents, Directory, FileContent
 from pants.engine.internals.native_engine import AddPrefix, Digest, MergeDigests, RemovePrefix
@@ -20,10 +20,13 @@ from pants.jvm.jdk_rules import InternalJdk, JdkEnvironment, JdkRequest, JvmProc
 from pants.jvm.resolve.common import ArtifactRequirements
 from pants.jvm.resolve.coordinate import Coordinate
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
-from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool, GenerateJvmToolLockfileSentinel, JvmToolBase
+from pants.jvm.resolve.jvm_tool import (
+    GenerateJvmLockfileFromTool,
+    GenerateJvmToolLockfileSentinel,
+    JvmToolBase,
+)
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
-from pants.util.ordered_set import FrozenOrderedSet
 from pants.util.resources import read_resource
 
 _PARSER_KOTLIN_VERSION = "1.6.20"
@@ -304,14 +307,14 @@ class KotlinParser(JvmToolBase):
 
     default_version = _PARSER_KOTLIN_VERSION
     default_artifacts = (
-                "org.jetbrains.kotlin:kotlin-compiler:{version}",
-                "org.jetbrains.kotlin:kotlin-stdlib:{version}",
-                "com.google.code.gson:gson:2.9.0",
+        "org.jetbrains.kotlin:kotlin-compiler:{version}",
+        "org.jetbrains.kotlin:kotlin-stdlib:{version}",
+        "com.google.code.gson:gson:2.9.0",
     )
     default_lockfile_resource = (
-            "pants.backend.kotlin.dependency_inference",
-            "kotlin_parser.lock",
-        )
+        "pants.backend.kotlin.dependency_inference",
+        "kotlin_parser.lock",
+    )
 
 
 @rule

--- a/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser.py
+++ b/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser.py
@@ -29,7 +29,7 @@ _PARSER_KOTLIN_VERSION = "1.6.20"
 
 
 class KotlinParser(JvmToolBase):
-    options_scope = "kotlin_parser"
+    options_scope = "kotlin-parser"
     help = "Internal tool for parsing Kotlin sources to identify dependencies"
 
     default_version = _PARSER_KOTLIN_VERSION

--- a/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser.py
+++ b/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser.py
@@ -244,7 +244,6 @@ async def setup_kotlin_parser_classfiles(
 
     parser_source = FileContent("KotlinParser.kt", parser_source_content)
 
-    parser_lockfile_request = GenerateJvmLockfileFromTool.create(tool)
     tool_classpath, parser_classpath, source_digest = await MultiGet(
         Get(
             ToolClasspath,
@@ -255,7 +254,7 @@ async def setup_kotlin_parser_classfiles(
                         Coordinate(
                             group="org.jetbrains.kotlin",
                             artifact="kotlin-compiler-embeddable",
-                            version=_PARSER_KOTLIN_VERSION,  # TODO: Pull from resolve or hard-code Kotlin version?
+                            version=tool.version
                         ),
                     ]
                 ),
@@ -263,7 +262,7 @@ async def setup_kotlin_parser_classfiles(
         ),
         Get(
             ToolClasspath,
-            ToolClasspathRequest(prefix="__parsercp", lockfile=parser_lockfile_request),
+            ToolClasspathRequest(prefix="__parsercp", lockfile=(GenerateJvmLockfileFromTool.create(tool))),
         ),
         Get(Digest, CreateDigest([parser_source, Directory(dest_dir)])),
     )

--- a/src/python/pants/backend/openapi/subsystems/openapi_generator.py
+++ b/src/python/pants/backend/openapi/subsystems/openapi_generator.py
@@ -1,10 +1,10 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
-from pants.engine.rules import collect_rules, rule
+from pants.core.goals.resolves import ExportableTool
+from pants.engine.rules import collect_rules
 from pants.engine.unions import UnionRule
-from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool, JvmToolBase
+from pants.jvm.resolve.jvm_tool import JvmToolBase
 
 
 class OpenAPIGenerator(JvmToolBase):
@@ -19,19 +19,8 @@ class OpenAPIGenerator(JvmToolBase):
     )
 
 
-class OpenAPIGeneratorLockfileSentinel(GenerateToolLockfileSentinel):
-    resolve_name = OpenAPIGenerator.options_scope
-
-
-@rule
-async def generate_openapi_generator_lockfile_request(
-    _: OpenAPIGeneratorLockfileSentinel, openapi_generator: OpenAPIGenerator
-) -> GenerateJvmLockfileFromTool:
-    return GenerateJvmLockfileFromTool.create(openapi_generator)
-
-
 def rules():
     return [
         *collect_rules(),
-        UnionRule(GenerateToolLockfileSentinel, OpenAPIGeneratorLockfileSentinel),
+        UnionRule(ExportableTool, OpenAPIGenerator),
     ]

--- a/src/python/pants/backend/openapi/util_rules/generator_process.py
+++ b/src/python/pants/backend/openapi/util_rules/generator_process.py
@@ -9,10 +9,7 @@ from enum import Enum, unique
 from typing import Iterable, Mapping
 
 from pants.backend.openapi.subsystems import openapi_generator
-from pants.backend.openapi.subsystems.openapi_generator import (
-    OpenAPIGenerator,
-    OpenAPIGeneratorLockfileSentinel,
-)
+from pants.backend.openapi.subsystems.openapi_generator import OpenAPIGenerator
 from pants.engine.fs import Digest
 from pants.engine.process import Process, ProcessCacheScope
 from pants.engine.rules import Get, collect_rules, rule
@@ -85,8 +82,9 @@ _GENERATOR_CLASS_NAME = "org.openapitools.codegen.OpenAPIGenerator"
 async def openapi_generator_process(
     request: OpenAPIGeneratorProcess, jdk: InternalJdk, subsystem: OpenAPIGenerator
 ) -> Process:
-    lockfile_request = await Get(GenerateJvmLockfileFromTool, OpenAPIGeneratorLockfileSentinel())
-    tool_classpath = await Get(ToolClasspath, ToolClasspathRequest(lockfile=lockfile_request))
+    tool_classpath = await Get(
+        ToolClasspath, ToolClasspathRequest(lockfile=GenerateJvmLockfileFromTool.create(subsystem))
+    )
 
     toolcp_relpath = "__toolcp"
     immutable_input_digests = {

--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -206,14 +206,6 @@ class KnownPythonUserResolveNamesRequest(KnownUserResolveNamesRequest):
     pass
 
 
-def python_exportable_tools(union_membership: UnionMembership) -> dict[str, type[PythonToolBase]]:
-    exportable_tools = union_membership.get(ExportableTool)
-    names_of_python_tools: dict[str, type[PythonToolBase]] = {
-        e.options_scope: e for e in exportable_tools if issubclass(e, PythonToolBase)  # type: ignore  # mypy isn't narrowing with `issubclass`
-    }
-    return names_of_python_tools
-
-
 @rule
 def determine_python_user_resolves(
     _: KnownPythonUserResolveNamesRequest,

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser.py
@@ -54,7 +54,7 @@ _PARSER_SCALA_BINARY_VERSION = _PARSER_SCALA_VERSION.binary
 
 
 class ScalaParser(JvmToolBase):
-    options_scope = "scala_parser"
+    options_scope = "scala-parser"
     help = "Internal tool for parsing Scala sources to identify dependencies"
 
     default_artifacts = (

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser.py
@@ -375,7 +375,7 @@ async def setup_scala_parser_classfiles(
 
     parser_source = FileContent("ScalaParser.scala", parser_source_content)
 
-    scala_artifacts = Get(
+    scala_artifacts = await Get(
         ScalaArtifactsForVersionResult, ScalaArtifactsForVersionRequest(_PARSER_SCALA_VERSION)
     )
 

--- a/src/python/pants/backend/scala/util_rules/versions.py
+++ b/src/python/pants/backend/scala/util_rules/versions.py
@@ -109,21 +109,20 @@ class ScalaArtifactsForVersionResult:
         return tuple(coords)
 
 
-@rule
-async def resolve_scala_artifacts_for_version(
-    request: ScalaArtifactsForVersionRequest,
+def _resolve_scala_artifacts_for_version(
+    scala_version: ScalaVersion,
 ) -> ScalaArtifactsForVersionResult:
-    if request.scala_version.major == 3:
+    if scala_version.major == 3:
         return ScalaArtifactsForVersionResult(
             compiler_coordinate=Coordinate(
                 group="org.scala-lang",
                 artifact="scala3-compiler_3",
-                version=str(request.scala_version),
+                version=str(scala_version),
             ),
             library_coordinate=Coordinate(
                 group="org.scala-lang",
                 artifact="scala3-library_3",
-                version=str(request.scala_version),
+                version=str(scala_version),
             ),
             reflect_coordinate=None,
             compiler_main="dotty.tools.dotc.Main",
@@ -134,21 +133,28 @@ async def resolve_scala_artifacts_for_version(
         compiler_coordinate=Coordinate(
             group="org.scala-lang",
             artifact="scala-compiler",
-            version=str(request.scala_version),
+            version=str(scala_version),
         ),
         library_coordinate=Coordinate(
             group="org.scala-lang",
             artifact="scala-library",
-            version=str(request.scala_version),
+            version=str(scala_version),
         ),
         reflect_coordinate=Coordinate(
             group="org.scala-lang",
             artifact="scala-reflect",
-            version=str(request.scala_version),
+            version=str(scala_version),
         ),
         compiler_main="scala.tools.nsc.Main",
         repl_main="scala.tools.nsc.MainGenericRunner",
     )
+
+
+@rule
+async def resolve_scala_artifacts_for_version(
+    request: ScalaArtifactsForVersionRequest,
+) -> ScalaArtifactsForVersionResult:
+    return _resolve_scala_artifacts_for_version(request.scala_version)
 
 
 def rules():

--- a/src/python/pants/jvm/goals/lockfile.py
+++ b/src/python/pants/jvm/goals/lockfile.py
@@ -219,9 +219,7 @@ async def setup_lockfile_request_from_tool(
         artifacts=artifacts,
         resolve_name=request.resolve_name,
         lockfile_dest=(
-            request.write_lockfile_dest
-            if request.read_lockfile_dest != DEFAULT_TOOL_LOCKFILE
-            else DEFAULT_TOOL_LOCKFILE
+            request.lockfile if request.lockfile != DEFAULT_TOOL_LOCKFILE else DEFAULT_TOOL_LOCKFILE
         ),
         diff=False,
     )

--- a/src/python/pants/jvm/jar_tool/jar_tool.py
+++ b/src/python/pants/jvm/jar_tool/jar_tool.py
@@ -11,7 +11,7 @@ from typing import Iterable, Mapping
 import pkg_resources
 
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
-from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
+from pants.core.goals.resolves import ExportableTool
 from pants.engine.fs import (
     CreateDigest,
     Digest,
@@ -35,6 +35,21 @@ from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool, JvmToolBase
 from pants.jvm.resolve.jvm_tool import rules as jvm_tool_rules
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
+
+
+class JarTool(JvmToolBase):
+    options_scope = "jar_tool"
+    help = "The Java Archive Tool"
+
+    default_artifacts = (
+        "args4j:args4j:2.33",
+        "com.google.code.findbugs:jsr305:3.0.2",
+        "com.google.guava:guava:18.0",
+    )
+    default_lockfile_resource = (
+        "pants.jvm.jar_tool",
+        "jar_tool.lock",
+    )
 
 
 @unique
@@ -111,10 +126,6 @@ class JarToolRequest:
 _JAR_TOOL_MAIN_CLASS = "org.pantsbuild.tools.jar.Main"
 
 
-class JarToolGenerateLockfileSentinel(GenerateToolLockfileSentinel):
-    resolve_name = "jar_tool"
-
-
 @dataclass(frozen=True)
 class JarToolCompiledClassfiles:
     digest: Digest
@@ -122,17 +133,15 @@ class JarToolCompiledClassfiles:
 
 @rule
 async def run_jar_tool(
-    request: JarToolRequest, jdk: InternalJdk, jar_tool: JarToolCompiledClassfiles
+    request: JarToolRequest, jdk: InternalJdk, tool: JarTool, jar_tool: JarToolCompiledClassfiles
 ) -> Digest:
     output_prefix = "__out"
     output_jarname = os.path.join(output_prefix, request.jar_name)
 
-    lockfile_request, empty_output_digest = await MultiGet(
-        Get(GenerateJvmLockfileFromTool, JarToolGenerateLockfileSentinel()),
+    tool_classpath, empty_output_digest = await MultiGet(
+        Get(ToolClasspath, ToolClasspathRequest(lockfile=GenerateJvmLockfileFromTool.create(tool))),
         Get(Digest, CreateDigest([Directory(output_prefix)])),
     )
-
-    tool_classpath = await Get(ToolClasspath, ToolClasspathRequest(lockfile=lockfile_request))
 
     toolcp_prefix = "__toolcp"
     jartoolcp_prefix = "__jartoolcp"
@@ -218,18 +227,20 @@ def _load_jar_tool_sources() -> list[FileContent]:
 
 # TODO(13879): Consolidate compilation of wrapper binaries to common rules.
 @rule
-async def build_jar_tool(jdk: InternalJdk) -> JarToolCompiledClassfiles:
-    lockfile_request, source_digest = await MultiGet(
-        Get(GenerateJvmLockfileFromTool, JarToolGenerateLockfileSentinel()),
-        Get(
-            Digest,
-            CreateDigest(_load_jar_tool_sources()),
-        ),
+async def build_jar_tool(jdk: InternalJdk, tool: JarTool) -> JarToolCompiledClassfiles:
+    source_digest = await Get(
+        Digest,
+        CreateDigest(_load_jar_tool_sources()),
     )
 
     dest_dir = "classfiles"
     materialized_classpath, java_subset_digest, empty_dest_dir = await MultiGet(
-        Get(ToolClasspath, ToolClasspathRequest(prefix="__toolcp", lockfile=lockfile_request)),
+        Get(
+            ToolClasspath,
+            ToolClasspathRequest(
+                prefix="__toolcp", lockfile=GenerateJvmLockfileFromTool.create(tool)
+            ),
+        ),
         Get(
             Digest,
             DigestSubset(
@@ -279,33 +290,11 @@ async def build_jar_tool(jdk: InternalJdk) -> JarToolCompiledClassfiles:
     return JarToolCompiledClassfiles(digest=stripped_classfiles_digest)
 
 
-class JarTool(JvmToolBase):
-    options_scope = "jar_tool"
-    help = "The Java Archive Tool"
-
-    default_artifacts = (
-        "args4j:args4j:2.33",
-        "com.google.code.findbugs:jsr305:3.0.2",
-        "com.google.guava:guava:18.0",
-    )
-    default_lockfile_resource = (
-        "pants.jvm.jar_tool",
-        "jar_tool.lock",
-    )
-
-
-@rule
-async def generate_jartool_lockfile_request(
-    _: JarToolGenerateLockfileSentinel, tool: JarTool
-) -> GenerateJvmLockfileFromTool:
-    return GenerateJvmLockfileFromTool.create(tool)
-
-
 def rules():
     return [
         *collect_rules(),
         *coursier_fetch_rules(),
         *jdk_rules(),
         *jvm_tool_rules(),
-        UnionRule(GenerateToolLockfileSentinel, JarToolGenerateLockfileSentinel),
+        UnionRule(ExportableTool, JarTool),
     ]

--- a/src/python/pants/jvm/jar_tool/jar_tool.py
+++ b/src/python/pants/jvm/jar_tool/jar_tool.py
@@ -11,7 +11,7 @@ from typing import Iterable, Mapping
 import pkg_resources
 
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
-from pants.core.goals.generate_lockfiles import DEFAULT_TOOL_LOCKFILE, GenerateToolLockfileSentinel
+from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.engine.fs import (
     CreateDigest,
     Digest,
@@ -35,7 +35,6 @@ from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool, JvmToolBase
 from pants.jvm.resolve.jvm_tool import rules as jvm_tool_rules
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
-from pants.util.ordered_set import FrozenOrderedSet
 
 
 @unique
@@ -279,16 +278,20 @@ async def build_jar_tool(jdk: InternalJdk) -> JarToolCompiledClassfiles:
     )
     return JarToolCompiledClassfiles(digest=stripped_classfiles_digest)
 
+
 class JarTool(JvmToolBase):
     options_scope = "jar_tool"
-    help = ""
+    help = "The Java Archive Tool"
 
     default_artifacts = (
-       "args4j:args4j:2.33",
-       "com.google.code.findbugs:jsr305:3.0.2",
-       "com.google.guava:guava:18.0",
+        "args4j:args4j:2.33",
+        "com.google.code.findbugs:jsr305:3.0.2",
+        "com.google.guava:guava:18.0",
     )
-    default_lockfile_resource = ("pants.jvm.jar_tool", "jar_tool.lock",)
+    default_lockfile_resource = (
+        "pants.jvm.jar_tool",
+        "jar_tool.lock",
+    )
 
 
 @rule

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -778,16 +778,16 @@ async def materialize_classpath_for_tool(request: ToolClasspathRequest) -> ToolC
         lockfile_req = request.lockfile
         assert lockfile_req is not None
         regen_command = f"`{GenerateLockfilesSubsystem.name} --resolve={lockfile_req.resolve_name}`"
-        if lockfile_req.read_lockfile_dest == DEFAULT_TOOL_LOCKFILE:
+        if lockfile_req.lockfile == DEFAULT_TOOL_LOCKFILE:
             lockfile_bytes = importlib.resources.read_binary(
                 *lockfile_req.default_lockfile_resource
             )
             resolution = CoursierResolvedLockfile.from_serialized(lockfile_bytes)
         else:
-            lockfile_snapshot = await Get(Snapshot, PathGlobs([lockfile_req.read_lockfile_dest]))
+            lockfile_snapshot = await Get(Snapshot, PathGlobs([lockfile_req.lockfile]))
             if not lockfile_snapshot.files:
                 raise ValueError(
-                    f"No lockfile found at {lockfile_req.read_lockfile_dest}, which is configured "
+                    f"No lockfile found at {lockfile_req.lockfile}, which is configured "
                     f"by the option {lockfile_req.lockfile_option_name}."
                     f"Run {regen_command} to generate it."
                 )
@@ -796,7 +796,7 @@ async def materialize_classpath_for_tool(request: ToolClasspathRequest) -> ToolC
                 CoursierResolvedLockfile,
                 CoursierResolveKey(
                     name=lockfile_req.resolve_name,
-                    path=lockfile_req.read_lockfile_dest,
+                    path=lockfile_req.lockfile,
                     digest=lockfile_snapshot.digest,
                 ),
             )
@@ -812,7 +812,7 @@ async def materialize_classpath_for_tool(request: ToolClasspathRequest) -> ToolC
             lockfile_inputs, LockfileContext.TOOL
         ):
             raise ValueError(
-                f"The lockfile {lockfile_req.read_lockfile_dest} (configured by the option "
+                f"The lockfile {lockfile_req.lockfile} (configured by the option "
                 f"{lockfile_req.lockfile_option_name}) was generated with different requirements "
                 f"than are currently set via {lockfile_req.artifact_option_name}. Run "
                 f"{regen_command} to regenerate the lockfile."

--- a/src/python/pants/jvm/resolve/jvm_tool.py
+++ b/src/python/pants/jvm/resolve/jvm_tool.py
@@ -198,24 +198,28 @@ class GenerateJvmLockfileFromTool:
     """
 
     artifact_inputs: FrozenOrderedSet[str]
-    artifact_option_name: str
-    lockfile_option_name: str
+    options_scope: str
     resolve_name: str
-    read_lockfile_dest: str  # Path to lockfile when reading, or DEFAULT_TOOL_LOCKFILE to read from resource.
-    write_lockfile_dest: str  # Path to lockfile when generating the lockfile.
+    lockfile: str
     default_lockfile_resource: tuple[str, str]
 
     @classmethod
     def create(cls, tool: JvmToolBase) -> GenerateJvmLockfileFromTool:
         return GenerateJvmLockfileFromTool(
             FrozenOrderedSet(tool.artifact_inputs),
-            artifact_option_name=f"[{tool.options_scope}].artifacts",
-            lockfile_option_name=f"[{tool.options_scope}].lockfile",
+            options_scope=tool.options_scope,
             resolve_name=tool.options_scope,
-            read_lockfile_dest=tool.lockfile,
-            write_lockfile_dest=tool.lockfile,
+            lockfile=tool.lockfile,
             default_lockfile_resource=tool.default_lockfile_resource,
         )
+
+    @property
+    def artifact_option_name(self) -> str:
+        return f"[{self.options_scope}].artifacts"
+
+    @property
+    def lockfile_option_name(self):
+        return f"[{self.options_scope}].lockfile"
 
 
 def rules():

--- a/src/python/pants/jvm/resolve/jvm_tool.py
+++ b/src/python/pants/jvm/resolve/jvm_tool.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import ClassVar
 
 from pants.build_graph.address import Address, AddressInput
-from pants.core.goals.generate_lockfiles import DEFAULT_TOOL_LOCKFILE, GenerateToolLockfileSentinel
+from pants.core.goals.generate_lockfiles import DEFAULT_TOOL_LOCKFILE
 from pants.core.goals.resolves import ExportableTool
 from pants.engine.addresses import Addresses
 from pants.engine.internals.selectors import Get, MultiGet
@@ -182,10 +182,6 @@ async def gather_coordinates_for_jvm_lockfile(
         )
 
     return ArtifactRequirements(requirements)
-
-
-class GenerateJvmToolLockfileSentinel(GenerateToolLockfileSentinel):
-    pass
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/jvm/resolve/jvm_tool_test.py
+++ b/src/python/pants/jvm/resolve/jvm_tool_test.py
@@ -17,7 +17,7 @@ from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
 from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool, JvmToolBase
 from pants.jvm.target_types import JvmArtifactTarget
 from pants.jvm.util_rules import rules as util_rules
-from pants.option.scope import ScopedOptions, Scope
+from pants.option.scope import Scope, ScopedOptions
 from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunner
 
 

--- a/src/python/pants/jvm/shading/jarjar.py
+++ b/src/python/pants/jvm/shading/jarjar.py
@@ -3,10 +3,10 @@
 
 from enum import Enum, unique
 
-from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
-from pants.engine.rules import collect_rules, rule
+from pants.core.goals.resolves import ExportableTool
+from pants.engine.rules import collect_rules
 from pants.engine.unions import UnionRule
-from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool, JvmToolBase
+from pants.jvm.resolve.jvm_tool import JvmToolBase
 from pants.option.option_types import BoolOption, EnumOption
 
 
@@ -37,19 +37,8 @@ class JarJar(JvmToolBase):
     )
 
 
-class JarJarGeneratorLockfileSentinel(GenerateToolLockfileSentinel):
-    resolve_name = JarJar.options_scope
-
-
-@rule
-async def generate_jarjar_lockfile_request(
-    _: JarJarGeneratorLockfileSentinel, jarjar: JarJar
-) -> GenerateJvmLockfileFromTool:
-    return GenerateJvmLockfileFromTool.create(jarjar)
-
-
 def rules():
     return [
         *collect_rules(),
-        UnionRule(GenerateToolLockfileSentinel, JarJarGeneratorLockfileSentinel),
+        UnionRule(ExportableTool, JarJar),
     ]

--- a/src/python/pants/jvm/shading/rules.py
+++ b/src/python/pants/jvm/shading/rules.py
@@ -25,7 +25,7 @@ from pants.jvm.jdk_rules import InternalJdk, JvmProcess
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
 from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool
 from pants.jvm.shading import jarjar
-from pants.jvm.shading.jarjar import JarJar, JarJarGeneratorLockfileSentinel, MisplacedClassStrategy
+from pants.jvm.shading.jarjar import JarJar, MisplacedClassStrategy
 from pants.jvm.target_types import JvmShadingRule, _shading_validate_rules
 from pants.util.logging import LogLevel
 
@@ -89,8 +89,7 @@ async def shade_jar(request: ShadeJarRequest, jdk: InternalJdk, jarjar: JarJar) 
     rule_config_content = "\n".join([rule.encode() for rule in request.rules]) + "\n"
     logger.debug(f"Using JarJar rule file with following contents:\n{rule_config_content}")
 
-    lockfile_request, conf_digest, output_digest = await MultiGet(
-        Get(GenerateJvmLockfileFromTool, JarJarGeneratorLockfileSentinel()),
+    conf_digest, output_digest = await MultiGet(
         Get(
             Digest,
             CreateDigest(
@@ -106,7 +105,9 @@ async def shade_jar(request: ShadeJarRequest, jdk: InternalJdk, jarjar: JarJar) 
     )
 
     tool_classpath, input_digest = await MultiGet(
-        Get(ToolClasspath, ToolClasspathRequest(lockfile=lockfile_request)),
+        Get(
+            ToolClasspath, ToolClasspathRequest(lockfile=GenerateJvmLockfileFromTool.create(jarjar))
+        ),
         Get(Digest, MergeDigests([request.digest, output_digest])),
     )
 

--- a/src/python/pants/jvm/strip_jar/strip_jar.py
+++ b/src/python/pants/jvm/strip_jar/strip_jar.py
@@ -22,7 +22,7 @@ _OUTPUT_PATH = "__stripped_jars"
 
 
 class StripJarTool(JvmToolBase):
-    options_scope = "strip_jar"
+    options_scope = "strip-jar"
     help = "Reproducible Build Maven Plugin"
 
     default_version = "0.16"

--- a/src/python/pants/jvm/strip_jar/strip_jar.py
+++ b/src/python/pants/jvm/strip_jar/strip_jar.py
@@ -6,7 +6,7 @@ from typing import Tuple
 
 import pkg_resources
 
-from pants.core.goals.generate_lockfiles import DEFAULT_TOOL_LOCKFILE, GenerateToolLockfileSentinel
+from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.engine.fs import AddPrefix, CreateDigest, Digest, Directory, FileContent
 from pants.engine.internals.native_engine import MergeDigests, RemovePrefix
 from pants.engine.process import FallibleProcessResult, ProcessResult
@@ -14,9 +14,12 @@ from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.jvm.jdk_rules import InternalJdk, JvmProcess
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
-from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool, GenerateJvmToolLockfileSentinel, JvmToolBase
+from pants.jvm.resolve.jvm_tool import (
+    GenerateJvmLockfileFromTool,
+    GenerateJvmToolLockfileSentinel,
+    JvmToolBase,
+)
 from pants.util.logging import LogLevel
-from pants.util.ordered_set import FrozenOrderedSet
 
 _STRIP_JAR_BASENAME = "StripJar.java"
 _OUTPUT_PATH = "__stripped_jars"
@@ -160,16 +163,12 @@ async def build_processors(jdk: InternalJdk) -> StripJarCompiledClassfiles:
 
 class StripJarTool(JvmToolBase):
     options_scope = "strip_jar"
-    help = ""
+    help = "Reproducible Build Maven Plugin"
 
     default_version = "0.16"
-    default_artifacts = (
-        "io.github.zlika:reproducible-build-maven-plugin:{version}",
-    )
-    default_lockfile_resource = (
-    "pants.jvm.strip_jar",
-    "strip_jar.lock"
-    )
+    default_artifacts = ("io.github.zlika:reproducible-build-maven-plugin:{version}",)
+    default_lockfile_resource = ("pants.jvm.strip_jar", "strip_jar.lock")
+
 
 @rule
 def generate_strip_jar_lockfile_request(

--- a/src/python/pants/jvm/strip_jar/strip_jar.py
+++ b/src/python/pants/jvm/strip_jar/strip_jar.py
@@ -6,7 +6,7 @@ from typing import Tuple
 
 import pkg_resources
 
-from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
+from pants.core.goals.resolves import ExportableTool
 from pants.engine.fs import AddPrefix, CreateDigest, Digest, Directory, FileContent
 from pants.engine.internals.native_engine import MergeDigests, RemovePrefix
 from pants.engine.process import FallibleProcessResult, ProcessResult
@@ -14,19 +14,20 @@ from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.jvm.jdk_rules import InternalJdk, JvmProcess
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
-from pants.jvm.resolve.jvm_tool import (
-    GenerateJvmLockfileFromTool,
-    GenerateJvmToolLockfileSentinel,
-    JvmToolBase,
-)
+from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool, JvmToolBase
 from pants.util.logging import LogLevel
 
 _STRIP_JAR_BASENAME = "StripJar.java"
 _OUTPUT_PATH = "__stripped_jars"
 
 
-class StripJarToolLockfileSentinel(GenerateJvmToolLockfileSentinel):
-    resolve_name = "strip-jar"
+class StripJarTool(JvmToolBase):
+    options_scope = "strip_jar"
+    help = "Reproducible Build Maven Plugin"
+
+    default_version = "0.16"
+    default_artifacts = ("io.github.zlika:reproducible-build-maven-plugin:{version}",)
+    default_lockfile_resource = ("pants.jvm.strip_jar", "strip_jar.lock")
 
 
 @dataclass(frozen=True)
@@ -50,6 +51,7 @@ async def strip_jar(
     processor_classfiles: StripJarCompiledClassfiles,
     jdk: InternalJdk,
     request: StripJarRequest,
+    tool: StripJarTool,
 ) -> Digest:
     filenames = list(request.filenames)
 
@@ -60,12 +62,10 @@ async def strip_jar(
     toolcp_relpath = "__toolcp"
     processorcp_relpath = "__processorcp"
 
-    lockfile_request = await Get(GenerateJvmLockfileFromTool, StripJarToolLockfileSentinel())
-
     tool_classpath, prefixed_jars_digest = await MultiGet(
         Get(
             ToolClasspath,
-            ToolClasspathRequest(lockfile=lockfile_request),
+            ToolClasspathRequest(lockfile=GenerateJvmLockfileFromTool.create(tool)),
         ),
         Get(Digest, AddPrefix(request.digest, input_path)),
     )
@@ -102,13 +102,14 @@ def _load_strip_jar_source() -> bytes:
 
 # TODO(13879): Consolidate compilation of wrapper binaries to common rules.
 @rule
-async def build_processors(jdk: InternalJdk) -> StripJarCompiledClassfiles:
+async def build_processors(jdk: InternalJdk, tool: StripJarTool) -> StripJarCompiledClassfiles:
     dest_dir = "classfiles"
-    lockfile_request = await Get(GenerateJvmLockfileFromTool, StripJarToolLockfileSentinel())
     materialized_classpath, source_digest = await MultiGet(
         Get(
             ToolClasspath,
-            ToolClasspathRequest(prefix="__toolcp", lockfile=lockfile_request),
+            ToolClasspathRequest(
+                prefix="__toolcp", lockfile=GenerateJvmLockfileFromTool.create(tool)
+            ),
         ),
         Get(
             Digest,
@@ -161,24 +162,5 @@ async def build_processors(jdk: InternalJdk) -> StripJarCompiledClassfiles:
     return StripJarCompiledClassfiles(digest=stripped_classfiles_digest)
 
 
-class StripJarTool(JvmToolBase):
-    options_scope = "strip_jar"
-    help = "Reproducible Build Maven Plugin"
-
-    default_version = "0.16"
-    default_artifacts = ("io.github.zlika:reproducible-build-maven-plugin:{version}",)
-    default_lockfile_resource = ("pants.jvm.strip_jar", "strip_jar.lock")
-
-
-@rule
-def generate_strip_jar_lockfile_request(
-    _: StripJarToolLockfileSentinel, tool: StripJarTool
-) -> GenerateJvmLockfileFromTool:
-    return GenerateJvmLockfileFromTool.create(tool)
-
-
 def rules():
-    return [
-        *collect_rules(),
-        UnionRule(GenerateToolLockfileSentinel, StripJarToolLockfileSentinel),
-    ]
+    return (*collect_rules(), UnionRule(ExportableTool, StripJarTool))


### PR DESCRIPTION
This MR ports the last JVM tools to use JvmToolBase and ExportableTool. This allows us to remove `GenerateToolLockfileSentinel` and the Sentinel machinery it used.

TODO:
- [x] port tools
- [x] make it work
- [x] mark `GenerateToolLockfileSentinel` deprecated