### PR TITLE
use entire URL string as cache key for download intrinsic rule (Cherry-pick of #21215)

### DIFF
--- a/src/rust/engine/src/nodes/downloaded_file.rs
+++ b/src/rust/engine/src/nodes/downloaded_file.rs
@@ -27,7 +27,7 @@ pub struct DownloadedFile(pub Key);
 impl DownloadedFile {
     fn url_key(url: &Url, digest: Digest) -> CacheKey {
         let observed_url = ObservedUrl {
-            url: url.path().to_owned(),
+            url: url.as_str().to_owned(),
             observed_digest: Some(digest.into()),
         };
         CacheKey {


### PR DESCRIPTION
As reported in https://github.com/pantsbuild/pants/issues/21163, query parameters apparently do not form part of the cache key when downloading files. Thus, while the query will be used on the first download from a URL, subsequent changes to just the query portion of the URL do not invalidate the cache and do not re-download the file.  Thus, the intrinsic would return stale cached content.

Switch the cache key for downloaded files to use the entire URL and not just the path. This will pick up query string changes and host name changes. Fixes the issue in manual testing.

Also adds a regression test for the bug.
