### PR TITLE
PyO3: migrate to `Bound` smart pointer for `src/rust/engine/src/externs/testutil.rs`

### DIFF
--- a/src/rust/engine/src/externs/testutil.rs
+++ b/src/rust/engine/src/externs/testutil.rs
@@ -41,13 +41,16 @@ impl PyStubCASBuilder {
         Ok(PyStubCASBuilder(self.0.clone()))
     }
 
-    fn build(&mut self, py_executor: &PyExecutor) -> PyResult<PyStubCAS> {
+    fn build(&mut self, py_executor: &Bound<'_, PyExecutor>) -> PyResult<PyStubCAS> {
         let mut builder_opt = self.0.lock();
         let builder = builder_opt
             .take()
             .ok_or_else(|| PyAssertionError::new_err("Unable to unwrap StubCASBuilder"))?;
         // NB: A Tokio runtime must be used when building StubCAS.
-        py_executor.0.enter(|| Ok(PyStubCAS(builder.build())))
+        py_executor
+            .borrow()
+            .0
+            .enter(|| Ok(PyStubCAS(builder.build())))
     }
 }
 
@@ -57,7 +60,7 @@ struct PyStubCAS(StubCAS);
 #[pymethods]
 impl PyStubCAS {
     #[classmethod]
-    fn builder(_cls: &PyType) -> PyStubCASBuilder {
+    fn builder(_cls: &Bound<'_, PyType>) -> PyStubCASBuilder {
         let builder = Arc::new(Mutex::new(Some(StubCAS::builder())));
         PyStubCASBuilder(builder)
     }
@@ -67,7 +70,7 @@ impl PyStubCAS {
         self.0.address()
     }
 
-    fn remove(&self, digest: &PyAny) -> PyResult<bool> {
+    fn remove(&self, digest: &Bound<'_, PyAny>) -> PyResult<bool> {
         let digest = digest
             .extract::<PyFileDigest>()
             .map(|fd| fd.0)


### PR DESCRIPTION
Migrate to the `Bound` smart pointer instead of `&PyAny` (and related reference types) in `src/rust/engine/src/externs/testutil.rs`. See the [PyO3 migration guide](https://pyo3.rs/main/migration#migrating-from-the-gil-refs-api-to-boundt) for details.