### PR TITLE
Document missing binary as common issue

### DIFF
--- a/docs/docs/contributions/releases/release-process.mdx
+++ b/docs/docs/contributions/releases/release-process.mdx
@@ -186,5 +186,5 @@ values are added.
 
 From time to time, a release will fail. It's a complex process. The first thing to do after you've
 exhausted your knowledge and debugging skills or patience is to contact others. You might reach out
-to the development or maintainers channels on Pantbuild Slack in the absence of other ideas about
+to the development or maintainers channels on Pantsbuild Slack in the absence of other ideas about
 whom to ask for help.

--- a/docs/docs/using-pants/key-concepts/options.mdx
+++ b/docs/docs/using-pants/key-concepts/options.mdx
@@ -359,7 +359,7 @@ pants --scope-option="@path/to/file.json"
 Until we resolve [this issue](https://github.com/pantsbuild/pants/issues/10360), changing
 the value in a file used with the `@` syntax as described above will not invalidate the build.
 For now, if such a file changes you will have to stop pantsd so that it will be restarted on
-the next invocation of pants. To do so, run `rm -r .pants.d/pids/`in the build root.
+the next invocation of pants. To do so, run `rm -r .pants.d/pids/` in the build root.
 :::
 
 ## `.pants.rc` file

--- a/docs/docs/using-pants/key-concepts/options.mdx
+++ b/docs/docs/using-pants/key-concepts/options.mdx
@@ -358,9 +358,8 @@ pants --scope-option="@path/to/file.json"
 :::caution Gotcha: If you modify the value file, you must manually restart pantsd
 Until we resolve [this issue](https://github.com/pantsbuild/pants/issues/10360), changing
 the value in a file used with the `@` syntax as described above will not invalidate the build.
-For now, if such a file changes you will have to restart the Pants daemon manually. You can
-do so by `kill`ing it (after using `ps -ef | grep pantsd` to find its pid), or by running
-Pants once with `--no-pantsd`.
+For now, if such a file changes you will have to stop pantsd so that it will be restarted on
+the next invocation of pants. To do so, run `rm -r .pants.d/pids/`in the build root.
 :::
 
 ## `.pants.rc` file

--- a/docs/docs/using-pants/troubleshooting-common-issues.mdx
+++ b/docs/docs/using-pants/troubleshooting-common-issues.mdx
@@ -71,6 +71,20 @@ pants_ignore.add = ["!folder/"]
 
 Alternatively, you can stop populating `pants_ignore` from your `.gitignore` by setting `pants_ignore_use_gitignore = false` in the `[GLOBAL]` scope.
 
+## Pants cannot find a required binary
+
+Pants may be unable to locate a required binary to execute a specified goal. This can manifest in an error message such as:
+
+```
+BinaryNotFoundError: Cannot find `required_binary` on `['/usr/bin/', '/bin', '/usr/local/bin', '/opt/homebrew/bin']`. Please ensure that it is installed so that Pants can interact with the required_binary.
+```
+
+Helpfully, the error message already contains the list of directories that pants searches for binaries. This list is controlled by the [`system_binary_paths`](../../reference/subsystems/system-binaries#system_binary_paths) setting in the system-binaries subsystem. Ensure that the directory that contains your binary is on the list.
+
+If `system_binary_paths` contains the special string `<PATH>`, note that the PATH variable can also be changed after the invocation of pants in [`.pants.bootstrap`](../..//docs/using-pants/key-concepts/options#pantsbootstrap-file).
+
+Pantsd caches the location of binaries and also negative hits. If you recently installed the binary or changed it's location, make sure to stop pantsd so that it will be restarted on the next invocation of pants. To do so, run `rm -r .pants.d/pids/`in the build root.
+
 ## Import errors and missing dependencies
 
 Because Pants runs processes in hermetic sandboxes (temporary directories), Pants must properly know about your [dependencies](../introduction/how-does-pants-work#dependency-inference) to avoid import errors.

--- a/docs/docs/using-pants/troubleshooting-common-issues.mdx
+++ b/docs/docs/using-pants/troubleshooting-common-issues.mdx
@@ -81,7 +81,7 @@ Helpfully, the error message already contains the list of directories that pants
 
 If `system_binary_paths` contains the special string `<PATH>`, note that the PATH variable can also be changed after the invocation of pants in [`.pants.bootstrap`](../..//docs/using-pants/key-concepts/options#pantsbootstrap-file).
 
-Pantsd caches the location of binaries and also negative hits. If you recently installed the binary or changed it's location, make sure to stop pantsd so that it will be restarted on the next invocation of pants. To do so, run `rm -r .pants.d/pids/`in the build root.
+Pantsd caches the location of binaries and also negative hits. If you recently installed the binary or changed its location, make sure to stop pantsd so that it will be restarted on the next invocation of pants. To do so, run `rm -r .pants.d/pids/` in the build root.
 
 ## Import errors and missing dependencies
 

--- a/docs/docs/using-pants/troubleshooting-common-issues.mdx
+++ b/docs/docs/using-pants/troubleshooting-common-issues.mdx
@@ -48,13 +48,11 @@ There is even a `__run.sh` script in the directory that will run the process usi
 
 If you are using the latest stable version of Pants and still experience a cache invalidation issue: we are sorry for the trouble. We have not yet added a comprehensive goal to "clear all caches", because we are very interested in coming up with coherent solutions to potential issues (see for more information). If you experience a cache issue, please absolutely [file a bug](https://github.com/pantsbuild/pants/issues/new) before proceeding to the following steps.
 
-To start with, first try using `--no-pantsd`. If that doesn't work, you can also try `--no-local-cache`.
-
-If `--no-pantsd` worked, you can stop pantsd so that it will restarted on the next invocation of pants. To do so, run `rm -r .pants.d/pids/`in the build root.
+To start with, first try using `--no-pantsd`. If `--no-pantsd` worked, you can stop pantsd so that it will restarted on the next invocation of pants. To do so, run `rm -r .pants.d/pids/`in the build root.
 
 If this resolves the issue, please report that on the ticket and attach the recent content of the `.pants.d/workdir/pantsd/pantsd.log` file.
 
-If restarting `pantsd` is not sufficient, you can also use `--no-local-cache` to ignore the persistent caches. If this resolves the issue, then it is possible that the contents of the cache (at `~/.cache/pants`) will be useful for debugging the ticket that you filed: please try to preserve the cache contents until it can be resolved.
+If restarting pantsd is not sufficient, you can also use `--no-local-cache` to ignore the persistent caches. If this resolves the issue, then it is possible that the contents of the cache (at `~/.cache/pants`) will be useful for debugging the ticket that you filed: please try to preserve the cache contents until it can be resolved.
 
 ## Pants cannot find a file in your project
 

--- a/docs/docs/using-pants/troubleshooting-common-issues.mdx
+++ b/docs/docs/using-pants/troubleshooting-common-issues.mdx
@@ -50,10 +50,7 @@ If you are using the latest stable version of Pants and still experience a cache
 
 To start with, first try using `--no-pantsd`. If that doesn't work, you can also try `--no-local-cache`.
 
-If `--no-pantsd` worked, you can restart `pantsd`, either by:
-
-- Killing the `pantsd` process associated with your workspace. You can use `ps aux | grep pants` to find the PID, the `kill -9 <pid>`.
-- Deleting the `<build root>/.pants.d/pids` directory.
+If `--no-pantsd` worked, you can stop pantsd so that it will restarted on the next invocation of pants. To do so, run `rm -r .pants.d/pids/`in the build root.
 
 If this resolves the issue, please report that on the ticket and attach the recent content of the `.pants.d/workdir/pantsd/pantsd.log` file.
 


### PR DESCRIPTION
I bumped into the issue regarding missing binaries. (Discussed here: https://pantsbuild.slack.com/archives/C046T6T9U/p1727110843074959)

Added a few other tiny things I stumbled across while reading the docs. Let me know if anything should be dropped or moved to a separate PR.

- **Harmonize instructions to restart pantsd**
- **Add common issue description for missing binaries**
- **Remove duplicate mention of --no-local-cache to improve flow**
