### PR TITLE
PyO3: migrate another spot in `src/rust/engine/src/externs/options.rs`

### DIFF
--- a/src/rust/engine/src/externs/options.rs
+++ b/src/rust/engine/src/externs/options.rs
@@ -281,8 +281,8 @@ impl PyOptionParser {
             .items()
             .into_iter()
             .map(|kv_pair| {
-                let (k, v) = kv_pair.extract::<(String, &PyAny)>()?;
-                Ok::<(String, Val), PyErr>((k, py_object_to_val(&v.as_borrowed())?))
+                let (k, v) = kv_pair.extract::<(String, Bound<'_, PyAny>)>()?;
+                Ok::<(String, Val), PyErr>((k, py_object_to_val(&v)?))
             })
             .collect::<Result<HashMap<_, _>, _>>()?;
         let opt_val = self


### PR DESCRIPTION
Migrate another location in `src/rust/engine/src/externs/options.rs` to use the `Bound` smart pointer.