### PR TITLE
A execute_process_or_raise rule alias.

### DIFF
--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -332,7 +332,10 @@ Plugins may now provide "auxiliary" goals by implememting the `auxiliary_goals` 
 
 Added support for plugins that implement provide `PytestPluginSetup` to inject additional `sys.path` entries. Simply pass a tuple of paths in `PytestPluginSetup(extra_sys_path=(...))`. This gets to pytest via `PEX_EXTRA_SYS_PATH`, similar to how scripts might modify `PYTHONPATH` when running pytest outside of pants.
 
-Several intrinsics have been renamed more succinctly, to make them more readable and developer-friendly when called by name.
+Several intrinsics have been renamed more succinctly, to make them more readable and developer-friendly when called by name. 
+
+An execute_process_or_raise() alias has been added for the fallible_to_exec_result_or_raise rule, so that
+code that calls it by name on an implicitly executed process will be more readable.
 
 ### Other minor tweaks
 

--- a/src/python/pants/backend/debian/rules.py
+++ b/src/python/pants/backend/debian/rules.py
@@ -22,7 +22,7 @@ from pants.core.util_rules.system_binaries import BinaryPathRequest, TarBinary, 
 from pants.engine.fs import CreateDigest, FileEntry
 from pants.engine.internals.graph import hydrate_sources
 from pants.engine.intrinsics import create_digest, get_digest_entries
-from pants.engine.process import Process, fallible_to_exec_result_or_raise
+from pants.engine.process import Process, execute_process_or_raise
 from pants.engine.rules import Rule, collect_rules, implicitly, rule
 from pants.engine.target import HydrateSourcesRequest
 from pants.engine.unions import UnionRule
@@ -63,7 +63,7 @@ async def package_debian_package(
     # snapshot.files isn't empty.
     sources_directory_name = PurePath(hydrated_sources.snapshot.files[0]).parts[0]
 
-    result = await fallible_to_exec_result_or_raise(
+    result = await execute_process_or_raise(
         **implicitly(
             Process(
                 argv=(

--- a/src/python/pants/backend/java/lint/google_java_format/rules.py
+++ b/src/python/pants/backend/java/lint/google_java_format/rules.py
@@ -9,7 +9,7 @@ from pants.backend.java.target_types import JavaSourceField
 from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
 from pants.core.goals.resolves import ExportableTool
 from pants.core.util_rules.partitions import PartitionerType
-from pants.engine.process import fallible_to_exec_result_or_raise
+from pants.engine.process import execute_process_or_raise
 from pants.engine.rules import collect_rules, implicitly, rule
 from pants.engine.target import FieldSet, Target
 from pants.engine.unions import UnionRule
@@ -74,7 +74,7 @@ async def google_java_format_fmt(
         *request.files,
     ]
 
-    result = await fallible_to_exec_result_or_raise(
+    result = await execute_process_or_raise(
         **implicitly(
             JvmProcess(
                 jdk=jdk,

--- a/src/python/pants/backend/kotlin/lint/ktlint/rules.py
+++ b/src/python/pants/backend/kotlin/lint/ktlint/rules.py
@@ -9,7 +9,7 @@ from pants.backend.kotlin.target_types import KotlinSourceField
 from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
 from pants.core.goals.resolves import ExportableTool
 from pants.core.util_rules.partitions import PartitionerType
-from pants.engine.process import fallible_to_exec_result_or_raise
+from pants.engine.process import execute_process_or_raise
 from pants.engine.rules import collect_rules, implicitly, rule
 from pants.engine.target import FieldSet, Target
 from pants.engine.unions import UnionRule
@@ -60,7 +60,7 @@ async def ktlint_fmt(
         *request.files,
     ]
 
-    result = await fallible_to_exec_result_or_raise(
+    result = await execute_process_or_raise(
         **implicitly(
             JvmProcess(
                 jdk=jdk,

--- a/src/python/pants/backend/makeself/goals/package.py
+++ b/src/python/pants/backend/makeself/goals/package.py
@@ -39,7 +39,7 @@ from pants.engine.fs import Digest, MergeDigests
 from pants.engine.internals.graph import find_valid_field_sets, hydrate_sources, resolve_targets
 from pants.engine.internals.native_engine import AddPrefix
 from pants.engine.intrinsics import add_prefix, digest_to_snapshot, merge_digests
-from pants.engine.process import Process, ProcessCacheScope, fallible_to_exec_result_or_raise
+from pants.engine.process import Process, ProcessCacheScope, execute_process_or_raise
 from pants.engine.rules import Rule, collect_rules, concurrently, implicitly, rule
 from pants.engine.target import FieldSetsPerTargetRequest, HydrateSourcesRequest, SourcesField
 from pants.engine.unions import UnionRule
@@ -180,7 +180,7 @@ async def package_makeself_binary(field_set: MakeselfArchiveFieldSet) -> BuiltPa
 
     output_path = PurePath(field_set.output_path.value_or_default(file_ending="run"))
     output_filename = output_path.name
-    result = await fallible_to_exec_result_or_raise(
+    result = await execute_process_or_raise(
         **implicitly(
             CreateMakeselfArchive(
                 archive_dir=archive_dir,

--- a/src/python/pants/backend/makeself/subsystem.py
+++ b/src/python/pants/backend/makeself/subsystem.py
@@ -14,7 +14,7 @@ from pants.core.util_rules.external_tool import (
 from pants.engine.fs import Digest, RemovePrefix
 from pants.engine.intrinsics import remove_prefix
 from pants.engine.platform import Platform
-from pants.engine.process import fallible_to_exec_result_or_raise
+from pants.engine.process import execute_process_or_raise
 from pants.engine.rules import Rule, collect_rules, implicitly, rule
 from pants.util.logging import LogLevel
 from pants.util.meta import classproperty
@@ -82,7 +82,7 @@ async def extract_makeself_distribution(
     dist: MakeselfDistribution,
 ) -> MakeselfTool:
     out = "__makeself"
-    result = await fallible_to_exec_result_or_raise(
+    result = await execute_process_or_raise(
         **implicitly(
             RunMakeselfArchive(
                 exe=dist.exe,

--- a/src/python/pants/backend/nfpm/rules.py
+++ b/src/python/pants/backend/nfpm/rules.py
@@ -32,7 +32,7 @@ from pants.engine.internals.native_engine import AddPrefix, RemovePrefix
 from pants.engine.internals.selectors import concurrently
 from pants.engine.intrinsics import create_digest, digest_to_snapshot, merge_digests, remove_prefix
 from pants.engine.platform import Platform
-from pants.engine.process import Process, fallible_to_exec_result_or_raise
+from pants.engine.process import Process, execute_process_or_raise
 from pants.engine.rules import collect_rules, implicitly, rule
 from pants.util.logging import LogLevel
 
@@ -88,7 +88,7 @@ async def package_nfpm_package(
         )
     )
 
-    result = await fallible_to_exec_result_or_raise(
+    result = await execute_process_or_raise(
         **implicitly(
             Process(
                 argv=(

--- a/src/python/pants/backend/scala/lint/scalafmt/rules.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/rules.py
@@ -20,7 +20,7 @@ from pants.core.util_rules.partitions import Partition
 from pants.engine.fs import Digest, DigestSubset, MergeDigests, PathGlobs, Snapshot
 from pants.engine.internals.selectors import concurrently
 from pants.engine.intrinsics import digest_to_snapshot, merge_digests
-from pants.engine.process import fallible_to_exec_result_or_raise
+from pants.engine.process import execute_process_or_raise
 from pants.engine.rules import collect_rules, implicitly, rule
 from pants.engine.target import FieldSet, Target
 from pants.engine.unions import UnionRule
@@ -138,7 +138,7 @@ async def scalafmt_fmt(
         MergeDigests([partition_info.config_snapshot.digest, request.snapshot.digest])
     )
 
-    result = await fallible_to_exec_result_or_raise(
+    result = await execute_process_or_raise(
         **implicitly(
             JvmProcess(
                 jdk=jdk,

--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -331,8 +331,25 @@ def fallible_to_exec_result_or_raise(
     )
 
 
+# fallible_to_exec_result_or_raise directly converts a FallibleProcessResult
+# to a ProcessResult, or raises an exception if the process failed.
+# Its name makes sense when you already have a FallibleProcessResult in hand.
+#
+# But, it is common to want to execute a process and automatically raise an exception
+# on process error. The execute_process_or_raise() alias below facilitates this idiom:
+#
+# result = await execute_process_or_raise(
+#         **implicitly(
+#             Process(...) # Or something that some other rule can convert to a Process.
+#         )
+#     )
+# Where the execute_process() intrinsic is invoked implicitly to create a FallibleProcessResult.
+# This is simply a better name for the same rule, when invoked in this use case.
+execute_process_or_raise = fallible_to_exec_result_or_raise
+
+
 @rule
-async def run_proc_with_retry(req: ProcessWithRetries) -> ProcessResultWithRetries:
+async def execute_process_with_retry(req: ProcessWithRetries) -> ProcessResultWithRetries:
     results: List[FallibleProcessResult] = []
     for attempt in range(0, req.attempts):
         proc = dataclasses.replace(req.proc, attempt=attempt)


### PR DESCRIPTION
`fallible_to_exec_result_or_raise` directly converts a FallibleProcessResult
 to a ProcessResult, or raises an exception if the process failed. Its name 
makes sense when you already have a FallibleProcessResult in hand.

But, it is common to want to execute a process and automatically raise 
an exception on process error. The new execute_process_or_raise() alias 
facilitates this idiom:

```
result = await execute_process_or_raise(
    **implicitly(
        Process(...) # Or something that some other rule can convert to a Process.
    )
)
```

Where the execute_process() intrinsic is invoked implicitly to create a FallibleProcessResult.
This is simply a better name for the same rule, when invoked in this use case.
