### PR TITLE
lookup the correct EnvironmentTarget for adhoc_tool

### DIFF
--- a/src/python/pants/backend/adhoc/adhoc_tool.py
+++ b/src/python/pants/backend/adhoc/adhoc_tool.py
@@ -53,7 +53,6 @@ class GenerateFilesFromAdhocToolRequest(GenerateSourcesRequest):
 @rule(desc="Running run_in_sandbox target", level=LogLevel.DEBUG)
 async def run_in_sandbox_request(
     request: GenerateFilesFromAdhocToolRequest,
-    env_target: EnvironmentTarget,
 ) -> GeneratedSources:
     target = request.protocol_target
     description = f"the `{target.alias}` at {target.address}"
@@ -61,6 +60,8 @@ async def run_in_sandbox_request(
     environment_name = await Get(
         EnvironmentName, EnvironmentNameRequest, EnvironmentNameRequest.from_target(target)
     )
+
+    environment_target = await Get(EnvironmentTarget, EnvironmentName, environment_name)
 
     runnable_address_str = target[AdhocToolRunnableField].value
     if not runnable_address_str:
@@ -84,7 +85,7 @@ async def run_in_sandbox_request(
     output_files = target.get(AdhocToolOutputFilesField).value or ()
     output_directories = target.get(AdhocToolOutputDirectoriesField).value or ()
 
-    cache_scope = env_target.default_cache_scope
+    cache_scope = environment_target.default_cache_scope
 
     workspace_invalidation_globs: PathGlobs | None = None
     workspace_invalidation_sources = (


### PR DESCRIPTION
One of the `adhoc_tool`-related rules was not looking up the correct `EnvironmentTarget` since it "changes into" a different environment inside the rule. Thus, the existing code taking the `EnvironmentTarget` as a parameter meant that the engine was supplying the `EnvironmentTarget` for the "outer" environment and not the one switched to for the `adhoc_tool` execution.

I discovered this bug while trying to fix https://github.com/pantsbuild/pants/issues/21137 and wondering why my modifications to `EnvironmentTarget` for workspace environments were being ignored.