### PR TITLE
PyO3: introduce `getattr_bound` helper (and friends) to ease migration to `Bound`

### DIFF
--- a/src/rust/engine/src/nodes/downloaded_file.rs
+++ b/src/rust/engine/src/nodes/downloaded_file.rs
@@ -98,17 +98,17 @@ impl DownloadedFile {
         let (url_str, expected_digest, auth_headers, retry_delay_duration, max_attempts) =
             Python::with_gil(|py| {
                 let py_download_file_val = self.0.to_value();
-                let py_download_file = (*py_download_file_val).as_ref(py);
-                let url_str: String = externs::getattr(py_download_file, "url")
+                let py_download_file = (*py_download_file_val).bind(py);
+                let url_str: String = externs::getattr_bound(py_download_file, "url")
                     .map_err(|e| format!("Failed to get `url` for field: {e}"))?;
                 let auth_headers =
-                    externs::getattr_from_str_frozendict(py_download_file, "auth_headers");
+                    externs::getattr_from_str_frozendict_bound(py_download_file, "auth_headers");
                 let py_file_digest: PyFileDigest =
-                    externs::getattr(py_download_file, "expected_digest")?;
+                    externs::getattr_bound(py_download_file, "expected_digest")?;
                 let retry_delay_duration: Duration =
-                    externs::getattr(py_download_file, "retry_error_duration")?;
+                    externs::getattr_bound(py_download_file, "retry_error_duration")?;
                 let max_attempts: NonZeroUsize =
-                    externs::getattr(py_download_file, "max_attempts")?;
+                    externs::getattr_bound(py_download_file, "max_attempts")?;
                 Ok::<_, String>((
                     url_str,
                     py_file_digest.0,

--- a/src/rust/engine/src/python.rs
+++ b/src/rust/engine/src/python.rs
@@ -313,7 +313,7 @@ impl Value {
         }
     }
 
-    /// Bind this value to the given Pythn context as a `pyo3::Bound` smart pointer.
+    /// Bind this value to the given Python GIL context as a `pyo3::Bound` smart pointer.
     pub fn bind<'py>(&self, py: Python<'py>) -> &Bound<'py, PyAny> {
         self.0.bind(py)
     }

--- a/src/rust/engine/src/python.rs
+++ b/src/rust/engine/src/python.rs
@@ -312,6 +312,11 @@ impl Value {
             Err(arc_handle) => arc_handle.clone_ref(py),
         }
     }
+
+    /// Bind this value to the given Pythn context as a `pyo3::Bound` smart pointer.
+    pub fn bind<'py>(&self, py: Python<'py>) -> &Bound<'py, PyAny> {
+        self.0.bind(py)
+    }
 }
 
 impl workunit_store::Value for Value {


### PR DESCRIPTION
Introduce `getattr_bound` and `getattr_from_str_frozendict_bound` helpers to ease the migration to the `Bound` smart pointer.  Re-implement `getattr` and `getattr_from_str_frozendict` in terms of the `_bound` variants.

This approach is similar to the approach taken by PyO3 itself in introducing `_bound` variants for methods which previously took `&PyAny` parameters. In PyO3, the `_bound` variants were eventually renamed in a future version back to the original name (but still taking `Bound` parameters). We will eventually rename these new `_bound` variants back to the original names, but during the migration these will make it easier to port code piecemeal.