### PR TITLE
Tighten regex on Simplifier/strip_v2_chroot_path

### DIFF
--- a/src/python/pants/util/strutil.py
+++ b/src/python/pants/util/strutil.py
@@ -139,7 +139,7 @@ def strip_v2_chroot_path(v: bytes | str) -> str:
     """
     if isinstance(v, bytes):
         v = v.decode()
-    return re.sub(r"/.*/pants-sandbox-[a-zA-Z0-9]+/", "", v)
+    return re.sub(r"/[a-zA-Z0-9-_\/]*/pants-sandbox-[a-zA-Z0-9]+/", "", v)
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/python/pants/util/strutil_test.py
+++ b/src/python/pants/util/strutil_test.py
@@ -114,6 +114,18 @@ def test_strip_chroot_path() -> None:
     assert strip_v2_chroot_path("") == ""
     assert strip_v2_chroot_path("hello world") == "hello world"
 
+    # Confirm other data (e.g. URLS) is unaffected
+    assert (
+        strip_v2_chroot_path("https://pantsbuild.org and /private/tmp/pants-sandbox-uPH7bl/sandbox")
+        == "https://pantsbuild.org and sandbox"
+    )
+    assert (
+        strip_v2_chroot_path(
+            "{'URL': 'https://pantsbuild.org', 'VENV': '/tmp/q_dt/pants-sandbox-K3/.cache/pex'}"
+        )
+        == "{'URL': 'https://pantsbuild.org', 'VENV': '.cache/pex'}"
+    )
+
 
 @pytest.mark.parametrize(
     ("strip_chroot_path", "strip_formatting", "expected"),


### PR DESCRIPTION
The regex that cleans up stdout was a bit aggressive looking for pants-sandbox absolute URLs.

e.g. 
```bash
"https://pantsbuild.org will be affected by simplifying /private/tmp/pants-sandbox-uPH7bl/whatever"

became:

"https:whatever"

rather than:
"https://pantsbuild.org will be affected by simplifying whatever"
```

This made debugging injected environment variables somewhere between hard and impossible, depending how far back the regex ended up going.

I tried a practical simplification, where we backtrack only on typical alphanumeric, hyphens, underscores, and forward slashes. In an earlier iteration, I tried to intentionally escape against space, quote, double quote, tab, but that felt like it was sketchy as there were other possible characters I'd missed.

As a final thought, I question whether we should ever strip information from debugging  stdout/stderr. I can see it being fine for output results on black/lint/etc - but sanitizing debug output seems incorrect.

`pytest_runner` uses this Simplifier, with the quote: "# it's ~never useful to show the chroot path to a user" - but I hope that only means when we're trying to show cleanly sanitized tool pass/fail output. When debugging, it's almost always useful to show the full path so the user can `ls` or `cd`.

```
def output_simplifier(self) -> Simplifier:
    """Create a `Simplifier` instance for use on stdout and stderr that will be shown to a
    user."""
    return Simplifier(
        # it's ~never useful to show the chroot path to a user
        strip_chroot_path=True,
        strip_formatting=not self.colors,
    )
```

I am not trying to solve this problem at the moment though, as I think that will end up with a bike shed on specifically what tools we should do this for.

(Closes #21240)