### PR TITLE
Remove GenerateToolLockfileSentinel

### DIFF
--- a/docs/notes/2.24.x.md
+++ b/docs/notes/2.24.x.md
@@ -16,7 +16,7 @@ We offer [formal sponsorship tiers for companies](https://www.pantsbuild.org/spo
 
 ### Deprecations
 
-- **Python 2.7**: As announced in the v2.23.x release series, Pants v2.24 and later are not proactively tested in CI with Python 2.7 since [Python 2.7 is no longer supported by its maintainers as of 1 January 2020](https://www.python.org/doc/sunset-python-2/). While Pants may continue to work with Python 2.7 in the near term, Pants no longer officially supports use of Python 2.7, and, consequently, any remaining support for Python 2.7 may "bit rot" and diverge over time. Contributions to fix issues with Python 2.7 support will continue to be accepted, but will depend on any community contributions and will not consitute continued official support for Python 2.7.
+- **Python 2.7**: As announced in the v2.23.x release series, Pants v2.24 and later are not proactively tested in CI with Python 2.7 since [Python 2.7 is no longer supported by its maintainers as of 1 January 2020](https://www.python.org/doc/sunset-python-2/). While Pants may continue to work with Python 2.7 in the near term, Pants no longer officially supports use of Python 2.7, and, consequently, any remaining support for Python 2.7 may "bit rot" and diverge over time. Contributions to fix issues with Python 2.7 support will continue to be accepted, but will depend on any community contributions and will not constitute continued official support for Python 2.7.
 - **macOS verisons**: as announced in the v2.23.x release series, Pants v2.24 is built on macOS 12 and so may not work on versions of macOS 10.15 and 11 (which Apple no longer supports).
 
 
@@ -103,6 +103,8 @@ Recognize `-fullpath` as a test binary flag.
 The `path_metadata_request` intrinsic rule can now access metadata for paths in the local system outside of the build root. Use the new `namespace` field on `PathMetadataRequest` to request metdata on local system paths using namespace `PathNamespace.SYSTEM`.
 
 PyO3, the interface crate between Rust and Python, has been upgraded to v0.22.x. A major change is that all Python values on the Rust side must be handled via either the `pyo3::Bound` or `pyo3::Py` smart pointers; direct references such as `&PyAny` are no longer supported.
+
+`GenerateToolLockfileSentinel` is removed. See the [porting guide details](https://www.pantsbuild.org/2.24/docs/writing-plugins/common-plugin-tasks/plugin-upgrade-guide#deprecated-generatetoollockfilesentinel) for instructions on migrating.
 
 ## Full Changelog
 

--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -216,11 +216,14 @@ def determine_python_user_resolves(
     python_setup: PythonSetup,
     union_membership: UnionMembership,
 ) -> KnownUserResolveNames:
-    """Find all know Python resolves, from both user-created resolves and internal tools"""
+    """Find all know Python resolves, from both user-created resolves and internal tools."""
     python_tool_resolves = ExportableTool.filter_for_subclasses(union_membership, PythonToolBase)
 
     return KnownUserResolveNames(
-        names=(*python_setup.resolves.keys(), *python_tool_resolves.keys()),  # the order of the keys doesn't matter since shadowing is done in `setup_user_lockfile_requests`
+        names=(
+            *python_setup.resolves.keys(),
+            *python_tool_resolves.keys(),
+        ),  # the order of the keys doesn't matter since shadowing is done in `setup_user_lockfile_requests`
         option_name="[python].resolves",
         requested_resolve_names_cls=RequestedPythonUserResolveNames,
     )
@@ -233,11 +236,10 @@ async def setup_user_lockfile_requests(
     python_setup: PythonSetup,
     union_membership: UnionMembership,
 ) -> UserGenerateLockfiles:
-    """
-    Transform the names of resolves requested into the `GeneratePythonLockfile` request object.
+    """Transform the names of resolves requested into the `GeneratePythonLockfile` request object.
 
-    Shadowing is done here by only checking internal resolves if the resolve is not a user-created resolve.
-
+    Shadowing is done here by only checking internal resolves if the resolve is not a user-created
+    resolve.
     """
     if not (python_setup.enable_resolves and python_setup.resolves_generate_lockfiles):
         return UserGenerateLockfiles()

--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -216,10 +216,11 @@ def determine_python_user_resolves(
     python_setup: PythonSetup,
     union_membership: UnionMembership,
 ) -> KnownUserResolveNames:
+    """Find all know Python resolves, from both user-created resolves and internal tools"""
     python_tool_resolves = ExportableTool.filter_for_subclasses(union_membership, PythonToolBase)
 
     return KnownUserResolveNames(
-        names=(*python_setup.resolves.keys(), *python_tool_resolves.keys()),
+        names=(*python_setup.resolves.keys(), *python_tool_resolves.keys()),  # the order of the keys doesn't matter since shadowing is done in `setup_user_lockfile_requests`
         option_name="[python].resolves",
         requested_resolve_names_cls=RequestedPythonUserResolveNames,
     )
@@ -232,6 +233,12 @@ async def setup_user_lockfile_requests(
     python_setup: PythonSetup,
     union_membership: UnionMembership,
 ) -> UserGenerateLockfiles:
+    """
+    Transform the names of resolves requested into the `GeneratePythonLockfile` request object.
+
+    Shadowing is done here by only checking internal resolves if the resolve is not a user-created resolve.
+
+    """
     if not (python_setup.enable_resolves and python_setup.resolves_generate_lockfiles):
         return UserGenerateLockfiles()
 

--- a/src/python/pants/core/goals/export.py
+++ b/src/python/pants/core/goals/export.py
@@ -12,7 +12,6 @@ from typing import Iterable, Mapping, Sequence, cast
 
 from pants.base.build_root import BuildRoot
 from pants.core.goals.generate_lockfiles import (
-    GenerateToolLockfileSentinel,
     KnownUserResolveNames,
     KnownUserResolveNamesRequest,
     UnrecognizedResolveNamesError,
@@ -251,10 +250,6 @@ async def export(
         all_valid_resolve_names = sorted(
             {
                 *itertools.chain.from_iterable(kurn.names for kurn in all_known_user_resolve_names),
-                *(
-                    sentinel.resolve_name
-                    for sentinel in union_membership.get(GenerateToolLockfileSentinel)
-                ),
             }
         )
         raise UnrecognizedResolveNamesError(

--- a/src/python/pants/jvm/resolve/jvm_tool.py
+++ b/src/python/pants/jvm/resolve/jvm_tool.py
@@ -75,7 +75,7 @@ class JvmToolBase(Subsystem, ExportableTool):
             See {cls.default_lockfile_url} for the default lockfile contents.
 
             To use a custom lockfile, set this option to a file path relative to the
-            build root, then run `{bin_name()} jvm-generate-lockfiles
+            build root, then run `{bin_name()} generate-lockfiles
             --resolve={cls.options_scope}`.
             """
         ),


### PR DESCRIPTION
We now use `ExportableTool` instead of `GenerateToolLockfileSentinel` to export internal tools. This results in less boilerplate, a unifying of user and tool lockfiles, and overall less code.

This MR removes `GenerateToolLockfileSentinel` and its codepaths. Simplification!