### PR TITLE
introduce `SubjectPath` to namespace paths between workspace and system

### DIFF
--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::nodes::{ExecuteProcess, NodeKey, NodeOutput, NodeResult};
+use crate::nodes::{ExecuteProcess, NodeKey, NodeOutput, NodeResult, SubjectPath};
 use crate::python::{throw, Failure};
 use crate::session::{Session, Sessions};
 use crate::tasks::{Rule, Tasks};
@@ -639,7 +639,9 @@ impl Core {
         .await?;
         log::debug!("Using {command_runners:?} for process execution.");
 
-        let graph = Arc::new(InvalidatableGraph(Graph::new(executor.clone())));
+        let graph = Arc::new(InvalidatableGraph {
+            graph: Graph::new(executor.clone()),
+        });
 
         // These certs are for downloads, not to be confused with the ones used for remoting.
         let ca_certs = Self::load_certificates(ca_certs_path)?;
@@ -729,7 +731,9 @@ impl Core {
     }
 }
 
-pub struct InvalidatableGraph(Graph<NodeKey>);
+pub struct InvalidatableGraph {
+    graph: Graph<NodeKey>,
+}
 
 fn caller_to_logging_info(caller: InvalidateCaller) -> (Level, &'static str) {
     match caller {
@@ -748,7 +752,11 @@ impl Invalidatable for InvalidatableGraph {
         let InvalidationResult { cleared, dirtied } =
             self.invalidate_from_roots(false, move |node| {
                 if let Some(fs_subject) = node.fs_subject() {
-                    paths.contains(fs_subject)
+                    match fs_subject {
+                        SubjectPath::Workspace(relpath) => paths.contains(relpath.as_path()),
+                        // TODO: Invalidation not supported currently for local system paths.
+                        SubjectPath::LocalSystem(_) => false,
+                    }
                 } else {
                     false
                 }
@@ -784,7 +792,7 @@ impl Deref for InvalidatableGraph {
     type Target = Graph<NodeKey>;
 
     fn deref(&self) -> &Graph<NodeKey> {
-        &self.0
+        &self.graph
     }
 }
 

--- a/src/rust/engine/src/intrinsics/digests.rs
+++ b/src/rust/engine/src/intrinsics/digests.rs
@@ -373,7 +373,7 @@ fn path_metadata_request(single_path: Value) -> PyGeneratorResponseNativeCall {
 
         let context = task_get_context();
         let metadata_opt = context
-            .get(PathMetadataNode::new(PathBuf::from_str(&path).unwrap()))
+            .get(PathMetadataNode::new(PathBuf::from_str(&path).unwrap())?)
             .await?
             .map(PyPathMetadata);
 

--- a/src/rust/engine/src/nodes/digest_file.rs
+++ b/src/rust/engine/src/nodes/digest_file.rs
@@ -6,7 +6,7 @@ use fs::File;
 use futures::TryFutureExt;
 use graph::CompoundNode;
 
-use super::{NodeKey, NodeOutput, NodeResult};
+use super::{NodeKey, NodeOutput, NodeResult, SubjectPath};
 use crate::context::Context;
 use crate::python::throw;
 
@@ -14,11 +14,14 @@ use crate::python::throw;
 /// A Node that represents reading a file and fingerprinting its contents.
 ///
 #[derive(Clone, Debug, DeepSizeOf, Eq, Hash, PartialEq)]
-pub struct DigestFile(pub File);
+pub struct DigestFile {
+    pub file: File,
+    pub subject_path: SubjectPath,
+}
 
 impl DigestFile {
     pub(super) async fn run_node(self, context: Context) -> NodeResult<hashing::Digest> {
-        let path = context.core.vfs.file_path(&self.0);
+        let path = context.core.vfs.file_path(&self.file);
         context
             .core
             .store()

--- a/src/rust/engine/src/nodes/mod.rs
+++ b/src/rust/engine/src/nodes/mod.rs
@@ -3,7 +3,7 @@
 
 use std::convert::TryFrom;
 use std::fmt::Display;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 

--- a/src/rust/engine/src/nodes/path_metadata.rs
+++ b/src/rust/engine/src/nodes/path_metadata.rs
@@ -4,7 +4,6 @@
 use std::path::{Path, PathBuf};
 
 use deepsize::DeepSizeOf;
-use fs::RelativePath;
 use graph::CompoundNode;
 
 use super::{NodeKey, NodeOutput, NodeResult, SubjectPath};
@@ -21,7 +20,7 @@ pub struct PathMetadata {
 
 impl PathMetadata {
     pub fn new(path: PathBuf) -> Result<Self, String> {
-        let subject_path = SubjectPath::Workspace(RelativePath::new(path)?);
+        let subject_path = SubjectPath::new_workspace(path)?;
         Ok(Self { subject_path })
     }
 

--- a/src/rust/engine/src/nodes/read_link.rs
+++ b/src/rust/engine/src/nodes/read_link.rs
@@ -7,7 +7,7 @@ use deepsize::DeepSizeOf;
 use fs::Link;
 use graph::CompoundNode;
 
-use super::{NodeKey, NodeOutput, NodeResult};
+use super::{NodeKey, NodeOutput, NodeResult, SubjectPath};
 use crate::context::Context;
 use crate::python::throw;
 
@@ -15,7 +15,10 @@ use crate::python::throw;
 /// A Node that represents reading the destination of a symlink (non-recursively).
 ///
 #[derive(Clone, Debug, DeepSizeOf, Eq, Hash, PartialEq)]
-pub struct ReadLink(pub(super) Link);
+pub struct ReadLink {
+    pub(super) link: Link,
+    pub(super) subject_path: SubjectPath,
+}
 
 impl ReadLink {
     pub(super) async fn run_node(self, context: Context) -> NodeResult<LinkDest> {
@@ -23,7 +26,7 @@ impl ReadLink {
         let link_dest = context
             .core
             .vfs
-            .read_link(&node.0)
+            .read_link(&node.link)
             .await
             .map_err(|e| throw(format!("{e}")))?;
         Ok(LinkDest(link_dest))

--- a/src/rust/engine/src/nodes/scandir.rs
+++ b/src/rust/engine/src/nodes/scandir.rs
@@ -7,7 +7,7 @@ use deepsize::DeepSizeOf;
 use fs::{Dir, DirectoryListing};
 use graph::CompoundNode;
 
-use super::{NodeKey, NodeOutput, NodeResult};
+use super::{NodeKey, NodeOutput, NodeResult, SubjectPath};
 use crate::context::Context;
 use crate::python::throw;
 
@@ -16,14 +16,17 @@ use crate::python::throw;
 /// entry (generally in one syscall). No symlinks are expanded.
 ///
 #[derive(Clone, Debug, DeepSizeOf, Eq, Hash, PartialEq)]
-pub struct Scandir(pub(super) Dir);
+pub struct Scandir {
+    pub(super) dir: Dir,
+    pub(super) subject_path: SubjectPath,
+}
 
 impl Scandir {
     pub(super) async fn run_node(self, context: Context) -> NodeResult<Arc<DirectoryListing>> {
         let directory_listing = context
             .core
             .vfs
-            .scandir(self.0)
+            .scandir(self.dir)
             .await
             .map_err(|e| throw(format!("{e}")))?;
         Ok(Arc::new(directory_listing))


### PR DESCRIPTION
As part of solving https://github.com/pantsbuild/pants/issues/20361, introduce a new enum `SubjectPath` to the engine representing a namespaced path (which currently can either be a relative to the buildroot or a system path).

The goal is to force rule code examining system paths  (in to-come PRs) to make that intention explicitly clear. Rule code should not escape the buildroot confinement unless it intends to do just that. It also allows future PRs to track changes on system paths to easily know when such paths are being requested.

Note: This is a safety issue and not really a security one since rule code can already escape the buildroot by using `open` and other filesystem operations directly. 