### PR TITLE
Switch to using runs-on Linux ARM64 runners (Cherry-pick of #21325)

### DIFF
--- a/.github/workflows/clear_self_hosted_persistent_caches.yaml
+++ b/.github/workflows/clear_self_hosted_persistent_caches.yaml
@@ -7,8 +7,10 @@ jobs:
   clean_linux_arm64:
     runs-on:
     - self-hosted
-    - Linux
-    - ARM64
+    - runs-on
+    - runner=4cpu-linux-arm64
+    - image=ubuntu22-full-arm64-python3.7-python3.8-python3.9
+    - run-id=${{ github.run_id }}
     steps:
     - name: df before
       run: df -h

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@
 jobs:
   build_wheels_linux_arm64:
     container:
-      image: ghcr.io/pantsbuild/wheel_build_aarch64:v3-8384c5cf
+      image: quay.io/pypa/manylinux2014_aarch64:latest
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
       PANTS_REMOTE_CACHE_READ: 'false'
@@ -17,8 +17,10 @@ jobs:
     - release_info
     runs-on:
     - self-hosted
-    - Linux
-    - ARM64
+    - runs-on
+    - runner=4cpu-linux-arm64
+    - image=ubuntu22-full-arm64-python3.7-python3.8-python3.9
+    - run-id=${{ github.run_id }}
     steps:
     - name: Check out code
       uses: actions/checkout@v3
@@ -47,12 +49,10 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         version: 23.x
-    - env:
-        PANTS_CONFIG_FILES: +['pants.ci.toml','pants.ci.aarch64.toml']
+    - env: {}
       name: Build wheels
       run: ./pants run src/python/pants_release/release.py -- build-wheels
-    - env:
-        PANTS_CONFIG_FILES: +['pants.ci.toml','pants.ci.aarch64.toml']
+    - env: {}
       name: Build Pants PEX
       run: ./pants package src/python/pants:pants-pex
     - continue-on-error: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,8 +20,10 @@ jobs:
     - classify_changes
     runs-on:
     - self-hosted
-    - Linux
-    - ARM64
+    - runs-on
+    - runner=4cpu-linux-arm64
+    - image=ubuntu22-full-arm64-python3.7-python3.8-python3.9
+    - run-id=${{ github.run_id }}
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -99,7 +101,7 @@ jobs:
         TMPDIR: ${{ runner.temp }}
       if: needs.classify_changes.outputs.rust == 'true'
       name: Test Rust
-      run: ./cargo test --locked --tests -- --nocapture --test-threads=8
+      run: ./cargo test --locked --tests -- --nocapture
     timeout-minutes: 60
   bootstrap_pants_linux_x86_64:
     env:
@@ -299,7 +301,7 @@ jobs:
     timeout-minutes: 60
   build_wheels_linux_arm64:
     container:
-      image: ghcr.io/pantsbuild/wheel_build_aarch64:v3-8384c5cf
+      image: quay.io/pypa/manylinux2014_aarch64:latest
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
       MODE: debug
@@ -312,8 +314,10 @@ jobs:
     - classify_changes
     runs-on:
     - self-hosted
-    - Linux
-    - ARM64
+    - runs-on
+    - runner=4cpu-linux-arm64
+    - image=ubuntu22-full-arm64-python3.7-python3.8-python3.9
+    - run-id=${{ github.run_id }}
     steps:
     - name: Check out code
       uses: actions/checkout@v3
@@ -340,12 +344,10 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         version: 23.x
-    - env:
-        PANTS_CONFIG_FILES: +['pants.ci.toml','pants.ci.aarch64.toml']
+    - env: {}
       name: Build wheels
       run: ./pants run src/python/pants_release/release.py -- build-wheels
-    - env:
-        PANTS_CONFIG_FILES: +['pants.ci.toml','pants.ci.aarch64.toml']
+    - env: {}
       name: Build Pants PEX
       run: ./pants package src/python/pants:pants-pex
     - continue-on-error: true
@@ -724,8 +726,7 @@ jobs:
     - id: set_merge_ok
       run: echo 'merge_ok=true' >> ${GITHUB_OUTPUT}
   test_python_linux_arm64:
-    env:
-      PANTS_CONFIG_FILES: +['pants.ci.toml','pants.ci.aarch64.toml']
+    env: {}
     if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only != 'true')
     name: Test Python (Linux-ARM64)
     needs:
@@ -733,8 +734,10 @@ jobs:
     - classify_changes
     runs-on:
     - self-hosted
-    - Linux
-    - ARM64
+    - runs-on
+    - runner=4cpu-linux-arm64
+    - image=ubuntu22-full-arm64-python3.7-python3.8-python3.9
+    - run-id=${{ github.run_id }}
     steps:
     - name: Check out code
       uses: actions/checkout@v4

--- a/pants.ci.aarch64.toml
+++ b/pants.ci.aarch64.toml
@@ -1,8 +1,0 @@
-[GLOBAL]
-# Our physical aarch64 CI instance is a very burly machine with 80 cores.
-# A single GHA self-hosted runner can only run one job at a time, so to use
-# more of the machine's resources, we run multiple self-hosted runners on it
-# and constrain each one here so they don't all try and use all the cores.
-# TODO: Control this externally, on the machine itself?
-rule_threads_core = 8
-process_execution_local_parallelism = 16

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -84,6 +84,8 @@ class Platform(Enum):
 
 GITHUB_HOSTED = {Platform.LINUX_X86_64, Platform.MACOS12_X86_64}
 SELF_HOSTED = {Platform.LINUX_ARM64, Platform.MACOS10_15_X86_64, Platform.MACOS11_ARM64}
+# We control these runners, so we preinstall and expose python on them.
+HAS_PYTHON = {Platform.LINUX_ARM64, Platform.MACOS10_15_X86_64, Platform.MACOS11_ARM64}
 CARGO_AUDIT_IGNORED_ADVISORY_IDS = (
     "RUSTSEC-2020-0128",  # returns a false positive on the cache crate, which is a local crate not a 3rd party crate
 )
@@ -450,7 +452,12 @@ class Helper:
         elif self.platform == Platform.LINUX_X86_64:
             ret += ["ubuntu-20.04"]
         elif self.platform == Platform.LINUX_ARM64:
-            ret += ["Linux", "ARM64"]
+            ret += [
+                "runs-on",
+                "runner=4cpu-linux-arm64",
+                "image=ubuntu22-full-arm64-python3.7-python3.8-python3.9",
+                "run-id=${{ github.run_id }}",
+            ]
         else:
             raise ValueError(f"Unsupported platform: {self.platform_name()}")
         return ret
@@ -463,8 +470,6 @@ class Helper:
             ret["ARCHFLAGS"] = "-arch x86_64"
         if self.platform == Platform.MACOS11_ARM64:
             ret["ARCHFLAGS"] = "-arch arm64"
-        if self.platform == Platform.LINUX_ARM64:
-            ret["PANTS_CONFIG_FILES"] = "+['pants.ci.toml','pants.ci.aarch64.toml']"
         if self.platform == Platform.LINUX_X86_64:
             # Currently we run Linux x86_64 CI on GitHub Actions-hosted hardware, and
             # these are weak dual-core machines. Default parallelism on those machines
@@ -474,14 +479,6 @@ class Helper:
             # TODO: If we add a "redo timed out tests" feature, we can kill this.
             ret["PANTS_PROCESS_EXECUTION_LOCAL_PARALLELISM"] = "1"
         return ret
-
-    def maybe_append_cargo_test_parallelism(self, cmd: str) -> str:
-        if self.platform == Platform.LINUX_ARM64:
-            # TODO: The ARM64 runner has enough cores to reliably trigger #18191 using
-            # our default settings. We lower parallelism here as a bandaid to work around
-            # #18191 until it can be resolved.
-            return f"{cmd} --test-threads=8"
-        return cmd
 
     def wrap_cmd(self, cmd: str) -> str:
         if self.platform == Platform.MACOS11_ARM64:
@@ -573,17 +570,13 @@ class Helper:
 
     def setup_primary_python(self) -> Sequence[Step]:
         ret = []
-        # We pre-install Python on our self-hosted platforms.
-        # We must set it up on Github-hosted platforms.
-        if self.platform in GITHUB_HOSTED:
+        if self.platform not in HAS_PYTHON:
             ret.append(install_python(PYTHON_VERSION))
         return ret
 
     def expose_all_pythons(self) -> Sequence[Step]:
         ret = []
-        # Self-hosted runners already have all relevant pythons exposed on their PATH, so we
-        # only use this action on the GitHub-hosted platforms.
-        if self.platform in GITHUB_HOSTED:
+        if self.platform not in HAS_PYTHON:
             ret.append(
                 {
                     "name": "Expose Pythons",
@@ -689,11 +682,7 @@ def bootstrap_jobs(
         # We pass --tests to skip doc tests because our generated protos contain
         # invalid doc tests in their comments. We do not pass --all as BRFS tests don't
         # pass on GHA MacOS containers.
-        step_cmd = helper.wrap_cmd(
-            helper.maybe_append_cargo_test_parallelism(
-                "./cargo test --locked --tests -- --nocapture"
-            )
-        )
+        step_cmd = helper.wrap_cmd("./cargo test --locked --tests -- --nocapture")
     elif rust_testing == RustTesting.ALL:
         human_readable_job_name += ", test and lint Rust"
         human_readable_step_name = "Test and lint Rust"
@@ -703,9 +692,7 @@ def bootstrap_jobs(
         step_cmd = "\n".join(
             [
                 "./build-support/bin/check_rust_pre_commit.sh",
-                helper.maybe_append_cargo_test_parallelism(
-                    "./cargo test --locked --all --tests --benches -- --nocapture"
-                ),
+                "./cargo test --locked --all --tests --benches -- --nocapture",
                 "./cargo doc",
             ]
         )
@@ -881,9 +868,7 @@ def build_wheels_job(
     if platform == Platform.LINUX_X86_64:
         container = {"image": "quay.io/pypa/manylinux2014_x86_64:latest"}
     elif platform == Platform.LINUX_ARM64:
-        # Unfortunately Equinix do not support the CentOS 7 image on the hardware we've been
-        # generously given by the Works on ARM program. So we have to build in this image.
-        container = {"image": "ghcr.io/pantsbuild/wheel_build_aarch64:v3-8384c5cf"}
+        container = {"image": "quay.io/pypa/manylinux2014_aarch64:latest"}
     else:
         container = None
 


### PR DESCRIPTION
The runners themselves have already been set up on AWS, 
using runs-on's cloudformation stack. 

See https://runs-on.com/
