### PR TITLE
Don't include macOS 12 in "_before_ 12" deprecation check

### DIFF
--- a/src/python/pants/util/osutil.py
+++ b/src/python/pants/util/osutil.py
@@ -114,7 +114,7 @@ def is_macos_big_sur() -> bool:
 def is_macos_before_12() -> bool:
     """MacOS 11 support ended Sep 2023."""
     version = _macos_major_version()
-    return version is not None and version <= 12
+    return version is not None and version < 12
 
 
 def getuser() -> str:


### PR DESCRIPTION
This was a fence-post error in #21326, where the "before 12" check included 12, instead of just 10.15 and 11. This mistake led to getting deprecation warnings about macOS 10.15 & 11 while running on macOS 12.