### PR TITLE
Explain rare quoting differences between the options parsers

### DIFF
--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -467,7 +467,7 @@ class Options:
                 log_func(
                     softwrap(
                         f"""
-                        Found differences between the new native options parser and the legacy 
+                        Found differences between the new native options parser and the legacy
                         options parser in scope [{scope_section}]:
 
                         {formatted_msgs}
@@ -485,7 +485,7 @@ class Options:
 
                         Note that there is a known issue with differences in the handling of backslash
                         escapes in config values of type list-of-string. The solution to this issue will
-                        be to change the escaping in your config values appropriately when switching to 
+                        be to change the escaping in your config values appropriately when switching to
                         2.23.x Typically this will mean removing superfluous escapes, and the new behavior
                         will be more ergonomic.
                         """

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -467,7 +467,8 @@ class Options:
                 log_func(
                     softwrap(
                         f"""
-                        Found differences between the new native options parser and the legacy options parser in scope [{scope_section}]:
+                        Found differences between the new native options parser and the legacy 
+                        options parser in scope [{scope_section}]:
 
                         {formatted_msgs}
 
@@ -481,6 +482,12 @@ class Options:
                         You can use the global native_options_validation option
                         ({doc_url('reference/global-options#native_options_validation')}) to
                         configure this check.
+
+                        Note that there is a known issue with differences in the handling of backslash
+                        escapes in config values of type list-of-string. The solution to this issue will
+                        be to change the escaping in your config values appropriately when switching to 
+                        2.23.x Typically this will mean removing superfluous escapes, and the new behavior
+                        will be more ergonomic.
                         """
                     )
                 )

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -484,7 +484,7 @@ class Options:
                         configure this check.
 
                         Note that there is a known issue with differences in the handling of backslash
-                        escapes in config values of type list-of-string. The solution to this issue will
+                        escapes in config values of type list-of-string. This surfaces as, for instance, legacy value `['"example"']` and native value `['\\"example\\"']`. The solution to this issue will
                         be to change the escaping in your config values appropriately when switching to
                         2.23.x. Typically this will mean removing superfluous escapes, and the new behavior
                         will be more ergonomic.

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -486,7 +486,7 @@ class Options:
                         Note that there is a known issue with differences in the handling of backslash
                         escapes in config values of type list-of-string. The solution to this issue will
                         be to change the escaping in your config values appropriately when switching to
-                        2.23.x Typically this will mean removing superfluous escapes, and the new behavior
+                        2.23.x. Typically this will mean removing superfluous escapes, and the new behavior
                         will be more ergonomic.
                         """
                     )


### PR DESCRIPTION
There isn't an easy fix to ensure backwards compatibility, and the
legacy behavior is actually worse, so on balance it seems like
warning about this uncommon case is probably best.

Addresses https://github.com/pantsbuild/pants/issues/21343