### PR TITLE
Silence macOS 10.15/11 errors for the Pants repo itself

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -86,6 +86,10 @@ unmatched_build_file_globs = "error"
 #   https://github.com/pantsbuild/pants/issues/16096.
 cache_content_behavior = "fetch"
 
+# Our current macOS 10.15 and 11 infrastructure is working okay, so for now (i.e. 2.24 dev
+# releases), we'll just keep building on them:
+allow_deprecated_macos_before_12 = true
+
 [DEFAULT]
 # Tell `scie-pants` to use our `./pants` bootstrap script.
 delegate_bootstrap = true


### PR DESCRIPTION
This unblocks doing 2.24 dev releases while we get ourselves sorted and upgrade OSes on CI.

Our current 2.23 builds are issuing the following warning, which becomes an error for 2.24-versioned builds (like #21412):

```
14:44:14.41 [WARN] DEPRECATED: using Pants on macOS 10.15 - 11 is scheduled to be removed in version 2.24.0.dev0.

Future versions of Pants will only run on macOS 12 and newer, but this machine appears older (macOS-10.15.7-x86_64-i386-64bit).

You can temporarily silence this warning with the `[GLOBAL].allow_deprecated_macos_before_12` option. If you have questions or concerns about this, please reach out to us at https://www.pantsbuild.org/community/getting-help.
```

The underlying deprecation is that Pants 2.24..0.dev0 and newer will no longer support running of Pants on macOS < 12, and that includes our own in-repo builds. However, it's strictly more permissive to build on macOS 10.15 or 11, so we're "allowed" to do that even though it's after the deprecation time.

Upgrading the runners properly is covered by #21413. The x86-64 change is in #21417.