### PR TITLE
Update to Pex 2.19.1

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -11,7 +11,7 @@ freezegun==1.2.1
 ijson==3.2.3
 libcst==1.4.0
 packaging==21.3
-pex==2.16.2
+pex==2.19.0
 psutil==5.9.8
 # This should be compatible with pytest.py, although it can be looser so that we don't
 # over-constrain pantsbuild.pants.testutil

--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -11,7 +11,7 @@ freezegun==1.2.1
 ijson==3.2.3
 libcst==1.4.0
 packaging==21.3
-pex==2.19.0
+pex==2.19.1
 psutil==5.9.8
 # This should be compatible with pytest.py, although it can be looser so that we don't
 # over-constrain pantsbuild.pants.testutil

--- a/3rdparty/python/user_reqs.lock
+++ b/3rdparty/python/user_reqs.lock
@@ -23,7 +23,7 @@
 //     "mypy-typing-asserts==0.1.1",
 //     "node-semver==0.9.0",
 //     "packaging==21.3",
-//     "pex==2.16.2",
+//     "pex==2.19.0",
 //     "psutil==5.9.8",
 //     "pydevd-pycharm==203.5419.8",
 //     "pytest<7.1.0,>=6.2.4",
@@ -832,19 +832,24 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "050b4e5baadcd44d760cedbd2b8e639f2ff89bbc7a5730fcc662954303377aac",
-              "url": "https://files.pythonhosted.org/packages/22/7e/d71db821f177828df9dea8c42ac46473366f191be53080e552e628aad991/idna-3.8-py3-none-any.whl"
+              "hash": "946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3",
+              "url": "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d838c2c0ed6fced7693d5e8ab8e734d5f8fda53a039c0164afb0b82e771e3603",
-              "url": "https://files.pythonhosted.org/packages/e8/ac/e349c5e6d4543326c6883ee9491e3921e0d07b55fdf3cce184b40d63e72a/idna-3.8.tar.gz"
+              "hash": "12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9",
+              "url": "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz"
             }
           ],
           "project_name": "idna",
-          "requires_dists": [],
+          "requires_dists": [
+            "flake8>=7.1.1; extra == \"all\"",
+            "mypy>=1.11.2; extra == \"all\"",
+            "pytest>=8.3.2; extra == \"all\"",
+            "ruff>=0.6.2; extra == \"all\""
+          ],
           "requires_python": ">=3.6",
-          "version": "3.8"
+          "version": "3.10"
         },
         {
           "artifacts": [
@@ -1064,21 +1069,22 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "8610b5bf7731c98d871421ff21e769e8fcf42ea56aa4ac7f8a271f2405733f24",
-              "url": "https://files.pythonhosted.org/packages/de/45/94497d22a1517b2462394f641ea272e7ec624823f223c01a5f0d7e6f571d/pex-2.16.2-py2.py3-none-any.whl"
+              "hash": "382efb4eff077f663df7dda789aaf8fef76f973d2faa6b7eda38f124177933e7",
+              "url": "https://files.pythonhosted.org/packages/57/a6/e0099871337d8ac4ee6d479c407b263adc2f12c971c750555b4ecee228ca/pex-2.19.0-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "feb2f1e9819a741915759fc221ee6119447acdfc3e0aaa5bbe5800c39fa10003",
-              "url": "https://files.pythonhosted.org/packages/87/cf/a39ace2db568e3bce48c79fd462aa289608208fe4509ff746349162e5196/pex-2.16.2.tar.gz"
+              "hash": "6ba070061261031da4ad8f1691c09186ee4f11bdd1d35d10e3bf6927bf7abe86",
+              "url": "https://files.pythonhosted.org/packages/bb/38/cb8dd13746c46f702ae552df5ef669c423e48dab9a90a8e2023eb23e4b53/pex-2.19.0.tar.gz"
             }
           ],
           "project_name": "pex",
           "requires_dists": [
+            "psutil>=5.3; extra == \"management\"",
             "subprocess32>=3.2.7; python_version < \"3\" and extra == \"subprocess\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.14,>=2.7",
-          "version": "2.16.2"
+          "version": "2.19.0"
         },
         {
           "artifacts": [
@@ -2395,7 +2401,7 @@
   "only_wheels": [],
   "overridden": [],
   "path_mappings": {},
-  "pex_version": "2.16.2",
+  "pex_version": "2.19.0",
   "pip_version": "24.2",
   "prefer_older_binary": false,
   "requirements": [
@@ -2413,7 +2419,7 @@
     "mypy-typing-asserts==0.1.1",
     "node-semver==0.9.0",
     "packaging==21.3",
-    "pex==2.16.2",
+    "pex==2.19.0",
     "psutil==5.9.8",
     "pydevd-pycharm==203.5419.8",
     "pytest<7.1.0,>=6.2.4",

--- a/3rdparty/python/user_reqs.lock
+++ b/3rdparty/python/user_reqs.lock
@@ -23,7 +23,7 @@
 //     "mypy-typing-asserts==0.1.1",
 //     "node-semver==0.9.0",
 //     "packaging==21.3",
-//     "pex==2.19.0",
+//     "pex==2.19.1",
 //     "psutil==5.9.8",
 //     "pydevd-pycharm==203.5419.8",
 //     "pytest<7.1.0,>=6.2.4",
@@ -1069,13 +1069,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "382efb4eff077f663df7dda789aaf8fef76f973d2faa6b7eda38f124177933e7",
-              "url": "https://files.pythonhosted.org/packages/57/a6/e0099871337d8ac4ee6d479c407b263adc2f12c971c750555b4ecee228ca/pex-2.19.0-py2.py3-none-any.whl"
+              "hash": "e837a1415e65fddad288de6e8b2209a0bca5a7e369cd0c20d02509364890c2ef",
+              "url": "https://files.pythonhosted.org/packages/9e/f3/4898a35e7963dae109710aa6dd19c929d72e93a017aa736ec79f1be0e1cc/pex-2.19.1-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6ba070061261031da4ad8f1691c09186ee4f11bdd1d35d10e3bf6927bf7abe86",
-              "url": "https://files.pythonhosted.org/packages/bb/38/cb8dd13746c46f702ae552df5ef669c423e48dab9a90a8e2023eb23e4b53/pex-2.19.0.tar.gz"
+              "hash": "9416ff00002a9eb21c725c67caf914cf387ea94c01329437328a9655d76b8311",
+              "url": "https://files.pythonhosted.org/packages/94/41/5d8a0bf2193f54a32a693185334e40064717f25a32b75fdc7820bd24420c/pex-2.19.1.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -1084,7 +1084,7 @@
             "subprocess32>=3.2.7; python_version < \"3\" and extra == \"subprocess\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.14,>=2.7",
-          "version": "2.19.0"
+          "version": "2.19.1"
         },
         {
           "artifacts": [
@@ -2401,7 +2401,7 @@
   "only_wheels": [],
   "overridden": [],
   "path_mappings": {},
-  "pex_version": "2.19.0",
+  "pex_version": "2.19.1",
   "pip_version": "24.2",
   "prefer_older_binary": false,
   "requirements": [
@@ -2419,7 +2419,7 @@
     "mypy-typing-asserts==0.1.1",
     "node-semver==0.9.0",
     "packaging==21.3",
-    "pex==2.19.0",
+    "pex==2.19.1",
     "psutil==5.9.8",
     "pydevd-pycharm==203.5419.8",
     "pytest<7.1.0,>=6.2.4",

--- a/docs/notes/2.24.x.md
+++ b/docs/notes/2.24.x.md
@@ -43,7 +43,7 @@ The default version of pip is now [24.2](https://pip.pypa.io/en/stable/news/#v24
 
 The versions of `setuptools` and `wheel` used in Pants have been upgraded to `74.1.2` and `0.44.0` to address a remote code execution vulnerability in versions before setuptools `70.0`. This forces the minimum Python version to 3.8, in line with the changes mentioned above.
 
-The default version of the [Pex](https://docs.pex-tool.org/) tool has been updated from 2.16.2 to [2.19.0](https://github.com/pex-tool/pex/releases/tag/v2.19.0).
+The default version of the [Pex](https://docs.pex-tool.org/) tool has been updated from 2.16.2 to [2.19.1](https://github.com/pex-tool/pex/releases/tag/v2.19.1).
 
 
 

--- a/docs/notes/2.24.x.md
+++ b/docs/notes/2.24.x.md
@@ -43,6 +43,10 @@ The default version of pip is now [24.2](https://pip.pypa.io/en/stable/news/#v24
 
 The versions of `setuptools` and `wheel` used in Pants have been upgraded to `74.1.2` and `0.44.0` to address a remote code execution vulnerability in versions before setuptools `70.0`. This forces the minimum Python version to 3.8, in line with the changes mentioned above.
 
+The default version of the [Pex](https://docs.pex-tool.org/) tool has been updated from 2.16.2 to [2.19.0](https://github.com/pex-tool/pex/releases/tag/v2.19.0).
+
+
+
 The deprecation of `resolve_local_platforms` (both a field of `pex_binary`, and a option of `[pex-binary-defaults]`) has expired and thus they have been removed.
 
 #### S3

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -40,7 +40,7 @@ class PexCli(TemplatedExternalTool):
     name = "pex"
     help = "The PEX (Python EXecutable) tool (https://github.com/pex-tool/pex)."
 
-    default_version = "v2.19.0"
+    default_version = "v2.19.1"
     default_url_template = "https://github.com/pex-tool/pex/releases/download/{version}/pex"
     version_constraints = ">=2.13.0,<3.0"
 
@@ -63,8 +63,8 @@ class PexCli(TemplatedExternalTool):
                 (
                     cls.default_version,
                     plat,
-                    "1b56d778fcf3b9504838277a7a20d6676b9f947aaa4759873830af2e78bf33ab",
-                    "4310167",
+                    "86ef2ac38d36aba203dc5b9819b77c3e25fb8588b01c9d15f66b1c94bdbc989b",
+                    "4310578",
                 )
             )
             for plat in ["macos_arm64", "macos_x86_64", "linux_x86_64", "linux_arm64"]

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -40,7 +40,7 @@ class PexCli(TemplatedExternalTool):
     name = "pex"
     help = "The PEX (Python EXecutable) tool (https://github.com/pex-tool/pex)."
 
-    default_version = "v2.16.2"
+    default_version = "v2.19.0"
     default_url_template = "https://github.com/pex-tool/pex/releases/download/{version}/pex"
     version_constraints = ">=2.13.0,<3.0"
 
@@ -63,8 +63,8 @@ class PexCli(TemplatedExternalTool):
                 (
                     cls.default_version,
                     plat,
-                    "f2ec29dda754c71a8b662e3b4a9071aef269a9991ae920666567669472dcd556",
-                    "4284448",
+                    "1b56d778fcf3b9504838277a7a20d6676b9f947aaa4759873830af2e78bf33ab",
+                    "4310167",
                 )
             )
             for plat in ["macos_arm64", "macos_x86_64", "linux_x86_64", "linux_arm64"]


### PR DESCRIPTION
Highlighted Changelogs:
 * https://github.com/pex-tool/pex/releases/tag/v2.17.0
 * https://github.com/pex-tool/pex/releases/tag/v2.18.0
 * https://github.com/pex-tool/pex/releases/tag/v2.19.0
 * https://github.com/pex-tool/pex/releases/tag/v2.19.1

```
Lockfile diff: 3rdparty/python/user_reqs.lock [python-default]
==                    Upgraded dependencies                     ==

  idna                           3.8          -->   3.10
  pex                            2.16.2       -->   2.19.1
```

ref #18294 #11167