### PR TITLE
Extend deprecation of [export].py_hermetic_scripts to 2.26

### DIFF
--- a/src/python/pants/backend/python/goals/export.py
+++ b/src/python/pants/backend/python/goals/export.py
@@ -134,7 +134,7 @@ class ExportPluginOptions:
             """
         ),
         advanced=True,
-        removal_version="2.24.0.dev0",
+        removal_version="2.26.0.dev0",
         removal_hint=softwrap(
             """
             Use `--export-py-non-hermetic-scripts-in-resolve` instead.


### PR DESCRIPTION
This `py_hermetic_scripts` option was deprecated in #21181 in favour of the new `py_non_hermetic_scripts_in_resolve` option. This was merged for 2.23.0.dev6 and thus will come in 2.23.0 soon-ish...

It seems to be very little code to support `py_hermetic_scripts` (just a single extra clause in an `if` statement, plus the option definition itself), so it seems unnecessarily aggressive to deprecate in one cycle. This extends it a few releases to make it easier for users to test pre-releases.

For instance, someone using 2.22.0 (current stable) with `py_hermetic_scripts` can currently test 2.23.0a0 with just a warning (e.g. adjust `pants_version` and run it through their CI), but would be blocked from doing _any_ testing of 2.24.0.dev0 (#21412) until they fix this option. That is, by removing the option quickly, it's harder for them to validate any part of the 2.24 or 2.25 release series and provide us feedback while on older versions.

(We're being more permissive than what we were previosuly communicating, so I don't think we need release notes or to otherwise highlight it.)