### PR TITLE
Allow --no-watch-filesystem with --pantsd

### DIFF
--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -2054,12 +2054,12 @@ class GlobalOptions(BootstrapOptions, Subsystem):
                 )
             )
 
-        if not opts.watch_filesystem and (opts.pantsd or opts.loop):
+        if not opts.watch_filesystem and opts.loop:
             raise OptionsError(
                 softwrap(
                     """
                     The `--no-watch-filesystem` option may not be set if
-                    `--pantsd` or `--loop` is set.
+                    `--loop` is set.
                     """
                 )
             )


### PR DESCRIPTION
Addresses #21448

Allows not watching the fs while keeping pants around. 

This is useful when running multiple commands in a read-only environment like CI where there are resource constraints that limit file watching. 