### PR TITLE
PyO3: migrate to `Bound` smart pointer for `src/rust/engine/src/externs/engine_aware.rs`

### DIFF
--- a/src/rust/engine/src/nodes/mod.rs
+++ b/src/rust/engine/src/nodes/mod.rs
@@ -396,7 +396,7 @@ impl NodeKey {
 
                 let displayable_param_names: Vec<_> = Python::with_gil(|py| {
                     Self::engine_aware_params(context, py, &task.params)
-                        .filter_map(|k| EngineAwareParameter::debug_hint((*k.value).as_ref(py)))
+                        .filter_map(|k| EngineAwareParameter::debug_hint((*k.value).bind(py)))
                         .collect()
                 });
 
@@ -502,7 +502,7 @@ impl Node for NodeKey {
                 if let Some(params) = maybe_params {
                     Python::with_gil(|py| {
                         Self::engine_aware_params(&context, py, params)
-                            .flat_map(|k| EngineAwareParameter::metadata((*k.value).as_ref(py)))
+                            .flat_map(|k| EngineAwareParameter::metadata((*k.value).bind(py)))
                             .collect()
                     })
                 } else {
@@ -601,7 +601,7 @@ impl Node for NodeKey {
             }
             (NodeKey::Task(ref t), NodeOutput::Value(ref v)) if t.task.engine_aware_return_type => {
                 Python::with_gil(|py| {
-                    EngineAwareReturnType::is_cacheable((**v).as_ref(py)).unwrap_or(true)
+                    EngineAwareReturnType::is_cacheable((**v).bind(py)).unwrap_or(true)
                 })
             }
             _ => true,
@@ -652,7 +652,7 @@ impl Display for NodeKey {
                             .keys()
                             .filter_map(|k| {
                                 EngineAwareParameter::debug_hint(
-                                    k.to_value().clone_ref(py).into_ref(py),
+                                    k.to_value().clone_ref(py).bind(py),
                                 )
                             })
                             .collect::<Vec<_>>()

--- a/src/rust/engine/src/nodes/task.rs
+++ b/src/rust/engine/src/nodes/task.rs
@@ -331,7 +331,7 @@ impl Task {
 
         if self.task.engine_aware_return_type {
             Python::with_gil(|py| {
-                EngineAwareReturnType::update_workunit(workunit, (*result_val).as_ref(py))
+                EngineAwareReturnType::update_workunit(workunit, (*result_val).bind(py))
             })
         };
 


### PR DESCRIPTION
Migrate to the `Bound` smart pointer instead of `&PyAny` (and related reference types) in `src/rust/engine/src/externs/engine_aware.rs`. See the [PyO3 migration guide](https://pyo3.rs/main/migration#migrating-from-the-gil-refs-api-to-boundt) for details.