### PR TITLE
[fix] propagate peek additional_info to output

### DIFF
--- a/docs/notes/2.24.x.md
+++ b/docs/notes/2.24.x.md
@@ -21,6 +21,8 @@ We offer [formal sponsorship tiers for companies](https://www.pantsbuild.org/spo
 
 ### General
 
+* Fixed bug where `pants peek --include-additional-info` was not actually displaying the additional info ([#21399](https://github.com/pantsbuild/pants/pull/21399)).
+
 ### New Options System
 
 This release switches the Pants [options system](https://www.pantsbuild.org/2.22/docs/using-pants/key-concepts/options) to use the new "native" implementation written in Rust first introduced in the 2.22.x series.

--- a/src/python/pants/backend/project_info/peek.py
+++ b/src/python/pants/backend/project_info/peek.py
@@ -8,7 +8,7 @@ import collections.abc
 import json
 import logging
 from abc import ABCMeta
-from dataclasses import dataclass, fields, is_dataclass
+from dataclasses import dataclass, fields, is_dataclass, replace
 from typing import Any, Iterable, Mapping, Protocol, runtime_checkable
 
 from pants.core.goals.deploy import Deploy, DeployFieldSet
@@ -432,14 +432,9 @@ async def peek(
         # TargetData is frozen so we need to create a new collection
         tds = TargetDatas(
             [
-                TargetData(
-                    td.target,
-                    td.expanded_sources,
-                    td.expanded_dependencies,
-                    td.dependencies_rules,
-                    td.dependents_rules,
-                    td.applicable_dep_rules,
-                    target_alias_to_goals_map.get(td.target.alias),
+                replace(
+                    td,
+                    goals=target_alias_to_goals_map.get(td.target.alias),
                 )
                 for td in tds
             ]


### PR DESCRIPTION
The field containing the additional info is not getting to output
because the additional info is being dropped when the TargetData copies
are being created - `dataclasses.replace()` is more appropriate here to
ensure creating a proper copy.

Tested by following the [example for populating additional_info](https://www.pantsbuild.org/2.21/docs/writing-plugins/the-target-api/concepts#adding-information-to-pants-peek-output) and verified the hello world additional info shows up in `pants peek --include-additional-info`.
