### PR TITLE
Update aarch64 AMI

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -1,6 +1,6 @@
 images:
-  ubuntu22-full-arm64-python3.9:
+  ubuntu22-full-arm64-python3.7-python3.8-python3.9:
     platform: "linux"
     arch: "arm64"
     owner: "408085265505"
-    ami: "ami-03799c9e952745a1b"
+    ami: "ami-072f12824058aa801"


### PR DESCRIPTION
The new AMI includes Pythons 3.7 and 3.8, as well as 3.9,
since some of the tests we run on aarch64 require those
earlier versions.

We should figure out if and why that is in fact necessary,
it may be enough to run those on x86_64.