### PR TITLE
let users point a bazooka a their foot wtih SetupKwargs plugins

### DIFF
--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -344,6 +344,9 @@ Several intrinsics have been renamed more succinctly, to make them more readable
 An execute_process_or_raise() alias has been added for the fallible_to_exec_result_or_raise rule, so that
 code that calls it by name on an implicitly executed process will be more readable.
 
+Previously `SetupKwargs` took `_allow_banned_keys` which would allow one to pass in certain critical setuptools args (ex: `install_requires`) that Pants calculates for you.  If you Really Really know what you are doing you can know also use `_overwrite_banned_keys` to exclusively use your  own values and ignore the Pants calculated ones.
+
+
 ### Other minor tweaks
 
 The "Provided by" information in the documentation now correctly reflects the proper backend to enable to activate a certain feature.


### PR DESCRIPTION
Preciously one could write a plugin and with `_allow_banned_keys` set something like `install_requires`.  The new and even more dangerous `_overwrite_banned_keys` allows one to exclusively use values calculated in their plugin.

The motivating use case is a plugin that builds a wheel with all dependencies pinned to the value from lockfile.

ref #21252