### PR TITLE
Run all vcs versioning processes locally

### DIFF
--- a/docs/notes/2.22.x.md
+++ b/docs/notes/2.22.x.md
@@ -121,6 +121,8 @@ The `runtime` field of [`aws_python_lambda_layer`](https://www.pantsbuild.org/2.
 
 `pants export` of a Python resolve will now include generated Python sources (for example, from `protobuf_sources` or `thrift_sources` targets) if the resolve is configured in the new `--export-py-generated-sources-in-resolve` advanced option.
 
+When using the `vcs_version` target, force `setuptools_scm` git operations to run in the local environment, so that the local git state is available to them.
+
 #### Semgrep
 
 The default version of `semgrep` used by the `pants.backends.experimental.tool.semgrep` backend is now version 1.72.0, upgraded from 1.46.0. This version requires Python 3.8 or greater.

--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -193,8 +193,6 @@ The docs for the `check` goal have been updated to state that third-party type s
 
 Deprecate the `--export-py-hermetic-scripts` option in favor of the new `--export-py-non-hermetic-scripts-in-resolve` option which allows configuring the hermetic scripts logic on a per-resolve basis.
 
-When using the `vcs_version` target, force `setuptools_scm` git operations to run in the local environment, so that the local git state is available to them.
-
 [The `pants.backend.python.providers.experimental.pyenv` backend](https://www.pantsbuild.org/2.23/reference/subsystems/pyenv-python-provider) now respects the patch version of the interpeter constraints.
 
 The function-as-a-service targets like `python_google_cloud_function`, `python_aws_lambda_function`, and `python_aws_lambda_layer` have had many changes to how they handle platforms:


### PR DESCRIPTION
When using environments we must ensure we run VCS-related
processes in the local environment and not the inherited one,
as a docker environment will not have access to Git state.

In #21188 we made setuptools_scm itself run locally,
but this was not sufficient: this change makes sure we
also run the pex building and git binary discovery 
in the local environment.

Fixes #21178