### PR TITLE
stop caching strip_jar

### DIFF
--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -61,6 +61,10 @@ Docker inference is improved. Pants can now make inferences by target address fo
 
 Experimental support for a rust-based dockerfile parser can be enabled via `[dockerfile-parser].use_rust_parser` option.
 
+#### JVM
+
+The Strip Jar process result is now only cached in memory. Caching Strip Jar results can consume a significant amount of storage space while being a relatively simple task to run locally.
+
 #### Scala
 
 Source files no longer produce a dependency on Scala plugins. If you are using a Scala plugin that is also required by the source code (such as acyclic), please add an explicit dependency or set the `packages` field on the artifact.

--- a/src/python/pants/jvm/strip_jar/strip_jar.py
+++ b/src/python/pants/jvm/strip_jar/strip_jar.py
@@ -9,7 +9,7 @@ import pkg_resources
 from pants.core.goals.generate_lockfiles import DEFAULT_TOOL_LOCKFILE, GenerateToolLockfileSentinel
 from pants.engine.fs import AddPrefix, CreateDigest, Digest, Directory, FileContent
 from pants.engine.internals.native_engine import MergeDigests, RemovePrefix
-from pants.engine.process import FallibleProcessResult, ProcessResult
+from pants.engine.process import FallibleProcessResult, ProcessCacheScope, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.jvm.jdk_rules import InternalJdk, JvmProcess
@@ -87,6 +87,7 @@ async def strip_jar(
             extra_nailgun_keys=extra_immutable_input_digests,
             description=f"Stripping jar {filenames[0]}",
             level=LogLevel.DEBUG,
+            cache_scope=ProcessCacheScope.PER_RESTART_SUCCESSFUL,
         ),
     )
 


### PR DESCRIPTION
Caching strip jar is expensive in terms of storage. The task is usually pretty fast and when using remote cache the speculative read delay is usually longer than the task itself, especially when increasing the delay to few seconds