### PR TITLE
PyO3: migrate various externs files to `Bound` smart pointer

### DIFF
--- a/src/rust/engine/src/externs/fs.rs
+++ b/src/rust/engine/src/externs/fs.rs
@@ -630,8 +630,8 @@ pub enum PyPathNamespace {
 
 #[pymethods]
 impl PyPathNamespace {
-    fn __eq__(&self, other: &PyPathNamespace) -> bool {
-        self == other
+    fn __eq__(&self, other: Bound<'_, PyPathNamespace>) -> bool {
+        *self == *other.borrow()
     }
 
     fn __hash__(&self) -> u64 {

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -220,29 +220,6 @@ pub fn collect_iterable_bound<'py>(
     }
 }
 
-pub fn collect_iterable(value: &PyAny) -> Result<Vec<&PyAny>, String> {
-    match value.iter() {
-        Ok(py_iter) => py_iter
-            .enumerate()
-            .map(|(i, py_res)| {
-                py_res.map_err(|py_err| {
-                    format!(
-                        "Could not iterate {}, failed to extract {}th item: {:?}",
-                        val_to_str(value),
-                        i,
-                        py_err
-                    )
-                })
-            })
-            .collect(),
-        Err(py_err) => Err(format!(
-            "Could not iterate {}: {:?}",
-            val_to_str(value),
-            py_err
-        )),
-    }
-}
-
 /// Read a `FrozenDict[str, T]`.
 pub fn getattr_from_str_frozendict_bound<'py, T: FromPyObject<'py>>(
     value: &Bound<'py, PyAny>,

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -195,6 +195,31 @@ where
 ///
 /// Collect the Values contained within an outer Python Iterable PyObject.
 ///
+pub fn collect_iterable_bound<'py>(
+    value: &Bound<'py, PyAny>,
+) -> Result<Vec<Bound<'py, PyAny>>, String> {
+    match value.iter() {
+        Ok(py_iter) => py_iter
+            .enumerate()
+            .map(|(i, py_res)| {
+                py_res.map_err(|py_err| {
+                    format!(
+                        "Could not iterate {}, failed to extract {}th item: {:?}",
+                        val_to_str_bound(value),
+                        i,
+                        py_err
+                    )
+                })
+            })
+            .collect(),
+        Err(py_err) => Err(format!(
+            "Could not iterate {}: {:?}",
+            val_to_str_bound(value),
+            py_err
+        )),
+    }
+}
+
 pub fn collect_iterable(value: &PyAny) -> Result<Vec<&PyAny>, String> {
     match value.iter() {
         Ok(py_iter) => py_iter
@@ -219,7 +244,6 @@ pub fn collect_iterable(value: &PyAny) -> Result<Vec<&PyAny>, String> {
 }
 
 /// Read a `FrozenDict[str, T]`.
-// TODO: Rename this back to getattr_from_str_frozendict_bound once migration is complete.
 pub fn getattr_from_str_frozendict_bound<'py, T: FromPyObject<'py>>(
     value: &Bound<'py, PyAny>,
     field: &str,
@@ -240,10 +264,6 @@ pub fn getattr_as_optional_string_bound(
     // TODO: It's possible to view a python string as a `Cow<str>`, so we could avoid actually
     // cloning in some cases.
     value.getattr(field)?.extract()
-}
-
-pub fn getattr_as_optional_string(value: &PyAny, field: &str) -> PyResult<Option<String>> {
-    getattr_as_optional_string_bound(&value.as_borrowed(), field)
 }
 
 /// Call the equivalent of `str()` on an arbitrary Python object.
@@ -272,10 +292,6 @@ pub fn val_to_log_level_bound(obj: &Bound<'_, PyAny>) -> Result<log::Level, Stri
             })
     });
     res.map(|py_level| py_level.into())
-}
-
-pub fn val_to_log_level(obj: &PyAny) -> Result<log::Level, String> {
-    val_to_log_level_bound(&obj.as_borrowed())
 }
 
 /// Link to the Pants docs using the current version of Pants.

--- a/src/rust/engine/src/intrinsics/digests.rs
+++ b/src/rust/engine/src/intrinsics/digests.rs
@@ -20,9 +20,8 @@ use crate::externs::fs::{
 };
 use crate::externs::PyGeneratorResponseNativeCall;
 use crate::nodes::{
-    lift_directory_digest_bound, task_get_context,
-    unmatched_globs_additional_context, DownloadedFile, NodeResult, PathMetadataNode, Snapshot,
-    SubjectPath,
+    lift_directory_digest_bound, task_get_context, unmatched_globs_additional_context,
+    DownloadedFile, NodeResult, PathMetadataNode, Snapshot, SubjectPath,
 };
 use crate::python::{throw, Key, Value};
 use crate::Failure;

--- a/src/rust/engine/src/nodes/snapshot.rs
+++ b/src/rust/engine/src/nodes/snapshot.rs
@@ -11,7 +11,7 @@ use fs::{
 use futures::TryFutureExt;
 use graph::CompoundNode;
 use pyo3::prelude::{Py, PyAny, Python};
-use pyo3::IntoPy;
+use pyo3::{Bound, IntoPy, PyNativeType};
 
 use super::{unmatched_globs_additional_context, NodeKey, NodeOutput, NodeResult};
 use crate::context::Context;
@@ -31,38 +31,49 @@ impl Snapshot {
         Snapshot { path_globs }
     }
 
-    pub fn lift_path_globs(item: &PyAny) -> Result<PathGlobs, String> {
-        let globs: Vec<String> = externs::getattr(item, "globs")
+    pub fn lift_path_globs_bound(item: &Bound<'_, PyAny>) -> Result<PathGlobs, String> {
+        let globs: Vec<String> = externs::getattr_bound(item, "globs")
             .map_err(|e| format!("Failed to get `globs` for field: {e}"))?;
 
         let description_of_origin =
-            externs::getattr_as_optional_string(item, "description_of_origin")
+            externs::getattr_as_optional_string_bound(item, "description_of_origin")
                 .map_err(|e| format!("Failed to get `description_of_origin` for field: {e}"))?;
 
-        let glob_match_error_behavior = externs::getattr(item, "glob_match_error_behavior")
-            .map_err(|e| format!("Failed to get `glob_match_error_behavior` for field: {e}"))?;
+        let glob_match_error_behavior: Bound<'_, PyAny> =
+            externs::getattr_bound(item, "glob_match_error_behavior")
+                .map_err(|e| format!("Failed to get `glob_match_error_behavior` for field: {e}"))?;
 
-        let failure_behavior: String = externs::getattr(glob_match_error_behavior, "value")
+        let failure_behavior: String = externs::getattr_bound(&glob_match_error_behavior, "value")
             .map_err(|e| format!("Failed to get `value` for field: {e}"))?;
 
         let strict_glob_matching =
             StrictGlobMatching::create(failure_behavior.as_str(), description_of_origin)?;
 
-        let conjunction_obj = externs::getattr(item, "conjunction")
+        let conjunction_obj: Bound<'_, PyAny> = externs::getattr_bound(item, "conjunction")
             .map_err(|e| format!("Failed to get `conjunction` for field: {e}"))?;
 
-        let conjunction_string: String = externs::getattr(conjunction_obj, "value")
+        let conjunction_string: String = externs::getattr_bound(&conjunction_obj, "value")
             .map_err(|e| format!("Failed to get `value` for field: {e}"))?;
 
         let conjunction = GlobExpansionConjunction::create(&conjunction_string)?;
         Ok(PathGlobs::new(globs, strict_glob_matching, conjunction))
     }
 
-    pub fn lift_prepared_path_globs(item: &PyAny) -> Result<PreparedPathGlobs, String> {
-        let path_globs = Snapshot::lift_path_globs(item)?;
+    pub fn lift_path_globs(item: &PyAny) -> Result<PathGlobs, String> {
+        Self::lift_path_globs_bound(&item.as_borrowed())
+    }
+
+    pub fn lift_prepared_path_globs_bound(
+        item: &Bound<'_, PyAny>,
+    ) -> Result<PreparedPathGlobs, String> {
+        let path_globs = Snapshot::lift_path_globs_bound(item)?;
         path_globs
             .parse()
             .map_err(|e| format!("Failed to parse PathGlobs for globs({item:?}): {e}"))
+    }
+
+    pub fn lift_prepared_path_globs(item: &PyAny) -> Result<PreparedPathGlobs, String> {
+        Self::lift_prepared_path_globs_bound(&item.as_borrowed())
     }
 
     pub fn store_directory_digest(py: Python, item: DirectoryDigest) -> Result<Value, String> {

--- a/src/rust/engine/src/python.rs
+++ b/src/rust/engine/src/python.rs
@@ -135,8 +135,15 @@ impl TypeId {
         Self(py_type.as_type_ptr())
     }
 
+    pub fn as_py_type_bound<'py>(&self, py: Python<'py>) -> Bound<'py, PyType> {
+        // SAFETY: Dereferencing a pointer to a PyTypeObject is safe as long as the module defining the
+        // type is not unloaded. That is true today, but would not be if we implemented support for hot
+        // reloading of plugins.
+        unsafe { PyType::from_type_ptr(py, self.0).as_borrowed().to_owned() }
+    }
+
     pub fn as_py_type<'py>(&self, py: Python<'py>) -> &'py PyType {
-        // NB: Dereferencing a pointer to a PyTypeObject is safe as long as the module defining the
+        // SAFETY: Dereferencing a pointer to a PyTypeObject is safe as long as the module defining the
         // type is not unloaded. That is true today, but would not be if we implemented support for hot
         // reloading of plugins.
         unsafe { PyType::from_type_ptr(py, self.0) }


### PR DESCRIPTION
Continue migrating various "externs" files to the `Bound` smart pointer. This should complete the migration of `src/rust/engine/src/externs/engine_aware.rs`, `src/rust/engine/src/externs/fs.rs`, `src/rust/engine/src/intrinsics/digests.rs`, `src/rust/engine/src/intrinsics/interactive_process.rs`, and `src/rust/engine/src/nodes/snapshot.rs`.