### PR TITLE
docs: Fix duped v1.pantsbuild.org link

### DIFF
--- a/docs/docs/introduction/welcome-to-pants.mdx
+++ b/docs/docs/introduction/welcome-to-pants.mdx
@@ -68,5 +68,5 @@ Pants is making engineering teams productive and happy at a range of companies a
 Pants is an open-source software project, developed at [github.com/pantsbuild/pants](https://github.com/pantsbuild/pants). Pants is released under the [Apache License 2.0](https://github.com/pantsbuild/pants/blob/master/LICENSE).
 
 :::note Pants v2 vs. v1
-This documentation is for Pants v2, which is a new system built from the ground up, based on lessons from past work on Pants v1, as well valued feedback from the user community. See [\[https://v1.pantsbuild.org](https://v1.pantsbuild.org)](https://v1.pantsbuild.org/) for Pants v1 documentation.
+This documentation is for Pants v2, which is a new system built from the ground up, based on lessons from past work on Pants v1, as well valued feedback from the user community. See [https://v1.pantsbuild.org](https://v1.pantsbuild.org/) for Pants v1 documentation.
 :::


### PR DESCRIPTION
Fix the raw link markup in the note [at the bottom of this page](https://www.pantsbuild.org/2.21/docs/introduction/welcome-to-pants):

![image](https://github.com/user-attachments/assets/6026a4fa-7c7d-428a-8027-972033c56b94)
