### PR TITLE
pass along query parameters to s3:// urls

### DIFF
--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -206,6 +206,10 @@ Lockfile generation now respects hermetic python selection. That means that lock
 
 A new `uv_requirements` macro has been added to allow importing [development dependencies specified in `pyproject.toml` files under the `[tool.uv]` section](https://docs.astral.sh/uv/concepts/dependencies/#development-dependencies).
 
+#### S3
+
+The `pants.backend.url_handlers.s3` backend now correctly passes along query parameters such as `versionId` for `s3://` urls.
+
 #### Terraform
 
 Terraform supports caching providers.

--- a/src/python/pants/backend/url_handlers/s3/integration_test.py
+++ b/src/python/pants/backend/url_handlers/s3/integration_test.py
@@ -104,6 +104,12 @@ def replace_url(monkeypatch):
             "https://bucket.s3.amazonaws.com/keypart1/keypart2/file.txt",
             DownloadS3SchemeURL,
         ),
+        (
+            "s3://bucket/keypart1/keypart2/file.txt?versionId=ABC123",
+            "https://bucket.s3.amazonaws.com/keypart1/keypart2/file.txt?versionId=ABC123",
+            "https://bucket.s3.amazonaws.com/keypart1/keypart2/file.txt?versionId=ABC123",
+            DownloadS3SchemeURL,
+        ),
         # Path-style
         (
             "https://s3.amazonaws.com/bucket/keypart1/keypart2/file.txt",

--- a/src/python/pants/backend/url_handlers/s3/register.py
+++ b/src/python/pants/backend/url_handlers/s3/register.py
@@ -124,7 +124,7 @@ async def download_file_from_s3_scheme(request: DownloadS3SchemeURL) -> Digest:
             region="",
             bucket=split.netloc,
             key=split.path[1:],
-            query="",
+            query=split.query,
             expected_digest=request.expected_digest,
         ),
     )


### PR DESCRIPTION
The brings s3://  protocal urls to party with handling of https:// ones.  The intent is to be able to pass along `versionId` or other S3 parameters along the lines of:

```
file(
    name="s3_source_test",
    source=http_source(
        url="s3://test-data/users/csb/foo.txt?versionId=1Pz.idoTGIoFJ6l8UB1aGV08QUmoj9gD"
        sha256="fe132f9f52c25bed628cb86ed2859ce73d7b366f4eb5eee6c5b09981565368d6",
        len=7,
    ),
)
```