### PR TITLE
PyO3: migrate to `Bound` smart pointer for `src/rust/engine/src/externs/stdio.rs`

### DIFF
--- a/src/rust/engine/src/externs/stdio.rs
+++ b/src/rust/engine/src/externs/stdio.rs
@@ -25,8 +25,8 @@ impl PyStdioRead {
             .map_err(PyException::new_err)
     }
 
-    fn readinto(&self, obj: &PyAny, py: Python) -> PyResult<usize> {
-        let py_buffer = PyBuffer::get(obj)?;
+    fn readinto(&self, obj: &Bound<'_, PyAny>, py: Python) -> PyResult<usize> {
+        let py_buffer = PyBuffer::get_bound(obj)?;
         let mut buffer = vec![0; py_buffer.len_bytes()];
         let read = py
             .allow_threads(|| stdio::get_destination().read_stdin(&mut buffer))


### PR DESCRIPTION
Migrate to the `Bound` smart pointer instead of `&PyAny` (and related reference types) in `src/rust/engine/src/externs/stdio.rs`. See the [PyO3 migration guide](https://pyo3.rs/main/migration#migrating-from-the-gil-refs-api-to-boundt) for details.