### PR TITLE
Squash errors from native options parser, treat as discrepancy

### DIFF
--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -992,7 +992,9 @@ class BootstrapOptions:
             This option controls how to report discrepancies that arise.
 
             - `error`: Discrepancies will cause Pants to exit.
+
             - `warning`: Discrepancies will be logged but Pants will continue.
+
             - `ignore`: A last resort to turn off this check entirely.
 
             If you encounter discrepancies that are not easily resolvable, please reach out to

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -396,6 +396,8 @@ class Options:
         )
         native_mismatch_msgs = []
 
+        scope_section = GLOBAL_SCOPE_CONFIG_SECTION if scope == GLOBAL_SCOPE else scope
+
         if self._native_options_validation == NativeOptionsValidation.ignore:
             native_values = None
         else:
@@ -403,7 +405,7 @@ class Options:
                 native_values = self.get_parser(scope).parse_args_native(self._native_parser)
             except Exception as e:
                 native_mismatch_msgs.append(
-                    f"Failed to parse options in scope [{scope}] "
+                    f"Failed to parse options in scope [{scope_section}] "
                     f"with native parser due to error: {e}"
                 )
                 native_values = None
@@ -454,7 +456,7 @@ class Options:
             for key in sorted(legacy_values.get_keys() | native_values.get_keys()):
                 if listify_tuples(legacy_values.get(key)) != native_values.get(key):
                     native_mismatch_msgs.append(
-                        f"Value mismatch for the option `{key}` in scope [{scope}]:\n"
+                        f"Value mismatch for the option `{key}` in scope [{scope_section}]:\n"
                         f"{legacy_val_info(key)}\n"
                         f"{native_val_info(key)}"
                     )

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -18,6 +18,7 @@ from pants.option.option_util import is_list_option
 from pants.option.option_value_container import OptionValueContainer, OptionValueContainerBuilder
 from pants.option.parser import Parser
 from pants.option.scope import GLOBAL_SCOPE, GLOBAL_SCOPE_CONFIG_SECTION, ScopeInfo
+from pants.util.docutil import doc_url
 from pants.util.memo import memoized_method
 from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
 from pants.util.strutil import softwrap
@@ -471,13 +472,15 @@ class Options:
                         {formatted_msgs}
 
                         If you can't resolve this discrepancy, please reach out to the Pants
-                        development team: https://www.pantsbuild.org/community/getting-help.
+                        development team: {doc_url('/community/getting-help')}.
 
                         The native parser will become the default in 2.23.x, and the legacy parser
                         will be removed in 2.24.x. So it is imperative that we find out about any
                         discrepancies during this transition period.
 
-                        You can use the global native_options_validation option to configure this check.
+                        You can use the global native_options_validation option
+                        ({doc_url('reference/global-options#native_options_validation')}) to
+                        configure this check.
                         """
                     )
                 )

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -399,7 +399,14 @@ class Options:
         if self._native_options_validation == NativeOptionsValidation.ignore:
             native_values = None
         else:
-            native_values = self.get_parser(scope).parse_args_native(self._native_parser)
+            try:
+                native_values = self.get_parser(scope).parse_args_native(self._native_parser)
+            except Exception as e:
+                native_mismatch_msgs.append(
+                    f"Failed to parse options in scope [{scope}] "
+                    f"with native parser due to error: {e}"
+                )
+                native_values = None
 
         # Check for any deprecation conditions, which are evaluated using `self._flag_matchers`.
         if check_deprecations:

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -396,8 +396,6 @@ class Options:
         )
         native_mismatch_msgs = []
 
-        scope_section = GLOBAL_SCOPE_CONFIG_SECTION if scope == GLOBAL_SCOPE else scope
-
         if self._native_options_validation == NativeOptionsValidation.ignore:
             native_values = None
         else:
@@ -405,8 +403,7 @@ class Options:
                 native_values = self.get_parser(scope).parse_args_native(self._native_parser)
             except Exception as e:
                 native_mismatch_msgs.append(
-                    f"Failed to parse options in scope [{scope_section}] "
-                    f"with native parser due to error: {e}"
+                    f"Failed to parse options with native parser due to error:\n    {e}"
                 )
                 native_values = None
 
@@ -456,27 +453,33 @@ class Options:
             for key in sorted(legacy_values.get_keys() | native_values.get_keys()):
                 if listify_tuples(legacy_values.get(key)) != native_values.get(key):
                     native_mismatch_msgs.append(
-                        f"Value mismatch for the option `{key}` in scope [{scope_section}]:\n"
-                        f"{legacy_val_info(key)}\n"
-                        f"{native_val_info(key)}"
+                        f"Value mismatch for the option `{key}`:\n"
+                        f"    {legacy_val_info(key)}\n"
+                        f"    {native_val_info(key)}"
                     )
 
         if native_mismatch_msgs:
 
             def log(log_func):
-                for msg in native_mismatch_msgs:
-                    log_func(msg)
+                scope_section = GLOBAL_SCOPE_CONFIG_SECTION if scope == GLOBAL_SCOPE else scope
+                formatted_msgs = "\n\n".join(f"- {m}" for m in native_mismatch_msgs)
                 log_func(
-                    "If you can't resolve this discrepancy, please reach out to the Pants "
-                    "development team: https://www.pantsbuild.org/community/getting-help. "
-                )
-                log_func(
-                    "The native parser will become the default in 2.23.x, and the legacy parser "
-                    "will be removed in 2.24.x. So it is imperative that we find out about any "
-                    "discrepancies during this transition period."
-                )
-                log_func(
-                    "You can use the global native_options_validation option to configure this check."
+                    softwrap(
+                        f"""
+                        Found differences between the new native options parser and the legacy options parser in scope [{scope_section}]:
+
+                        {formatted_msgs}
+
+                        If you can't resolve this discrepancy, please reach out to the Pants
+                        development team: https://www.pantsbuild.org/community/getting-help.
+
+                        The native parser will become the default in 2.23.x, and the legacy parser
+                        will be removed in 2.24.x. So it is imperative that we find out about any
+                        discrepancies during this transition period.
+
+                        You can use the global native_options_validation option to configure this check.
+                        """
+                    )
                 )
 
             if self._native_options_validation == NativeOptionsValidation.warning:

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -486,7 +486,9 @@ class Options:
                 log(logger.warning)
             elif self._native_options_validation == NativeOptionsValidation.error:
                 log(logger.error)
-                raise Exception("Option value mismatches detected, aborting.")
+                raise Exception(
+                    "Option value mismatches detected, see logs above for details. Aborting."
+                )
         # TODO: In a future release, switch to the native_values as authoritative.
         return legacy_values
 


### PR DESCRIPTION
This adjusts the code that compares the legacy and native parsers to catch any exception from the native parser and treat that as a discrepancy between legacy and native in the same way as the option values being parsed differently. That is, if the native parser throws an exception, catch & log it with all the extra info about the legacy -> native parser switch, rather than letting it bubble up as a normal exception.

Fixes #21262.

NB. this doesn't fix the underlying int vs. float parsing discrepancy (see #21264 and #21265), that'll just now be surfaced as logged errors rather than an exception after this change.

This also makes a few drive-by fixes related to this validation:

- fix the spacing in the docs of https://www.pantsbuild.org/2.22/reference/global-options#native_options_validation, so that the list is not softwrapped into oblivion
- log the error/warning as one big message, so that it's (arguably) easier to understand.
- add some more links
- use the `[GLOBAL]` section name not `[]` when the scope is empty

Before:

```
Exception: Expected [GLOBAL] pantsd_timeout_when_multiple_invocations to be a float but given 1
```

After the basic fix f152565 to convert the hard exception into logged errors:

```
11:39:00.96 [ERROR] Failed to parse options in scope [] with native parser due to error: Expected [GLOBAL] pantsd_timeout_when_multiple_invocations to be a float but given 1
11:39:00.96 [ERROR] If you can't resolve this discrepancy, please reach out to the Pants development team: https://www.pantsbuild.org/community/getting-help. 
11:39:00.96 [ERROR] The native parser will become the default in 2.23.x, and the legacy parser will be removed in 2.24.x. So it is imperative that we find out about any discrepancies during this transition period.
11:39:00.96 [ERROR] You can use the global native_options_validation option to configure this check.
```

After all the other changes:

```
12:03:02.33 [ERROR] Found differences between the new native options parser and the legacy options parser in scope [GLOBAL]:

- Failed to parse options with native parser due to error:
    Expected [GLOBAL] pantsd_timeout_when_multiple_invocations to be a float but given 1

If you can't resolve this discrepancy, please reach out to the Pants development team: https://www.pantsbuild.org//community/getting-help.

The native parser will become the default in 2.23.x, and the legacy parser will be removed in 2.24.x. So it is imperative that we find out about any discrepancies during this transition period.

You can use the global native_options_validation option (https://www.pantsbuild.org/2.23/reference/global-options#native_options_validation) to configure this check.
```