### PR TITLE
A runs-on config file

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -1,0 +1,6 @@
+images:
+  ubuntu22-full-arm64-python3.9:
+    platform: "linux"
+    arch: "arm64"
+    owner: "408085265505"
+    ami: "ami-0d16a07627bf409b8"


### PR DESCRIPTION
We want to use RunsOn (https://runs-on.com/) for managing
self-hosted aarch64 runners on AWS. However their config
must be read from main, so we must get this in separately,
(and without a green CI, since we currently have no
aarch64 runner). 

However this file clearly affects nothing at all in our code
or CI config (yet), it is just an inert file until we set up RunsOn,
so it should be fine to merge even without green CI.