### PR TITLE
jvm resources action is not reproducible (Cherry-pick of #21259)

### DIFF
--- a/src/python/pants/jvm/resources.py
+++ b/src/python/pants/jvm/resources.py
@@ -28,6 +28,7 @@ from pants.jvm.compile import (
     FallibleClasspathEntries,
     FallibleClasspathEntry,
 )
+from pants.jvm.strip_jar.strip_jar import StripJarRequest
 from pants.jvm.subsystems import JvmSubsystem
 from pants.util.logging import LogLevel
 
@@ -119,6 +120,9 @@ async def assemble_resources_jar(
     )
 
     output_digest = resources_jar_result.output_digest
+    if jvm.reproducible_jars:
+        output_digest = await Get(Digest, StripJarRequest(output_digest, tuple(output_files)))
+
     cpe = ClasspathEntry(output_digest, output_files, [])
 
     merged_cpe_digest = await Get(


### PR DESCRIPTION
While we are trying to zip the file without extra data and same creation date, we noticed in CI that the action can produce different digests. This commit adds another strip jar action after zipping the resources.

It would be great if this can be cherry-picked to 2.20.X and above
