### PR TITLE
PyO3: migrate to `Bound` for `src/rust/engine/src/intrinsics/docker.rs`

### DIFF
--- a/src/rust/engine/src/intrinsics/docker.rs
+++ b/src/rust/engine/src/intrinsics/docker.rs
@@ -3,7 +3,7 @@
 
 use docker::docker::{ImagePullPolicy, ImagePullScope, DOCKER, IMAGE_PULL_CACHE};
 use process_execution::Platform;
-use pyo3::prelude::{pyfunction, wrap_pyfunction, PyAny, PyModule, PyResult, Python, ToPyObject};
+use pyo3::prelude::{pyfunction, wrap_pyfunction, PyModule, PyResult, Python};
 use pyo3::types::{PyModuleMethods, PyString};
 use pyo3::Bound;
 
@@ -26,9 +26,10 @@ fn docker_resolve_image(docker_request: Value) -> PyGeneratorResponseNativeCall 
         let docker_resolve_image_result = types.docker_resolve_image_result;
 
         let (image_name, platform) = Python::with_gil(|py| {
-            let py_docker_request: &PyAny = docker_request.as_ref().as_ref(py);
-            let image_name: String = externs::getattr(py_docker_request, "image_name").unwrap();
-            let platform: String = externs::getattr(py_docker_request, "platform").unwrap();
+            let py_docker_request = docker_request.bind(py);
+            let image_name: String =
+                externs::getattr_bound(py_docker_request, "image_name").unwrap();
+            let platform: String = externs::getattr_bound(py_docker_request, "platform").unwrap();
             (image_name, platform)
         });
 
@@ -64,7 +65,7 @@ fn docker_resolve_image(docker_request: Value) -> PyGeneratorResponseNativeCall 
             externs::unsafe_call(
                 py,
                 docker_resolve_image_result,
-                &[Value::from(PyString::new(py, &image_id).to_object(py))],
+                &[Value::from(&PyString::new_bound(py, &image_id))],
             )
         }))
     })

--- a/src/rust/engine/src/python.rs
+++ b/src/rust/engine/src/python.rs
@@ -391,6 +391,12 @@ impl From<PyObject> for Value {
     }
 }
 
+impl<'py, T> From<&Bound<'py, T>> for Value {
+    fn from(value: &Bound<'py, T>) -> Self {
+        Value::new(value.clone().into_py(value.py()))
+    }
+}
+
 impl IntoPy<PyObject> for &Value {
     fn into_py(self, py: Python) -> PyObject {
         (*self.0).as_ref(py).into_py(py)


### PR DESCRIPTION
Migrate to `pyo3::Bound` smart pointer for `src/rust/engine/src/intrinsics/docker.rs`.

This PR adds an additional converation for `Value` from `&Bound<'py, PyAny>`.