### PR TITLE
[WIP] add a duration custom option type to support arbitrary duration units

### DIFF
--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import logging
 import sys
 from dataclasses import dataclass
+from datetime import timedelta
 from typing import Any
 
 from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE, ExitCode
@@ -53,7 +54,7 @@ class LocalPantsRunner:
 
     options: Options
     options_bootstrapper: OptionsBootstrapper
-    session_end_tasks_timeout: float
+    session_end_tasks_timeout: timedelta
     build_config: BuildConfiguration
     run_tracker: RunTracker
     specs: Specs

--- a/src/python/pants/engine/internals/native_engine.pyi
+++ b/src/python/pants/engine/internals/native_engine.pyi
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from io import RawIOBase
 from typing import (
     Any,
@@ -863,7 +863,7 @@ def session_record_test_observation(
 ) -> None: ...
 def session_isolated_shallow_clone(session: PySession, build_id: str) -> PySession: ...
 def session_wait_for_tail_tasks(
-    scheduler: PyScheduler, session: PySession, timeout: float
+    scheduler: PyScheduler, session: PySession, timeout: timedelta
 ) -> None: ...
 def graph_len(scheduler: PyScheduler) -> int: ...
 def graph_visualize(scheduler: PyScheduler, session: PySession, path: str) -> None: ...

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -7,6 +7,7 @@ import logging
 import os
 import time
 from dataclasses import dataclass
+from datetime import timedelta
 from pathlib import PurePath
 from types import CoroutineType
 from typing import Any, Callable, Dict, Iterable, NoReturn, Sequence, cast
@@ -661,7 +662,7 @@ class SchedulerSession:
     def cancel(self) -> None:
         self.py_session.cancel()
 
-    def wait_for_tail_tasks(self, timeout: float) -> None:
+    def wait_for_tail_tasks(self, timeout: timedelta) -> None:
         native_engine.session_wait_for_tail_tasks(self.py_scheduler, self.py_session, timeout)
 
 

--- a/src/python/pants/option/custom_types_test.py
+++ b/src/python/pants/option/custom_types_test.py
@@ -1,6 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from datetime import timedelta
 from textwrap import dedent
 from typing import Dict, List, Union
 
@@ -11,6 +12,7 @@ from pants.option.custom_types import (
     ListValueComponent,
     UnsetBool,
     _flatten_shlexed_list,
+    duration,
     memory_size,
 )
 from pants.option.errors import ParseError
@@ -62,6 +64,34 @@ def test_flatten_shlexed_list() -> None:
         "arg1=foo bar",
         "arg2=baz",
     ]
+
+
+@pytest.mark.parametrize(
+    "unit,key",
+    [
+        ("s", "seconds"),
+        ("second", "seconds"),
+        ("seconds", "seconds"),
+        ("ms", "milliseconds"),
+        ("milli", "milliseconds"),
+        ("millis", "milliseconds"),
+        ("millisecond", "milliseconds"),
+        ("milliseconds", "milliseconds"),
+        ("us", "microseconds"),
+        ("micro", "microseconds"),
+        ("micros", "microseconds"),
+        ("microsecond", "microseconds"),
+        ("microseconds", "microseconds"),
+        ("m", "minutes"),
+        ("minute", "minutes"),
+        ("minutes", "minutes"),
+        ("h", "hours"),
+        ("hour", "hours"),
+        ("hours", "hours"),
+    ],
+)
+def test_duration_accepts_units(unit, key) -> None:
+    assert duration(f"10{unit}") == timedelta(**{key: 10})
 
 
 class TestCustomTypes:

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -10,7 +10,7 @@ import re
 import sys
 import tempfile
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 from enum import Enum
 from pathlib import Path, PurePath
 from typing import Any, Callable, Type, TypeVar, cast
@@ -35,6 +35,7 @@ from pants.option.option_types import (
     BoolOption,
     DictOption,
     DirOption,
+    DurationOption,
     EnumOption,
     FloatOption,
     IntOption,
@@ -1489,8 +1490,8 @@ class BootstrapOptions:
         ),
         advanced=True,
     )
-    session_end_tasks_timeout = FloatOption(
-        default=3.0,
+    session_end_tasks_timeout = DurationOption(
+        default=timedelta(seconds=3.0),
         help=softwrap(
             """
             The time in seconds to wait for still-running "session end" tasks to complete before finishing

--- a/src/python/pants/option/option_types.py
+++ b/src/python/pants/option/option_types.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import inspect
 from dataclasses import dataclass
+from datetime import timedelta
 from enum import Enum
 from typing import Any, Callable, Generic, Iterator, TypeVar, Union, cast, overload
 
@@ -784,6 +785,18 @@ class DictOption(_OptionBase["dict[str, _ValueT]", "dict[str, _ValueT]"], Generi
 
     def _convert_(self, val: Any) -> dict[str, _ValueT]:
         return cast("dict[str, _ValueT]", val)
+
+
+# -----------------------------------------------------------------------------------------------
+# Duration Concrete Option Classes
+# -----------------------------------------------------------------------------------------------
+_DurationDefault = TypeVar("_DurationDefault", timedelta, None)
+
+
+class DurationOption(_OptionBase[timedelta, _DurationDefault]):
+    """An option representing a time duration (e.g., 50 milliseconds or 30 microseconds)."""
+
+    option_type: Any = custom_types.duration
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/option/option_types_test.py
+++ b/src/python/pants/option/option_types_test.py
@@ -4,13 +4,21 @@
 from __future__ import annotations
 
 import unittest.mock
+from datetime import timedelta
 from enum import Enum
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
 import pytest
 
-from pants.option.custom_types import dir_option, file_option, memory_size, shell_str, target_option
+from pants.option.custom_types import (
+    dir_option,
+    duration,
+    file_option,
+    memory_size,
+    shell_str,
+    target_option,
+)
 from pants.option.option_types import (
     ArgsListOption,
     BoolListOption,
@@ -18,6 +26,7 @@ from pants.option.option_types import (
     DictOption,
     DirListOption,
     DirOption,
+    DurationOption,
     EnumListOption,
     EnumOption,
     FileListOption,
@@ -68,6 +77,7 @@ def opt_info(*names, **options):
         (FileOption, "a str", ".", dict(type=file_option)),
         (ShellStrOption, "a str", "", dict(type=shell_str)),
         (MemorySizeOption, 20, 22, dict(type=memory_size)),
+        (DurationOption, "10s", timedelta(microseconds=10), dict(type=duration)),
         # List options
         (StrListOption, ["a str"], ["str1", "str2"], dict(type=list, member_type=str)),
         (IntListOption, [10], [1, 2], dict(type=list, member_type=int)),
@@ -314,6 +324,7 @@ def test_subsystem_option_ordering() -> None:
         FileOption,
         ShellStrOption,
         MemorySizeOption,
+        DurationOption,
         StrListOption,
         IntListOption,
         FloatListOption,

--- a/src/python/pants/option/options_fingerprinter.py
+++ b/src/python/pants/option/options_fingerprinter.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import os
 from collections import defaultdict
+from datetime import timedelta
 from enum import Enum
 from hashlib import sha1
 
@@ -21,6 +22,8 @@ class OptionEncoder(json.JSONEncoder):
         if isinstance(o, dict):
             # Sort by key to ensure that we don't invalidate if the insertion order changes.
             return {k: self.default(v) for k, v in sorted(o.items())}
+        if isinstance(o, timedelta):
+            return str(o)
         return super().default(o)
 
 

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -35,7 +35,7 @@ use pyo3::prelude::{
     pyclass, pyfunction, pymethods, pymodule, wrap_pyfunction, PyModule, PyObject,
     PyResult as PyO3Result, Python, ToPyObject,
 };
-use pyo3::types::{PyBytes, PyDict, PyList, PyTuple, PyType};
+use pyo3::types::{PyBytes, PyDelta, PyDict, PyList, PyTuple, PyType};
 use pyo3::{create_exception, IntoPy, PyAny, PyRef};
 use regex::Regex;
 use remote::remote_cache::RemoteCacheWarningsBehavior;
@@ -1354,10 +1354,10 @@ fn session_wait_for_tail_tasks(
     py: Python,
     py_scheduler: &PyScheduler,
     py_session: &PySession,
-    timeout: f64,
+    timeout: &PyDelta,
 ) -> PyO3Result<()> {
     let core = &py_scheduler.0.core;
-    let timeout = Duration::from_secs_f64(timeout);
+    let timeout = timeout.extract()?;
     core.executor.enter(|| {
         py.allow_threads(|| {
             core.executor


### PR DESCRIPTION
Add a `duration` custom type for options (and companion class `DurationOption`) to support users specifying duration-typed values with a number and a unit. This will allow migrating existing options which takes milliseconds or seconds or some other unit to finally be consistent with one another.

E.g., the user can specify `10ms` for 10 milliseconds or `50us` for 50 microseconds.