### PR TITLE
pyo3: use `FromPyObject::extract_bound`

### DIFF
--- a/src/rust/engine/src/externs/fs.rs
+++ b/src/rust/engine/src/externs/fs.rs
@@ -383,8 +383,8 @@ impl PyRemovePrefix {
 
 struct PyPathGlobs(#[allow(dead_code)] PathGlobs);
 
-impl<'source> FromPyObject<'source> for PyPathGlobs {
-    fn extract(obj: &'source PyAny) -> PyResult<Self> {
+impl<'py> FromPyObject<'py> for PyPathGlobs {
+    fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
         let globs: Vec<String> = obj.getattr("globs")?.extract()?;
 
         let description_of_origin_field = obj.getattr("description_of_origin")?;

--- a/src/rust/engine/src/python.rs
+++ b/src/rust/engine/src/python.rs
@@ -252,8 +252,8 @@ impl fmt::Display for Key {
     }
 }
 
-impl<'source> FromPyObject<'source> for Key {
-    fn extract(obj: &'source PyAny) -> PyResult<Self> {
+impl<'py> FromPyObject<'py> for Key {
+    fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
         let py = obj.py();
         externs::INTERNS.key_insert(py, obj.into_py(py))
     }
@@ -353,8 +353,8 @@ impl fmt::Display for Value {
     }
 }
 
-impl<'source> FromPyObject<'source> for Value {
-    fn extract(obj: &'source PyAny) -> PyResult<Self> {
+impl<'py> FromPyObject<'py> for Value {
+    fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
         let py = obj.py();
         Ok(obj.into_py(py).into())
     }


### PR DESCRIPTION
PyO3 will eventually remove use of `&'py PyAny` references in favor of the `Bound<'py, T>` smart pointer. Migrate to using the `FromPyObject::extract_bound` trait function instead of the deprecated `FromPyObject::extract` trait function. (`extract` defaults to just calling `extract_bound` in this version of PyO3).