### PR TITLE
Allow build file symbols / macros with leading _s

### DIFF
--- a/src/python/pants/engine/internals/parser.py
+++ b/src/python/pants/engine/internals/parser.py
@@ -69,8 +69,6 @@ class BuildFilePreludeSymbols(BuildFileSymbolsInfo):
         info = {}
         annotations = ns.get("__annotations__", {})
         for name, symb in ns.items():
-            if name.startswith("_"):
-                continue
             # We only need type hints via `annotations` for top-level values which doesn't work with `inspect`.
             info[name] = BuildFileSymbolInfo(name, symb, type_hints=annotations.get(name))
         return cls(info=FrozenDict(info), referenced_env_vars=tuple(sorted(env_vars)))


### PR DESCRIPTION
This is a naive approach that doesn't yet consider the internals that might need removing: https://github.com/pantsbuild/pants/pull/21028#discussion_r1694403255

Fixes #21228
