### PR TITLE
Run all vcs versioning processes locally (cherrypick of #21353)

### DIFF
--- a/docs/notes/2.22.x.md
+++ b/docs/notes/2.22.x.md
@@ -123,6 +123,8 @@ The `runtime` field of [`aws_python_lambda_layer`](https://www.pantsbuild.org/2.
 
 Fix running python source files that have dashes in them (bug introduced in 2.20). For example: `pants run path/to/some-executable.py`
 
+When using the `vcs_version` target, force `setuptools_scm` git operations to run in the local environment, so that the local git state is available to them.
+
 #### Semgrep
 
 The default version of `semgrep` used by the `pants.backends.experimental.tool.semgrep` backend is now version 1.72.0, upgraded from 1.46.0. This version requires Python 3.8 or greater.


### PR DESCRIPTION
When using environments we must ensure we run VCS-related processes
in the local environment and not the inherited one, as a docker environment
will not have access to Git state.

In #21188 we made setuptools_scm itself run locally, but this was not sufficient:
this change makes sure we also run the pex building and git binary discovery
in the local environment.

Fixes #21178