### PR TITLE
PyO3: continue porting to the `Bound` smart pointer (including `TypeId` and `Value`)

### DIFF
--- a/src/rust/engine/src/externs/options.rs
+++ b/src/rust/engine/src/externs/options.rs
@@ -34,7 +34,7 @@ fn val_to_py_object(py: Python, val: &Val) -> PyResult<PyObject> {
             pylist.into_py(py)
         }
         Val::Dict(dict) => {
-            let pydict = PyDict::new(py);
+            let pydict = PyDict::new_bound(py);
             for (k, v) in dict {
                 pydict.set_item(k.into_py(py), val_to_py_object(py, v)?)?;
             }

--- a/src/rust/engine/src/interning.rs
+++ b/src/rust/engine/src/interning.rs
@@ -45,15 +45,15 @@ pub struct Interns {
 impl Interns {
     pub fn new() -> Self {
         Self {
-            keys: Python::with_gil(|py| PyDict::new(py).into()),
+            keys: Python::with_gil(|py| PyDict::new_bound(py).unbind()),
             id_generator: atomic::AtomicU64::default(),
         }
     }
 
     pub fn key_insert(&self, py: Python, v: PyObject) -> PyResult<Key> {
         let (id, type_id): (u64, TypeId) = {
-            let v = v.as_ref(py);
-            let keys = self.keys.as_ref(py);
+            let v = v.bind(py);
+            let keys = self.keys.bind(py);
             let id: u64 = if let Some(key) = keys.get_item(v)? {
                 key.extract()?
             } else {
@@ -61,7 +61,7 @@ impl Interns {
                 keys.set_item(v, id)?;
                 id
             };
-            (id, v.get_type().into())
+            (id, TypeId::new(&v.get_type()))
         };
 
         Ok(Key::new(id, type_id, v.into()))

--- a/src/rust/engine/src/intrinsics/dep_inference.rs
+++ b/src/rust/engine/src/intrinsics/dep_inference.rs
@@ -16,7 +16,7 @@ use protos::gen::pants::cache::{
     dependency_inference_request, CacheKey, CacheKeyType, DependencyInferenceRequest,
 };
 use pyo3::prelude::{pyfunction, wrap_pyfunction, PyModule, PyResult, Python, ToPyObject};
-use pyo3::types::PyModuleMethods;
+use pyo3::types::{PyAnyMethods, PyModuleMethods};
 use pyo3::{Bound, IntoPy};
 use store::Store;
 use workunit_store::{in_workunit, Level};
@@ -54,7 +54,7 @@ impl PreparedInferenceRequest {
         let PyNativeDependenciesRequest {
             directory_digest,
             metadata,
-        } = Python::with_gil(|py| deps_request.extract(py))?;
+        } = Python::with_gil(|py| deps_request.bind(py).extract())?;
 
         let (path, digest) = Self::find_one_file(directory_digest, store, backend).await?;
         let str_path = path.display().to_string();

--- a/src/rust/engine/src/intrinsics/digests.rs
+++ b/src/rust/engine/src/intrinsics/digests.rs
@@ -364,7 +364,7 @@ fn digest_subset_to_digest(digest_subset: Value) -> PyGeneratorResponseNativeCal
 fn path_metadata_request(single_path: Value) -> PyGeneratorResponseNativeCall {
     PyGeneratorResponseNativeCall::new(async move {
         let subject_path = Python::with_gil(|py| -> Result<_, String> {
-            let arg = (*single_path).bind(py);
+            let arg = single_path.bind(py);
             let path = externs::getattr_as_optional_string_bound(arg, "path")
                 .map_err(|e| format!("Failed to get `path` for field: {e}"))?;
             let path = path.ok_or_else(|| "Path must not be `None`.".to_string())?;

--- a/src/rust/engine/src/intrinsics/interactive_process.rs
+++ b/src/rust/engine/src/intrinsics/interactive_process.rs
@@ -12,7 +12,7 @@ use process_execution::local::{
 };
 use process_execution::{ManagedChild, ProcessExecutionStrategy};
 use pyo3::prelude::{pyfunction, wrap_pyfunction, PyAny, PyModule, PyResult, Python};
-use pyo3::types::PyModuleMethods;
+use pyo3::types::{PyAnyMethods, PyModuleMethods};
 use pyo3::Bound;
 use stdio::TryCloneAsFile;
 use tokio::process;
@@ -56,9 +56,9 @@ pub async fn interactive_process_inner(
         Value,
         externs::process::PyProcessExecutionEnvironment,
     ) = Python::with_gil(|py| {
-        let py_interactive_process = interactive_process.as_ref().as_ref(py);
-        let py_process: Value = externs::getattr(py_interactive_process, "process").unwrap();
-        let process_config = process_config.as_ref().as_ref(py).extract().unwrap();
+        let py_interactive_process = interactive_process.bind(py);
+        let py_process: Value = externs::getattr_bound(py_interactive_process, "process").unwrap();
+        let process_config = process_config.bind(py).extract().unwrap();
         (
             py_interactive_process.extract().unwrap(),
             py_process,

--- a/src/rust/engine/src/intrinsics/process.rs
+++ b/src/rust/engine/src/intrinsics/process.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use futures::future::TryFutureExt;
 use futures::try_join;
-use pyo3::types::{PyModule, PyModuleMethods};
+use pyo3::types::{PyAnyMethods, PyModule, PyModuleMethods};
 use pyo3::{pyfunction, wrap_pyfunction, Bound, IntoPy, PyResult, Python};
 
 use crate::externs::{self, PyGeneratorResponseNativeCall};
@@ -24,7 +24,7 @@ fn execute_process(process: Value, process_config: Value) -> PyGeneratorResponse
         let context = task_get_context();
 
         let process_config: externs::process::PyProcessExecutionEnvironment =
-            Python::with_gil(|py| process_config.extract(py)).map_err(|e| format!("{e}"))?;
+            Python::with_gil(|py| process_config.bind(py).extract()).map_err(|e| format!("{e}"))?;
         let process_request = ExecuteProcess::lift(&context.core.store(), process, process_config)
             .map_err(|e| e.enrich("Error lifting Process"))
             .await?;

--- a/src/rust/engine/src/nodes/downloaded_file.rs
+++ b/src/rust/engine/src/nodes/downloaded_file.rs
@@ -98,7 +98,7 @@ impl DownloadedFile {
         let (url_str, expected_digest, auth_headers, retry_delay_duration, max_attempts) =
             Python::with_gil(|py| {
                 let py_download_file_val = self.0.to_value();
-                let py_download_file = (*py_download_file_val).bind(py);
+                let py_download_file = py_download_file_val.bind(py);
                 let url_str: String = externs::getattr_bound(py_download_file, "url")
                     .map_err(|e| format!("Failed to get `url` for field: {e}"))?;
                 let auth_headers =

--- a/src/rust/engine/src/nodes/snapshot.rs
+++ b/src/rust/engine/src/nodes/snapshot.rs
@@ -11,7 +11,7 @@ use fs::{
 use futures::TryFutureExt;
 use graph::CompoundNode;
 use pyo3::prelude::{Py, PyAny, Python};
-use pyo3::{Bound, IntoPy, PyNativeType};
+use pyo3::{Bound, IntoPy};
 
 use super::{unmatched_globs_additional_context, NodeKey, NodeOutput, NodeResult};
 use crate::context::Context;
@@ -59,10 +59,6 @@ impl Snapshot {
         Ok(PathGlobs::new(globs, strict_glob_matching, conjunction))
     }
 
-    pub fn lift_path_globs(item: &PyAny) -> Result<PathGlobs, String> {
-        Self::lift_path_globs_bound(&item.as_borrowed())
-    }
-
     pub fn lift_prepared_path_globs_bound(
         item: &Bound<'_, PyAny>,
     ) -> Result<PreparedPathGlobs, String> {
@@ -70,10 +66,6 @@ impl Snapshot {
         path_globs
             .parse()
             .map_err(|e| format!("Failed to parse PathGlobs for globs({item:?}): {e}"))
-    }
-
-    pub fn lift_prepared_path_globs(item: &PyAny) -> Result<PreparedPathGlobs, String> {
-        Self::lift_prepared_path_globs_bound(&item.as_borrowed())
     }
 
     pub fn store_directory_digest(py: Python, item: DirectoryDigest) -> Result<Value, String> {

--- a/src/rust/engine/src/nodes/task.rs
+++ b/src/rust/engine/src/nodes/task.rs
@@ -276,12 +276,12 @@ impl Task {
             &self.side_effected,
             async move {
                 Python::with_gil(|py| {
-                    let func = (*self.task.func.0.value).bind(py);
+                    let func = self.task.func.0.value.bind(py);
 
                     // If there are explicit positional arguments, apply any computed arguments as
                     // keywords. Otherwise, apply computed arguments as positional.
                     let res = if let Some(args) = args {
-                        let args = args.value.extract::<Bound<'_, PyTuple>>(py)?;
+                        let args = args.value.bind(py).extract::<Bound<'_, PyTuple>>()?;
                         let kwargs = PyDict::new_bound(py);
                         for ((name, _), value) in self
                             .task
@@ -332,7 +332,7 @@ impl Task {
 
         if self.task.engine_aware_return_type {
             Python::with_gil(|py| {
-                EngineAwareReturnType::update_workunit(workunit, (*result_val).bind(py))
+                EngineAwareReturnType::update_workunit(workunit, result_val.bind(py))
             })
         };
 

--- a/src/rust/engine/src/python.rs
+++ b/src/rust/engine/src/python.rs
@@ -1,8 +1,6 @@
 // Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-use std::convert::AsRef;
-use std::ops::Deref;
 use std::sync::Arc;
 use std::{fmt, hash};
 
@@ -142,20 +140,13 @@ impl TypeId {
         unsafe { PyType::from_type_ptr(py, self.0).as_borrowed().to_owned() }
     }
 
-    pub fn as_py_type<'py>(&self, py: Python<'py>) -> &'py PyType {
-        // SAFETY: Dereferencing a pointer to a PyTypeObject is safe as long as the module defining the
-        // type is not unloaded. That is true today, but would not be if we implemented support for hot
-        // reloading of plugins.
-        unsafe { PyType::from_type_ptr(py, self.0) }
-    }
-
     pub fn is_union(&self) -> bool {
-        Python::with_gil(|py| externs::is_union(py, self.as_py_type(py)).unwrap())
+        Python::with_gil(|py| externs::is_union(py, &self.as_py_type_bound(py)).unwrap())
     }
 
     pub fn union_in_scope_types(&self) -> Option<Vec<TypeId>> {
         Python::with_gil(|py| {
-            externs::union_in_scope_types(py, self.as_py_type(py))
+            externs::union_in_scope_types(py, &self.as_py_type_bound(py))
                 .unwrap()
                 .map(|types| {
                     types
@@ -167,16 +158,11 @@ impl TypeId {
     }
 }
 
-impl From<&PyType> for TypeId {
-    fn from(py_type: &PyType) -> Self {
-        TypeId(py_type.as_type_ptr())
-    }
-}
-
 impl fmt::Debug for TypeId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         Python::with_gil(|py| {
-            let name = self.as_py_type(py).name().unwrap();
+            let type_bound = self.as_py_type_bound(py);
+            let name = type_bound.name().unwrap();
             write!(f, "{name}")
         })
     }
@@ -206,12 +192,12 @@ impl Function {
     /// The function represented as `path.to.module:lineno:func_name`.
     pub fn full_name(&self) -> String {
         let (module, name, line_no) = Python::with_gil(|py| {
-            let obj = (*self.0.value).as_ref(py);
-            let module: String = externs::getattr(obj, "__module__").unwrap();
-            let name: String = externs::getattr(obj, "__name__").unwrap();
+            let obj = self.0.value.bind(py);
+            let module: String = externs::getattr_bound(obj, "__module__").unwrap();
+            let name: String = externs::getattr_bound(obj, "__name__").unwrap();
             // NB: this is a custom dunder method that Python code should populate before sending the
             // function (e.g. an `@rule`) through FFI.
-            let line_no: u64 = externs::getattr(obj, "__line_number__").unwrap();
+            let line_no: u64 = externs::getattr_bound(obj, "__line_number__").unwrap();
             (module, name, line_no)
         });
         format!("{module}:{line_no}:{name}")
@@ -334,31 +320,17 @@ impl workunit_store::Value for Value {
 
 impl PartialEq for Value {
     fn eq(&self, other: &Value) -> bool {
-        Python::with_gil(|py| externs::equals((*self.0).as_ref(py), (*other.0).as_ref(py)))
+        Python::with_gil(|py| externs::equals(self.bind(py), other.0.bind(py)))
     }
 }
 
 impl Eq for Value {}
 
-impl Deref for Value {
-    type Target = PyObject;
-
-    fn deref(&self) -> &PyObject {
-        &self.0
-    }
-}
-
-impl AsRef<PyObject> for Value {
-    fn as_ref(&self) -> &PyObject {
-        &self.0
-    }
-}
-
 impl fmt::Debug for Value {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let repr = Python::with_gil(|py| {
-            let obj = (*self.0).as_ref(py);
-            externs::val_to_str(obj)
+            let obj = self.0.bind(py);
+            externs::val_to_str_bound(obj)
         });
         write!(f, "{repr}")
     }
@@ -486,7 +458,7 @@ impl Failure {
                 }) => {
                     // Preserve tracebacks (both engine and python) from upstream error by using any existing
                     // engine traceback and restoring the original python exception cause.
-                    py_err.set_cause(py, Some(PyErr::from_value((*val.0).as_ref(py))));
+                    py_err.set_cause(py, Some(PyErr::from_value_bound(val.0.bind(py).to_owned())));
                     (
             format!(
               "{python_traceback}\nDuring handling of the above exception, another exception occurred:\n\n"
@@ -505,22 +477,22 @@ impl Failure {
             .map(|traceback| traceback.to_object(py));
         let val = Value::from(py_err.into_py(py));
         let python_traceback = if let Some(tb) = maybe_ptraceback {
-            let locals = PyDict::new(py);
+            let locals = PyDict::new_bound(py);
             locals
                 .set_item("traceback", py.import("traceback").unwrap())
                 .unwrap();
             locals.set_item("tb", tb).unwrap();
             locals.set_item("val", &val).unwrap();
-            py.eval(
+            py.eval_bound(
                 "''.join(traceback.format_exception(None, value=val, tb=tb))",
                 None,
-                Some(locals),
+                Some(&locals),
             )
             .unwrap()
             .extract::<String>()
             .unwrap()
         } else {
-            Self::native_traceback(&externs::val_to_str((*val).as_ref(py)))
+            Self::native_traceback(&externs::val_to_str_bound(val.bind(py)))
         };
         Failure::Throw {
             val,
@@ -536,7 +508,10 @@ impl Failure {
 
 impl Failure {
     fn from_wrapped_failure(py: Python, py_err: &PyErr) -> Option<Failure> {
-        match py_err.value(py).downcast::<externs::NativeEngineFailure>() {
+        match py_err
+            .value_bound(py)
+            .downcast::<externs::NativeEngineFailure>()
+        {
             Ok(n_e_failure) => {
                 let failure = n_e_failure
                     .getattr("failure")
@@ -559,8 +534,8 @@ impl fmt::Display for Failure {
             }
             Failure::Throw { val, .. } => {
                 let repr = Python::with_gil(|py| {
-                    let obj = (*val.0).as_ref(py);
-                    externs::val_to_str(obj)
+                    let obj = val.0.bind(py);
+                    externs::val_to_str_bound(obj)
                 });
                 write!(f, "{repr}")
             }


### PR DESCRIPTION
Continue the porting to the `pyo3::Bound` smart pointer by doing several cleanups:
- Remove the "GIL refs" APIs (e.g., `&PyAny`) from `TypeId` and `Value`.
  - For `TypeId`, the `as_py_type` method has been removed in favor of `as_py_type_bound`.
  - For `Value`, callers should use `.bind(py)` to obtain a `Bound` and not rely on the prior dereference to a `&PyAny`. This cleaned up many call sites which did `(*value).bind(py)` or `value.as_ref().as_ref(py)` to just call `value.bind(py)` without a dereference.
  - There was also a `AsRef<PyObject>` conversion on `Value` which has now been removed. It may be worth adding a `to_object()` method directly on `Value` but this PR does not do that.
- Make sure to use `new_bound` constructors for `PyTuple`, `PyList`, and `PyDict`.
- Removed some of the helpers since applicable code has been migrated.
