### PR TITLE
PyO3: migrate `PyModule` setup to `Bound` smart pointer

### DIFF
--- a/src/rust/engine/src/externs/address.rs
+++ b/src/rust/engine/src/externs/address.rs
@@ -23,7 +23,7 @@ create_exception!(native_engine, InvalidTargetNameError, InvalidAddressError);
 create_exception!(native_engine, InvalidParametersError, InvalidAddressError);
 create_exception!(native_engine, UnsupportedWildcardError, InvalidAddressError);
 
-pub fn register(py: Python, m: &PyModule) -> PyResult<()> {
+pub fn register(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(address_spec_parse, m)?)?;
 
     m.add(

--- a/src/rust/engine/src/externs/dep_inference.rs
+++ b/src/rust/engine/src/externs/dep_inference.rs
@@ -15,7 +15,7 @@ use protos::gen::pants::cache::{
 
 use crate::externs::fs::PyDigest;
 
-pub(crate) fn register(m: &PyModule) -> PyResult<()> {
+pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyNativeDependenciesRequest>()?;
     m.add_class::<PyInferenceMetadata>()
 }

--- a/src/rust/engine/src/externs/fs.rs
+++ b/src/rust/engine/src/externs/fs.rs
@@ -22,7 +22,7 @@ use store::Snapshot;
 
 use crate::Failure;
 
-pub(crate) fn register(m: &PyModule) -> PyResult<()> {
+pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyDigest>()?;
     m.add_class::<PyFileDigest>()?;
     m.add_class::<PySnapshot>()?;

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -57,7 +57,7 @@ use crate::{
 };
 
 #[pymodule]
-fn native_engine(py: Python, m: &PyModule) -> PyO3Result<()> {
+fn native_engine(py: Python, m: &Bound<'_, PyModule>) -> PyO3Result<()> {
     intrinsics::register(py, m)?;
     externs::register(py, m)?;
     externs::address::register(py, m)?;

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -42,7 +42,7 @@ mod target;
 pub mod testutil;
 pub mod workunits;
 
-pub fn register(py: Python, m: &PyModule) -> PyResult<()> {
+pub fn register(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyFailure>()?;
     m.add_class::<PyGeneratorResponseNativeCall>()?;
     m.add_class::<PyGeneratorResponseCall>()?;

--- a/src/rust/engine/src/externs/nailgun.rs
+++ b/src/rust/engine/src/externs/nailgun.rs
@@ -9,7 +9,7 @@ use pyo3::types::PyDict;
 use crate::externs::scheduler::PyExecutor;
 use task_executor::Executor;
 
-pub fn register(py: Python, m: &PyModule) -> PyResult<()> {
+pub fn register(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add(
         "PantsdConnectionException",
         py.get_type::<PantsdConnectionException>(),

--- a/src/rust/engine/src/externs/options.rs
+++ b/src/rust/engine/src/externs/options.rs
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 
 pyo3::import_exception!(pants.option.errors, ParseError);
 
-pub(crate) fn register(m: &PyModule) -> PyResult<()> {
+pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyOptionId>()?;
     m.add_class::<PyConfigSource>()?;
     m.add_class::<PyOptionParser>()?;

--- a/src/rust/engine/src/externs/pantsd.rs
+++ b/src/rust/engine/src/externs/pantsd.rs
@@ -8,7 +8,7 @@ use pyo3::prelude::*;
 
 use options::{Args, BuildRoot, Env, OptionParser};
 
-pub fn register(_py: Python, m: &PyModule) -> PyResult<()> {
+pub fn register(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(pantsd_fingerprint_compute, m)?)?;
     Ok(())
 }

--- a/src/rust/engine/src/externs/process.rs
+++ b/src/rust/engine/src/externs/process.rs
@@ -10,7 +10,7 @@ use pyo3::prelude::*;
 
 use process_execution::{Platform, ProcessExecutionEnvironment, ProcessExecutionStrategy};
 
-pub(crate) fn register(m: &PyModule) -> PyResult<()> {
+pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyProcessExecutionEnvironment>()?;
 
     Ok(())

--- a/src/rust/engine/src/externs/scheduler.rs
+++ b/src/rust/engine/src/externs/scheduler.rs
@@ -7,7 +7,7 @@ use pyo3::exceptions::PyException;
 use pyo3::ffi;
 use pyo3::prelude::*;
 
-pub fn register(m: &PyModule) -> PyResult<()> {
+pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyExecutor>()?;
     Ok(())
 }

--- a/src/rust/engine/src/externs/target.rs
+++ b/src/rust/engine/src/externs/target.rs
@@ -11,7 +11,7 @@ use pyo3::types::PyType;
 
 use crate::externs::address::Address;
 
-pub fn register(m: &PyModule) -> PyResult<()> {
+pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Field>()?;
     m.add_class::<NoFieldValue>()?;
 

--- a/src/rust/engine/src/externs/testutil.rs
+++ b/src/rust/engine/src/externs/testutil.rs
@@ -13,7 +13,7 @@ use testutil_mock::{StubCAS, StubCASBuilder};
 use crate::externs::fs::{PyDigest, PyFileDigest};
 use crate::externs::scheduler::PyExecutor;
 
-pub fn register(m: &PyModule) -> PyResult<()> {
+pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyStubCAS>()?;
     m.add_class::<PyStubCASBuilder>()?;
     Ok(())

--- a/src/rust/engine/src/externs/workunits.rs
+++ b/src/rust/engine/src/externs/workunits.rs
@@ -4,7 +4,7 @@
 use pyo3::prelude::*;
 use workunit_store::Metric;
 
-pub fn register(m: &PyModule) -> PyResult<()> {
+pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(all_counter_names, m)?)?;
     Ok(())
 }

--- a/src/rust/engine/src/intrinsics/dep_inference.rs
+++ b/src/rust/engine/src/intrinsics/dep_inference.rs
@@ -16,7 +16,8 @@ use protos::gen::pants::cache::{
     dependency_inference_request, CacheKey, CacheKeyType, DependencyInferenceRequest,
 };
 use pyo3::prelude::{pyfunction, wrap_pyfunction, PyModule, PyResult, Python, ToPyObject};
-use pyo3::IntoPy;
+use pyo3::types::PyModuleMethods;
+use pyo3::{Bound, IntoPy};
 use store::Store;
 use workunit_store::{in_workunit, Level};
 
@@ -26,7 +27,7 @@ use crate::nodes::{task_get_context, NodeResult};
 use crate::python::{Failure, Value};
 use crate::{externs, Core};
 
-pub fn register(_py: Python, m: &PyModule) -> PyResult<()> {
+pub fn register(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(parse_dockerfile_info, m)?)?;
     m.add_function(wrap_pyfunction!(parse_python_deps, m)?)?;
     m.add_function(wrap_pyfunction!(parse_javascript_deps, m)?)?;

--- a/src/rust/engine/src/intrinsics/digests.rs
+++ b/src/rust/engine/src/intrinsics/digests.rs
@@ -9,8 +9,8 @@ use fs::{
 };
 use hashing::{Digest, EMPTY_DIGEST};
 use pyo3::prelude::{pyfunction, wrap_pyfunction, PyModule, PyRef, PyResult, Python};
-use pyo3::types::PyTuple;
-use pyo3::IntoPy;
+use pyo3::types::{PyModuleMethods, PyTuple};
+use pyo3::{Bound, IntoPy};
 use store::{SnapshotOps, SubsetParams};
 
 use crate::externs;
@@ -25,7 +25,7 @@ use crate::nodes::{
 use crate::python::{throw, Key, Value};
 use crate::Failure;
 
-pub fn register(_py: Python, m: &PyModule) -> PyResult<()> {
+pub fn register(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(add_prefix, m)?)?;
     m.add_function(wrap_pyfunction!(create_digest, m)?)?;
     m.add_function(wrap_pyfunction!(digest_subset_to_digest, m)?)?;

--- a/src/rust/engine/src/intrinsics/docker.rs
+++ b/src/rust/engine/src/intrinsics/docker.rs
@@ -4,13 +4,14 @@
 use docker::docker::{ImagePullPolicy, ImagePullScope, DOCKER, IMAGE_PULL_CACHE};
 use process_execution::Platform;
 use pyo3::prelude::{pyfunction, wrap_pyfunction, PyAny, PyModule, PyResult, Python, ToPyObject};
-use pyo3::types::PyString;
+use pyo3::types::{PyModuleMethods, PyString};
+use pyo3::Bound;
 
 use crate::externs::{self, PyGeneratorResponseNativeCall};
 use crate::nodes::task_get_context;
 use crate::python::{Failure, Value};
 
-pub fn register(_py: Python, m: &PyModule) -> PyResult<()> {
+pub fn register(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(docker_resolve_image, m)?)?;
 
     Ok(())

--- a/src/rust/engine/src/intrinsics/interactive_process.rs
+++ b/src/rust/engine/src/intrinsics/interactive_process.rs
@@ -12,6 +12,8 @@ use process_execution::local::{
 };
 use process_execution::{ManagedChild, ProcessExecutionStrategy};
 use pyo3::prelude::{pyfunction, wrap_pyfunction, PyAny, PyModule, PyResult, Python, ToPyObject};
+use pyo3::types::PyModuleMethods;
+use pyo3::Bound;
 use stdio::TryCloneAsFile;
 use tokio::process;
 use workunit_store::{in_workunit, Level};
@@ -21,7 +23,7 @@ use crate::externs::{self, PyGeneratorResponseNativeCall};
 use crate::nodes::{task_get_context, ExecuteProcess, NodeResult};
 use crate::python::{Failure, Value};
 
-pub fn register(_py: Python, m: &PyModule) -> PyResult<()> {
+pub fn register(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(interactive_process, m)?)?;
     Ok(())
 }

--- a/src/rust/engine/src/intrinsics/mod.rs
+++ b/src/rust/engine/src/intrinsics/mod.rs
@@ -1,7 +1,8 @@
 // Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-use pyo3::prelude::{PyModule, PyResult, Python};
+use pyo3::types::PyModule;
+use pyo3::{Bound, PyResult, Python};
 
 // Sub-modules with intrinsic implementations.
 mod dep_inference;
@@ -13,7 +14,7 @@ mod values;
 
 pub use interactive_process::interactive_process_inner;
 
-pub fn register(py: Python, m: &PyModule) -> PyResult<()> {
+pub fn register(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     dep_inference::register(py, m)?;
     digests::register(py, m)?;
     docker::register(py, m)?;

--- a/src/rust/engine/src/intrinsics/process.rs
+++ b/src/rust/engine/src/intrinsics/process.rs
@@ -5,13 +5,14 @@ use std::time::Duration;
 
 use futures::future::TryFutureExt;
 use futures::try_join;
-use pyo3::prelude::{pyfunction, wrap_pyfunction, IntoPy, PyModule, PyResult, Python};
+use pyo3::types::{PyModule, PyModuleMethods};
+use pyo3::{pyfunction, wrap_pyfunction, Bound, IntoPy, PyResult, Python};
 
 use crate::externs::{self, PyGeneratorResponseNativeCall};
 use crate::nodes::{task_get_context, ExecuteProcess, NodeResult, Snapshot};
 use crate::python::Value;
 
-pub fn register(_py: Python, m: &PyModule) -> PyResult<()> {
+pub fn register(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(execute_process, m)?)?;
 
     Ok(())

--- a/src/rust/engine/src/intrinsics/values.rs
+++ b/src/rust/engine/src/intrinsics/values.rs
@@ -1,12 +1,13 @@
 // Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-use pyo3::prelude::{pyfunction, wrap_pyfunction, PyModule, PyResult, Python};
+use pyo3::types::{PyModule, PyModuleMethods};
+use pyo3::{pyfunction, wrap_pyfunction, Bound, PyResult, Python};
 
 use crate::externs::PyGeneratorResponseNativeCall;
 use crate::nodes::{task_get_context, RunId, SessionValues};
 
-pub fn register(_py: Python, m: &PyModule) -> PyResult<()> {
+pub fn register(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(session_values, m)?)?;
     m.add_function(wrap_pyfunction!(run_id, m)?)?;
 


### PR DESCRIPTION
Migrate to using the `Bound` smart pointer with initializing the `native_engine` `PyModule`.