### PR TITLE
Remove long-deprecated `resolve_local_platforms` field and options

### DIFF
--- a/docs/notes/2.24.x.md
+++ b/docs/notes/2.24.x.md
@@ -37,6 +37,8 @@ As a consequence of the lockfile generation, newer versions of many tools are no
 
 The versions of `setuptools` and `wheel` used in Pants have been upgraded to `74.1.2` and `0.44.0` to address a remote code execution vulnerability in versions before setuptools `70.0`. This forces the minimum Python version to 3.8, in line with the changes mentioned above.
 
+The deprecation of `resolve_local_platforms` (both a field of `pex_binary`, and a option of `[pex-binary-defaults]`) has expired and thus they have been removed.
+
 #### S3
 
 The `pants.backend.url_handlers.s3` backend now correctly passes along query parameters such as `versionId` for `s3://` urls.

--- a/src/python/pants/backend/python/goals/package_pex_binary.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary.py
@@ -24,7 +24,6 @@ from pants.backend.python.target_types import (
     PexInheritPathField,
     PexLayout,
     PexLayoutField,
-    PexResolveLocalPlatformsField,
     PexScriptField,
     PexShBootField,
     PexShebangField,
@@ -72,7 +71,6 @@ class PexBinaryFieldSet(PackageFieldSet, RunFieldSet):
     shebang: PexShebangField
     strip_env: PexStripEnvField
     complete_platforms: PexCompletePlatformsField
-    resolve_local_platforms: PexResolveLocalPlatformsField
     layout: PexLayoutField
     execution_mode: PexExecutionModeField
     include_requirements: PexIncludeRequirementsField
@@ -94,8 +92,6 @@ class PexBinaryFieldSet(PackageFieldSet, RunFieldSet):
             args.append("--no-emit-warnings")
         elif self.emit_warnings.value_or_global_default(pex_binary_defaults) is True:
             args.append("--emit-warnings")
-        if self.resolve_local_platforms.value_or_global_default(pex_binary_defaults) is True:
-            args.append("--resolve-local-platforms")
         if self.ignore_errors.value is True:
             args.append("--ignore-errors")
         if self.inherit_path.value is not None:

--- a/src/python/pants/backend/python/goals/package_pex_binary_integration_test.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary_integration_test.py
@@ -252,44 +252,6 @@ def pex_executable(rule_runner: PythonRuleRunner) -> str:
     return os.path.join(rule_runner.build_root, expected_pex_relpath)
 
 
-def test_resolve_local_platforms(pex_executable: str, rule_runner: PythonRuleRunner) -> None:
-    complete_current_platform = subprocess.run(
-        args=[pex_executable, "interpreter", "inspect", "-mt"],
-        env=dict(PEX_MODULE="pex.cli", **os.environ),
-        stdout=subprocess.PIPE,
-    ).stdout
-
-    # N.B.: ansicolors 1.0.2 is available sdist-only on PyPI, so resolving it requires using a
-    # local interpreter.
-    rule_runner.write_files(
-        {
-            "src/py/project/app.py": "import colors",
-            "src/py/project/platform.json": complete_current_platform,
-            "src/py/project/BUILD": dedent(
-                """\
-                python_requirement(name="ansicolors", requirements=["ansicolors==1.0.2"])
-                file(name="platform", source="platform.json")
-                pex_binary(
-                    dependencies=[":ansicolors"],
-                    complete_platforms=[":platform"],
-                    resolve_local_platforms=True,
-                )
-                """
-            ),
-        }
-    )
-    tgt = rule_runner.get_target(Address("src/py/project"))
-    field_set = PexBinaryFieldSet.create(tgt)
-    result = rule_runner.request(BuiltPackage, [field_set])
-    assert len(result.artifacts) == 1
-    expected_pex_relpath = "src.py.project/project.pex"
-    assert expected_pex_relpath == result.artifacts[0].relpath
-
-    rule_runner.write_digest(result.digest)
-    executable = os.path.join(rule_runner.build_root, expected_pex_relpath)
-    subprocess.run([executable], check=True)
-
-
 @skip_unless_python38_present
 @pytest.mark.parametrize("target_type", ["files", "resources"])
 def test_complete_platforms(rule_runner: PythonRuleRunner, target_type: str) -> None:

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -605,26 +605,6 @@ class PexEmitWarningsField(TriBoolField):
         return self.value
 
 
-class PexResolveLocalPlatformsField(TriBoolField):
-    alias = "resolve_local_platforms"
-    removal_version = "2.24.0.dev0"
-    removal_hint = softwrap(
-        f"""\
-        This {alias} field is no longer used now that the `platforms` field has been removed. Remove it.
-        """
-    )
-    help = help_text(
-        """
-        Now unused.
-        """
-    )
-
-    def value_or_global_default(self, pex_binary_defaults: PexBinaryDefaults) -> bool:
-        if self.value is None:
-            return pex_binary_defaults.resolve_local_platforms
-        return self.value
-
-
 class PexExecutionMode(Enum):
     ZIPAPP = "zipapp"
     VENV = "venv"
@@ -756,7 +736,6 @@ _PEX_BINARY_COMMON_FIELDS = (
     PexBinaryDependenciesField,
     PexCheckField,
     PexCompletePlatformsField,
-    PexResolveLocalPlatformsField,
     PexInheritPathField,
     PexStripEnvField,
     PexIgnoreErrorsField,
@@ -899,21 +878,6 @@ class PexBinaryDefaults(Subsystem):
 
             Can be overridden by specifying the `emit_warnings` parameter of individual
             `pex_binary` targets
-            """
-        ),
-        advanced=True,
-    )
-    resolve_local_platforms = BoolOption(
-        default=False,
-        help=softwrap(
-            """
-            Now unused.
-            """
-        ),
-        removal_version="2.24.0.dev0",
-        removal_hint=softwrap(
-            """\
-            This `resolve_local_platforms` option is no longer used now that the `platforms` field has been removed. You can safely delete this setting.
             """
         ),
         advanced=True,


### PR DESCRIPTION
In #20823 (included in 2.22.0.dev0 and thus the recently released 2.22.0), we deprecated the `resolve_local_platforms` field on `pex_binary` and the `[pex-binary-defaults]` option version too.

We're about to do 2.24.0.dev0, and thus the deprecation has expired => time to remove!