### PR TITLE
Terraform multi-platform lockfiles

### DIFF
--- a/docs/docs/terraform/index.mdx
+++ b/docs/docs/terraform/index.mdx
@@ -83,6 +83,8 @@ terraform_deployment(name="test", root_module=":root", dependencies=["test_backe
 
 Lockfiles will be loaded from the directory of the root module of a deployment, just like with the `terraform` command. Pants will automatically generate targets for them if they exist.
 
+Pants can generate and update lockfiles with the `generate-lockfiles` command. Use the target of the `terraform_module`'s address as the resolve name. For example, `pants generate-lockfiles --resolve=tf:infrastructure`.
+
 ```python tab={"label":"prod/BUILD"}
 terraform_deployment(name="prod", root_module="//tf:infrastructure")
 ```
@@ -119,7 +121,12 @@ provider "registry.terraform.io/hashicorp/null" {
 }
 ```
 
-Pants can generate and update lockfiles with the `generate-lockfiles` command. Use the target of the `terraform_module`'s address as the resolve name. For example, `pants generate-lockfiles --resolve=tf:infrastructure`.
+Pants can generate multi-platform lockfiles for Terraform. The setting `[download-terraform].platforms` uses the same values as [Terraform's multi-platform implementation](https://developer.hashicorp.com/terraform/cli/commands/providers/lock#specifying-target-platforms).
+
+```toml title=pants.toml
+[download_terraform]
+platforms = ["windows_amd64", "darwin_amd64", "linux_amd64"]
+```
 
 ### Basic Operations
 

--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -130,6 +130,8 @@ Sandboxes for the `experimental-deploy` deployment (the execution of `terraform 
 
 Terraform Lockfiles now participate in the dependency graph. `--changed-since` will now include targets affected by the changed lockfile.
 
+The Terraform backend supports creating lockfiles which support multiple platforms. See the [platforms option documentation](https://www.pantsbuild.org/2.23/reference/subsystems/download-terraform#platforms) and the [documentation on lockfiles](https://www.pantsbuild.org/2.23/docs/terraform#lockfiles) for examples.
+
 #### Javascript
 
 The Node.js runtime now uses version 20.15.1 by default. This is 2 major version upgrades from the 16.x series, which was used before.

--- a/src/python/pants/backend/terraform/dependencies.py
+++ b/src/python/pants/backend/terraform/dependencies.py
@@ -232,26 +232,54 @@ async def terraform_init(request: TerraformInitRequest) -> TerraformInitResponse
 
 @rule
 async def terraform_upgrade_lockfile(request: TerraformInitRequest) -> TerraformUpgradeResponse:
-    """Run `terraform init -upgrade`. Returns just the lockfile.
+    """Run `terraform init -upgrade`. Returns all terraform files with the new lockfile.
 
     This split exists because the new and old lockfile will conflict if merging digests
     """
 
-    _, _, init_response, chdir = await run_terraform_init(request, upgrade=True)
+    source_files, dependencies_files, init_response, chdir = await run_terraform_init(
+        request, upgrade=True
+    )
 
-    lockfile = await Get(
-        Digest,
-        DigestSubset(
-            init_response.digest,
-            PathGlobs(
-                (os.path.join(chdir, ".terraform.lock.hcl"),),
-                glob_match_error_behavior=GlobMatchErrorBehavior.error,
-                description_of_origin="upgrade terraform lockfile with `terraform init`",
+    updated_lockfile, dependencies_except_lockfile = await MultiGet(
+        Get(
+            Digest,
+            DigestSubset(
+                init_response.digest,
+                PathGlobs(
+                    (os.path.join(chdir, ".terraform.lock.hcl"),),
+                    glob_match_error_behavior=GlobMatchErrorBehavior.error,
+                    description_of_origin="upgrade terraform lockfile with `terraform init`",
+                ),
+            ),
+        ),
+        Get(
+            Digest,
+            DigestSubset(
+                dependencies_files.snapshot.digest,
+                PathGlobs(
+                    (
+                        "**",
+                        "!" + os.path.join(chdir, ".terraform.lock.hcl"),
+                    ),
+                ),
             ),
         ),
     )
 
-    return TerraformUpgradeResponse(init_response.digest, lockfile, chdir)
+    all_terraform_files = await Get(
+        Digest,
+        MergeDigests(
+            [
+                source_files.snapshot.digest,
+                dependencies_except_lockfile,
+                init_response.digest,
+                updated_lockfile,
+            ]
+        ),
+    )
+
+    return TerraformUpgradeResponse(all_terraform_files, updated_lockfile, chdir)
 
 
 def rules():

--- a/src/python/pants/backend/terraform/dependencies.py
+++ b/src/python/pants/backend/terraform/dependencies.py
@@ -117,6 +117,7 @@ class TerraformInitResponse:
 
 @dataclass(frozen=True)
 class TerraformUpgradeResponse:
+    sources_and_deps: Digest
     lockfile: Digest
     chdir: str
 
@@ -250,7 +251,7 @@ async def terraform_upgrade_lockfile(request: TerraformInitRequest) -> Terraform
         ),
     )
 
-    return TerraformUpgradeResponse(lockfile, chdir)
+    return TerraformUpgradeResponse(init_response.digest, lockfile, chdir)
 
 
 def rules():

--- a/src/python/pants/backend/terraform/goals/lockfiles.py
+++ b/src/python/pants/backend/terraform/goals/lockfiles.py
@@ -117,14 +117,17 @@ async def generate_lockfile_from_sources(
         ),
     )
 
-    args = ["providers", "lock"]
-    args.extend(terraform_arg("-platform", platform) for platform in lockfile_request.platforms)
+    args = (
+        "providers",
+        "lock",
+        *(terraform_arg("-platform", platform) for platform in lockfile_request.platforms),
+    )
 
     provider_lock_description = f"Update terraform lockfile for {lockfile_request.resolve_name}"
     multiplatform_lockfile = await Get(
         FallibleProcessResult,
         TerraformProcess(
-            args=tuple(args),
+            args=args,
             input_digest=initialised_terraform.sources_and_deps,
             output_files=(".terraform.lock.hcl",),
             description=provider_lock_description,

--- a/src/python/pants/backend/terraform/goals/lockfiles.py
+++ b/src/python/pants/backend/terraform/goals/lockfiles.py
@@ -108,6 +108,19 @@ async def generate_lockfile_from_sources(
             initialise_backend=False,
         ),
     )
+    result = await Get(
+        ProcessResult,
+        TerraformProcess(
+            args=(
+                "providers",
+                "lock",
+            ),
+            input_digest=initialised_terraform.sources_and_deps,
+            output_files=(".terraform.lock.hcl",),
+            description=f"Update terraform lockfile for {lockfile_request.resolve_name}",
+            chdir=initialised_terraform.chdir,
+        ),
+    )
 
     return GenerateLockfileResult(
         initialised_terraform.lockfile,

--- a/src/python/pants/backend/terraform/goals/lockfiles_test.py
+++ b/src/python/pants/backend/terraform/goals/lockfiles_test.py
@@ -29,7 +29,10 @@ def test_integration_generate_lockfile(
     result = rule_runner.run_goal_rule(
         GenerateLockfilesGoal,
         global_args=[*rule_runner.options_bootstrapper.args],
-        args=["--generate-lockfiles-resolve=src/tf:mod"],
+        args=[
+            "--generate-lockfiles-resolve=src/tf:mod",
+            "--download-terraform-platforms=['linux_amd64','linux_arm64']",  # the 'linux_arm64' platform is not in the original lockfile
+        ],
     )
 
     # assert Pants things we succeeded

--- a/src/python/pants/backend/terraform/testutil.py
+++ b/src/python/pants/backend/terraform/testutil.py
@@ -135,6 +135,7 @@ provider "registry.terraform.io/hashicorp/null" {
   version     = "3.2.2"
   constraints = "~> 3.2.0, <= 3.2.2"
   hashes = [
+    "h1:Gef5VGfobY5uokA5nV/zFvWeMNR2Pmq79DH94QnNZPM=",
     "h1:zT1ZbegaAYHwQa+QwIFugArWikRJI9dqohj8xb0GY88=",
     "zh:3248aae6a2198f3ec8394218d05bd5e42be59f43a3a7c0b71c66ec0df08b69e7",
     "zh:32b1aaa1c3013d33c245493f4a65465eab9436b454d250102729321a44c8ab9a",

--- a/src/python/pants/backend/terraform/tool.py
+++ b/src/python/pants/backend/terraform/tool.py
@@ -361,7 +361,8 @@ class TerraformTool(TemplatedExternalTool):
     platforms = StrListOption(
         help=softwrap(
             """
-            Platforms to generate lockfiles for. See the [documentation for the providers lock command](https://developer.hashicorp.com/terraform/cli/commands/providers/lock#platform-os_arch)
+            Platforms to generate lockfiles for. See the [documentation for the providers lock command](https://developer.hashicorp.com/terraform/cli/commands/providers/lock#platform-os_arch).
+            For example, `["windows_amd64", "darwin_amd64", "linux_amd64"]`
             """
         ),
         advanced=True,

--- a/src/python/pants/backend/terraform/tool.py
+++ b/src/python/pants/backend/terraform/tool.py
@@ -358,6 +358,15 @@ class TerraformTool(TemplatedExternalTool):
         ),
     )
 
+    platforms = StrListOption(
+        help=softwrap(
+            """
+            Platforms to generate lockfiles for. See the [documentation for the providers lock command](https://developer.hashicorp.com/terraform/cli/commands/providers/lock#platform-os_arch)
+            """
+        ),
+        advanced=True,
+    )
+
     tailor = BoolOption(
         default=True,
         help="If true, add `terraform_module` targets with the `tailor` goal.",


### PR DESCRIPTION
Terraform lockfiles include the hashes for only a subset of platforms. On an upgrade, it will only use the current platform. The intention is that every other platform will run `terraform init`, and this will modify the lockfile. We generate lockfiles statically and don't allow them to be modified, so this expectation doesn't hold. Terraform supports generating a lockfile with multiple providers with the `terraform providers lock` command.

This MR runs this command with a list of providers forwarded to it.

Closes #21229 