### PR TITLE
docs: mention that --changed-* filters only apply to first party dependencies

### DIFF
--- a/docs/docs/using-pants/advanced-target-selection.mdx
+++ b/docs/docs/using-pants/advanced-target-selection.mdx
@@ -38,6 +38,10 @@ By default, `--changed-since` will only run over files directly changed. Often, 
   test
 ```
 
+:::note Hint: Pants does not understand transitive third-party dependencies in this context.
+All of the `--changed-*` filters apply only to first party dependencies in your codebase.
+:::
+
 ## `filter` options
 
 Use filters to operate on only targets that match the predicate, e.g. only running Python tests.

--- a/docs/docs/using-pants/advanced-target-selection.mdx
+++ b/docs/docs/using-pants/advanced-target-selection.mdx
@@ -39,7 +39,10 @@ By default, `--changed-since` will only run over files directly changed. Often, 
 ```
 
 :::note Hint: Pants does not understand transitive third-party dependencies in this context.
-All of the `--changed-*` filters apply only to first party dependencies in your codebase.
+Changes to third-party dependencies (particularly, dependencies of dependencies) may not be
+surfaced as you expect via `--changed-*`. In particular, any change to a single dependency
+within a lockfile or a target generator (such as `python_requirements`) will consider all
+users of _any_ dependency changed, transitively.
 :::
 
 ## `filter` options


### PR DESCRIPTION
Clarifying what `--changed-*` filters apply to as I saw a couple of questions from users so it may be helpful to reflect this nuance in the docs.