### PR TITLE
golang: fix exception when coverage enabled and external tests import the base package (Cherry-pick of #21452)

### DIFF
--- a/src/python/pants/backend/go/util_rules/build_pkg_target.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target.py
@@ -458,7 +458,10 @@ async def setup_build_go_package_target_request(
         maybe_base_pkg_dep = await Get(
             FallibleBuildGoPackageRequest,
             BuildGoPackageTargetRequest(
-                request.address, for_tests=True, build_opts=request.build_opts
+                request.address,
+                for_tests=True,
+                with_coverage=request.with_coverage,
+                build_opts=request.build_opts,
             ),
         )
         if maybe_base_pkg_dep.request is None:


### PR DESCRIPTION
As reported in https://github.com/pantsbuild/pants/issues/21386, Pants raises an exception when coverage is enabled and a package has external tests (i.e., "xtests") which import the base package. The bug occurred because the code which injects the base package dependency did not properly pass through the coverage flag. Consequently, the compile graph ended up with two different variants of the base package: one with coverage codegen and the other without coverage codegen. This resulted in two different copies of the package archive which Pants cannot merge together into a single `Digest`.

The solution is to properly pass through the coverage flag when injecting the base package dependency on the external test package to ensure there are not multiple variants of the base package in the compile graph.

Fixes #21386.
