### PR TITLE
PyO3: migrate to `Bound` smart pointer for `src/rust/engine/src/externs/dep_inference.rs`

### DIFF
--- a/src/rust/engine/src/externs/dep_inference.rs
+++ b/src/rust/engine/src/externs/dep_inference.rs
@@ -25,7 +25,7 @@ pub(crate) fn register(m: &PyModule) -> PyResult<()> {
 pub struct PyInferenceMetadata(pub dependency_inference_request::Metadata);
 
 fn as_import_patterns(
-    dict: &PyDict,
+    dict: &Bound<'_, PyDict>,
 ) -> PyResult<Vec<javascript_inference_metadata::ImportPattern>> {
     dict.iter()
         .map(|(key, value)| {
@@ -41,11 +41,11 @@ fn as_import_patterns(
 impl PyInferenceMetadata {
     #[staticmethod]
     #[pyo3(signature = (package_root, import_patterns, config_root, paths))]
-    fn javascript(
+    fn javascript<'py>(
         package_root: String,
-        import_patterns: &PyDict,
+        import_patterns: &Bound<'py, PyDict>,
         config_root: Option<String>,
-        paths: &PyDict,
+        paths: &Bound<'py, PyDict>,
     ) -> PyResult<Self> {
         let import_patterns = as_import_patterns(import_patterns)?;
         let paths = as_import_patterns(paths)?;


### PR DESCRIPTION
Migrate to the `Bound` smart pointer instead of `&PyAny` (and related reference types) in `src/rust/engine/src/externs/dep_inference.rs`. See the [PyO3 migration guide](https://pyo3.rs/main/migration#migrating-from-the-gil-refs-api-to-boundt) for details.