### PR TITLE
bump default version of pip to support Python 3.13

### DIFF
--- a/docs/notes/2.24.x.md
+++ b/docs/notes/2.24.x.md
@@ -30,6 +30,8 @@ The default lockfiles bundled with Pants for various tools (ex: to run `black`) 
 
 As a consequence of the lockfile generation, newer versions of many tools are now included in the default lockfiles.
 
+The default version of pip is now [24.2](https://pip.pypa.io/en/stable/news/#v24-2) bringing performance improvements to dependency resolution and support or the upcoming Python 3.13 release.
+
 
 #### Shell
 

--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -253,7 +253,7 @@ class PythonSetup(Subsystem):
         ),
     )
     pip_version = StrOption(
-        default="24.0",
+        default="24.2",
         help=softwrap(
             f"""
             Use this version of Pip for resolving requirements and generating lockfiles.

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -42,7 +42,7 @@ class PexCli(TemplatedExternalTool):
 
     default_version = "v2.16.2"
     default_url_template = "https://github.com/pex-tool/pex/releases/download/{version}/pex"
-    version_constraints = ">=2.3.0,<3.0"
+    version_constraints = ">=2.13.0,<3.0"
 
     # extra args to be passed to the pex tool; note that they
     # are going to apply to all invocations of the pex tool.


### PR DESCRIPTION
The first version of pip to support Python 3.13 was 24.1, but I don't think there is any merit to holding back when 24.2 is already out. (Pants itself uses `latest`.) The first version of Pex to support 24.2 is v2.13.0.

(Pip 24.1 and 24.2 also both contain meaningful performance improvements to dependency resolution --> #21223)

Release notes for where pex added support:
https://github.com/pex-tool/pex/releases/tag/v2.13.0

ref #20852