### PR TITLE
system_binaries: output errors from failed candidate binaries

### DIFF
--- a/src/python/pants/backend/adhoc/run_system_binary_integration_test.py
+++ b/src/python/pants/backend/adhoc/run_system_binary_integration_test.py
@@ -1,11 +1,14 @@
 # Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import os
 from textwrap import dedent
 
 import pytest
 
 from pants.testutil.pants_integration_test import run_pants, setup_tmpdir
+from pants.util.contextutil import temporary_dir
+from pants.util.dirutil import safe_file_dump
 
 
 def test_system_binary_and_adhoc_tool() -> None:
@@ -91,6 +94,60 @@ def test_fingerprint(fingerprint: str, passes: bool) -> None:
         else:
             assert result.exit_code != 0
             assert "Could not find a binary with name `bash`" in result.stderr.strip()
+
+
+def test_logging_binaries_skipped_due_to_error_exit() -> None:
+    sources = {
+        "src/BUILD": dedent(
+            """\
+        system_binary(
+            name="grokker",
+            binary_name="grokker",
+        )
+
+        system_binary(
+            name="bash",
+            binary_name="bash",
+        )
+
+        adhoc_tool(
+            name="adhoc",
+            runnable=":grokker",
+            args=["-c", "grokker"],
+            log_output=True,
+            stdout="stdout",
+            stderr="stderr",
+        )
+        """
+        )
+    }
+
+    with setup_tmpdir(sources) as tmpdir, temporary_dir() as tmpdir_outside_buildroot:
+        # Put the test binary outside of the buildroot.
+        script_path = os.path.join(tmpdir_outside_buildroot, "grokker")
+        safe_file_dump(
+            script_path,
+            dedent(
+                """\
+            #!/bin/bash
+            echo "ERROR: This will always error." 1>&2
+            exit 1
+            """
+            ),
+            makedirs=True,
+        )
+        os.chmod(script_path, 0o555)
+
+        args = [
+            "--backend-packages=['pants.backend.experimental.adhoc',]",
+            f"--source-root-patterns=['{tmpdir}/src']",
+            f"--system-binaries-system-binary-paths=['{tmpdir_outside_buildroot}', '<PATH>']",
+            "export-codegen",
+            f"{tmpdir}/src:adhoc",
+        ]
+        result = run_pants(args)
+        assert result.exit_code != 0
+        assert "ERROR: This will always error." in result.stderr.strip()
 
 
 def test_runnable_dependencies() -> None:


### PR DESCRIPTION
When searching for system binaries, if no satisfactory binaries are found, inform the user of any candidate binaries which failed when invoked (including stdout/stderr outputs).

Motivation: The lack of this logging confused me when I was trying to setup a `system_binary` target in a test in another PR and had not included some necessary `fingerprint_args` for the binary. I was confused why Pants seemed to just silently skip the binary. With this PR, Pants would have displayed the relevant error for me.