### PR TITLE
PyO3: migrate to `Bound` smart pointer for `src/rust/engine/src/externs/nailgun.rs`

### DIFF
--- a/src/rust/engine/src/externs/nailgun.rs
+++ b/src/rust/engine/src/externs/nailgun.rs
@@ -34,10 +34,10 @@ struct PyNailgunClient {
 #[pymethods]
 impl PyNailgunClient {
     #[new]
-    fn __new__(port: u16, py_executor: &PyExecutor) -> Self {
+    fn __new__(port: u16, py_executor: &Bound<'_, PyExecutor>) -> Self {
         Self {
             port,
-            executor: py_executor.0.clone(),
+            executor: py_executor.borrow().0.clone(),
         }
     }
 
@@ -45,7 +45,7 @@ impl PyNailgunClient {
         &self,
         command: String,
         args: Vec<String>,
-        env: &PyDict,
+        env: &Bound<'_, PyDict>,
         py: Python,
     ) -> PyResult<i32> {
         use nailgun::NailgunClientError;


### PR DESCRIPTION
Migrate to the `Bound` smart pointer instead of `&PyAny` (and related reference types) in `src/rust/engine/src/externs/nailgun.rs`. See the [PyO3 migration guide](https://pyo3.rs/main/migration#migrating-from-the-gil-refs-api-to-boundt) for details.