### PR TITLE
Explain rare quoting differences between the options parsers (Cherry-pick of #21352)

### DIFF
--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -462,7 +462,8 @@ class Options:
                 log_func(
                     softwrap(
                         f"""
-                        Found differences between the new native options parser and the legacy options parser in scope [{scope_section}]:
+                        Found differences between the new native options parser and the legacy
+                        options parser in scope [{scope_section}]:
 
                         {formatted_msgs}
 
@@ -476,6 +477,12 @@ class Options:
                         You can use the global native_options_validation option
                         ({doc_url('reference/global-options#native_options_validation')}) to
                         configure this check.
+
+                        Note that there is a known issue with differences in the handling of backslash
+                        escapes in config values of type list-of-string. This surfaces as, for instance, legacy value `['"example"']` and native value `['\\"example\\"']`. The solution to this issue will
+                        be to change the escaping in your config values appropriately when switching to
+                        2.23.x. Typically this will mean removing superfluous escapes, and the new behavior
+                        will be more ergonomic.
                         """
                     )
                 )


### PR DESCRIPTION
There isn't an easy fix to ensure backwards compatibility, and the
legacy behavior is actually worse, so on balance it seems like
warning about this uncommon case is probably best.

Addresses https://github.com/pantsbuild/pants/issues/21343
