### PR TITLE
Terraform: downgrade python-hcl2 from 4.3.2 to 4.3.0 to work around parsing issues (Cherry-pick of #21361)

### DIFF
--- a/src/python/pants/backend/terraform/dependency_inference.py
+++ b/src/python/pants/backend/terraform/dependency_inference.py
@@ -47,7 +47,8 @@ class TerraformHcl2Parser(PythonToolRequirementsBase):
     options_scope = "terraform-hcl2-parser"
     help = "Used to parse Terraform modules to infer their dependencies."
 
-    default_requirements = ["python-hcl2>=3.0.5,<5"]
+    # versions 4.3.2+ have parsing issues; bump once resolved
+    default_requirements = ["python-hcl2>=3.0.5,<=4.3.0"]
 
     register_interpreter_constraints = True
 

--- a/src/python/pants/backend/terraform/hcl2.lock
+++ b/src/python/pants/backend/terraform/hcl2.lock
@@ -9,7 +9,7 @@
 //     "CPython<4,>=3.7"
 //   ],
 //   "generated_with_requirements": [
-//     "python-hcl2<5,>=3.0.5"
+//     "python-hcl2<=4.3.0,>=3.0.5"
 //   ],
 //   "manylinux": "manylinux2014",
 //   "requirement_constraints": [],
@@ -54,13 +54,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "e958fe52ca0519e3500eb621caa16be6be9c27870cbcd1879d8c538fb85067ea",
-              "url": "https://files.pythonhosted.org/packages/34/0a/39813c22334a22b43ffd16acb06aa4541ea1d34bfeab2aa2bcece83a471f/python_hcl2-4.3.2-py3-none-any.whl"
+              "hash": "6c76d1d523b6fb8ca6d1f70308459f310853e124c4bbfe9fcc018bcacdc78a40",
+              "url": "https://files.pythonhosted.org/packages/0d/58/32f70aa0d776a467472ee0077929e03d4febb681f6b564cec1d58c09d95b/python_hcl2-4.3.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7122661438be27ccd8b8f3db71969d8ef2cce3b3cf183e88f8172575e7405a65",
-              "url": "https://files.pythonhosted.org/packages/ef/94/cc6f7100a857a5a4a676c2c71322ca476051278fad4ec956f0116c1d3834/python-hcl2-4.3.2.tar.gz"
+              "hash": "41e37e2a9b3d223da5e8ebc99e72b40d2315087e966f458f7eac13c7831d9b9e",
+              "url": "https://files.pythonhosted.org/packages/0b/8c/9c7858604212b25e040652fba3eb06514b363b857544f7321ca97185f001/python-hcl2-4.3.0.tar.gz"
             }
           ],
           "project_name": "python-hcl2",
@@ -68,7 +68,7 @@
             "lark<2,>=1"
           ],
           "requires_python": ">=3.7.0",
-          "version": "4.3.2"
+          "version": "4.3.0"
         }
       ],
       "platform_tag": null
@@ -77,11 +77,11 @@
   "only_builds": [],
   "only_wheels": [],
   "path_mappings": {},
-  "pex_version": "2.2.1",
+  "pex_version": "2.3.3",
   "pip_version": "24.0",
   "prefer_older_binary": false,
   "requirements": [
-    "python-hcl2<5,>=3.0.5"
+    "python-hcl2<=4.3.0,>=3.0.5"
   ],
   "requires_python": [
     "<4,>=3.7"


### PR DESCRIPTION
`python-hcl2` 4.3.1+ has some serious issues with parsing certain kinds of expressions, like multi-line 
ternaries. The issues opened can be seen [here](https://github.com/amplify-education/python-hcl2/issues?q=is%3Aissue+is%3Aopen+%22unexpected+token%22).

It looks like 4.3.5 has fixed a bunch of the issues, but I'm still seeing some errors on our repo, and I think
it's better to keep to 4.3.0 until the authors of the issues close them and we're sure there are no regressions.

Also, 4.3.0 is still compatible with py3.12, so it doesn't undo the efforts of https://github.com/pantsbuild/pants/pull/20365.

Generated with `pants run build-support/bin/generate_builtin_lockfiles.py -- terraform-hcl2-parser`.
