### PR TITLE
Allow int values for float options in native config file parser (Cherry-pick of #21265)

### DIFF
--- a/src/rust/engine/options/src/config.rs
+++ b/src/rust/engine/options/src/config.rs
@@ -192,6 +192,9 @@ impl FromValue for f64 {
     fn from_value(value: &Value) -> Result<f64, ValueConversionError> {
         if let Some(float) = value.as_float() {
             Ok(float)
+        } else if let Some(int) = value.as_integer() {
+            // See if we can parse as an int and coerce it to a float.
+            Ok(int as f64)
         } else {
             Err(ValueConversionError {
                 expected_type: "float",

--- a/src/rust/engine/options/src/config_tests.rs
+++ b/src/rust/engine/options/src/config_tests.rs
@@ -216,6 +216,7 @@ fn test_default_section_scalar() {
         99.88,
         ConfigReader::get_float,
     );
+    do_test("11", "22", "33", 11.0, 33.0, ConfigReader::get_float);
     do_test(
         "\"xx\"",
         "\"yy\"",


### PR DESCRIPTION
This adjusts the native parser handling of a TOML config file to allow an integer value to satisfy a float option, e.g. `123` and `123.0` are now equivalent, previously `123` was rejected. This makes config file parsing match env var and arg parsing.

This adds a test that fails before and passes after.

I've confirmed that the other mechanisms have tests for int-as-float, and thus only config files needed a change:

- env var: https://github.com/pantsbuild/pants/blob/459d39bb39f1f6bef605fd3b4fa129c5d721ea6f/src/rust/engine/options/src/env_tests.rs#L130
- arg: https://github.com/pantsbuild/pants/blob/459d39bb39f1f6bef605fd3b4fa129c5d721ea6f/src/rust/engine/options/src/args_tests.rs#L107


Fixes #21264 
