### PR TITLE
PyO3: migrate `src/rust/engine/src/nodes/execute_process.rs` to `Bound` smart pointer (and add more helpers)

### DIFF
--- a/src/rust/engine/src/nodes/execute_process.rs
+++ b/src/rust/engine/src/nodes/execute_process.rs
@@ -13,12 +13,13 @@ use process_execution::{
     ProcessResultSource,
 };
 use pyo3::prelude::{PyAny, Python};
+use pyo3::Bound;
 use store::{self, Store, StoreError};
 use workunit_store::{
     Metric, ObservationMetric, RunningWorkunit, UserMetadataItem, WorkunitMetadata,
 };
 
-use super::{lift_directory_digest, NodeKey, NodeOutput, NodeResult};
+use super::{lift_directory_digest, lift_directory_digest_bound, NodeKey, NodeOutput, NodeResult};
 use crate::context::Context;
 use crate::externs;
 use crate::python::{throw, Value};
@@ -36,17 +37,22 @@ impl ExecuteProcess {
         value: &Value,
     ) -> Result<InputDigests, StoreError> {
         let input_digests_fut: Result<_, String> = Python::with_gil(|py| {
-            let value = (**value).as_ref(py);
-            let input_files = lift_directory_digest(externs::getattr(value, "input_digest")?)
+            let value = (**value).bind(py);
+            let input_files = lift_directory_digest(externs::getattr_bound(value, "input_digest")?)
                 .map_err(|err| format!("Error parsing input_digest {err}"))?;
-            let immutable_inputs =
-                externs::getattr_from_str_frozendict::<&PyAny>(value, "immutable_input_digests")
-                    .into_iter()
-                    .map(|(path, digest)| {
-                        Ok((RelativePath::new(path)?, lift_directory_digest(digest)?))
-                    })
-                    .collect::<Result<BTreeMap<_, _>, String>>()?;
-            let use_nailgun = externs::getattr::<Vec<String>>(value, "use_nailgun")?
+            let immutable_inputs = externs::getattr_from_str_frozendict_bound::<Bound<PyAny>>(
+                value,
+                "immutable_input_digests",
+            )
+            .into_iter()
+            .map(|(path, digest)| {
+                Ok((
+                    RelativePath::new(path)?,
+                    lift_directory_digest_bound(&digest)?,
+                ))
+            })
+            .collect::<Result<BTreeMap<_, _>, String>>()?;
+            let use_nailgun = externs::getattr_bound::<Vec<String>>(value, "use_nailgun")?
                 .into_iter()
                 .map(RelativePath::new)
                 .collect::<Result<BTreeSet<_>, _>>()?;
@@ -65,28 +71,30 @@ impl ExecuteProcess {
     }
 
     fn lift_process_fields(
-        value: &PyAny,
+        value: &Bound<'_, PyAny>,
         input_digests: InputDigests,
         process_config: externs::process::PyProcessExecutionEnvironment,
     ) -> Result<Process, StoreError> {
-        let env = externs::getattr_from_str_frozendict(value, "env");
+        let env = externs::getattr_from_str_frozendict_bound(value, "env");
 
-        let working_directory = externs::getattr_as_optional_string(value, "working_directory")
-            .map_err(|e| format!("Failed to get `working_directory` from field: {e}"))?
-            .map(RelativePath::new)
-            .transpose()?;
+        let working_directory =
+            externs::getattr_as_optional_string_bound(value, "working_directory")
+                .map_err(|e| format!("Failed to get `working_directory` from field: {e}"))?
+                .map(RelativePath::new)
+                .transpose()?;
 
-        let output_files = externs::getattr::<Vec<String>>(value, "output_files")?
+        let output_files = externs::getattr_bound::<Vec<String>>(value, "output_files")?
             .into_iter()
             .map(RelativePath::new)
             .collect::<Result<_, _>>()?;
 
-        let output_directories = externs::getattr::<Vec<String>>(value, "output_directories")?
-            .into_iter()
-            .map(RelativePath::new)
-            .collect::<Result<_, _>>()?;
+        let output_directories =
+            externs::getattr_bound::<Vec<String>>(value, "output_directories")?
+                .into_iter()
+                .map(RelativePath::new)
+                .collect::<Result<_, _>>()?;
 
-        let timeout_in_seconds: f64 = externs::getattr(value, "timeout_seconds")?;
+        let timeout_in_seconds: f64 = externs::getattr_bound(value, "timeout_seconds")?;
 
         let timeout = if timeout_in_seconds < 0.0 {
             None
@@ -94,42 +102,42 @@ impl ExecuteProcess {
             Some(Duration::from_millis((timeout_in_seconds * 1000.0) as u64))
         };
 
-        let description: String = externs::getattr(value, "description")?;
+        let description: String = externs::getattr_bound(value, "description")?;
 
-        let py_level = externs::getattr(value, "level")?;
+        let py_level = externs::getattr_bound(value, "level")?;
 
-        let level = externs::val_to_log_level(py_level)?;
+        let level = externs::val_to_log_level_bound(&py_level)?;
 
         let append_only_caches =
-            externs::getattr_from_str_frozendict::<&str>(value, "append_only_caches")
+            externs::getattr_from_str_frozendict_bound::<&str>(value, "append_only_caches")
                 .into_iter()
                 .map(|(name, dest)| Ok((CacheName::new(name)?, RelativePath::new(dest)?)))
                 .collect::<Result<_, String>>()?;
 
-        let jdk_home = externs::getattr_as_optional_string(value, "jdk_home")
+        let jdk_home = externs::getattr_as_optional_string_bound(value, "jdk_home")
             .map_err(|e| format!("Failed to get `jdk_home` from field: {e}"))?
             .map(PathBuf::from);
 
         let execution_slot_variable =
-            externs::getattr_as_optional_string(value, "execution_slot_variable")
+            externs::getattr_as_optional_string_bound(value, "execution_slot_variable")
                 .map_err(|e| format!("Failed to get `execution_slot_variable` for field: {e}"))?;
 
-        let concurrency_available: usize = externs::getattr(value, "concurrency_available")?;
+        let concurrency_available: usize = externs::getattr_bound(value, "concurrency_available")?;
 
         let cache_scope: ProcessCacheScope = {
-            let cache_scope_enum = externs::getattr(value, "cache_scope")?;
+            let cache_scope_enum = externs::getattr_bound(value, "cache_scope")?;
             externs::getattr::<String>(cache_scope_enum, "name")?.try_into()?
         };
 
         let remote_cache_speculation_delay = std::time::Duration::from_millis(
-            externs::getattr::<i32>(value, "remote_cache_speculation_delay_millis")
+            externs::getattr_bound::<i32>(value, "remote_cache_speculation_delay_millis")
                 .map_err(|e| format!("Failed to get `name` for field: {e}"))? as u64,
         );
 
-        let attempt = externs::getattr(value, "attempt").unwrap_or(0);
+        let attempt = externs::getattr_bound(value, "attempt").unwrap_or(0);
 
         Ok(Process {
-            argv: externs::getattr(value, "argv").unwrap(),
+            argv: externs::getattr_bound(value, "argv").unwrap(),
             env,
             working_directory,
             input_digests,
@@ -156,7 +164,7 @@ impl ExecuteProcess {
     ) -> Result<Self, StoreError> {
         let input_digests = Self::lift_process_input_digests(store, &value).await?;
         let process = Python::with_gil(|py| {
-            Self::lift_process_fields((*value).as_ref(py), input_digests, process_config)
+            Self::lift_process_fields((*value).bind(py), input_digests, process_config)
         })?;
         Ok(Self { process })
     }

--- a/src/rust/engine/src/nodes/mod.rs
+++ b/src/rust/engine/src/nodes/mod.rs
@@ -17,6 +17,8 @@ use graph::{Node, NodeError};
 use internment::Intern;
 use process_execution::{self, ProcessCacheScope};
 use pyo3::prelude::{PyAny, Python};
+use pyo3::types::PyAnyMethods;
+use pyo3::{Bound, PyNativeType};
 use rule_graph::{DependencyKey, Query};
 use store::{self, StoreFileByDigest};
 use workunit_store::{in_workunit, Level};
@@ -218,14 +220,22 @@ fn select_reentry(
     .boxed()
 }
 
-pub fn lift_directory_digest(digest: &PyAny) -> Result<DirectoryDigest, String> {
+pub fn lift_directory_digest_bound(digest: &Bound<'_, PyAny>) -> Result<DirectoryDigest, String> {
     let py_digest: externs::fs::PyDigest = digest.extract().map_err(|e| format!("{e}"))?;
     Ok(py_digest.0)
 }
 
-pub fn lift_file_digest(digest: &PyAny) -> Result<hashing::Digest, String> {
+pub fn lift_directory_digest(digest: &PyAny) -> Result<DirectoryDigest, String> {
+    lift_directory_digest_bound(&digest.as_borrowed())
+}
+
+pub fn lift_file_digest_bound(digest: &Bound<'_, PyAny>) -> Result<hashing::Digest, String> {
     let py_file_digest: externs::fs::PyFileDigest = digest.extract().map_err(|e| format!("{e}"))?;
     Ok(py_file_digest.0)
+}
+
+pub fn lift_file_digest(digest: &PyAny) -> Result<hashing::Digest, String> {
+    lift_file_digest_bound(&digest.as_borrowed())
 }
 
 pub fn unmatched_globs_additional_context() -> Option<String> {


### PR DESCRIPTION
Add more helpers for migrating to `Bound` plus migrate `src/rust/engine/src/nodes/execute_process.rs` to use the `Bound` smart pointer.