### PR TITLE
Add new `uv_requirements` macro for parsing `uv` dev dependencies

### DIFF
--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -204,6 +204,8 @@ The function-as-a-service targets like `python_google_cloud_function`, `python_a
 
 Lockfile generation now respects hermetic python selection. That means that lockfile generation can use an interpreter provided by the [`pants.backend.python.providers.experimental.pyenv` backend](https://www.pantsbuild.org/2.23/reference/subsystems/pyenv-python-provider).
 
+A new `uv_requirements` macro has been added to allow importing [development dependencies specified in `pyproject.toml` files under the `[tool.uv]` section](https://docs.astral.sh/uv/concepts/dependencies/#development-dependencies).
+
 #### Terraform
 
 Terraform supports caching providers.
@@ -332,7 +334,7 @@ Plugins may now provide "auxiliary" goals by implememting the `auxiliary_goals` 
 
 Added support for plugins that implement provide `PytestPluginSetup` to inject additional `sys.path` entries. Simply pass a tuple of paths in `PytestPluginSetup(extra_sys_path=(...))`. This gets to pytest via `PEX_EXTRA_SYS_PATH`, similar to how scripts might modify `PYTHONPATH` when running pytest outside of pants.
 
-Several intrinsics have been renamed more succinctly, to make them more readable and developer-friendly when called by name. 
+Several intrinsics have been renamed more succinctly, to make them more readable and developer-friendly when called by name.
 
 An execute_process_or_raise() alias has been added for the fallible_to_exec_result_or_raise rule, so that
 code that calls it by name on an implicitly executed process will be more readable.

--- a/src/python/pants/backend/python/macros/uv_requirements.py
+++ b/src/python/pants/backend/python/macros/uv_requirements.py
@@ -1,0 +1,119 @@
+from functools import partial
+import logging
+from pathlib import PurePath
+
+from pants.backend.python.macros.common_fields import ModuleMappingField, RequirementsOverrideField, TypeStubsModuleMappingField
+from pants.backend.python.macros.common_requirements_rule import _generate_requirements
+from pants.backend.python.macros.poetry_requirements import PyProjectToml
+from pants.backend.python.subsystems.setup import PythonSetup
+from pants.backend.python.target_types import PythonRequirementResolveField, PythonRequirementTarget
+from pants.base.build_root import BuildRoot
+from pants.engine.rules import collect_rules, rule
+from pants.engine.target import COMMON_TARGET_FIELDS, GenerateTargetsRequest, GeneratedTargets, SingleSourceField, TargetGenerator
+from pants.engine.unions import UnionMembership, UnionRule
+from pants.util.logging import LogLevel
+from pants.util.pip_requirement import PipRequirement
+from pants.util.strutil import softwrap
+
+
+logger = logging.getLogger(__name__)
+
+
+def parse_pyproject_toml(pyproject_toml: PyProjectToml) -> set[PipRequirement]:
+    parsed = pyproject_toml.parse()
+    try:
+        uv_vals = parsed["tool"]["uv"]
+    except KeyError:
+        raise KeyError(
+            softwrap(
+                f"""
+                No section `tool.uv` found in {pyproject_toml.toml_relpath}, which
+                is loaded by Pants from a `uv_requirements` macro.
+
+                Did you mean to set up uv?
+                """
+            )
+        )
+
+    # See https://docs.astral.sh/uv/concepts/dependencies/#development-dependencies
+    # This should be a list of PEP 508 compliant strings.
+    dev_dependencies = uv_vals.get("dev-dependencies", [])
+    if not dev_dependencies:
+        logger.warning(
+            softwrap(
+                f"""
+                No requirements defined in `tool.uv.dev-dependencies` in {pyproject_toml.toml_relpath},
+                which is loaded by Pants from a uv_requirements macro. Did you mean to populate
+                this section with requirements?.
+                """
+            )
+        )
+
+    return set(
+        PipRequirement.parse(line) for line in dev_dependencies.items()
+    )
+
+
+def parse_uv_requirements(
+    build_root: BuildRoot, file_contents: bytes, file_path: str
+) -> set[PipRequirement]:
+    return parse_pyproject_toml(
+        PyProjectToml(
+            build_root=PurePath(build_root.path),
+            toml_relpath=PurePath(file_path),
+            toml_contents=file_contents.decode(),
+        )
+    )
+
+
+# ---------------------------------------------------------------------------------
+# Target generator
+# ---------------------------------------------------------------------------------
+
+
+class UvRequirementsSourceField(SingleSourceField):
+    default = "pyproject.toml"
+    required = False
+
+
+class UvRequirementsTargetGenerator(TargetGenerator):
+    alias = "uv_requirements"
+    help = "Generate a `python_requirement` for each entry in `pyproject.toml` under the `[tool.uv]` section."
+    generated_target_cls = PythonRequirementTarget
+    # Note that this does not have a `dependencies` field.
+    core_fields = (
+        *COMMON_TARGET_FIELDS,
+        ModuleMappingField,
+        TypeStubsModuleMappingField,
+        UvRequirementsSourceField,
+        RequirementsOverrideField,
+    )
+    copied_fields = COMMON_TARGET_FIELDS
+    moved_fields = (PythonRequirementResolveField,)
+
+
+class GenerateFromUvRequirementsRequest(GenerateTargetsRequest):
+    generate_from = UvRequirementsTargetGenerator
+
+
+@rule(desc="Generate `python_requirement` targets from uv pyproject.toml", level=LogLevel.DEBUG)
+async def generate_from_uv_requirement(
+    request: GenerateFromUvRequirementsRequest,
+    build_root: BuildRoot,
+    union_membership: UnionMembership,
+    python_setup: PythonSetup,
+) -> GeneratedTargets:
+    result = await _generate_requirements(
+        request,
+        union_membership,
+        python_setup,
+        parse_requirements_callback=partial(parse_uv_requirements, build_root),
+    )
+    return GeneratedTargets(request.generator, result)
+
+
+def rules():
+    return (
+        *collect_rules(),
+        UnionRule(GenerateTargetsRequest, GenerateFromUvRequirementsRequest),
+    )

--- a/src/python/pants/backend/python/macros/uv_requirements_test.py
+++ b/src/python/pants/backend/python/macros/uv_requirements_test.py
@@ -33,12 +33,12 @@ def rule_runner() -> RuleRunner:
 def assert_uv_requirements(
     rule_runner: RuleRunner,
     build_file_entry: str,
-    requirements_txt: str,
+    pyproject_toml: str,
     *,
     expected_targets: set[Target],
-    requirements_txt_relpath: str = "requirements.txt",
+    pyproject_toml_relpath: str = "pyproject.toml",
 ) -> None:
-    rule_runner.write_files({"BUILD": build_file_entry, requirements_txt_relpath: requirements_txt})
+    rule_runner.write_files({"BUILD": build_file_entry, pyproject_toml_relpath: pyproject_toml})
     result = rule_runner.request(
         _TargetParametrizations,
         [
@@ -155,7 +155,6 @@ def test_pyproject_toml(rule_runner: RuleRunner) -> None:
             ),
             TargetGeneratorSourcesHelperTarget({"source": "pyproject.toml"}, file_addr),
         },
-        requirements_txt_relpath="pyproject.toml",
     )
 
 
@@ -167,5 +166,4 @@ def test_invalid_req_pyproject_toml(rule_runner: RuleRunner) -> None:
             "uv_requirements(name='reqs', source='pyproject.toml')",
             """[tool.uv]\ndev-dependencies = ["Not A Valid Req == 3.7"]""",
             expected_targets=set(),
-            requirements_txt_relpath="pyproject.toml",
         )

--- a/src/python/pants/backend/python/macros/uv_requirements_test.py
+++ b/src/python/pants/backend/python/macros/uv_requirements_test.py
@@ -1,0 +1,171 @@
+# Copyright 2024 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from textwrap import dedent
+
+import pytest
+
+from pants.backend.python.goals import lockfile
+from pants.backend.python.macros import uv_requirements
+from pants.backend.python.macros.uv_requirements import UvRequirementsTargetGenerator
+from pants.backend.python.target_types import PythonRequirementTarget
+from pants.core.target_types import TargetGeneratorSourcesHelperTarget
+from pants.engine.addresses import Address
+from pants.engine.internals.graph import _TargetParametrizations, _TargetParametrizationsRequest
+from pants.engine.target import Target
+from pants.testutil.rule_runner import QueryRule, RuleRunner, engine_error
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    return RuleRunner(
+        rules=[
+            *lockfile.rules(),
+            *uv_requirements.rules(),
+            QueryRule(_TargetParametrizations, [_TargetParametrizationsRequest]),
+        ],
+        target_types=[UvRequirementsTargetGenerator],
+    )
+
+
+def assert_uv_requirements(
+    rule_runner: RuleRunner,
+    build_file_entry: str,
+    requirements_txt: str,
+    *,
+    expected_targets: set[Target],
+    requirements_txt_relpath: str = "requirements.txt",
+) -> None:
+    rule_runner.write_files({"BUILD": build_file_entry, requirements_txt_relpath: requirements_txt})
+    result = rule_runner.request(
+        _TargetParametrizations,
+        [
+            _TargetParametrizationsRequest(
+                Address("", target_name="reqs"), description_of_origin="tests"
+            )
+        ],
+    )
+    assert set(result.parametrizations.values()) == expected_targets
+
+
+def test_pyproject_toml(rule_runner: RuleRunner) -> None:
+    """This tests that we correctly create a new python_requirement for each entry in a
+    pyproject.toml file, where each dependency is unique.
+
+    Some edge cases:
+    * We ignore comments and options (values that start with `--`).
+    * module_mapping works regardless of capitalization.
+    * Projects get normalized thanks to Requirement.parse().
+    * Overrides works, including for dependencies and optional-dependencies
+    """
+    file_addr = Address("", target_name="reqs", relative_file_path="pyproject.toml")
+    assert_uv_requirements(
+        rule_runner,
+        dedent(
+            """\
+            uv_requirements(
+                name='reqs',
+                module_mapping={'ansiCOLORS': ['colors']},
+                type_stubs_module_mapping={'Django-types': ['django']},
+                overrides={
+                  "ansicolors": {"tags": ["overridden"]},
+                  "Django": {"dependencies": ["#Django-types"]},
+                  "notebook": {"tags": ["another-tag"]},
+                },
+                source='pyproject.toml',
+            )
+            """
+        ),
+        dedent(
+            """\
+            [tool.uv]
+            dev-dependencies = [
+                # Comment.
+                "",  # Empty line.
+                "ansicolors>=1.18.0",
+                "coverage>=7.0,<8.0",
+                "Django==3.2 ; python_version>'3'",
+                "Django-types",
+                "Un-Normalized-PROJECT",  # Inline comment.
+                "pip@ git+https://github.com/pypa/pip.git",
+                "pytest>=5.7.0",
+                "notebook>=6.1.0",
+            ]
+            """
+        ),
+        expected_targets={
+            PythonRequirementTarget(
+                {
+                    "requirements": ["ansicolors>=1.18.0"],
+                    "modules": ["colors"],
+                    "dependencies": [file_addr.spec],
+                    "tags": ["overridden"],
+                },
+                Address("", target_name="reqs", generated_name="ansicolors"),
+            ),
+            PythonRequirementTarget(
+                {
+                    "requirements": ["coverage>=7.0,<8.0"],
+                    "dependencies": [file_addr.spec],
+                },
+                Address("", target_name="reqs", generated_name="coverage"),
+            ),
+            PythonRequirementTarget(
+                {
+                    "requirements": ["Django==3.2 ; python_version>'3'"],
+                    "dependencies": ["#Django-types", file_addr.spec],
+                },
+                Address("", target_name="reqs", generated_name="Django"),
+            ),
+            PythonRequirementTarget(
+                {
+                    "requirements": ["Django-types"],
+                    "type_stub_modules": ["django"],
+                    "dependencies": [file_addr.spec],
+                },
+                Address("", target_name="reqs", generated_name="Django-types"),
+            ),
+            PythonRequirementTarget(
+                {"requirements": ["Un_Normalized_PROJECT"], "dependencies": [file_addr.spec]},
+                Address("", target_name="reqs", generated_name="Un-Normalized-PROJECT"),
+            ),
+            PythonRequirementTarget(
+                {
+                    "requirements": ["pip@ git+https://github.com/pypa/pip.git"],
+                    "dependencies": [file_addr.spec],
+                },
+                Address("", target_name="reqs", generated_name="pip"),
+            ),
+            PythonRequirementTarget(
+                {
+                    "requirements": ["pytest>=5.7.0"],
+                    "dependencies": [file_addr.spec],
+                },
+                Address("", target_name="reqs", generated_name="pytest"),
+            ),
+            PythonRequirementTarget(
+                {
+                    "requirements": ["notebook>=6.1.0"],
+                    "dependencies": [file_addr.spec],
+                    "tags": ["another-tag"],
+                },
+                Address("", target_name="reqs", generated_name="notebook"),
+            ),
+            TargetGeneratorSourcesHelperTarget({"source": "pyproject.toml"}, file_addr),
+        },
+        requirements_txt_relpath="pyproject.toml",
+    )
+
+
+def test_invalid_req_pyproject_toml(rule_runner: RuleRunner) -> None:
+    """Test that we give a nice error message."""
+    with engine_error(contains="Invalid requirement 'Not A Valid Req == 3.7' in pyproject.toml"):
+        assert_uv_requirements(
+            rule_runner,
+            "uv_requirements(name='reqs', source='pyproject.toml')",
+            """[tool.uv]\ndev-dependencies = ["Not A Valid Req == 3.7"]""",
+            expected_targets=set(),
+            requirements_txt_relpath="pyproject.toml",
+        )

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -25,11 +25,13 @@ from pants.backend.python.macros import (
     pipenv_requirements,
     poetry_requirements,
     python_requirements,
+    uv_requirements,
 )
 from pants.backend.python.macros.pipenv_requirements import PipenvRequirementsTargetGenerator
 from pants.backend.python.macros.poetry_requirements import PoetryRequirementsTargetGenerator
 from pants.backend.python.macros.python_artifact import PythonArtifact
 from pants.backend.python.macros.python_requirements import PythonRequirementsTargetGenerator
+from pants.backend.python.macros.uv_requirements import UvRequirementsTargetGenerator
 from pants.backend.python.subsystems import debugpy
 from pants.backend.python.target_types import (
     PexBinariesGeneratorTarget,
@@ -91,6 +93,7 @@ def rules():
         *pipenv_requirements.rules(),
         *poetry_requirements.rules(),
         *python_requirements.rules(),
+        *uv_requirements.rules(),
         *wrap_python.rules,
     )
 
@@ -111,5 +114,6 @@ def target_types():
         PipenvRequirementsTargetGenerator,
         PoetryRequirementsTargetGenerator,
         PythonRequirementsTargetGenerator,
+        UvRequirementsTargetGenerator,
         *wrap_python.target_types,
     )


### PR DESCRIPTION
Closes #21350.

This macro allows parsing development dependencies from the `tool.uv` section in `pyproject.toml`, [as outlined in the uv docs](https://docs.astral.sh/uv/concepts/dependencies/#development-dependencies). Dev dependencies must be specified in a PEP 508 compliant manner, so we reuse the logic for parsing Python requirement strings from the `python_requirements` macro.