### PR TITLE
add new cache scope to cache locally only

### DIFF
--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -136,8 +136,6 @@ Support for including additional binaries in the pants sandbox through the `--go
 
 When [the `jvm.reproducible_jars` flag](https://www.pantsbuild.org/2.21/reference/subsystems/jvm#reproducible_jars) is set resources jars are now also made reproducible, previously it was assumed resources jars are reproducible without additional action.
 
-Compression of class files into a jar file is not reading or writing from the remote cache. The size of jar files, combined with the low computational cost of compression, can outweigh the advantages of using a remote cache.
-
 #### Scala
 
 Source files no longer produce a dependency on Scala plugins. If you are using a Scala plugin that is also required by the source code (such as acyclic), please add an explicit dependency or set the `packages` field on the artifact.

--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -136,6 +136,8 @@ Support for including additional binaries in the pants sandbox through the `--go
 
 When [the `jvm.reproducible_jars` flag](https://www.pantsbuild.org/2.21/reference/subsystems/jvm#reproducible_jars) is set resources jars are now also made reproducible, previously it was assumed resources jars are reproducible without additional action.
 
+Compression of class files into a jar file is not reading or writing from the remote cache. The size of jar files, combined with the low computational cost of compression, can outweigh the advantages of using a remote cache.
+
 #### Scala
 
 Source files no longer produce a dependency on Scala plugins. If you are using a Scala plugin that is also required by the source code (such as acyclic), please add an explicit dependency or set the `packages` field on the artifact.

--- a/docs/notes/2.24.x.md
+++ b/docs/notes/2.24.x.md
@@ -25,6 +25,10 @@ We offer [formal sponsorship tiers for companies](https://www.pantsbuild.org/spo
 
 ### Backends
 
+#### JVM
+
+Compression of class files into a jar file is not reading or writing from the remote cache. The size of jar files, combined with the low computational cost of compression, can outweigh the advantages of using a remote cache.
+
 #### Kotlin
 
 The kotlin linter, [ktlint](https://pinterest.github.io/ktlint/), has been updated to version 1.3.1.

--- a/src/python/pants/backend/java/compile/javac.py
+++ b/src/python/pants/backend/java/compile/javac.py
@@ -17,7 +17,7 @@ from pants.backend.java.target_types import JavaFieldSet, JavaGeneratorFieldSet,
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.core.util_rules.system_binaries import BashBinary, ZipBinary
 from pants.engine.fs import EMPTY_DIGEST, CreateDigest, Digest, Directory, MergeDigests, Snapshot
-from pants.engine.process import FallibleProcessResult, Process, ProcessResult
+from pants.engine.process import FallibleProcessResult, Process, ProcessCacheScope, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import CoarsenedTarget, SourcesField
 from pants.engine.unions import UnionRule
@@ -214,6 +214,7 @@ async def compile_java_source(
                 output_files=output_files,
                 description=f"Capture outputs of {request.component} for javac",
                 level=LogLevel.TRACE,
+                cache_scope=ProcessCacheScope.LOCAL_SUCCESSFUL,
             ),
         )
         jar_output_digest = jar_result.output_digest

--- a/src/python/pants/backend/scala/compile/scalac.py
+++ b/src/python/pants/backend/scala/compile/scalac.py
@@ -29,7 +29,7 @@ from pants.core.util_rules.source_files import SourceFilesRequest
 from pants.core.util_rules.stripped_source_files import StrippedSourceFiles
 from pants.core.util_rules.system_binaries import BashBinary, ZipBinary
 from pants.engine.fs import EMPTY_DIGEST, CreateDigest, Digest, Directory, MergeDigests
-from pants.engine.process import FallibleProcessResult, Process, ProcessResult
+from pants.engine.process import FallibleProcessResult, Process, ProcessCacheScope, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import CoarsenedTarget, SourcesField
 from pants.engine.unions import UnionRule
@@ -240,6 +240,7 @@ async def compile_scala_source(
                 output_files=(output_file,),
                 description=f"Capture outputs of {request.component} for scalac",
                 level=LogLevel.TRACE,
+                cache_scope=ProcessCacheScope.LOCAL_SUCCESSFUL,
             ),
         )
         output_digest = jar_result.output_digest

--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -35,6 +35,10 @@ class ProcessCacheScope(Enum):
     ALWAYS = "always"
     # Cached in all locations, but only if the process exits successfully.
     SUCCESSFUL = "successful"
+    # Cached only locally, regardless of success or failure.
+    LOCAL_ALWAYS = "local_always"
+
+    LOCAL_SUCCESSFUL = "local_successful"
     # Cached only in memory (i.e. memoized in pantsd), but never persistently, regardless of
     # success vs. failure.
     PER_RESTART_ALWAYS = "per_restart_always"

--- a/src/python/pants/jvm/strip_jar/strip_jar.py
+++ b/src/python/pants/jvm/strip_jar/strip_jar.py
@@ -9,7 +9,7 @@ import pkg_resources
 from pants.core.goals.resolves import ExportableTool
 from pants.engine.fs import AddPrefix, CreateDigest, Digest, Directory, FileContent
 from pants.engine.internals.native_engine import MergeDigests, RemovePrefix
-from pants.engine.process import FallibleProcessResult, ProcessResult
+from pants.engine.process import FallibleProcessResult, ProcessCacheScope, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.jvm.jdk_rules import InternalJdk, JvmProcess
@@ -90,6 +90,7 @@ async def strip_jar(
             extra_nailgun_keys=extra_immutable_input_digests,
             description=f"Stripping jar {filenames[0]}",
             level=LogLevel.DEBUG,
+            cache_scope=ProcessCacheScope.LOCAL_SUCCESSFUL,
         ),
     )
 

--- a/src/rust/engine/process_execution/remote/src/remote_cache_tests.rs
+++ b/src/rust/engine/process_execution/remote/src/remote_cache_tests.rs
@@ -846,3 +846,48 @@ async fn make_action_result_basic() {
     };
     assert_eq!(expected_digests_set, actual_digests_set);
 }
+
+#[tokio::test]
+async fn no_remote_cache_on_scope_local() {
+    let (_, mut workunit) = WorkunitStore::setup_for_tests();
+
+    async fn run_process(
+        cache_hit: bool,
+        cache_scope: ProcessCacheScope,
+        workunit: &mut RunningWorkunit,
+    ) -> (i32, usize) {
+        let store_setup = StoreSetup::new_with_stub_cas(
+            StubCAS::builder()
+                .ac_read_delay(Duration::from_millis(100))
+                .build(),
+        )
+        .await;
+        let (local_runner, local_runner_call_counter) = create_local_runner(1, 500);
+        let cache_runner =
+            create_cached_runner(local_runner, &store_setup, CacheContentBehavior::Defer).await;
+
+        let (process, action_digest) = create_process(&store_setup).await;
+        let process = process.cache_scope(cache_scope);
+        if cache_hit {
+            store_setup
+                .cas
+                .action_cache
+                .insert(action_digest, 0, EMPTY_DIGEST, EMPTY_DIGEST);
+        }
+
+        assert_eq!(local_runner_call_counter.load(Ordering::SeqCst), 0);
+        let result = cache_runner
+            .run(Context::default(), workunit, process)
+            .await
+            .unwrap();
+
+        let final_local_count = local_runner_call_counter.load(Ordering::SeqCst);
+        (result.exit_code, final_local_count)
+    }
+
+    // remote is not used because of cache scope LocalSuccessful.
+    let (exit_code, local_call_count) =
+        run_process(true, ProcessCacheScope::LocalSuccessful, &mut workunit).await;
+    assert_eq!(exit_code, 1);
+    assert_eq!(local_call_count, 1);
+}

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -76,7 +76,8 @@ impl crate::CommandRunner for CommandRunner {
         workunit: &mut RunningWorkunit,
         req: Process,
     ) -> Result<FallibleProcessResultWithPlatform, ProcessError> {
-        let write_failures_to_cache = req.cache_scope == ProcessCacheScope::Always;
+        let write_failures_to_cache = req.cache_scope == ProcessCacheScope::Always
+            || req.cache_scope == ProcessCacheScope::LocalAlways;
         let key = CacheKey {
             digest: Some(
                 crate::get_digest(

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -218,6 +218,10 @@ pub enum ProcessCacheScope {
     Always,
     // Cached in all locations, but only if the process exits successfully.
     Successful,
+    // Cached only locally, regardless of success or failure.
+    LocalAlways,
+    // Cached only locally, but only if the process exits successfully.
+    LocalSuccessful,
     // Cached only in memory (i.e. memoized in pantsd), but never persistently, regardless of
     // success vs. failure.
     PerRestartAlways,
@@ -235,6 +239,8 @@ impl TryFrom<String> for ProcessCacheScope {
         match variant_candidate.to_lowercase().as_ref() {
             "always" => Ok(ProcessCacheScope::Always),
             "successful" => Ok(ProcessCacheScope::Successful),
+            "local_always" => Ok(ProcessCacheScope::LocalAlways),
+            "local_successful" => Ok(ProcessCacheScope::LocalSuccessful),
             "per_restart_always" => Ok(ProcessCacheScope::PerRestartAlways),
             "per_restart_successful" => Ok(ProcessCacheScope::PerRestartSuccessful),
             "per_session" => Ok(ProcessCacheScope::PerSession),

--- a/src/rust/engine/src/nodes/mod.rs
+++ b/src/rust/engine/src/nodes/mod.rs
@@ -588,8 +588,12 @@ impl Node for NodeKey {
         match (self, output) {
             (NodeKey::ExecuteProcess(ref ep), NodeOutput::ProcessResult(ref process_result)) => {
                 match ep.process.cache_scope {
-                    ProcessCacheScope::Always | ProcessCacheScope::PerRestartAlways => true,
-                    ProcessCacheScope::Successful | ProcessCacheScope::PerRestartSuccessful => {
+                    ProcessCacheScope::Always
+                    | ProcessCacheScope::LocalAlways
+                    | ProcessCacheScope::PerRestartAlways => true,
+                    ProcessCacheScope::Successful
+                    | ProcessCacheScope::LocalSuccessful
+                    | ProcessCacheScope::PerRestartSuccessful => {
                         process_result.result.exit_code == 0
                     }
                     ProcessCacheScope::PerSession => false,


### PR DESCRIPTION
Sometimes caching remotely can be more costly than caching locally. This is true when the size of the output is known to be big but the processing part is actually pretty fast. For JVM, this is true when zipping class files into jars.