### PR TITLE
Scala: Read consumed symbols from types applied to terms

### DIFF
--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -85,6 +85,8 @@ The deprecation for `crossversion="partial"` on `scala_artifact` has expired. Us
 
 The Scala dependency inference now understand usages of the `_root_` package name as a marker for disambiguating between colliding dependencies and will try to resolve those symbols as absolute. For instance, `import _root_.io.circe.syntax` will now be understood as an import of `io.circie.syntax`.
 
+Scala inference can also now identify dependencies between files when types are being used applied to other terms (i.e. nested function calls).
+
 ##### BSP (Build Server Protocol)
 
 The BSP (Build Server Protocol) support has been moved out of the Pants core into several new backends to faciliate disabling this support if it is not needed. The new backends are:

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
@@ -801,3 +801,24 @@ def test_typed_pattern_on_same_package(rule_runner: RuleRunner) -> None:
         "foo.Any",
         "foo.v",
     ]
+
+def test_applied_types_to_terms(rule_runner: RuleRunner) -> None:
+    analysis = _analyze(
+        rule_runner,
+        textwrap.dedent(
+            """\
+            package foo
+            
+            object B {
+                val valDef = bar(applied[List[Foo]])
+            }
+            """
+        ),
+    )
+
+    assert sorted(analysis.fully_qualified_consumed_symbols()) == [
+        "foo.Foo",
+        "foo.List",
+        "foo.applied",
+        "foo.bar",
+    ]

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
@@ -802,13 +802,13 @@ def test_typed_pattern_on_same_package(rule_runner: RuleRunner) -> None:
         "foo.v",
     ]
 
+
 def test_applied_types_to_terms(rule_runner: RuleRunner) -> None:
     analysis = _analyze(
         rule_runner,
         textwrap.dedent(
             """\
             package foo
-            
             object B {
                 val valDef = bar(applied[List[Foo]])
             }


### PR DESCRIPTION
Currently the Scala parser ignores the consumed types used when applied to terms (i.e. function calls).

This PR makes the parser aware of those types too.