### PR TITLE
typescript: add support for unowned dependency behavior

### DIFF
--- a/src/python/pants/backend/javascript/dependency_inference/rules.py
+++ b/src/python/pants/backend/javascript/dependency_inference/rules.py
@@ -157,7 +157,7 @@ async def _prepare_inference_metadata(address: Address, file_path: str) -> Infer
     )
 
 
-def _add_extensions(file_imports: frozenset[str], file_extensions: tuple[str]) -> PathGlobs:
+def _add_extensions(file_imports: frozenset[str], file_extensions: tuple[str, ...]) -> PathGlobs:
     extensions = file_extensions + tuple(f"/index{ext}" for ext in file_extensions)
     return PathGlobs(
         string
@@ -173,7 +173,7 @@ def _add_extensions(file_imports: frozenset[str], file_extensions: tuple[str]) -
 async def _determine_import_from_candidates(
     candidates: ParsedJavascriptDependencyCandidate,
     package_candidate_map: NodePackageCandidateMap,
-    file_extensions: tuple[str],
+    file_extensions: tuple[str, ...],
 ) -> Addresses:
     paths = await path_globs_to_paths(
         _add_extensions(

--- a/src/python/pants/backend/javascript/dependency_inference/rules.py
+++ b/src/python/pants/backend/javascript/dependency_inference/rules.py
@@ -157,8 +157,7 @@ async def _prepare_inference_metadata(address: Address, file_path: str) -> Infer
     )
 
 
-def _add_extensions(file_imports: frozenset[str]) -> PathGlobs:
-    file_extensions = (*JS_FILE_EXTENSIONS, *JSX_FILE_EXTENSIONS)
+def _add_extensions(file_imports: frozenset[str], file_extensions: tuple[str]) -> PathGlobs:
     extensions = file_extensions + tuple(f"/index{ext}" for ext in file_extensions)
     return PathGlobs(
         string
@@ -174,8 +173,14 @@ def _add_extensions(file_imports: frozenset[str]) -> PathGlobs:
 async def _determine_import_from_candidates(
     candidates: ParsedJavascriptDependencyCandidate,
     package_candidate_map: NodePackageCandidateMap,
+    file_extensions: tuple[str],
 ) -> Addresses:
-    paths = await path_globs_to_paths(_add_extensions(candidates.file_imports))
+    paths = await path_globs_to_paths(
+        _add_extensions(
+            candidates.file_imports,
+            file_extensions,
+        )
+    )
     local_owners = await Get(Owners, OwnersRequest(paths.files))
 
     owning_targets = await Get(Targets, Addresses(local_owners))
@@ -250,7 +255,11 @@ async def infer_js_source_dependencies(
         zip(
             import_strings.imports,
             await concurrently(
-                _determine_import_from_candidates(candidates, candidate_pkgs)
+                _determine_import_from_candidates(
+                    candidates,
+                    candidate_pkgs,
+                    file_extensions=JS_FILE_EXTENSIONS + JSX_FILE_EXTENSIONS,
+                )
                 for string, candidates in import_strings.imports.items()
             ),
         )

--- a/src/python/pants/backend/typescript/dependency_inference/rules.py
+++ b/src/python/pants/backend/typescript/dependency_inference/rules.py
@@ -143,15 +143,6 @@ async def infer_typescript_source_dependencies(
             if not addresses and not _is_node_builtin_module(string)
         ),
     )
-    _handle_unowned_imports(
-        request.field_set.address,
-        nodejs_infer.unowned_dependency_behavior,
-        frozenset(
-            string
-            for string, addresses in imports.items()
-            if not addresses and not _is_node_builtin_module(string)
-        ),
-    )
     return InferredDependencies(itertools.chain.from_iterable(imports.values()))
 
 

--- a/src/python/pants/backend/typescript/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/typescript/dependency_inference/rules_test.py
@@ -60,7 +60,7 @@ def rule_runner() -> RuleRunner:
 def test_infers_typescript_file_imports_dependencies(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
-            "src/ts/BUILD": "typescript_sources()",
+            "src/ts/BUILD": "typescript_sources()\njavascript_sources(name='js')",
             "src/ts/index.ts": dedent(
                 """\
                 import { x } from "./localModuleA";
@@ -73,6 +73,9 @@ def test_infers_typescript_file_imports_dependencies(rule_runner: RuleRunner) ->
 
                 // You can import a file and not include any variables
                 import "./localModuleC";
+
+                // You can import a JS module in a TypeScript module
+                import { x } from './localModuleJs';
                 """
             ),
             "src/ts/localModuleA.ts": "",
@@ -83,6 +86,7 @@ def test_infers_typescript_file_imports_dependencies(rule_runner: RuleRunner) ->
             "src/ts/localModuleF.ts": "",
             "src/ts/localModuleG.ts": "",
             "src/ts/localModuleH.ts": "",
+            "src/ts/localModuleJs.js": "",
         }
     )
 
@@ -101,6 +105,7 @@ def test_infers_typescript_file_imports_dependencies(rule_runner: RuleRunner) ->
         Address("src/ts", relative_file_path="localModuleF.ts"),
         Address("src/ts", relative_file_path="localModuleG.ts"),
         Address("src/ts", relative_file_path="localModuleH.ts"),
+        Address("src/ts", relative_file_path="localModuleJs.js", target_name="js"),
     }
 
 

--- a/src/python/pants/backend/typescript/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/typescript/dependency_inference/rules_test.py
@@ -26,10 +26,11 @@ from pants.backend.typescript.target_types import (
     TypeScriptSourceTarget,
 )
 from pants.build_graph.address import Address
+from pants.core.util_rules.unowned_dependency_behavior import UnownedDependencyError
 from pants.engine.internals.graph import Owners, OwnersRequest
 from pants.engine.rules import QueryRule
 from pants.engine.target import InferredDependencies
-from pants.testutil.rule_runner import RuleRunner
+from pants.testutil.rule_runner import RuleRunner, engine_error
 
 
 @pytest.fixture
@@ -145,3 +146,45 @@ def test_infers_typescript_file_imports_dependencies_parent_dirs(rule_runner: Ru
         Address("src/ts", relative_file_path="localModuleB.ts"),
         Address("src/ts/subdir1", relative_file_path="localModuleC.ts"),
     }
+
+
+def test_unmatched_ts_dependencies_error_unowned_behaviour(rule_runner: RuleRunner) -> None:
+    rule_runner.set_options(["--nodejs-infer-unowned-dependency-behavior=error"])
+    rule_runner.write_files(
+        {
+            "root/project/src/modA.ts": "",
+            "root/project/src/index.ts": dedent(
+                """\
+                import { foo } from "./bar";
+                import { something } from "./modA";
+                """
+            ),
+            "root/project/src/BUILD": "typescript_sources()",
+        }
+    )
+
+    root_index_tgt = rule_runner.get_target(
+        Address("root/project/src", relative_file_path="index.ts")
+    )
+
+    with engine_error(UnownedDependencyError, contains="./bar"):
+        rule_runner.request(
+            InferredDependencies,
+            [
+                InferTypeScriptDependenciesRequest(
+                    TypeScriptSourceInferenceFieldSet.create(root_index_tgt)
+                )
+            ],
+        )
+
+    # having unowned dependencies should not lead to errors
+    rule_runner.set_options(["--nodejs-infer-unowned-dependency-behavior=warning"])
+    addresses = rule_runner.request(
+        InferredDependencies,
+        [
+            InferTypeScriptDependenciesRequest(
+                TypeScriptSourceInferenceFieldSet.create(root_index_tgt)
+            )
+        ],
+    ).include
+    assert list(addresses)[0].spec == Address("root/project/src/modA.ts").spec_path

--- a/testprojects/src/ts/frontend/config/app.ts
+++ b/testprojects/src/ts/frontend/config/app.ts
@@ -11,3 +11,5 @@ import * as Sentry from '@sentry/react';
 // local file import
 import { dispatcher } from './dispatcher';
 import { receiver } from './receiver';
+
+import { generator } from './generator';

--- a/testprojects/src/ts/frontend/config/generator.js
+++ b/testprojects/src/ts/frontend/config/generator.js
@@ -1,0 +1,2 @@
+// Copyright 2024 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).


### PR DESCRIPTION
This is a follow-up of https://github.com/pantsbuild/pants/pull/20293.

As per https://github.com/pantsbuild/pants/pull/20293#discussion_r1686305608, Pants should be able to gracefully handle invalid imports. 

Instead of having the warnings shown (by default), an error will be raised:

```
$ pants --backend-packages="+['pants.backend.experimental.typescript']" \
  --nodejs-infer-unowned-dependency-behavior=error \
  dependencies testprojects/src/ts/frontend/config/app.ts
```