### PR TITLE
upgrade to Rust v1.80.1

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -197,7 +197,7 @@ jobs:
       with:
         key: macOS10-15-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain')
           }}-v2
-        path: '~/.rustup/toolchains/1.80.0-*
+        path: '~/.rustup/toolchains/1.80.1-*
 
           ~/.rustup/update-hashes
 
@@ -283,7 +283,7 @@ jobs:
       with:
         key: macOS11-ARM64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain')
           }}-v2
-        path: '~/.rustup/toolchains/1.80.0-*
+        path: '~/.rustup/toolchains/1.80.1-*
 
           ~/.rustup/update-hashes
 
@@ -375,7 +375,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.80.0-*
+        path: '~/.rustup/toolchains/1.80.1-*
 
           ~/.rustup/update-hashes
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,7 +38,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: Linux-ARM64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.80.0-*
+        path: '~/.rustup/toolchains/1.80.1-*
 
           ~/.rustup/update-hashes
 
@@ -131,7 +131,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.80.0-*
+        path: '~/.rustup/toolchains/1.80.1-*
 
           ~/.rustup/update-hashes
 
@@ -234,7 +234,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: macOS12-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.80.0-*
+        path: '~/.rustup/toolchains/1.80.1-*
 
           ~/.rustup/update-hashes
 
@@ -449,7 +449,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: macOS10-15-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.80.0-*
+        path: '~/.rustup/toolchains/1.80.1-*
 
           ~/.rustup/update-hashes
 
@@ -518,7 +518,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: macOS11-ARM64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.80.0-*
+        path: '~/.rustup/toolchains/1.80.1-*
 
           ~/.rustup/update-hashes
 

--- a/src/rust/engine/rust-toolchain
+++ b/src/rust/engine/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.80.0"
+channel = "1.80.1"
 # NB: We don't list the components (namely `clippy` and `rustfmt`) and instead rely on either the
 #  the profile being "default" (by-and-large the default profile) or the nice error message from
 #  `cargo fmt` and `cargo clippy` if the required component isn't installed


### PR DESCRIPTION
Upgrade to Rust v1.80.1.  Release notes are [here](https://blog.rust-lang.org/2024/08/08/Rust-1.80.1.html).