### PR TITLE
upgrade to Rust v1.81.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -197,7 +197,7 @@ jobs:
       with:
         key: macOS10-15-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain')
           }}-v2
-        path: '~/.rustup/toolchains/1.80.1-*
+        path: '~/.rustup/toolchains/1.81.0-*
 
           ~/.rustup/update-hashes
 
@@ -283,7 +283,7 @@ jobs:
       with:
         key: macOS11-ARM64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain')
           }}-v2
-        path: '~/.rustup/toolchains/1.80.1-*
+        path: '~/.rustup/toolchains/1.81.0-*
 
           ~/.rustup/update-hashes
 
@@ -375,7 +375,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.80.1-*
+        path: '~/.rustup/toolchains/1.81.0-*
 
           ~/.rustup/update-hashes
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,7 +40,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: Linux-ARM64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.80.1-*
+        path: '~/.rustup/toolchains/1.81.0-*
 
           ~/.rustup/update-hashes
 
@@ -133,7 +133,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.80.1-*
+        path: '~/.rustup/toolchains/1.81.0-*
 
           ~/.rustup/update-hashes
 
@@ -236,7 +236,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: macOS12-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.80.1-*
+        path: '~/.rustup/toolchains/1.81.0-*
 
           ~/.rustup/update-hashes
 
@@ -451,7 +451,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: macOS10-15-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.80.1-*
+        path: '~/.rustup/toolchains/1.81.0-*
 
           ~/.rustup/update-hashes
 
@@ -520,7 +520,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: macOS11-ARM64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.80.1-*
+        path: '~/.rustup/toolchains/1.81.0-*
 
           ~/.rustup/update-hashes
 

--- a/src/rust/engine/pantsd/src/lib.rs
+++ b/src/rust/engine/pantsd/src/lib.rs
@@ -65,13 +65,12 @@ impl Metadata {
             .and_then(|(pid_metadata_path, value)| {
                 value
                     .parse()
-                    .map(|pid| {
+                    .inspect(|&pid| {
                         debug!(
                             "Parsed pid {pid} from {pid_metadata_path}.",
                             pid = pid,
                             pid_metadata_path = pid_metadata_path.display()
                         );
-                        pid
                     })
                     .map_err(|e| {
                         format!(
@@ -92,13 +91,12 @@ impl Metadata {
             .and_then(|(socket_metadata_path, value)| {
                 value
                     .parse()
-                    .map(|port| {
+                    .inspect(|&port| {
                         debug!(
                             "Parsed port {port} from {socket_metadata_path}.",
                             port = port,
                             socket_metadata_path = socket_metadata_path.display()
                         );
-                        port
                     })
                     .map_err(|e| {
                         format!(

--- a/src/rust/engine/rust-toolchain
+++ b/src/rust/engine/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.80.1"
+channel = "1.81.0"
 # NB: We don't list the components (namely `clippy` and `rustfmt`) and instead rely on either the
 #  the profile being "default" (by-and-large the default profile) or the nice error message from
 #  `cargo fmt` and `cargo clippy` if the required component isn't installed


### PR DESCRIPTION
Upgrade to Rust v1.81.0. [Release notes](https://blog.rust-lang.org/2024/09/05/Rust-1.81.0.html).

The main interesting change for us is that Clippy lints which are disabled via `#[allow(clippy::FOO)]` can now be marked as `#[expect(clippy::FOO)]` in order to warn / error if the lint is _not_ triggered. This means we can have `cargo clippy` warn us when the allow / expect is no longer needed. ((This PR does not take advantage of this change.)