### PR TITLE
Support trailing global flags in the native parser. (Cherry-pick of #21480)

### DIFF
--- a/src/rust/engine/options/src/args.rs
+++ b/src/rust/engine/options/src/args.rs
@@ -127,6 +127,9 @@ impl Args {
                 });
             } else if is_valid_scope_name(&arg_str) {
                 scope = Scope::Scope(arg_str)
+            } else {
+                // The arg is a spec, so revert to global context for any trailing flags.
+                scope = Scope::Global;
             }
         }
 

--- a/src/rust/engine/options/src/args_tests.rs
+++ b/src/rust/engine/options/src/args_tests.rs
@@ -78,6 +78,8 @@ fn test_bool() {
         "scope",
         "--no-quuxf",
         "--quuxt",
+        "path/to/target",
+        "--global-flag",
     ]);
 
     let assert_bool =
@@ -91,6 +93,7 @@ fn test_bool() {
     assert_bool(false, option_id!(["scope"], "quxf"));
     assert_bool(false, option_id!(["scope"], "quuxf"));
     assert_bool(true, option_id!(["scope"], "quuxt"));
+    assert_bool(true, option_id!("global", "flag"));
 
     assert!(args.get_bool(&option_id!("dne")).unwrap().is_none());
     assert!(args.get_passthrough_args().is_none());


### PR DESCRIPTION
The legacy parser supports having global flags at the end of
the command-line invocation, after all specs.

Now the native parser supports this too.

Fixes #21478
