### PR TITLE
Apply InteractiveProcess restartability correctly (Cherry-pick of #21303)

### DIFF
--- a/src/python/pants/core/goals/deploy.py
+++ b/src/python/pants/core/goals/deploy.py
@@ -14,8 +14,9 @@ from pants.core.goals.publish import PublishFieldSet, PublishProcesses, PublishP
 from pants.engine.console import Console
 from pants.engine.environment import EnvironmentName
 from pants.engine.goal import Goal, GoalSubsystem
-from pants.engine.process import InteractiveProcess, InteractiveProcessResult
-from pants.engine.rules import Effect, Get, MultiGet, collect_rules, goal_rule, rule
+from pants.engine.intrinsics import run_interactive_process
+from pants.engine.process import InteractiveProcess
+from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule, rule
 from pants.engine.target import (
     FieldSet,
     FieldSetsPerTarget,
@@ -163,7 +164,7 @@ async def _invoke_process(
         return 0, tuple(results)
 
     logger.debug(f"Execute {process}")
-    res = await Effect(InteractiveProcessResult, InteractiveProcess, process)
+    res = await run_interactive_process(process)
     if res.exit_code == 0:
         sigil = console.sigil_succeeded()
         status = success_status

--- a/src/python/pants/core/goals/export.py
+++ b/src/python/pants/core/goals/export.py
@@ -23,8 +23,9 @@ from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.environment import EnvironmentName
 from pants.engine.fs import EMPTY_DIGEST, AddPrefix, Digest, MergeDigests, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
-from pants.engine.internals.selectors import Effect, Get, MultiGet
-from pants.engine.process import InteractiveProcess, InteractiveProcessResult
+from pants.engine.internals.selectors import Get, MultiGet
+from pants.engine.intrinsics import run_interactive_process
+from pants.engine.process import InteractiveProcess
 from pants.engine.rules import collect_rules, goal_rule
 from pants.engine.target import FilteredTargets, Target
 from pants.engine.unions import UnionMembership, union
@@ -174,7 +175,7 @@ async def export(
                 env={"PATH": environment.get("PATH", ""), **cmd.extra_env},
                 run_in_workspace=True,
             )
-            ipr = await Effect(InteractiveProcessResult, InteractiveProcess, ip)
+            ipr = await run_interactive_process(ip)
             if ipr.exit_code:
                 raise ExportError(f"Failed to write {result.description} to {result_dir}")
         if result.resolve:

--- a/src/python/pants/core/goals/publish.py
+++ b/src/python/pants/core/goals/publish.py
@@ -35,8 +35,9 @@ from pants.engine.collection import Collection
 from pants.engine.console import Console
 from pants.engine.environment import ChosenLocalEnvironmentName, EnvironmentName
 from pants.engine.goal import Goal, GoalSubsystem
-from pants.engine.process import InteractiveProcess, InteractiveProcessResult
-from pants.engine.rules import Effect, Get, MultiGet, collect_rules, goal_rule, rule
+from pants.engine.intrinsics import run_interactive_process_in_environment
+from pants.engine.process import InteractiveProcess
+from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule, rule
 from pants.engine.target import (
     FieldSet,
     ImmutableValue,
@@ -244,10 +245,7 @@ async def run_publish(
             continue
 
         logger.debug(f"Execute {pub.process}")
-        res = await Effect(
-            InteractiveProcessResult,
-            {pub.process: InteractiveProcess, local_environment.val: EnvironmentName},
-        )
+        res = await run_interactive_process_in_environment(pub.process, local_environment.val)
         if res.exit_code == 0:
             sigil = console.sigil_succeeded()
             status = "published"

--- a/src/python/pants/core/goals/repl.py
+++ b/src/python/pants/core/goals/repl.py
@@ -14,8 +14,9 @@ from pants.engine.env_vars import CompleteEnvironmentVars
 from pants.engine.environment import EnvironmentName
 from pants.engine.fs import Digest
 from pants.engine.goal import Goal, GoalSubsystem
-from pants.engine.process import InteractiveProcess, InteractiveProcessResult
-from pants.engine.rules import Effect, Get, collect_rules, goal_rule
+from pants.engine.intrinsics import run_interactive_process
+from pants.engine.process import InteractiveProcess
+from pants.engine.rules import Get, collect_rules, goal_rule
 from pants.engine.target import FilteredTargets, Target
 from pants.engine.unions import UnionMembership, union
 from pants.option.option_types import ArgsListOption, BoolOption, StrOption
@@ -147,8 +148,7 @@ async def run_repl(
 
     env = {**complete_env, **request.extra_env}
 
-    result = await Effect(
-        InteractiveProcessResult,
+    result = await run_interactive_process(
         InteractiveProcess(
             argv=(*request.args, *repl_subsystem.args),
             env=env,

--- a/src/python/pants/core/goals/run.py
+++ b/src/python/pants/core/goals/run.py
@@ -21,8 +21,9 @@ from pants.engine.internals.specs_rules import (
     AmbiguousImplementationsException,
     TooManyTargetsException,
 )
-from pants.engine.process import InteractiveProcess, InteractiveProcessResult
-from pants.engine.rules import Effect, Get, Rule, _uncacheable_rule, collect_rules, goal_rule, rule
+from pants.engine.intrinsics import run_interactive_process
+from pants.engine.process import InteractiveProcess
+from pants.engine.rules import Get, Rule, _uncacheable_rule, collect_rules, goal_rule, rule
 from pants.engine.target import (
     BoolField,
     FieldSet,
@@ -254,8 +255,7 @@ async def run(
             )
         )
 
-    result = await Effect(
-        InteractiveProcessResult,
+    result = await run_interactive_process(
         InteractiveProcess(
             argv=(*request.args, *run_subsystem.args),
             env={**complete_env, **request.extra_env},
@@ -265,7 +265,7 @@ async def run(
             keep_sandboxes=global_options.keep_sandboxes,
             immutable_input_digests=request.immutable_input_digests,
             append_only_caches=request.append_only_caches,
-        ),
+        )
     )
 
     return Run(result.exit_code)

--- a/src/python/pants/core/goals/run_integration_test.py
+++ b/src/python/pants/core/goals/run_integration_test.py
@@ -1,6 +1,5 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
 import time
 from pathlib import Path
 from textwrap import dedent
@@ -13,29 +12,34 @@ from pants.testutil.pants_integration_test import (
 
 
 @ensure_daemon
-def test_run_then_edit(use_pantsd: bool) -> None:
+def test_restartable(use_pantsd: bool) -> None:
     # These files must exist outside of a Pants `source_root` so that `coverage-py` doesn't try
     # to collect coverage metrics for them (as they are local to the chroot and coverage will
-    # error unable to find their source)
-    dirname = "not-a-source-root"
+    # error unable to find their source). We also need them to be in different locations for
+    # each parametrization of this test.
+    dirname = Path(f"test_restartable+{use_pantsd}/not-a-source-root").absolute()
+    dirname.mkdir(parents=True)
+
     files = {
-        f"{dirname}/slow.py": dedent(
+        dirname
+        / "slow.py": dedent(
             """\
             import time
             time.sleep(30)
             raise Exception("Should have been restarted by now!")
             """
         ),
-        f"{dirname}/BUILD": dedent(
+        dirname
+        / "BUILD": dedent(
             """\
             python_sources(name='lib')
             pex_binary(name='bin', entry_point='slow.py', restartable=True)
             """
         ),
     }
-    Path(dirname).mkdir(exist_ok=True)
-    for name, content in files.items():
-        Path(name).write_text(content)
+
+    for path, content in files.items():
+        path.write_text(content)
 
     with temporary_workdir() as workdir:
         client_handle = run_pants_with_workdir_without_waiting(
@@ -53,7 +57,70 @@ def test_run_then_edit(use_pantsd: bool) -> None:
         assert client_handle.process.poll() is None
 
         # Edit the file to restart the run, and check that it re-ran
-        Path(f"{dirname}/slow.py").write_text('print("No longer slow!")')
+        (dirname / "slow.py").write_text('print("No longer slow!")')
         result = client_handle.join()
         result.assert_success()
         assert result.stdout == "No longer slow!\n"
+
+
+@ensure_daemon
+def test_non_restartable(use_pantsd: bool) -> None:
+    # These files must exist outside of a Pants `source_root` so that `coverage-py` doesn't try
+    # to collect coverage metrics for them (as they are local to the chroot and coverage will
+    # error unable to find their source). We also need them to be in different locations for
+    # each parametrization of this test.
+    dirname = Path(f"test_non_restartable+{use_pantsd}/not-a-source-root").absolute()
+    dirname.mkdir(parents=True)
+
+    files = {
+        dirname
+        / "script.py": dedent(
+            """\
+            import os
+            import time
+
+            # Signal to the outside world that we've started.
+            touch_path = os.path.join("{dirname}", "touch")
+            with open(touch_path, "w") as fp:
+                fp.write("")
+            time.sleep(5)
+            print("Not restarted")
+            """.format(
+                dirname=dirname
+            )
+        ),
+        dirname
+        / "BUILD": dedent(
+            """\
+            python_sources(name="src", restartable=False)
+            """
+        ),
+    }
+
+    for path, content in files.items():
+        path.write_text(content)
+
+    with temporary_workdir() as workdir:
+        client_handle = run_pants_with_workdir_without_waiting(
+            [
+                "--backend-packages=['pants.backend.python']",
+                "run",
+                str(dirname / "script.py"),
+            ],
+            workdir=workdir,
+            use_pantsd=use_pantsd,
+        )
+
+        # Check that the pants run has actually started.
+        num_checks = 0
+        touch_path = dirname / "touch"
+        while not touch_path.exists():
+            time.sleep(1)
+            num_checks += 1
+            if num_checks > 30:
+                raise Exception("Failed to detect `pants run` process startup")
+
+        (dirname / "script.py").write_text('print("Restarted")')
+        result = client_handle.join()
+        result.assert_success()
+        assert result.stdout == "Not restarted\n"

--- a/src/python/pants/core/goals/run_test.py
+++ b/src/python/pants/core/goals/run_test.py
@@ -8,6 +8,7 @@ import sys
 from typing import Iterable, Mapping, cast
 
 import pytest
+from _pytest.monkeypatch import MonkeyPatch
 
 from pants.core.goals.run import (
     Run,
@@ -81,6 +82,7 @@ A_FIELD_SET = TestRunFieldSet.create(A_TARGET)
 
 def single_target_run(
     rule_runner: RuleRunner,
+    monkeypatch: MonkeyPatch,
     *,
     program_text: bytes,
     targets_to_field_sets: Mapping[Target, Iterable[FieldSet]] = FrozenDict(
@@ -89,6 +91,10 @@ def single_target_run(
 ) -> Run:
     workspace = Workspace(rule_runner.scheduler, _enforce_effects=False)
 
+    def noop():
+        pass
+
+    monkeypatch.setattr("pants.engine.intrinsics.task_side_effected", noop)
     with mock_console(rule_runner.options_bootstrapper) as (console, _):
         return run_rule_with_mocks(
             run,
@@ -139,16 +145,17 @@ def single_target_run(
         )
 
 
-def test_normal_run(rule_runner: RuleRunner) -> None:
+def test_normal_run(rule_runner: RuleRunner, monkeypatch: MonkeyPatch) -> None:
     program_text = f'#!{sys.executable}\nprint("hello")'.encode()
     res = single_target_run(
         rule_runner,
+        monkeypatch,
         program_text=program_text,
     )
     assert res.exit_code == 0
 
 
-def test_materialize_input_files(rule_runner: RuleRunner) -> None:
+def test_materialize_input_files(rule_runner: RuleRunner, monkeypatch: MonkeyPatch) -> None:
     program_text = f'#!{sys.executable}\nprint("hello")'.encode()
     binary = create_mock_run_request(rule_runner, program_text)
     with mock_console(rule_runner.options_bootstrapper):
@@ -162,13 +169,13 @@ def test_materialize_input_files(rule_runner: RuleRunner) -> None:
     assert result.exit_code == 0
 
 
-def test_failed_run(rule_runner: RuleRunner) -> None:
+def test_failed_run(rule_runner: RuleRunner, monkeypatch: MonkeyPatch) -> None:
     program_text = f'#!{sys.executable}\nraise RuntimeError("foo")'.encode()
-    res = single_target_run(rule_runner, program_text=program_text)
+    res = single_target_run(rule_runner, monkeypatch, program_text=program_text)
     assert res.exit_code == 1
 
 
-def test_multi_target_error(rule_runner: RuleRunner) -> None:
+def test_multi_target_error(rule_runner: RuleRunner, monkeypatch: MonkeyPatch) -> None:
     program_text = f'#!{sys.executable}\nprint("hello")'.encode()
     t1 = TestBinaryTarget({}, Address("some/addr"))
     t1_fs = TestRunFieldSet.create(t1)
@@ -176,16 +183,22 @@ def test_multi_target_error(rule_runner: RuleRunner) -> None:
     t2_fs = TestRunFieldSet.create(t2)
     with pytest.raises(TooManyTargetsException):
         single_target_run(
-            rule_runner, program_text=program_text, targets_to_field_sets={t1: [t1_fs], t2: [t2_fs]}
+            rule_runner,
+            monkeypatch,
+            program_text=program_text,
+            targets_to_field_sets={t1: [t1_fs], t2: [t2_fs]},
         )
 
 
-def test_multi_field_set_error(rule_runner: RuleRunner) -> None:
+def test_multi_field_set_error(rule_runner: RuleRunner, monkeypatch: MonkeyPatch) -> None:
     program_text = f'#!{sys.executable}\nprint("hello")'.encode()
     target = TestBinaryTarget({}, Address("some/addr"))
     fs1 = TestRunFieldSet.create(target)
     fs2 = TestRunFieldSet.create(target)
     with pytest.raises(AmbiguousImplementationsException):
         single_target_run(
-            rule_runner, program_text=program_text, targets_to_field_sets={target: [fs1, fs2]}
+            rule_runner,
+            monkeypatch,
+            program_text=program_text,
+            targets_to_field_sets={target: [fs1, fs2]},
         )

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -38,13 +38,9 @@ from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import EMPTY_FILE_DIGEST, Digest, FileDigest, MergeDigests, Snapshot, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.internals.session import RunId
-from pants.engine.process import (
-    FallibleProcessResult,
-    InteractiveProcess,
-    InteractiveProcessResult,
-    ProcessResultMetadata,
-)
-from pants.engine.rules import Effect, Get, MultiGet, collect_rules, goal_rule, rule
+from pants.engine.intrinsics import run_interactive_process_in_environment
+from pants.engine.process import FallibleProcessResult, InteractiveProcess, ProcessResultMetadata
+from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule, rule
 from pants.engine.target import (
     FieldSet,
     FieldSetsPerTarget,
@@ -857,12 +853,8 @@ async def _run_debug_tests(
                 )
             )
 
-        debug_result = await Effect(
-            InteractiveProcessResult,
-            {
-                debug_request.process: InteractiveProcess,
-                environment_name: EnvironmentName,
-            },
+        debug_result = await run_interactive_process_in_environment(
+            debug_request.process, environment_name
         )
         if debug_result.exit_code != 0:
             exit_code = debug_result.exit_code
@@ -1014,9 +1006,8 @@ async def run_tests(
                 OpenFiles, OpenFilesRequest(coverage_report_files, error_if_open_not_found=False)
             )
             for process in open_files.processes:
-                _ = await Effect(
-                    InteractiveProcessResult,
-                    {process: InteractiveProcess, local_environment_name.val: EnvironmentName},
+                _ = await run_interactive_process_in_environment(
+                    process, local_environment_name.val
                 )
 
         for coverage_reports in coverage_reports_collections:

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -11,6 +11,7 @@ from textwrap import dedent
 from typing import Any, Iterable
 
 import pytest
+from _pytest.monkeypatch import MonkeyPatch
 
 from pants.backend.python.goals import package_pex_binary
 from pants.backend.python.target_types import PexBinary, PythonSourcesGeneratorTarget
@@ -600,7 +601,11 @@ def test_format_rerun_command(results: list[TestResult], expected: None | str) -
     assert expected == _format_test_rerun_command(results)
 
 
-def test_debug_target(rule_runner: PythonRuleRunner) -> None:
+def test_debug_target(rule_runner: PythonRuleRunner, monkeypatch: MonkeyPatch) -> None:
+    def noop():
+        pass
+
+    monkeypatch.setattr("pants.engine.intrinsics.task_side_effected", noop)
     exit_code, _ = run_test_rule(
         rule_runner,
         request_type=SuccessfulRequest,

--- a/src/python/pants/engine/intrinsics.py
+++ b/src/python/pants/engine/intrinsics.py
@@ -3,6 +3,9 @@
 
 from __future__ import annotations
 
+import logging
+
+from pants.engine.environment import EnvironmentName
 from pants.engine.fs import (
     AddPrefix,
     CreateDigest,
@@ -23,7 +26,7 @@ from pants.engine.internals.native_dep_inference import (
     NativeParsedJavascriptDependencies,
     NativeParsedPythonDependencies,
 )
-from pants.engine.internals.native_engine import NativeDependenciesRequest
+from pants.engine.internals.native_engine import NativeDependenciesRequest, task_side_effected
 from pants.engine.internals.session import RunId, SessionValues
 from pants.engine.process import (
     FallibleProcessResult,
@@ -32,7 +35,8 @@ from pants.engine.process import (
     Process,
     ProcessExecutionEnvironment,
 )
-from pants.engine.rules import _uncacheable_rule, collect_rules, rule
+from pants.engine.rules import _uncacheable_rule, collect_rules, implicitly, rule
+from pants.util.docutil import git_url
 
 
 @rule
@@ -117,11 +121,55 @@ async def run_id() -> RunId:
     return await native_engine.run_id()
 
 
+__SQUELCH_WARNING = "__squelch_warning"
+
+
+# NB: Call one of the helpers below, instead of calling this rule directly,
+#  to ensure correct application of restartable logic.
 @_uncacheable_rule
-async def interactive_process(
+async def _interactive_process(
     process: InteractiveProcess, process_execution_environment: ProcessExecutionEnvironment
 ) -> InteractiveProcessResult:
+    # This is a crafty way for a caller to signal into this function without a dedicated arg
+    # (which would confound the solver).  Note that we go via __dict__ instead of using
+    # setattr/delattr, because those error for frozen dataclasses.
+    if __SQUELCH_WARNING in process.__dict__:
+        del process.__dict__[__SQUELCH_WARNING]
+    else:
+        logging.warning(
+            "A plugin is calling `await Effect(InteractiveProcessResult, InteractiveProcess, "
+            "process)` directly. This will cause restarting logic not to be applied. "
+            "Use `await run_interactive_process(process)` or `await "
+            "run_interactive_process_in_environment(process, environment_name)` instead. "
+            f"See {git_url('src/python/pants/engine/intrinsics.py')} for more details."
+        )
     return await native_engine.interactive_process(process, process_execution_environment)
+
+
+async def run_interactive_process(process: InteractiveProcess) -> InteractiveProcessResult:
+    # NB: We must call task_side_effected() in this helper, rather than in a nested @rule call,
+    #  so that the Task for the @rule that calls this helper is the one marked as non-restartable.
+    if not process.restartable:
+        task_side_effected()
+
+    process.__dict__[__SQUELCH_WARNING] = True
+    ret: InteractiveProcessResult = await _interactive_process(process, **implicitly())
+    return ret
+
+
+async def run_interactive_process_in_environment(
+    process: InteractiveProcess, environment_name: EnvironmentName
+) -> InteractiveProcessResult:
+    # NB: We must call task_side_effected() in this helper, rather than in a nested @rule call,
+    #  so that the Task for the @rule that calls this helper is the one marked as non-restartable.
+    if not process.restartable:
+        task_side_effected()
+
+    process.__dict__[__SQUELCH_WARNING] = True
+    ret: InteractiveProcessResult = await _interactive_process(
+        process, **implicitly({environment_name: EnvironmentName})
+    )
+    return ret
 
 
 @rule

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -399,9 +399,28 @@ def goal_rule(*args, **kwargs):
     return inner_rule(*args, **kwargs, rule_type=RuleType.goal_rule, cacheable=False)
 
 
+@overload
+def _uncacheable_rule(
+    func: Callable[P, Coroutine[Any, Any, R]]
+) -> Callable[P, Coroutine[Any, Any, R]]:
+    ...
+
+
+@overload
+def _uncacheable_rule(func: Callable[P, R]) -> Callable[P, Coroutine[Any, Any, R]]:
+    ...
+
+
+@overload
+def _uncacheable_rule(
+    *args, func: None = None, **kwargs: Any
+) -> Callable[[Union[SyncRuleT, AsyncRuleT]], AsyncRuleT]:
+    ...
+
+
 # This has a "private" name, as we don't (yet?) want it to be part of the rule API, at least
 # until we figure out the implications, and have a handle on the semantics and use-cases.
-def _uncacheable_rule(*args, **kwargs) -> AsyncRuleT | RuleDecorator:
+def _uncacheable_rule(*args, **kwargs):
     return inner_rule(*args, **kwargs, rule_type=RuleType.uncacheable_rule, cacheable=False)
 
 


### PR DESCRIPTION
The switch in #20874 to exposing intrinsics as python functions
meant that running an InteractiveProcess now occurs under a
separate engine Task than the goal that invokes it.

This introduced a bug where the `restartable` property was
applied to the InteractiveProcess intrinsic's Task, and not, as 
previously, to the goal's Task.

This change ensures that the restartability applies correctly,
via new rule helpers.

Fixes #21243.
