### PR TITLE
Distinguish git worktree finding errors.

### DIFF
--- a/src/python/pants/backend/python/util_rules/vcs_versioning.py
+++ b/src/python/pants/backend/python/util_rules/vcs_versioning.py
@@ -70,7 +70,7 @@ async def generate_python_from_setuptools_scm(
             softwrap(
                 f"""
                 Trying to determine the version for the {request.protocol_target.address} target at
-                {request.protocol_target.address}, but you are not running in a git worktree.
+                {request.protocol_target.address}, but {maybe_git_worktree.failure_reason}.
                 """
             )
         )


### PR DESCRIPTION
Previously we would report an inability to locate the `git` binary as "you're not in a git worktree", which is confusing.

Now we properly distinguish the cases in the user-facing error message.