### PR TITLE
Make ExternalTool exportable

### DIFF
--- a/docs/docs/using-pants/setting-up-an-ide.mdx
+++ b/docs/docs/using-pants/setting-up-an-ide.mdx
@@ -51,6 +51,10 @@ The `--py-resolve-format=symlinked_immutable_virtualenv` option symlinks to an i
 
 `pants export` can also create a virtualenv for each of the Python tools you use via Pants, such as `black`, `isort`, `pytest`, `mypy`, `flake8` and so on. This allows you to configure your editor to use the same version of the tool as Pants does for workflows like formatting on save. To use a custom version of these tools, follow [the instructions for creating a tool lockfile](../python/overview/lockfiles#lockfiles-for-tools).
 
+### Binary tools
+
+`pants export` can export many tools fetched by Pants. For example, `pants export --bin=taplo`.
+
 ## Generated code
 
 If you're using [Protobuf and gRPC](../python/integrations/protobuf-and-grpc.mdx), you may want your editor to be able to index and navigate the generated source code.

--- a/docs/docs/writing-plugins/common-plugin-tasks/add-a-formatter.mdx
+++ b/docs/docs/writing-plugins/common-plugin-tasks/add-a-formatter.mdx
@@ -178,3 +178,8 @@ Now, when you run `pants fmt ::` or `pants lint ::`, your new formatter should r
 ## 4. Add tests (optional)
 
 Refer to [Testing rules](../the-rules-api/testing-plugins.mdx).
+
+
+## 5. Make the tool exportable (optional)
+
+Refer to [Allowing tool export](allowing-tool-export.mdx) to allow users to export the tool for use in external programs.

--- a/docs/docs/writing-plugins/common-plugin-tasks/add-a-linter.mdx
+++ b/docs/docs/writing-plugins/common-plugin-tasks/add-a-linter.mdx
@@ -211,6 +211,7 @@ def rules():
     return [
       	*collect_rules(),
         ShellcheckRequest.rules(partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION),
+        UnionRule(ExportableTool, Shellcheck),  # allows exporting the `shellcheck` binary
     ]
 ```
 

--- a/docs/docs/writing-plugins/common-plugin-tasks/add-a-linter.mdx
+++ b/docs/docs/writing-plugins/common-plugin-tasks/add-a-linter.mdx
@@ -230,3 +230,7 @@ Now, when you run `pants lint ::`, your new linter should run.
 ## 4. Add tests (optional)
 
 Refer to [Testing rules](../the-rules-api/testing-plugins.mdx).
+
+## 5. Make the tool exportable (optional)
+
+Refer to [Allowing tool export](allowing-tool-export.mdx) to allow users to export the tool for use in external programs.

--- a/docs/docs/writing-plugins/common-plugin-tasks/add-codegen.mdx
+++ b/docs/docs/writing-plugins/common-plugin-tasks/add-codegen.mdx
@@ -19,9 +19,7 @@ This guide assumes that you are running a code generator that already exists out
 
 If you are instead writing your own code generation logic inline, you can skip Step 2. In Step 4, rather than running a `Process`, use [`CreateDigest`](../the-rules-api/file-system.mdx).
 
-1. Create a target type for the protocol
-
----
+## 1. Create a target type for the protocol
 
 You will need to define a new target type to allow users to provide metadata for their protocol files, e.g. their `.proto` files. See [Creating new targets](../the-target-api/creating-new-targets.mdx) for a guide on how to do this.
 
@@ -91,9 +89,7 @@ def rules():
 
 This example hardcodes the injected address. You can instead add logic to your rule to make this dynamic. For example, in Pants's Protobuf implementation, Pants looks for a `python_requirement` target with `protobuf`. See [protobuf/python/python_protobuf_subsystem.py](https://github.com/pantsbuild/pants/blob/main/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py).
 
-2. Install your code generator
-
----
+## 2. Install your code generator
 
 There are several ways for Pants to install your tool. See [Installing tools](../the-rules-api/installing-tools.mdx). This example will use `ExternalTool` because there is already a pre-compiled binary for Protoc.
 
@@ -130,9 +126,7 @@ class Protoc(ExternalTool):
         return "./bin/protoc"
 ```
 
-3. Create a `GenerateSourcesRequest`
-
----
+## 3. Create a `GenerateSourcesRequest`
 
 `GenerateSourcesRequest` tells Pants the `input` and the `output` of your code generator, such as going from `ProtobufSourceField -> PythonSourceField`. Pants will use this to determine when to use your code generation implementation.
 
@@ -165,9 +159,7 @@ def rules():
     ]
 ```
 
-4. Create a rule for your codegen logic
-
----
+## 4. Create a rule for your codegen logic
 
 Your rule should take as a parameter the `GenerateSourcesRequest` from Step 3 and the `Subsystem` (or `ExternalTool`) from Step 2. It should return `GeneratedSources`.
 
@@ -286,9 +278,7 @@ def rules():
 Run `pants export-codegen path/to/file.ext` to ensure Pants is correctly generating the file. This will write the generated file(s) under the `dist/` directory, using the same path that will be used during Pants runs.
 :::
 
-5. Audit call sites to ensure they've enabled codegen
-
----
+## 5. Audit call sites to ensure they've enabled codegen
 
 Call sites must opt into using codegen, and they must also specify what types of sources they're expecting. See [Rules and the Target API](../the-rules-api/rules-and-the-target-api.mdx) about `SourcesField`.
 
@@ -296,8 +286,10 @@ For example, if you added a code generator that goes from `ProtobufSourceField -
 
 You should check that everywhere you're expecting is using your new codegen implementation by manually testing it out. Create a new protocol target, add it to the `dependencies` field of a target, and then run goals like `pants package` and `pants test` to make sure that the generated file works correctly.
 
-6. Add tests (optional)
-
----
+## 6. Add tests (optional)
 
 Refer to [Testing rules](../the-rules-api/testing-plugins.mdx).
+
+## 7. Make the tool exportable (optional)
+
+Refer to [Allowing tool export](allowing-tool-export.mdx) to allow users to export the tool for use in external programs.

--- a/docs/docs/writing-plugins/common-plugin-tasks/allowing-tool-export.mdx
+++ b/docs/docs/writing-plugins/common-plugin-tasks/allowing-tool-export.mdx
@@ -1,0 +1,61 @@
+---
+    title: Making a tool exportable
+    sidebar_position: 10
+---
+
+How to make a tool exportable with the `export` goal.
+
+---
+
+Backends that implement the `export` goal can indicate binaries that should be exported. These will have their contents exported to a subfolder in the `dist/bins` directory, and the binary itself will be linked in `dist/bin`.
+
+## Downloadable Tools
+
+Subclasses of `ExternalTool` (including `TemplatedExternalTool`) have the logic for exporting implemented. Tools are marked for export as follows:
+
+1. Implement `ExternalTool.generate_exe` if the default is not correct. For instance, a tool downloaded might include a binary, a readme, and a license. This method will point to the binary within the downloaded files.
+
+2. Register a `UnionRule` with `ExportableTool`. For example, `UnionRule(ExportableTool, FortranLint)`
+
+## Implementing for new backends
+
+Backends need to implement:
+
+1. A subclass of `ExportRequest`
+
+```python
+@dataclass(frozen=True)
+class ExportExternalToolRequest(ExportRequest):
+    pass
+```
+
+2. A rule from this subclass to `ExportResults`
+
+```python
+@rule
+async def export_external_tools(
+    request: ExportExternalToolRequest, export: ExportSubsystem
+) -> ExportResults:
+```
+
+3. Inside of that rule, fill the `ExportResult.exported_binaries` field.
+
+```python
+ExportResult(
+    description=f"Export tool {req.resolve}",
+    reldir=dest,
+    digest=downloaded_tool.digest,
+    resolve=req.resolve,
+    exported_binaries=(ExportedBinary(name=Path(exe).name, path_in_export=exe),),
+)
+```
+
+4. For every tool, mark it for export registering a `UnionRule` with `ExportableTool`.
+
+```python
+def rules():
+    return [
+        ...,
+        `UnionRule(ExportableTool, FortranLint)`,
+    ]
+```

--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -67,6 +67,10 @@ New advanced options `--file-downloads-retry-delay` and `--file-downloads-max-at
 
 The `output_path` field present on targets which can be packaged by `pants package` is now based on a template so that you can use parts of `output_path`'s default behavior when overriding it on a target. For example, you can use the template replacement `${{spec_path_normalized}}` to obtain the default output directory for the target (i.e., the directory in which the target lives with slashes replaced by dots).
 
+#### Export
+
+Many tools that Pants downloads can now be exported. For example, `pants export --bin="helm"` will export the `helm` binary to `dist/export/bin/helm`.
+
 ### Backends
 
 #### NEW: nFPM

--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -67,10 +67,6 @@ New advanced options `--file-downloads-retry-delay` and `--file-downloads-max-at
 
 The `output_path` field present on targets which can be packaged by `pants package` is now based on a template so that you can use parts of `output_path`'s default behavior when overriding it on a target. For example, you can use the template replacement `${{spec_path_normalized}}` to obtain the default output directory for the target (i.e., the directory in which the target lives with slashes replaced by dots).
 
-#### Export
-
-Many tools that Pants downloads can now be exported. For example, `pants export --bin="helm"` will export the `helm` binary to `dist/export/bin/helm`. For each tool, all the files are exported to a subfolder in `dist/export/bins/`, and the main executable is linked to `dist/export/bin/`.
-
 ### Backends
 
 #### NEW: nFPM

--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -69,7 +69,7 @@ The `output_path` field present on targets which can be packaged by `pants packa
 
 #### Export
 
-Many tools that Pants downloads can now be exported. For example, `pants export --bin="helm"` will export the `helm` binary to `dist/export/bin/helm`.
+Many tools that Pants downloads can now be exported. For example, `pants export --bin="helm"` will export the `helm` binary to `dist/export/bin/helm`. For each tool, all the files are exported to a subfolder in `dist/export/bins/`, and the main executable is linked to `dist/export/bin/`.
 
 ### Backends
 

--- a/docs/notes/2.24.x.md
+++ b/docs/notes/2.24.x.md
@@ -34,6 +34,12 @@ If you encounter such discrepancies, and you can't resolve them easily, please [
 
 The "legacy" system will be removed in the 2.25.x series.
 
+### Goals
+
+#### Export
+
+Many tools that Pants downloads can now be exported. For example, `pants export --bin="helm"` will export the `helm` binary to `dist/export/bin/helm`. For each tool, all the files are exported to a subfolder in `dist/export/bins/`, and the main executable is linked to `dist/export/bin/`.
+
 ### Backends
 
 #### JVM

--- a/docs/notes/2.24.x.md
+++ b/docs/notes/2.24.x.md
@@ -38,7 +38,7 @@ The "legacy" system will be removed in the 2.25.x series.
 
 #### Export
 
-Many tools that Pants downloads can now be exported. For example, `pants export --bin="helm"` will export the `helm` binary to `dist/export/bin/helm`. For each tool, all the files are exported to a subfolder in `dist/export/bins/`, and the main executable is linked to `dist/export/bin/`.
+Many tools that Pants downloads can now be exported using [the new `export --bin` option](https://www.pantsbuild.org/2.24/reference/goals/export#bin). For example, `pants export --bin="helm"` will export the `helm` binary to `dist/export/bin/helm`. For each tool, all the files are exported to a subfolder in `dist/export/bins/`, and the main executable is linked to `dist/export/bin/`.
 
 ### Backends
 

--- a/src/python/pants/backend/build_files/fmt/buildifier/rules.py
+++ b/src/python/pants/backend/build_files/fmt/buildifier/rules.py
@@ -4,12 +4,14 @@
 from pants.backend.build_files.fmt.base import FmtBuildFilesRequest
 from pants.backend.build_files.fmt.buildifier.subsystem import Buildifier
 from pants.core.goals.fmt import AbstractFmtRequest, FmtResult
+from pants.core.goals.resolves import ExportableTool
 from pants.core.util_rules.external_tool import download_external_tool
 from pants.engine.internals.native_engine import MergeDigests
 from pants.engine.intrinsics import merge_digests
 from pants.engine.platform import Platform
 from pants.engine.process import Process, fallible_to_exec_result_or_raise
 from pants.engine.rules import collect_rules, implicitly, rule
+from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize
 
@@ -51,4 +53,5 @@ def rules():
     return [
         *collect_rules(),
         *BuildifierRequest.rules(),
+        UnionRule(ExportableTool, Buildifier),
     ]

--- a/src/python/pants/backend/cc/subsystems/compiler.py
+++ b/src/python/pants/backend/cc/subsystems/compiler.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import logging
 from typing import Iterable
 
+from pants.core.goals.resolves import ExportableTool
 from pants.core.util_rules.external_tool import TemplatedExternalTool
 from pants.engine.rules import Rule, collect_rules
 from pants.engine.unions import UnionRule
@@ -147,4 +148,5 @@ def rules() -> Iterable[Rule | UnionRule]:
         *collect_rules(),
         *CCSubsystem.rules(),
         *ExternalCCSubsystem.rules(),
+        UnionRule(ExportableTool, ExternalCCSubsystem),
     )

--- a/src/python/pants/backend/codegen/protobuf/go/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/go/rules.py
@@ -9,6 +9,7 @@ import textwrap
 from collections import defaultdict
 from dataclasses import dataclass
 
+from pants.backend.codegen.protobuf import protoc
 from pants.backend.codegen.protobuf.protoc import Protoc
 from pants.backend.codegen.protobuf.target_types import (
     AllProtobufTargets,
@@ -644,6 +645,7 @@ def rules():
         UnionRule(GoModuleImportPathsMappingsHook, ProtobufGoModuleImportPathsMappingsHook),
         ProtobufSourcesGeneratorTarget.register_plugin_field(GoOwningGoModAddressField),
         ProtobufSourceTarget.register_plugin_field(GoOwningGoModAddressField),
+        *protoc.rules(),
         # Rules needed for this to pass src/python/pants/init/load_backends_integration_test.py:
         *assembly.rules(),
         *build_pkg.rules(),

--- a/src/python/pants/backend/codegen/protobuf/java/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/java/rules.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import PurePath
 
+from pants.backend.codegen.protobuf import protoc
 from pants.backend.codegen.protobuf.java import dependency_inference, symbol_mapper
 from pants.backend.codegen.protobuf.java.subsystem import JavaProtobufGrpcSubsystem
 from pants.backend.codegen.protobuf.protoc import Protoc
@@ -204,6 +205,7 @@ def rules():
         *collect_rules(),
         *dependency_inference.rules(),
         *symbol_mapper.rules(),
+        *protoc.rules(),
         UnionRule(GenerateSourcesRequest, GenerateJavaFromProtobufRequest),
         UnionRule(ExportableTool, JavaProtobufGrpcSubsystem),
         ProtobufSourceTarget.register_plugin_field(PrefixedJvmJdkField),

--- a/src/python/pants/backend/codegen/protobuf/lint/buf/register.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/register.py
@@ -4,7 +4,15 @@
 from pants.backend.codegen.protobuf.lint.buf import skip_field
 from pants.backend.codegen.protobuf.lint.buf.format_rules import rules as buf_format_rules
 from pants.backend.codegen.protobuf.lint.buf.lint_rules import rules as buf_lint_rules
+from pants.backend.codegen.protobuf.lint.buf.subsystem import BufSubsystem
+from pants.core.goals.resolves import ExportableTool
+from pants.engine.unions import UnionRule
 
 
 def rules():
-    return (*buf_format_rules(), *buf_lint_rules(), *skip_field.rules())
+    return (
+        *buf_format_rules(),
+        *buf_lint_rules(),
+        *skip_field.rules(),
+        UnionRule(ExportableTool, BufSubsystem),
+    )

--- a/src/python/pants/backend/codegen/protobuf/protoc.py
+++ b/src/python/pants/backend/codegen/protobuf/protoc.py
@@ -1,9 +1,9 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
-
+from pants.core.goals.resolves import ExportableTool
 from pants.core.util_rules.external_tool import TemplatedExternalTool
 from pants.engine.platform import Platform
+from pants.engine.unions import UnionRule
 from pants.option.option_types import BoolOption
 
 
@@ -51,3 +51,7 @@ class Protoc(TemplatedExternalTool):
 
     def generate_exe(self, plat: Platform) -> str:
         return "./bin/protoc"
+
+
+def rules():
+    return UnionRule(ExportableTool, Protoc)

--- a/src/python/pants/backend/codegen/protobuf/protoc.py
+++ b/src/python/pants/backend/codegen/protobuf/protoc.py
@@ -54,4 +54,4 @@ class Protoc(TemplatedExternalTool):
 
 
 def rules():
-    return UnionRule(ExportableTool, Protoc)
+    return (UnionRule(ExportableTool, Protoc),)

--- a/src/python/pants/backend/codegen/protobuf/python/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/python/rules.py
@@ -4,6 +4,7 @@ import logging
 import os
 from pathlib import PurePath
 
+from pants.backend.codegen.protobuf import protoc
 from pants.backend.codegen.protobuf.protoc import Protoc
 from pants.backend.codegen.protobuf.python.additional_fields import PythonSourceRootField
 from pants.backend.codegen.protobuf.python.grpc_python_plugin import GrpcPythonPlugin
@@ -17,6 +18,7 @@ from pants.backend.python.target_types import PythonSourceField
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import PexResolveInfo, VenvPex, VenvPexRequest
 from pants.backend.python.util_rules.pex_environment import PexEnvironment
+from pants.core.goals.resolves import ExportableTool
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
 from pants.core.util_rules.source_files import SourceFilesRequest
 from pants.core.util_rules.stripped_source_files import StrippedSourceFiles
@@ -245,4 +247,6 @@ def rules():
         *collect_rules(),
         *pex.rules(),
         UnionRule(GenerateSourcesRequest, GeneratePythonFromProtobufRequest),
+        *protoc.rules(),
+        UnionRule(ExportableTool, GrpcPythonPlugin),
     ]

--- a/src/python/pants/backend/codegen/protobuf/scala/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/scala/rules.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 
+from pants.backend.codegen.protobuf import protoc
 from pants.backend.codegen.protobuf.protoc import Protoc
 from pants.backend.codegen.protobuf.scala import dependency_inference, symbol_mapper
 from pants.backend.codegen.protobuf.scala.subsystem import PluginArtifactSpec, ScalaPBSubsystem
@@ -314,6 +315,7 @@ def rules():
         *symbol_mapper.rules(),
         UnionRule(GenerateSourcesRequest, GenerateScalaFromProtobufRequest),
         UnionRule(ExportableTool, ScalaPBSubsystem),
+        *protoc.rules(),
         ProtobufSourceTarget.register_plugin_field(PrefixedJvmJdkField),
         ProtobufSourcesGeneratorTarget.register_plugin_field(PrefixedJvmJdkField),
         ProtobufSourceTarget.register_plugin_field(PrefixedJvmResolveField),

--- a/src/python/pants/backend/cue/goals/fix.py
+++ b/src/python/pants/backend/cue/goals/fix.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from typing import Iterable
 
+from pants.backend.cue import subsystem
 from pants.backend.cue.rules import _run_cue
 from pants.backend.cue.subsystem import Cue
 from pants.backend.cue.target_types import CueFieldSet
@@ -37,4 +38,5 @@ def rules() -> Iterable[Rule]:
     return (
         *collect_rules(),
         *CueFmtRequest.rules(),
+        *subsystem.rules(),
     )

--- a/src/python/pants/backend/cue/goals/lint.py
+++ b/src/python/pants/backend/cue/goals/lint.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from typing import Any, Iterable
 
+from pants.backend.cue import subsystem
 from pants.backend.cue.rules import _run_cue
 from pants.backend.cue.subsystem import Cue
 from pants.backend.cue.target_types import CueFieldSet
@@ -39,4 +40,5 @@ def rules() -> Iterable[Rule]:
     return (
         *collect_rules(),
         *CueLintRequest.rules(),
+        *subsystem.rules(),
     )

--- a/src/python/pants/backend/cue/subsystem.py
+++ b/src/python/pants/backend/cue/subsystem.py
@@ -3,8 +3,10 @@
 
 from __future__ import annotations
 
+from pants.core.goals.resolves import ExportableTool
 from pants.core.util_rules.external_tool import TemplatedExternalTool
 from pants.engine.platform import Platform
+from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, SkipOption
 from pants.util.strutil import help_text
 
@@ -42,3 +44,7 @@ class Cue(TemplatedExternalTool):
 
     def generate_exe(self, plat: Platform) -> str:
         return "cue"
+
+
+def rules():
+    return (UnionRule(ExportableTool, Cue),)

--- a/src/python/pants/backend/docker/lint/hadolint/rules.py
+++ b/src/python/pants/backend/docker/lint/hadolint/rules.py
@@ -10,6 +10,7 @@ from pants.backend.docker.lint.hadolint.subsystem import Hadolint
 from pants.backend.docker.subsystems.dockerfile_parser import DockerfileInfo, DockerfileInfoRequest
 from pants.backend.docker.target_types import DockerImageSourceField
 from pants.core.goals.lint import LintResult, LintTargetsRequest
+from pants.core.goals.resolves import ExportableTool
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
 from pants.core.util_rules.partitions import PartitionerType
@@ -18,6 +19,7 @@ from pants.engine.platform import Platform
 from pants.engine.process import FallibleProcessResult, Process
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import FieldSet, Target
+from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize
 
@@ -106,4 +108,5 @@ def rules():
     return [
         *collect_rules(),
         *HadolintRequest.rules(),
+        UnionRule(ExportableTool, Hadolint),
     ]

--- a/src/python/pants/backend/experimental/helm/check/kubeconform/register.py
+++ b/src/python/pants/backend/experimental/helm/check/kubeconform/register.py
@@ -7,6 +7,9 @@ from pants.backend.experimental.helm.register import rules as helm_rules
 from pants.backend.experimental.helm.register import target_types as helm_target_types
 from pants.backend.helm.check.kubeconform.chart import rules as chart_rules
 from pants.backend.helm.check.kubeconform.deployment import rules as deployment_rules
+from pants.backend.helm.check.kubeconform.subsystem import KubeconformSubsystem
+from pants.core.goals.resolves import ExportableTool
+from pants.engine.unions import UnionRule
 
 
 def target_types():
@@ -14,4 +17,9 @@ def target_types():
 
 
 def rules():
-    return [*helm_rules(), *chart_rules(), *deployment_rules()]
+    return [
+        *helm_rules(),
+        *chart_rules(),
+        *deployment_rules(),
+        UnionRule(ExportableTool, KubeconformSubsystem),
+    ]

--- a/src/python/pants/backend/experimental/helm/register.py
+++ b/src/python/pants/backend/experimental/helm/register.py
@@ -3,6 +3,7 @@
 
 from pants.backend.helm.dependency_inference import deployment
 from pants.backend.helm.goals import deploy, lint, package, publish, tailor
+from pants.backend.helm.subsystems.helm import HelmSubsystem
 from pants.backend.helm.target_types import (
     HelmArtifactTarget,
     HelmChartTarget,
@@ -12,6 +13,8 @@ from pants.backend.helm.target_types import (
 )
 from pants.backend.helm.target_types import rules as target_types_rules
 from pants.backend.helm.test.unittest import rules as unittest_rules
+from pants.core.goals.resolves import ExportableTool
+from pants.engine.unions import UnionRule
 
 
 def target_types():
@@ -34,4 +37,5 @@ def rules():
         *tailor.rules(),
         *unittest_rules(),
         *target_types_rules(),
+        UnionRule(ExportableTool, HelmSubsystem),
     ]

--- a/src/python/pants/backend/go/lint/golangci_lint/rules.py
+++ b/src/python/pants/backend/go/lint/golangci_lint/rules.py
@@ -18,6 +18,7 @@ from pants.backend.go.util_rules.go_mod import (
 )
 from pants.backend.go.util_rules.goroot import GoRoot
 from pants.core.goals.lint import LintResult, LintTargetsRequest
+from pants.core.goals.resolves import ExportableTool
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
 from pants.core.util_rules.partitions import PartitionerType
@@ -35,6 +36,7 @@ from pants.engine.target import (
     TransitiveTargets,
     TransitiveTargetsRequest,
 )
+from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
 
 
@@ -194,4 +196,5 @@ def rules():
     return [
         *collect_rules(),
         *GolangciLintRequest.rules(),
+        UnionRule(ExportableTool, GolangciLint),
     ]

--- a/src/python/pants/backend/helm/subsystems/unittest.py
+++ b/src/python/pants/backend/helm/subsystems/unittest.py
@@ -8,6 +8,7 @@ from pants.backend.helm.util_rules.tool import (
     ExternalHelmPluginBinding,
     ExternalHelmPluginRequest,
 )
+from pants.core.goals.resolves import ExportableTool
 from pants.engine.platform import Platform
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
@@ -78,4 +79,5 @@ def rules():
     return [
         *collect_rules(),
         UnionRule(ExternalHelmPluginBinding, HelmUnitTestPluginBinding),
+        UnionRule(ExportableTool, HelmUnitTestSubsystem),
     ]

--- a/src/python/pants/backend/makeself/subsystem.py
+++ b/src/python/pants/backend/makeself/subsystem.py
@@ -5,6 +5,7 @@ import logging
 from dataclasses import dataclass
 from typing import Iterable, Optional
 
+from pants.core.goals.resolves import ExportableTool
 from pants.core.util_rules import external_tool
 from pants.core.util_rules.external_tool import (
     DownloadedExternalTool,
@@ -16,6 +17,7 @@ from pants.engine.intrinsics import remove_prefix
 from pants.engine.platform import Platform
 from pants.engine.process import execute_process_or_raise
 from pants.engine.rules import Rule, collect_rules, implicitly, rule
+from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
 from pants.util.meta import classproperty
 
@@ -110,4 +112,5 @@ def rules() -> Iterable[Rule]:
     return (
         *collect_rules(),
         *external_tool.rules(),
+        UnionRule(ExportableTool, MakeselfTool),
     )

--- a/src/python/pants/backend/makeself/subsystem.py
+++ b/src/python/pants/backend/makeself/subsystem.py
@@ -1,5 +1,6 @@
 # Copyright 2024 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
@@ -108,7 +109,7 @@ async def extract_makeself_distribution(
     return MakeselfTool(digest=digest, exe="makeself.sh")
 
 
-def rules() -> Iterable[Rule, UnionRule]:
+def rules() -> Iterable[Rule | UnionRule]:
     return (
         *collect_rules(),
         *external_tool.rules(),

--- a/src/python/pants/backend/makeself/subsystem.py
+++ b/src/python/pants/backend/makeself/subsystem.py
@@ -108,7 +108,7 @@ async def extract_makeself_distribution(
     return MakeselfTool(digest=digest, exe="makeself.sh")
 
 
-def rules() -> Iterable[Rule]:
+def rules() -> Iterable[Rule, UnionRule]:
     return (
         *collect_rules(),
         *external_tool.rules(),

--- a/src/python/pants/backend/makeself/subsystem.py
+++ b/src/python/pants/backend/makeself/subsystem.py
@@ -113,5 +113,5 @@ def rules() -> Iterable[Rule | UnionRule]:
     return (
         *collect_rules(),
         *external_tool.rules(),
-        UnionRule(ExportableTool, MakeselfTool),
+        UnionRule(ExportableTool, MakeselfSubsystem),
     )

--- a/src/python/pants/backend/nfpm/subsystem.py
+++ b/src/python/pants/backend/nfpm/subsystem.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 
 import logging
 
+from pants.core.goals.resolves import ExportableTool
 from pants.core.util_rules import external_tool
 from pants.core.util_rules.external_tool import TemplatedExternalTool
 from pants.engine.platform import Platform
+from pants.engine.unions import UnionRule
 from pants.option.option_types import StrOption
 from pants.option.subsystem import Subsystem
 from pants.util.strutil import softwrap
@@ -97,4 +99,5 @@ def rules():
     return [
         *external_tool.rules(),
         *NfpmSubsystem.rules(),
+        UnionRule(ExportableTool, NfpmSubsystem),
     ]

--- a/src/python/pants/backend/project_info/count_loc.py
+++ b/src/python/pants/backend/project_info/count_loc.py
@@ -1,6 +1,6 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
+from pants.core.goals.resolves import ExportableTool
 from pants.core.util_rules.external_tool import (
     DownloadedExternalTool,
     ExternalToolRequest,
@@ -12,6 +12,7 @@ from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.platform import Platform
 from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule
+from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption
 from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize
@@ -92,4 +93,4 @@ async def count_loc(
 
 
 def rules():
-    return collect_rules()
+    return (*collect_rules(), UnionRule(ExportableTool, SuccinctCodeCounter))

--- a/src/python/pants/backend/python/providers/pyenv/rules.py
+++ b/src/python/pants/backend/python/providers/pyenv/rules.py
@@ -7,6 +7,7 @@ from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.util_rules.pex import PythonProvider
 from pants.backend.python.util_rules.pex import rules as pex_rules
 from pants.backend.python.util_rules.pex_environment import PythonExecutable
+from pants.core.goals.resolves import ExportableTool
 from pants.core.goals.run import RunRequest
 from pants.core.util_rules.adhoc_binaries import PythonBuildStandaloneBinary
 from pants.core.util_rules.external_tool import (
@@ -320,4 +321,5 @@ def rules():
         *pex_rules(),
         *external_tools_rules(),
         UnionRule(PythonProvider, PyenvPythonProvider),
+        UnionRule(ExportableTool, PyenvPythonProviderSubsystem),
     )

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -13,6 +13,7 @@ from pants.backend.python.subsystems.python_native_code import PythonNativeCodeS
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.util_rules import pex_environment
 from pants.backend.python.util_rules.pex_environment import PexEnvironment, PexSubsystem
+from pants.core.goals.resolves import ExportableTool
 from pants.core.util_rules import adhoc_binaries, external_tool
 from pants.core.util_rules.adhoc_binaries import PythonBuildStandaloneBinary
 from pants.core.util_rules.external_tool import (
@@ -25,6 +26,7 @@ from pants.engine.internals.selectors import MultiGet
 from pants.engine.platform import Platform
 from pants.engine.process import Process, ProcessCacheScope
 from pants.engine.rules import Get, collect_rules, rule
+from pants.engine.unions import UnionRule
 from pants.option.global_options import GlobalOptions, ca_certs_path_to_file_content
 from pants.option.option_types import ArgsListOption
 from pants.util.frozendict import FrozenDict
@@ -239,4 +241,5 @@ def rules():
         *external_tool.rules(),
         *pex_environment.rules(),
         *adhoc_binaries.rules(),
+        UnionRule(ExportableTool, PexCli),
     ]

--- a/src/python/pants/backend/shell/lint/shellcheck/rules.py
+++ b/src/python/pants/backend/shell/lint/shellcheck/rules.py
@@ -8,6 +8,7 @@ from pants.backend.shell.lint.shellcheck.skip_field import SkipShellcheckField
 from pants.backend.shell.lint.shellcheck.subsystem import Shellcheck
 from pants.backend.shell.target_types import ShellDependenciesField, ShellSourceField
 from pants.core.goals.lint import LintResult, LintTargetsRequest
+from pants.core.goals.resolves import ExportableTool
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
 from pants.core.util_rules.partitions import PartitionerType
@@ -17,6 +18,7 @@ from pants.engine.platform import Platform
 from pants.engine.process import FallibleProcessResult, Process
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import DependenciesRequest, FieldSet, SourcesField, Target, Targets
+from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize
 
@@ -107,4 +109,5 @@ def rules():
     return [
         *collect_rules(),
         *ShellcheckRequest.rules(),
+        UnionRule(ExportableTool, Shellcheck),
     ]

--- a/src/python/pants/backend/shell/lint/shfmt/rules.py
+++ b/src/python/pants/backend/shell/lint/shfmt/rules.py
@@ -7,6 +7,7 @@ from pants.backend.shell.lint.shfmt.skip_field import SkipShfmtField
 from pants.backend.shell.lint.shfmt.subsystem import Shfmt
 from pants.backend.shell.target_types import ShellSourceField
 from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
+from pants.core.goals.resolves import ExportableTool
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
 from pants.core.util_rules.partitions import PartitionerType
@@ -15,6 +16,7 @@ from pants.engine.platform import Platform
 from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import FieldSet, Target
+from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize
 
@@ -78,4 +80,5 @@ def rules():
     return [
         *collect_rules(),
         *ShfmtRequest.rules(),
+        UnionRule(ExportableTool, Shfmt),
     ]

--- a/src/python/pants/backend/shell/subsystems/shunit2.py
+++ b/src/python/pants/backend/shell/subsystems/shunit2.py
@@ -1,9 +1,10 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
+from pants.core.goals.resolves import ExportableTool
 from pants.core.util_rules import external_tool
 from pants.core.util_rules.external_tool import TemplatedExternalTool
 from pants.engine.rules import collect_rules
+from pants.engine.unions import UnionRule
 from pants.option.option_types import SkipOption
 from pants.util.meta import classproperty
 
@@ -38,4 +39,5 @@ def rules():
     return [
         *collect_rules(),
         *external_tool.rules(),
+        UnionRule(ExportableTool, Shunit2),
     ]

--- a/src/python/pants/backend/terraform/lint/tfsec/rules.py
+++ b/src/python/pants/backend/terraform/lint/tfsec/rules.py
@@ -3,6 +3,7 @@
 from pants.backend.terraform.lint.tfsec.tfsec import SkipTfSecField, TFSec, TfSecRequest
 from pants.backend.terraform.target_types import TerraformModuleTarget
 from pants.core.goals.lint import REPORT_DIR, LintResult
+from pants.core.goals.resolves import ExportableTool
 from pants.core.util_rules import config_files
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
@@ -11,6 +12,7 @@ from pants.engine.fs import CreateDigest, Digest, Directory, MergeDigests, Remov
 from pants.engine.platform import Platform
 from pants.engine.process import FallibleProcessResult, Process
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize
 
@@ -80,4 +82,5 @@ def rules():
         *TfSecRequest.rules(),
         *config_files.rules(),
         TerraformModuleTarget.register_plugin_field(SkipTfSecField),
+        UnionRule(ExportableTool, TFSec),
     ]

--- a/src/python/pants/backend/terraform/tool.py
+++ b/src/python/pants/backend/terraform/tool.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Tuple
 
+from pants.core.goals.resolves import ExportableTool
 from pants.core.util_rules import external_tool
 from pants.core.util_rules.external_tool import (
     DownloadedExternalTool,
@@ -34,6 +35,7 @@ from pants.engine.internals.selectors import Get
 from pants.engine.platform import Platform
 from pants.engine.process import Process
 from pants.engine.rules import collect_rules, rule
+from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, BoolOption, StrListOption
 from pants.util.logging import LogLevel
 from pants.util.meta import classproperty
@@ -457,4 +459,8 @@ async def setup_terraform_process(
 
 
 def rules():
-    return [*collect_rules(), *external_tool.rules()]
+    return [
+        *collect_rules(),
+        *external_tool.rules(),
+        UnionRule(ExportableTool, TerraformTool),
+    ]

--- a/src/python/pants/backend/terraform/tool.py
+++ b/src/python/pants/backend/terraform/tool.py
@@ -391,6 +391,9 @@ class TerraformTool(TemplatedExternalTool):
         advanced=True,
     )
 
+    def generate_exe(self, plat: Platform) -> str:
+        return "./terraform"
+
     @property
     def plugin_cache_dir(self) -> str:
         return "__terraform_filesystem_mirror"

--- a/src/python/pants/backend/tools/taplo/rules.py
+++ b/src/python/pants/backend/tools/taplo/rules.py
@@ -5,12 +5,14 @@ from typing import Any
 
 from pants.backend.tools.taplo.subsystem import Taplo
 from pants.core.goals.fmt import FmtFilesRequest, FmtResult, Partitions
+from pants.core.goals.resolves import ExportableTool
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
 from pants.engine.fs import Digest, MergeDigests
 from pants.engine.platform import Platform
 from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.unions import UnionRule
 from pants.source.filespec import FilespecMatcher
 from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize
@@ -76,4 +78,5 @@ def rules():
     return [
         *collect_rules(),
         *TaploFmtRequest.rules(),
+        UnionRule(ExportableTool, Taplo),
     ]

--- a/src/python/pants/core/goals/export.py
+++ b/src/python/pants/core/goals/export.py
@@ -221,7 +221,7 @@ async def export(
         build_root, environment, output_dir, flattened_results
     )
     iprs = await MultiGet(
-        Effect(InteractiveProcessResult, InteractiveProcess, link_requests) for link_requests in link_requests
+        run_interactive_process(link_request) for link_request in link_requests
     )
 
     errors_linking_bins = [

--- a/src/python/pants/core/goals/export.py
+++ b/src/python/pants/core/goals/export.py
@@ -157,7 +157,7 @@ class ExportSubsystem(GoalSubsystem):
     binaries = StrListOption(
         flag_name="--bin",  # `bin` is a python builtin
         default=[],
-        help="Export the specified binaries.",
+        help="Export the specified binaries. To select a binary, provide its subsystem scope name, as used for setting its options.",
     )
 
 
@@ -261,7 +261,7 @@ async def export(
             unexported_resolves,
             all_valid_resolve_names,
             all_known_bin_names,
-            description_of_origin="the option --export-resolve",
+            description_of_origin="the options --export-resolve and/or --export-bin",
         )
 
     return Export(exit_code=0)

--- a/src/python/pants/core/goals/export.py
+++ b/src/python/pants/core/goals/export.py
@@ -185,8 +185,7 @@ async def export(
 
     requests = tuple(request_type(targets) for request_type in request_types)
     all_results = await MultiGet(Get(ExportResults, ExportRequest, request) for request in requests)
-    # TODO: sort
-    flattened_results = [res for results in all_results for res in results]
+    flattened_results = sorted((res for results in all_results for res in results), key=lambda res: res.resolve)  # sorting provides predictable resolution in conflicts
 
     prefixed_digests = await MultiGet(
         Get(Digest, AddPrefix(result.digest, result.reldir)) for result in flattened_results
@@ -227,7 +226,7 @@ async def export(
     ]
     if errors_linking_bins:
         raise ExportError(
-            "; ".join(f'Failed in porcess "{description}"' for description in errors_linking_bins)
+            "; ".join(f'Failed in process "{description}"' for description in errors_linking_bins)
         )
 
     exported_bin_warnings = warn_exported_bin_conflicts(exported_bins_by_exporting_resolve)

--- a/src/python/pants/core/goals/export.py
+++ b/src/python/pants/core/goals/export.py
@@ -26,9 +26,9 @@ from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.environment import EnvironmentName
 from pants.engine.fs import EMPTY_DIGEST, AddPrefix, Digest, MergeDigests, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
-from pants.engine.internals.selectors import Get, MultiGet
+from pants.engine.internals.selectors import Effect, Get, MultiGet
 from pants.engine.intrinsics import run_interactive_process
-from pants.engine.process import InteractiveProcess
+from pants.engine.process import InteractiveProcess, InteractiveProcessResult
 from pants.engine.rules import collect_rules, goal_rule
 from pants.engine.target import FilteredTargets, Target
 from pants.engine.unions import UnionMembership, union
@@ -78,12 +78,14 @@ class PostProcessingCommand:
 class ExportedBinary:
     """Binaries exposed by an export.
 
-    These will be added under the "bin" folder.
-    The `name` is the name that will be linked as in the `bin` folder.
-    The `path_in_export` is the path within the exported digest to link to.
-    These can be used to abstract details from the name of the tool and avoid the other files in the tool's digest.
-    For example, "my-tool" might have a downloaded file of "my_tool/my_tool_linux_x86-64.bin" and a readme.
-    We would use `ExportedBinary(name="my-tool", path_in_export=my_tool/my_tool_linux_x86-64.bin"`
+    These will be added under the "bin" folder. The `name` is the name that will be linked as in the
+    `bin` folder. The `path_in_export` is the path within the exported digest to link to. These can
+    be used to abstract details from the name of the tool and avoid the other files in the tool's
+    digest.
+
+    For example, "my-tool" might have a downloaded file of
+    "my_tool/my_tool_linux_x86-64.bin" and a readme. We would use `ExportedBinary(name="my-tool",
+    path_in_export=my_tool/my_tool_linux_x86-64.bin"`
     """
 
     name: str

--- a/src/python/pants/core/goals/export.py
+++ b/src/python/pants/core/goals/export.py
@@ -185,7 +185,9 @@ async def export(
 
     requests = tuple(request_type(targets) for request_type in request_types)
     all_results = await MultiGet(Get(ExportResults, ExportRequest, request) for request in requests)
-    flattened_results = sorted((res for results in all_results for res in results), key=lambda res: res.resolve)  # sorting provides predictable resolution in conflicts
+    flattened_results = sorted(
+        (res for results in all_results for res in results), key=lambda res: res.resolve
+    )  # sorting provides predictable resolution in conflicts
 
     prefixed_digests = await MultiGet(
         Get(Digest, AddPrefix(result.digest, result.reldir)) for result in flattened_results

--- a/src/python/pants/core/goals/export.py
+++ b/src/python/pants/core/goals/export.py
@@ -79,6 +79,11 @@ class ExportedBinary:
     """Binaries exposed by an export.
 
     These will be added under the "bin" folder.
+    The `name` is the name that will be linked as in the `bin` folder.
+    The `path_in_export` is the path within the exported digest to link to.
+    These can be used to abstract details from the name of the tool and avoid the other files in the tool's digest.
+    For example, "my-tool" might have a downloaded file of "my_tool/my_tool_linux_x86-64.bin" and a readme.
+    We would use `ExportedBinary(name="my-tool", path_in_export=my_tool/my_tool_linux_x86-64.bin"`
     """
 
     name: str
@@ -178,6 +183,7 @@ async def export(
 
     requests = tuple(request_type(targets) for request_type in request_types)
     all_results = await MultiGet(Get(ExportResults, ExportRequest, request) for request in requests)
+    # TODO: sort
     flattened_results = [res for results in all_results for res in results]
 
     prefixed_digests = await MultiGet(

--- a/src/python/pants/core/goals/export.py
+++ b/src/python/pants/core/goals/export.py
@@ -186,7 +186,7 @@ async def export(
     requests = tuple(request_type(targets) for request_type in request_types)
     all_results = await MultiGet(Get(ExportResults, ExportRequest, request) for request in requests)
     flattened_results = sorted(
-        (res for results in all_results for res in results), key=lambda res: res.resolve
+        (res for results in all_results for res in results), key=lambda res: res.resolve or ""
     )  # sorting provides predictable resolution in conflicts
 
     prefixed_digests = await MultiGet(

--- a/src/python/pants/core/goals/export.py
+++ b/src/python/pants/core/goals/export.py
@@ -50,6 +50,11 @@ class ExportRequest:
 
 
 @dataclass(frozen=True)
+class ExportExternalToolRequest:
+    tool: type[ExternalTool]
+
+
+@dataclass(frozen=True)
 class PostProcessingCommand:
     """A command to run as a local process after an exported digest is materialized."""
 
@@ -129,6 +134,12 @@ class ExportSubsystem(GoalSubsystem):
         "e.g., Python resolves are exported as virtualenvs.",
     )
 
+    binaries = StrListOption(
+        flag_name="--bin",  # `bin` is a python builtin
+        default=[],
+        help="Export the specified binaries."
+    )
+
 
 class Export(Goal):
     subsystem_cls = ExportSubsystem
@@ -147,14 +158,18 @@ async def export(
 ) -> Export:
     request_types = cast("Iterable[type[ExportRequest]]", union_membership.get(ExportRequest))
 
-    if not export_subsys.options.resolve:
-        raise ExportError("Must specify at least one --resolve to export")
+    if not (export_subsys.options.resolve or export_subsys.options.binaries):
+        raise ExportError("Must specify at least one `--resolve` or `--bin` to export")
     if targets:
         raise ExportError("The `export` goal does not take target specs.")
 
     requests = tuple(request_type(targets) for request_type in request_types)
     all_results = await MultiGet(Get(ExportResults, ExportRequest, request) for request in requests)
     flattened_results = [res for results in all_results for res in results]
+
+    from pants.backend.terraform.tool import TerraformTool
+    tool_export = await Get(ExportResult, ExportExternalToolRequest(TerraformTool))
+    prefixed = await Get(Digest, AddPrefix(tool_export.digest, tool_export.reldir))
 
     prefixed_digests = await MultiGet(
         Get(Digest, AddPrefix(result.digest, result.reldir)) for result in flattened_results
@@ -163,7 +178,7 @@ async def export(
     for result in flattened_results:
         digest_root = os.path.join(build_root.path, output_dir, result.reldir)
         safe_rmtree(digest_root)
-    merged_digest = await Get(Digest, MergeDigests(prefixed_digests))
+    merged_digest = await Get(Digest, MergeDigests([*prefixed_digests, prefixed]))
     dist_digest = await Get(Digest, AddPrefix(merged_digest, output_dir))
     workspace.write_digest(dist_digest)
     environment = await Get(EnvironmentVars, EnvironmentVarsRequest(["PATH"]))

--- a/src/python/pants/core/goals/export_integration_test.py
+++ b/src/python/pants/core/goals/export_integration_test.py
@@ -1,0 +1,180 @@
+# Copyright 2024 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+import os.path
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+import pytest
+
+from pants.core.goals import export
+from pants.core.goals.export import (
+    Export,
+    ExportedBinary,
+    ExportRequest,
+    ExportResult,
+    ExportResults,
+    ExportSubsystem,
+)
+from pants.core.util_rules import archive, distdir
+from pants.engine.engine_aware import EngineAwareParameter
+from pants.engine.fs import CreateDigest, FileContent
+from pants.engine.internals.native_engine import Digest
+from pants.engine.internals.selectors import Get, MultiGet
+from pants.engine.rules import rule
+from pants.engine.unions import UnionRule
+from pants.testutil.rule_runner import RuleRunner, mock_console
+
+
+class MyExportableBin(ABC):
+    """ABC for all these exportable bins."""
+
+    @classmethod
+    @abstractmethod
+    def bins_to_export(cls) -> tuple[ExportedBinary, ...]:
+        pass
+
+
+class MyBin0(MyExportableBin):
+    @classmethod
+    def bins_to_export(cls) -> tuple[ExportedBinary, ...]:
+        return (ExportedBinary(name="mybin_0", path_in_export=f"{cls.__name__}.exe"),)
+
+
+class MyBin1(MyExportableBin):
+    @classmethod
+    def bins_to_export(cls) -> tuple[ExportedBinary, ...]:
+        return (ExportedBinary(name="mybin_1", path_in_export=f"{cls.__name__}.exe"),)
+
+
+class MyBinMulti(MyExportableBin):
+    """A test item exporting multiple binaries."""
+
+    @classmethod
+    def bins_to_export(cls) -> tuple[ExportedBinary, ...]:
+        return (
+            ExportedBinary(name="mybin_m0", path_in_export=f"{cls.__name__}_m0.exe"),
+            ExportedBinary(name="mybin_m1", path_in_export=f"{cls.__name__}_m1.exe"),
+        )
+
+
+class MyBinConflict(MyExportableBin):
+    """A test item with a binary conflict with MyBin0."""
+
+    @classmethod
+    def bins_to_export(cls) -> tuple[ExportedBinary, ...]:
+        return (ExportedBinary(name="mybin_0", path_in_export=f"{cls.__name__}.exe"),)
+
+
+classes = {e.__name__: e for e in [MyBin0, MyBin1, MyBinMulti, MyBinConflict]}
+
+
+@dataclass(frozen=True)
+class ExportMyBinRequest(ExportRequest):
+    pass
+
+
+@dataclass(frozen=True)
+class _ExportMyBinForResolve(EngineAwareParameter):
+    resolve: str
+
+
+@rule
+async def export_mybin(req: _ExportMyBinForResolve) -> ExportResult:
+    """Sample export function.
+
+    We don't use `UnionMembership` to find the class instance and create it with
+    `_construct_subsystem` since that's not necessary for what we're testing.
+    """
+    tool = classes[req.resolve]
+    bins_to_export = tool.bins_to_export()
+
+    digest = await Get(
+        Digest,
+        CreateDigest(
+            [
+                *[FileContent(e.path_in_export, req.resolve.encode()) for e in bins_to_export],
+                FileContent("readme.md", b"another file that would conflict if exported to `bin`"),
+            ]
+        ),
+    )
+
+    return ExportResult(
+        description=f"Export for test item {req.resolve}",
+        reldir=os.path.join("testitems", req.resolve),
+        digest=digest,
+        resolve=req.resolve,
+        exported_binaries=bins_to_export,
+    )
+
+
+@rule
+async def export_external_tools(
+    request: ExportMyBinRequest, export: ExportSubsystem
+) -> ExportResults:
+    maybe_tools = await MultiGet(
+        Get(ExportResult, _ExportMyBinForResolve(resolve)) for resolve in export.binaries
+    )
+    return ExportResults(maybe_tools)
+
+
+@pytest.fixture
+def rule_runner():
+    return RuleRunner(
+        rules=[
+            *export.rules(),
+            *archive.rules(),
+            *distdir.rules(),
+            export_mybin,
+            export_external_tools,
+            UnionRule(ExportRequest, ExportMyBinRequest),
+        ],
+    )
+
+
+def assert_export(rule_runner: RuleRunner, cls, was_linked: bool = True) -> None:
+    resolve = cls.__name__
+    bins = cls.bins_to_export()
+
+    for bin in bins:
+        assert rule_runner.read_file(
+            os.path.join("dist", "export", "testitems", resolve, bin.path_in_export)
+        )
+        linked_path = os.path.join("dist", "export", "bin", bin.name)
+        linked_content = rule_runner.read_file(linked_path)
+        if was_linked:
+            assert (
+                linked_content == resolve
+            ), f"bin {bin.name} was not linked to the `bin` directory, instead {linked_content!r} was"
+        else:
+            assert (
+                linked_content != resolve
+            ), f"bin {bin.name} was linked to `bin` directory but we expected it to not be"
+
+
+def test_export_binary(rule_runner):
+    """Test we export binaries."""
+
+    with mock_console(rule_runner.options_bootstrapper):
+        result = rule_runner.run_goal_rule(Export, args=["--bin=MyBin0", "--bin=MyBin1"])
+        assert result.exit_code == 0
+    assert_export(rule_runner, MyBin0)
+    assert_export(rule_runner, MyBin1)
+
+
+def test_export_multiple_binaries(rule_runner):
+    """Test that a single class can export multiple binaries."""
+    with mock_console(rule_runner.options_bootstrapper):
+        result = rule_runner.run_goal_rule(Export, args=["--bin=MyBinMulti"])
+        assert result.exit_code == 0
+    assert_export(rule_runner, MyBinMulti)
+
+
+def test_export_conflict(rule_runner):
+    """Test that we still export even with binary conflicts."""
+    with mock_console(rule_runner.options_bootstrapper):
+        result = rule_runner.run_goal_rule(Export, args=["--bin=MyBin0", "--bin=MyBinConflict"])
+        assert result.exit_code == 0
+    assert_export(rule_runner, MyBin0)
+    assert_export(rule_runner, MyBinConflict, was_linked=False)

--- a/src/python/pants/core/goals/export_test.py
+++ b/src/python/pants/core/goals/export_test.py
@@ -18,7 +18,8 @@ from pants.core.goals.export import (
     ExportResults,
     ExportSubsystem,
     PostProcessingCommand,
-    export, warn_exported_bin_conflicts,
+    export,
+    warn_exported_bin_conflicts,
 )
 from pants.core.goals.generate_lockfiles import KnownUserResolveNames, KnownUserResolveNamesRequest
 from pants.core.util_rules.distdir import DistDir

--- a/src/python/pants/core/goals/export_test.py
+++ b/src/python/pants/core/goals/export_test.py
@@ -32,13 +32,7 @@ from pants.engine.rules import QueryRule
 from pants.engine.target import Target, Targets
 from pants.engine.unions import UnionMembership, UnionRule
 from pants.testutil.option_util import create_subsystem
-from pants.testutil.rule_runner import (
-    MockEffect,
-    MockGet,
-    RuleRunner,
-    mock_console,
-    run_rule_with_mocks,
-)
+from pants.testutil.rule_runner import MockGet, RuleRunner, mock_console, run_rule_with_mocks
 
 
 class MockTarget(Target):
@@ -166,7 +160,7 @@ def run_export_rule(
                     output_type=InteractiveProcessResult,
                     input_types=(InteractiveProcess,),
                     mock=lambda ip: _mock_run(rule_runner, ip),
-                )
+                ),
             ],
             union_membership=union_membership,
         )

--- a/src/python/pants/core/goals/export_test.py
+++ b/src/python/pants/core/goals/export_test.py
@@ -65,6 +65,7 @@ def mock_export(
 
 
 def _mock_run(rule_runner: RuleRunner, ip: InteractiveProcess) -> InteractiveProcessResult:
+    """This is still necessary for writing files, which uses a `cp` process."""
     subprocess.check_call(
         ip.process.argv,
         stderr=subprocess.STDOUT,
@@ -156,11 +157,12 @@ def run_export_rule(
                 rule_runner.do_not_use_mock(Digest, (AddPrefix,)),
                 rule_runner.do_not_use_mock(EnvironmentVars, (EnvironmentVarsRequest,)),
                 rule_runner.do_not_use_mock(KnownUserResolveNames, (KnownUserResolveNamesRequest,)),
+                rule_runner.do_not_use_mock(Digest, (CreateDigest,)),
                 MockGet(
                     output_type=InteractiveProcessResult,
                     input_types=(InteractiveProcess,),
                     mock=lambda ip: _mock_run(rule_runner, ip),
-                ),
+                ),  # for workspace.write_digest
             ],
             union_membership=union_membership,
         )

--- a/src/python/pants/core/goals/export_test.py
+++ b/src/python/pants/core/goals/export_test.py
@@ -162,11 +162,11 @@ def run_export_rule(
                 rule_runner.do_not_use_mock(Digest, (AddPrefix,)),
                 rule_runner.do_not_use_mock(EnvironmentVars, (EnvironmentVarsRequest,)),
                 rule_runner.do_not_use_mock(KnownUserResolveNames, (KnownUserResolveNamesRequest,)),
-                MockEffect(
+                MockGet(
                     output_type=InteractiveProcessResult,
                     input_types=(InteractiveProcess,),
                     mock=lambda ip: _mock_run(rule_runner, ip),
-                ),
+                )
             ],
             union_membership=union_membership,
         )
@@ -195,7 +195,7 @@ def test_run_export_rule_resolve(monkeypatch) -> None:
             assert fp.read() == b"BAR"
 
 
-def test_run_export_rule_binary() -> None:
+def test_run_export_rule_binary(monkeypatch) -> None:
     rule_runner = RuleRunner(
         rules=[
             UnionRule(ExportRequest, MockExportRequest),
@@ -205,7 +205,7 @@ def test_run_export_rule_binary() -> None:
         ],
         target_types=[MockTarget],
     )
-    exit_code, stdout = run_export_rule(rule_runner, binaries=["mybin"])
+    exit_code, stdout = run_export_rule(rule_runner, monkeypatch, binaries=["mybin"])
     assert exit_code == 0
     assert "Wrote mock export for mybin to dist/export/mock" in stdout
     for filename in ["mybin"]:

--- a/src/python/pants/core/goals/export_test.py
+++ b/src/python/pants/core/goals/export_test.py
@@ -92,7 +92,10 @@ def list_files_with_paths(directory):
 
 
 def run_export_rule(
-    rule_runner: RuleRunner, monkeypatch: MonkeyPatch,resolves: List[str] | None = None, binaries: List[str] | None = None
+    rule_runner: RuleRunner,
+    monkeypatch: MonkeyPatch,
+    resolves: List[str] | None = None,
+    binaries: List[str] | None = None,
 ) -> Tuple[int, str]:
     resolves = resolves or []
     binaries = binaries or []

--- a/src/python/pants/core/goals/generate_lockfiles.py
+++ b/src/python/pants/core/goals/generate_lockfiles.py
@@ -295,6 +295,7 @@ class UnrecognizedResolveNamesError(Exception):
         self,
         unrecognized_resolve_names: list[str],
         all_valid_names: Iterable[str],
+        all_valid_binaries: Iterable[str] | None = None,
         *,
         description_of_origin: str,
     ) -> None:
@@ -305,16 +306,17 @@ class UnrecognizedResolveNamesError(Exception):
         else:
             unrecognized_str = str(sorted(unrecognized_resolve_names))
             name_description = "names"
-        super().__init__(
-            softwrap(
-                f"""
+
+        message = f"""
                 Unrecognized resolve {name_description} from {description_of_origin}:
                 {unrecognized_str}
 
                 All valid resolve names: {sorted(all_valid_names)}
                 """
-            )
-        )
+        if all_valid_binaries:
+            message += f"\nAll valid exportable binaries: {sorted(all_valid_binaries)}"
+
+        super().__init__(softwrap(message))
 
 
 class _ResolveProviderType(Enum):

--- a/src/python/pants/core/goals/generate_lockfiles.py
+++ b/src/python/pants/core/goals/generate_lockfiles.py
@@ -299,6 +299,8 @@ class UnrecognizedResolveNamesError(Exception):
         *,
         description_of_origin: str,
     ) -> None:
+        all_valid_binaries = all_valid_binaries or set()
+
         # TODO(#12314): maybe implement "Did you mean?"
         if len(unrecognized_resolve_names) == 1:
             unrecognized_str = unrecognized_resolve_names[0]
@@ -307,16 +309,25 @@ class UnrecognizedResolveNamesError(Exception):
             unrecognized_str = str(sorted(unrecognized_resolve_names))
             name_description = "names"
 
-        message = f"""
-                Unrecognized resolve {name_description} from {description_of_origin}:
-                {unrecognized_str}
-
-                All valid resolve names: {sorted(all_valid_names)}
-                """
+        message = [
+            f"Unrecognized resolve {name_description} from {description_of_origin}: {unrecognized_str}",
+            f"All valid resolve names: {sorted(all_valid_names)}",
+        ]
         if all_valid_binaries:
-            message += f"\nAll valid exportable binaries: {sorted(all_valid_binaries)}"
+            message.append(f"All valid exportable binaries: {sorted(all_valid_binaries)}")
 
-        super().__init__(softwrap(message))
+        should_be_bins = set(unrecognized_resolve_names) & set(all_valid_binaries)
+        should_be_resolves = set(unrecognized_resolve_names) & set(all_valid_names)
+
+        if should_be_bins:
+            cmd = " ".join([f"--bin={e}" for e in should_be_bins])
+            message.append(f"HINT: Some resolves should be binaries, try with `{cmd}`")
+
+        if should_be_resolves:
+            cmd = " ".join([f"--resolve={e}" for e in should_be_resolves])
+            message.append(f"HINT: Some binaries should be resolves, try with `{cmd}`")
+
+        super().__init__(softwrap("\n\n".join(message)))
 
 
 class _ResolveProviderType(Enum):

--- a/src/python/pants/core/goals/resolves.py
+++ b/src/python/pants/core/goals/resolves.py
@@ -2,12 +2,24 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from __future__ import annotations
 
+from enum import Enum
 from typing import TypeVar
 
 from pants.engine.unions import UnionMembership, union
 from pants.util.strutil import softwrap
 
 T = TypeVar("T", bound="ExportableTool")
+
+
+class ExportMode(Enum):
+    """How this tool should be exported.
+
+    resolve: in a language-based resolve
+    binary: as a single binary
+    """
+
+    resolve = "resolve"
+    binary = "binary"
 
 
 @union
@@ -23,6 +35,7 @@ class ExportableTool:
     """
 
     options_scope: str
+    export_mode: ExportMode = ExportMode.resolve
 
     @classmethod
     def help_for_generate_lockfile_with_default_location(cls, resolve_name: str):

--- a/src/python/pants/core/util_rules/external_tool.py
+++ b/src/python/pants/core/util_rules/external_tool.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import dataclasses
 import logging
+import os
 import textwrap
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
@@ -419,11 +420,11 @@ class MaybeExportResult:
 async def export_external_tool(
     req: _ExportExternalToolForResolveRequest, platform: Platform, union_membership: UnionMembership
 ) -> MaybeExportResult:
-    exporatbles = ExportableTool.filter_for_subclasses(
+    exportables = ExportableTool.filter_for_subclasses(
         union_membership,
         ExternalTool,  # type:ignore[type-abstract]  # ExternalTool is abstract, and mypy doesn't like that we might return it
     )
-    maybe_exportable = exporatbles.get(req.resolve)
+    maybe_exportable = exportables.get(req.resolve)
     if not maybe_exportable:
         return MaybeExportResult(None)
 
@@ -432,7 +433,7 @@ async def export_external_tool(
         DownloadedExternalTool, ExternalToolRequest, tool.get_request(platform)
     )
 
-    dest = "bin"
+    dest = os.path.join("bins", tool.name)
 
     return MaybeExportResult(
         ExportResult(

--- a/src/python/pants/core/util_rules/external_tool.py
+++ b/src/python/pants/core/util_rules/external_tool.py
@@ -440,6 +440,7 @@ async def export_external_tool(
             description=f"Export tool {req.resolve}",
             reldir=dest,
             digest=downloaded_tool.digest,
+            resolve=req.resolve
         )
     )
 

--- a/src/python/pants/core/util_rules/external_tool.py
+++ b/src/python/pants/core/util_rules/external_tool.py
@@ -13,7 +13,7 @@ from enum import Enum
 from pkg_resources import Requirement
 
 from pants.core.goals.export import ExportRequest, ExportResult, ExportResults, ExportSubsystem
-from pants.core.goals.resolves import ExportableTool
+from pants.core.goals.resolves import ExportableTool, ExportMode
 from pants.core.util_rules import archive
 from pants.core.util_rules.archive import ExtractedArchive
 from pants.engine.engine_aware import EngineAwareParameter
@@ -183,6 +183,8 @@ class ExternalTool(Subsystem, ExportableTool, ExternalToolOptionsMixin, metaclas
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.check_version_constraints()
+
+    export_mode = ExportMode.binary
 
     use_unsupported_version = EnumOption(
         advanced=True,

--- a/src/python/pants/core/util_rules/external_tool.py
+++ b/src/python/pants/core/util_rules/external_tool.py
@@ -10,7 +10,6 @@ import textwrap
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from pathlib import Path
 
 from pkg_resources import Requirement
 
@@ -104,6 +103,16 @@ class ExternalToolOptionsMixin:
         Derived from the classname, but subclasses can override, e.g., with a classproperty.
         """
         return cls.__name__.lower()
+
+    @classproperty
+    def binary_name(cls):
+        """The name of the binary, as it normally known.
+
+        This allows renaming a built binary to what users expect, even when the name is different.
+        For example, the binary might be "taplo-linux-x86_64" and the name "Taplo", but users expect
+        just "taplo".
+        """
+        return cls.name.lower()
 
     # The default values for --version and --known-versions, and the supported versions.
     # Subclasses must set appropriately.
@@ -456,7 +465,7 @@ async def export_external_tool(
             reldir=dest,
             digest=downloaded_tool.digest,
             resolve=req.resolve,
-            exported_binaries=(ExportedBinary(name=Path(exe).name, path_in_export=exe),),
+            exported_binaries=(ExportedBinary(name=tool.binary_name, path_in_export=exe),),
         )
     )
 

--- a/src/python/pants/core/util_rules/external_tool.py
+++ b/src/python/pants/core/util_rules/external_tool.py
@@ -440,7 +440,7 @@ async def export_external_tool(
             description=f"Export tool {req.resolve}",
             reldir=dest,
             digest=downloaded_tool.digest,
-            resolve=req.resolve
+            resolve=req.resolve,
         )
     )
 

--- a/src/python/pants/core/util_rules/external_tool_test.py
+++ b/src/python/pants/core/util_rules/external_tool_test.py
@@ -6,19 +6,32 @@ import re
 
 import pytest
 
+from pants.core.goals.export import ExportedBinary, ExportRequest
+from pants.core.goals.resolves import ExportableTool
+from pants.core.util_rules import external_tool
 from pants.core.util_rules.external_tool import (
+    DownloadedExternalTool,
+    ExportExternalToolRequest,
     ExternalTool,
     ExternalToolError,
     ExternalToolRequest,
+    MaybeExportResult,
     TemplatedExternalTool,
     UnknownVersion,
     UnsupportedVersion,
     UnsupportedVersionUsage,
+    _ExportExternalToolForResolveRequest,
+    export_external_tool,
 )
-from pants.engine.fs import DownloadFile, FileDigest
+from pants.engine.fs import CreateDigest, DigestContents, DownloadFile, FileContent, FileDigest
+from pants.engine.internals.native_engine import Digest
 from pants.engine.platform import Platform
+from pants.engine.rules import QueryRule
+from pants.engine.unions import UnionMembership
+from pants.option.scope import Scope, ScopedOptions
 from pants.testutil.option_util import create_subsystem
 from pants.testutil.pytest_util import no_exception
+from pants.testutil.rule_runner import MockGet, RuleRunner, run_rule_with_mocks
 from pants.util.strutil import softwrap
 
 
@@ -124,6 +137,85 @@ def test_generate_request() -> None:
         create_subsystem(
             FooBar, version="9.9.9", known_versions=FooBar.default_known_versions
         ).get_request(Platform.macos_x86_64)
+
+
+@pytest.fixture
+def rule_runner():
+    return RuleRunner(
+        rules=[QueryRule(ScopedOptions, (Scope,)), *external_tool.rules()],
+    )
+
+
+def test_export(rule_runner):
+    """Tests export_external_tool. Ensures we locate the class and prepare the Digest correctly"""
+
+    platform = Platform.linux_x86_64
+    union_membership = UnionMembership(
+        {ExportRequest: [ExportExternalToolRequest], ExportableTool: [TemplatedFooBar]}
+    )
+
+    templated_foobar = create_subsystem(
+        TemplatedFooBar,
+        version=TemplatedFooBar.default_version,
+        known_versions=TemplatedFooBar.default_known_versions,
+        url_template=TemplatedFooBar.default_url_template,
+        url_platform_mapping=TemplatedFooBar.default_url_platform_mapping,
+    )
+
+    def fake_get_options(scope) -> ScopedOptions:
+        """Copy the options from the instantiated tool."""
+        assert scope.scope == "foobar"
+        return ScopedOptions(
+            Scope("foobar"),
+            templated_foobar.options,
+        )
+
+    def fake_download(_) -> DownloadedExternalTool:
+        exe = templated_foobar.generate_exe(platform)
+        digest = rule_runner.request(
+            Digest,
+            (
+                CreateDigest(
+                    [
+                        FileContent(exe, b"exe"),
+                        FileContent(
+                            "readme.md", b"another file that would conflict if exported to `bin`"
+                        ),
+                    ]
+                ),
+            ),
+        )
+
+        return DownloadedExternalTool(digest, exe)
+
+    result: MaybeExportResult = run_rule_with_mocks(
+        export_external_tool,
+        rule_args=[_ExportExternalToolForResolveRequest("foobar"), platform, union_membership],
+        mock_gets=[
+            MockGet(output_type=ScopedOptions, input_types=(Scope,), mock=fake_get_options),
+            MockGet(
+                output_type=DownloadedExternalTool,
+                input_types=(ExternalToolRequest,),
+                mock=fake_download,
+            ),
+        ],
+        union_membership=union_membership,
+    )
+
+    assert result.result is not None, "failed to export anything at all"
+
+    exported = result.result
+    assert exported.exported_binaries == (
+        ExportedBinary("foobar", "foobar-3.4.7/bin/foobar"),
+    ), "didn't request exporting correct bin"
+
+    exported_digest: DigestContents = rule_runner.request(DigestContents, (exported.digest,))
+    assert len(exported_digest) == 2, "digest didn't contain all files"
+
+    exported_files = {e.path: e.content for e in exported_digest}
+    assert (
+        exported_files["foobar-3.4.7/bin/foobar"] == b"exe"
+    ), "digest didn't export our executable"
 
 
 class ConstrainedTool(TemplatedExternalTool):

--- a/src/python/pants/core/util_rules/external_tool_test.py
+++ b/src/python/pants/core/util_rules/external_tool_test.py
@@ -147,7 +147,10 @@ def rule_runner():
 
 
 def test_export(rule_runner):
-    """Tests export_external_tool. Ensures we locate the class and prepare the Digest correctly"""
+    """Tests export_external_tool.
+
+    Ensures we locate the class and prepare the Digest correctly
+    """
 
     platform = Platform.linux_x86_64
     union_membership = UnionMembership(

--- a/src/python/pants/jvm/resolve/coursier_setup.py
+++ b/src/python/pants/jvm/resolve/coursier_setup.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from hashlib import sha256
 from typing import ClassVar, Iterable, Tuple
 
+from pants.core.goals.resolves import ExportableTool
 from pants.core.util_rules import external_tool
 from pants.core.util_rules.adhoc_binaries import PythonBuildStandaloneBinary
 from pants.core.util_rules.external_tool import (
@@ -22,6 +23,7 @@ from pants.engine.fs import CreateDigest, Digest, FileContent, MergeDigests
 from pants.engine.platform import Platform
 from pants.engine.process import Process
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.unions import UnionRule
 from pants.option.option_types import StrListOption, StrOption
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
@@ -339,4 +341,5 @@ def rules():
     return [
         *collect_rules(),
         *external_tool.rules(),
+        UnionRule(ExportableTool, Coursier),
     ]

--- a/src/python/pants/jvm/resolve/coursier_setup.py
+++ b/src/python/pants/jvm/resolve/coursier_setup.py
@@ -341,5 +341,5 @@ def rules():
     return [
         *collect_rules(),
         *external_tool.rules(),
-        UnionRule(ExportableTool, Coursier),
+        UnionRule(ExportableTool, CoursierSubsystem),
     ]

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -23,10 +23,12 @@ from typing import (
     Generic,
     Iterable,
     Iterator,
+    Literal,
     Mapping,
     Sequence,
     Type,
     TypeVar,
+    Union,
     cast,
     overload,
 )
@@ -46,7 +48,7 @@ from pants.engine.goal import CurrentExecutingGoals, Goal
 from pants.engine.internals import native_engine
 from pants.engine.internals.native_engine import ProcessExecutionEnvironment, PyExecutor
 from pants.engine.internals.scheduler import ExecutionError, Scheduler, SchedulerSession
-from pants.engine.internals.selectors import Call, Effect, Get, Params
+from pants.engine.internals.selectors import AwaitableConstraints, Call, Effect, Get, Params
 from pants.engine.internals.session import SessionValues
 from pants.engine.platform import Platform
 from pants.engine.process import InteractiveProcess, InteractiveProcessResult
@@ -666,6 +668,66 @@ class MockGet(Generic[_O]):
     mock: Callable[..., _O]
 
 
+@dataclass(frozen=True)
+class MockRequestExceptionComparable:
+    category: Union[Literal["Get"], Literal["Effect"], str]
+    output_type: str
+    input_types: tuple[str, ...]
+
+    def __str__(self):
+        inputs = ",".join(str(e) for e in self.input_types)
+        return f"{self.category}({self.output_type}, ({inputs},))"
+
+
+def _compare_expected_mocks(
+    expected: Sequence[Union[Get, Effect, AwaitableConstraints]],
+    actual: Sequence[Union[MockGet, MockEffect]],
+) -> str:
+    """Try to be helpful with identifying the problem with supplied mocks."""
+
+    def as_comparable(
+        o: Union[Get, Effect, MockGet, MockEffect, AwaitableConstraints, type]
+    ) -> MockRequestExceptionComparable:
+        if isinstance(o, MockGet) or isinstance(o, Get):
+            category = "Get"
+        elif isinstance(o, MockEffect) or isinstance(o, Effect):
+            category = "Effect"
+        elif isinstance(o, AwaitableConstraints):
+            category = "Effect" if o.is_effect else "Get"
+        else:
+            # If we don't know of this class, try to give something meaningful
+            # This happened with AwaitableContraints
+            maybe_output_type = getattr(o, "output_type", None)
+            maybe_input_types = getattr(o, "input_types", None)
+            return MockRequestExceptionComparable(
+                category=f"Uncategorised of type {type(o).__qualname__}",
+                output_type=maybe_output_type.__name__ if maybe_output_type is not None else None,
+                input_types=tuple(e.__name__ for e in maybe_input_types)
+                if maybe_input_types is not None
+                else tuple(),
+            )
+
+        output_type = o.output_type.__name__
+        input_types = tuple(e.__name__ for e in o.input_types)
+
+        return MockRequestExceptionComparable(
+            category=category,
+            output_type=output_type,
+            input_types=input_types,
+        )
+
+    expected_as_comparable = {as_comparable(e) for e in expected}
+    actual_as_comparable = {as_comparable(e) for e in actual}
+
+    missing = expected_as_comparable - actual_as_comparable
+    additional = actual_as_comparable - expected_as_comparable
+
+    return (
+        f"HINT: missing : {[str(e) for e in missing]}\n"
+        f"HINT: additional : {[str(e) for e in additional]}\n"
+    )
+
+
 def run_rule_with_mocks(
     rule: Callable[..., Coroutine[Any, Any, _O]],
     *,
@@ -721,14 +783,17 @@ def run_rule_with_mocks(
     if task_rule:
         if len(rule_args) != len(task_rule.parameters):
             raise ValueError(
-                f"Rule expected to receive arguments of the form: {task_rule.parameters}; got: {rule_args}"
+                "Error running rule with mocks:\n"
+                f"Rule {task_rule.func.__qualname__} expected to receive arguments of the form: {task_rule.parameters}; got: {rule_args}"
             )
 
+        hints = _compare_expected_mocks(task_rule.awaitables, mock_gets)
         if len(mock_gets) != len(task_rule.awaitables):
             raise ValueError(
-                f"Rule expected to receive Get providers for:\n"
-                f"{pformat(task_rule.awaitables)}\ngot:\n"
-                f"{pformat(mock_gets)}"
+                "Error running rule with mocks:\n"
+                f"Rule {task_rule.func.__qualname__} expected to receive Get providers for:\n"
+                f"{pformat(list(task_rule.awaitables))}\ngot:\n"
+                f"{pformat(mock_gets)}\n" + hints
             )
         # Access the original function, rather than the trampoline that we would get by calling
         # it directly.


### PR DESCRIPTION
This MR wires `ExternalTool`s into the export machinery.

It exposes them under a separate cli arg `--bin`. Although it uses some of the same machinery as `--resolve`, there are several differences that I think support a separate flag (and some separate internal):
1. `ExternalTool`s don't have a resolve. They therefore must not show up for generating lockfiles. We have to implement this separation interally, so we should probably surface that.
2. They would be invoked directly (instead of `source dist/export/.../activate`)
3. We can put them all in a folder "dist/export/bin" so people can get them all

Closes #21251 

Bikeshedding:
- [x] Do we like `--bin` (yes)
- [x] Is putting all the bins in the same dir what we want (yes, we want a "bin" folder with all the binaries. But we have to put each binary's digest in its own folder to prevent collisions of supporting files)
- [-] Do we want to make all TemplatedExternalTools exportable? We could extend Subsystem.rules and add the UnionRule there (deferred from this MR)
