### PR TITLE
remove extraneous request logging

### DIFF
--- a/src/rust/engine/grpc_util/src/channel.rs
+++ b/src/rust/engine/grpc_util/src/channel.rs
@@ -100,7 +100,6 @@ impl Service<http::Request<BoxBody>> for Channel {
             .unwrap();
         *req.uri_mut() = uri;
 
-        log::info!("sending request {:?}", &req);
         let client = self.client.clone();
         Box::pin(async move {
             match &client {


### PR DESCRIPTION
Forgot to remove extra logging when I was debugging the Tonic upgrade.