### PR TITLE
PyO3: migrate to `Bound` smart pointer for `src/rust/engine/src/externs/process.rs`

### DIFF
--- a/src/rust/engine/src/externs/process.rs
+++ b/src/rust/engine/src/externs/process.rs
@@ -72,13 +72,14 @@ impl PyProcessExecutionEnvironment {
 
     fn __richcmp__(
         &self,
-        other: &PyProcessExecutionEnvironment,
+        other: &Bound<'_, PyProcessExecutionEnvironment>,
         op: CompareOp,
         py: Python,
     ) -> PyObject {
+        let other = other.borrow();
         match op {
-            CompareOp::Eq => (self == other).into_py(py),
-            CompareOp::Ne => (self != other).into_py(py),
+            CompareOp::Eq => (*self == *other).into_py(py),
+            CompareOp::Ne => (*self != *other).into_py(py),
             _ => py.NotImplemented(),
         }
     }


### PR DESCRIPTION
Migrate to the `Bound` smart pointer instead of `&PyAny` (and related reference types) in `src/rust/engine/src/externs/process.rs`. See the [PyO3 migration guide](https://pyo3.rs/main/migration#migrating-from-the-gil-refs-api-to-boundt) for details.