### PR TITLE
log logfile path when error opening

### DIFF
--- a/src/rust/engine/logging/src/logger.rs
+++ b/src/rust/engine/logging/src/logger.rs
@@ -79,8 +79,14 @@ impl PantsLogger {
         let log_file = OpenOptions::new()
             .create(true)
             .append(true)
-            .open(log_file_path)
-            .map_err(|err| format!("Error opening pantsd logfile: {err}"))?;
+            .open(&log_file_path)
+            .map_err(|err| {
+                format!(
+                    "Error opening pantsd logfile at '{}': {}",
+                    log_file_path.display(),
+                    err
+                )
+            })?;
 
         PANTS_LOGGER.0.store(Arc::new(Inner {
             per_run_logs: Mutex::default(),


### PR DESCRIPTION
this can help debug several issues:
- permission problems on directory
- logdir not making it to Pants
- logdir is not as expected
- logdir does not exist