### PR TITLE
PyO3: migrate more of `externs/interface.rs` to `Bound` smart pointer

### DIFF
--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -1676,7 +1676,7 @@ fn capture_snapshots(
 }
 
 #[pyfunction]
-fn ensure_remote_has_recursive<'py>(
+fn ensure_remote_has_recursive(
     py: Python<'_>,
     py_scheduler: &Bound<'_, PyScheduler>,
     py_digests: &Bound<'_, PyList>,

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -35,7 +35,9 @@ use pyo3::prelude::{
     pyclass, pyfunction, pymethods, pymodule, wrap_pyfunction, PyModule, PyObject,
     PyResult as PyO3Result, Python, ToPyObject,
 };
-use pyo3::types::{PyAnyMethods, PyBytes, PyDict, PyDictMethods, PyList, PyListMethods, PyTuple, PyType};
+use pyo3::types::{
+    PyAnyMethods, PyBytes, PyDict, PyDictMethods, PyList, PyListMethods, PyTuple, PyType,
+};
 use pyo3::{create_exception, AsPyPointer, Bound, IntoPy, PyAny, PyNativeType, PyRef};
 use regex::Regex;
 use remote::remote_cache::RemoteCacheWarningsBehavior;

--- a/src/rust/engine/src/nodes/mod.rs
+++ b/src/rust/engine/src/nodes/mod.rs
@@ -234,10 +234,6 @@ pub fn lift_file_digest_bound(digest: &Bound<'_, PyAny>) -> Result<hashing::Dige
     Ok(py_file_digest.0)
 }
 
-pub fn lift_file_digest(digest: &PyAny) -> Result<hashing::Digest, String> {
-    lift_file_digest_bound(&digest.as_borrowed())
-}
-
 pub fn unmatched_globs_additional_context() -> Option<String> {
     let url = Python::with_gil(|py| {
         externs::doc_url(


### PR DESCRIPTION
Migrate more of `src/rust/engine/src/externs/interface.rs` to the `pyo3::Bound` smart pointer. The only remaining call sites in that file to still be migrated either involve (1) a weird use of `RefCell` and mutable borrows or (2) digest-related logic which will be handled instead in https://github.com/pantsbuild/pants/pull/21490 which has digest-related `Bound` helpers.