### PR TITLE
`[export].py_generated_sources_in_resolve` is an advanced option (Cherry-pick of #21270)

### DIFF
--- a/docs/notes/2.22.x.md
+++ b/docs/notes/2.22.x.md
@@ -119,7 +119,7 @@ New field `pex_build_extra_args` is available on FaaS targets [python_aws_lambda
 
 The `runtime` field of [`aws_python_lambda_layer`](https://www.pantsbuild.org/2.22/reference/targets/python_aws_lambda_layer#runtime) or [`aws_python_lambda_function`](https://www.pantsbuild.org/2.22/reference/targets/python_aws_lambda_function#runtime) now has a built-in complete platform configuration for x86-64 Python 3.12. This provides stable support for Python 3.12 lambdas out of the box, allowing deleting manual `complete_platforms` configuration if any.
 
-`pants export` of a Python resolve will now include generated Python sources (for example, from `protobuf_sources` or `thrift_sources` targets) if the resolve is configured in the new `--export-py-generated-sources-in-resolve` option.
+`pants export` of a Python resolve will now include generated Python sources (for example, from `protobuf_sources` or `thrift_sources` targets) if the resolve is configured in the new `--export-py-generated-sources-in-resolve` advanced option.
 
 Fix running python source files that have dashes in them (bug introduced in 2.20). For example: `pants run path/to/some-executable.py`
 

--- a/src/python/pants/backend/python/goals/export.py
+++ b/src/python/pants/backend/python/goals/export.py
@@ -144,7 +144,8 @@ class ExportPluginOptions:
             virtualenv exported for that resolve. Generated sources will be placed in the appropriate location within
             the site-packages directory of the mutable virtualenv.
             """
-        )
+        ),
+        advanced=True,
     )
 
 


### PR DESCRIPTION
Set `advaned=True` for the `[export].py_generated_sources_in_resolve`.

Feature added in 2.22.0a0 in #20975. Since this is essentially a documentation change, I think we should backport to 2.22.
