### PR TITLE
python: a mandatory option is not really "advanced" (interpreter_constraints)

### DIFF
--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -77,7 +77,6 @@ class PythonSetup(Subsystem):
             constraint strings will be ORed together.
             """
         ),
-        advanced=True,
         metavar="<requirement>",
     )
 


### PR DESCRIPTION
Pants currently requires users to set `--python-interpreter-constraints` and raises an exception if they do not. The option, however, is marked "advanced" which really should only apply to optional configuration with defaults most users will not touch, not to mandatory options with no default.

Remove the "advanced" marking so that this option is more discoverable by being output for `./pants help python`.