### PR TITLE
jvm resources action is not reproducible

### DIFF
--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -61,6 +61,10 @@ Docker inference is improved. Pants can now make inferences by target address fo
 
 Experimental support for a rust-based dockerfile parser can be enabled via `[dockerfile-parser].use_rust_parser` option.
 
+#### JVM
+
+When `jvm.reproducible_jars` flag is set resources jars would also be made reproducible, previously it was assumed resources jars are reproducible without additional action.
+
 #### Scala
 
 Source files no longer produce a dependency on Scala plugins. If you are using a Scala plugin that is also required by the source code (such as acyclic), please add an explicit dependency or set the `packages` field on the artifact.

--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -63,7 +63,7 @@ Experimental support for a rust-based dockerfile parser can be enabled via `[doc
 
 #### JVM
 
-When `jvm.reproducible_jars` flag is set resources jars would also be made reproducible, previously it was assumed resources jars are reproducible without additional action.
+When [the `jvm.reproducible_jars` flag](https://www.pantsbuild.org/2.21/reference/subsystems/jvm#reproducible_jars) is set resources jars are now also made reproducible, previously it was assumed resources jars are reproducible without additional action.
 
 #### Scala
 

--- a/src/python/pants/jvm/resources.py
+++ b/src/python/pants/jvm/resources.py
@@ -28,6 +28,7 @@ from pants.jvm.compile import (
     FallibleClasspathEntries,
     FallibleClasspathEntry,
 )
+from pants.jvm.strip_jar.strip_jar import StripJarRequest
 from pants.jvm.subsystems import JvmSubsystem
 from pants.util.logging import LogLevel
 
@@ -119,6 +120,9 @@ async def assemble_resources_jar(
     )
 
     output_digest = resources_jar_result.output_digest
+    if jvm.reproducible_jars:
+        output_digest = await Get(Digest, StripJarRequest(output_digest, tuple(output_files)))
+
     cpe = ClasspathEntry(output_digest, output_files, [])
 
     merged_cpe_digest = await Get(


### PR DESCRIPTION
While we are trying to zip the file without extra data and same creation date, we noticed in CI that the action can produce different digests. This commit adds another strip jar action after zipping the resources.

It would be great if this can be cherry-picked to 2.20.X and above