### PR TITLE
golang: fix exception when coverage enabled and external tests import the base package (Cherry-pick of #21452)

### DIFF
--- a/docs/notes/2.22.x.md
+++ b/docs/notes/2.22.x.md
@@ -137,6 +137,10 @@ The default version of `semgrep` used by the `pants.backends.experimental.tool.s
 
 Setting [the `orphan_files_behaviour = "ignore"` option](https://www.pantsbuild.org/2.22/reference/subsystems/yamllint#orphan_files_behavior) the `pants.backend.experimental.tools.yamllint` backend is now properly silent. It previously showed spurious warnings.
 
+#### Go
+
+Fix a bug where Pants raised an internal exception which occurred when compiling a Go package with coverage support when the package also had an external test which imported the base package.
+
 ### Plugin API changes
 
 The `PythonToolRequirementsBase` and `PythonToolBase` classes now have a new `help_short` field. Subclasses should now use `help_short` instead of the `help` field. The `help` field will be automatically generated using `help_short`, and will include the tool's default package version and provide instructions on how to override this version using a custom lockfile.

--- a/src/python/pants/backend/go/util_rules/build_pkg_target.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target.py
@@ -458,7 +458,10 @@ async def setup_build_go_package_target_request(
         maybe_base_pkg_dep = await Get(
             FallibleBuildGoPackageRequest,
             BuildGoPackageTargetRequest(
-                request.address, for_tests=True, build_opts=request.build_opts
+                request.address,
+                for_tests=True,
+                with_coverage=request.with_coverage,
+                build_opts=request.build_opts,
             ),
         )
         if maybe_base_pkg_dep.request is None:


### PR DESCRIPTION
As reported in https://github.com/pantsbuild/pants/issues/21386, Pants raises an exception when coverage is enabled and a package has external tests (i.e., "xtests") which import the base package. The bug occurred because the code which injects the base package dependency did not properly pass through the coverage flag. Consequently, the compile graph ended up with two different variants of the base package: one with coverage codegen and the other without coverage codegen. This resulted in two different copies of the package archive which Pants cannot merge together into a single `Digest`.

The solution is to properly pass through the coverage flag when injecting the base package dependency on the external test package to ensure there are not multiple variants of the base package in the compile graph.

Fixes #21386.
