### PR TITLE
Squash errors from native options parser, treat as discrepancy (Cherry-pick of #21263)

### DIFF
--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1005,7 +1005,9 @@ class BootstrapOptions:
             This option controls how to report discrepancies that arise.
 
             - `error`: Discrepancies will cause Pants to exit.
+
             - `warning`: Discrepancies will be logged but Pants will continue.
+
             - `ignore`: A last resort to turn off this check entirely.
 
             If you encounter discrepancies that are not easily resolvable, please reach out to

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -18,6 +18,7 @@ from pants.option.option_util import is_list_option
 from pants.option.option_value_container import OptionValueContainer, OptionValueContainerBuilder
 from pants.option.parser import Parser
 from pants.option.scope import GLOBAL_SCOPE, GLOBAL_SCOPE_CONFIG_SECTION, ScopeInfo
+from pants.util.docutil import doc_url
 from pants.util.memo import memoized_method
 from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
 from pants.util.strutil import softwrap
@@ -389,11 +390,18 @@ class Options:
         legacy_values = self.get_parser(scope).parse_args(
             parse_args_request, log_warnings=log_parser_warnings
         )
+        native_mismatch_msgs = []
 
         if self._native_options_validation == NativeOptionsValidation.ignore:
             native_values = None
         else:
-            native_values = self.get_parser(scope).parse_args_native(self._native_parser)
+            try:
+                native_values = self.get_parser(scope).parse_args_native(self._native_parser)
+            except Exception as e:
+                native_mismatch_msgs.append(
+                    f"Failed to parse options with native parser due to error:\n    {e}"
+                )
+                native_values = None
 
         # Check for any deprecation conditions, which are evaluated using `self._flag_matchers`.
         if check_deprecations:
@@ -417,7 +425,6 @@ class Options:
                 return x
 
         if native_values:
-            msgs = []
 
             def legacy_val_info(k):
                 if k in legacy_values:
@@ -441,35 +448,45 @@ class Options:
 
             for key in sorted(legacy_values.get_keys() | native_values.get_keys()):
                 if listify_tuples(legacy_values.get(key)) != native_values.get(key):
-                    msgs.append(
-                        f"Value mismatch for the option `{key}` in scope [{scope}]:\n"
-                        f"{legacy_val_info(key)}\n"
-                        f"{native_val_info(key)}"
+                    native_mismatch_msgs.append(
+                        f"Value mismatch for the option `{key}`:\n"
+                        f"    {legacy_val_info(key)}\n"
+                        f"    {native_val_info(key)}"
                     )
 
-            if msgs:
+        if native_mismatch_msgs:
 
-                def log(log_func):
-                    for msg in msgs:
-                        log_func(msg)
-                    log_func(
-                        "If you can't resolve this discrepancy, please reach out to the Pants "
-                        "development team: https://www.pantsbuild.org/community/getting-help. "
-                    )
-                    log_func(
-                        "The native parser will become the default in 2.23.x, and the legacy parser "
-                        "will be removed in 2.24.x. So it is imperative that we find out about any "
-                        "discrepancies during this transition period."
-                    )
-                    log_func(
-                        "You can use the global native_options_validation option to configure this check."
-                    )
+            def log(log_func):
+                scope_section = GLOBAL_SCOPE_CONFIG_SECTION if scope == GLOBAL_SCOPE else scope
+                formatted_msgs = "\n\n".join(f"- {m}" for m in native_mismatch_msgs)
+                log_func(
+                    softwrap(
+                        f"""
+                        Found differences between the new native options parser and the legacy options parser in scope [{scope_section}]:
 
-                if self._native_options_validation == NativeOptionsValidation.warning:
-                    log(logger.warning)
-                elif self._native_options_validation == NativeOptionsValidation.error:
-                    log(logger.error)
-                    raise Exception("Option value mismatches detected, aborting.")
+                        {formatted_msgs}
+
+                        If you can't resolve this discrepancy, please reach out to the Pants
+                        development team: {doc_url('/community/getting-help')}.
+
+                        The native parser will become the default in 2.23.x, and the legacy parser
+                        will be removed in 2.24.x. So it is imperative that we find out about any
+                        discrepancies during this transition period.
+
+                        You can use the global native_options_validation option
+                        ({doc_url('reference/global-options#native_options_validation')}) to
+                        configure this check.
+                        """
+                    )
+                )
+
+            if self._native_options_validation == NativeOptionsValidation.warning:
+                log(logger.warning)
+            elif self._native_options_validation == NativeOptionsValidation.error:
+                log(logger.error)
+                raise Exception(
+                    "Option value mismatches detected, see logs above for details. Aborting."
+                )
         # TODO: In a future release, switch to the native_values as authoritative.
         return legacy_values
 


### PR DESCRIPTION
This adjusts the code that compares the legacy and native parsers to catch any exception from the native parser and treat that as a discrepancy between legacy and native in the same way as the option values being parsed differently. That is, if the native parser throws an exception, catch & log it with all the extra info about the legacy -> native parser switch, rather than letting it bubble up as a normal exception.

Fixes #21262.

NB. this doesn't fix the underlying int vs. float parsing discrepancy (see #21264 and #21265), that'll just now be surfaced as logged errors rather than an exception after this change.

This also makes a few drive-by fixes related to this validation:

- fix the spacing in the docs of https://www.pantsbuild.org/2.22/reference/global-options#native_options_validation, so that the list is not softwrapped into oblivion
- log the error/warning as one big message, so that it's (arguably) easier to understand.
- add some more links
- use the `[GLOBAL]` section name not `[]` when the scope is empty

Before:

```
Exception: Expected [GLOBAL] pantsd_timeout_when_multiple_invocations to be a float but given 1
```

After the basic fix f152565 to convert the hard exception into logged errors:

```
11:39:00.96 [ERROR] Failed to parse options in scope [] with native parser due to error: Expected [GLOBAL] pantsd_timeout_when_multiple_invocations to be a float but given 1
11:39:00.96 [ERROR] If you can't resolve this discrepancy, please reach out to the Pants development team: https://www.pantsbuild.org/community/getting-help. 
11:39:00.96 [ERROR] The native parser will become the default in 2.23.x, and the legacy parser will be removed in 2.24.x. So it is imperative that we find out about any discrepancies during this transition period.
11:39:00.96 [ERROR] You can use the global native_options_validation option to configure this check.
```

After all the other changes:

```
12:03:02.33 [ERROR] Found differences between the new native options parser and the legacy options parser in scope [GLOBAL]:

- Failed to parse options with native parser due to error:
    Expected [GLOBAL] pantsd_timeout_when_multiple_invocations to be a float but given 1

If you can't resolve this discrepancy, please reach out to the Pants development team: https://www.pantsbuild.org//community/getting-help.

The native parser will become the default in 2.23.x, and the legacy parser will be removed in 2.24.x. So it is imperative that we find out about any discrepancies during this transition period.

You can use the global native_options_validation option (https://www.pantsbuild.org/2.23/reference/global-options#native_options_validation) to configure this check.
```
