### PR TITLE
Add global option `process_extra_env` for every Process call

### DIFF
--- a/src/python/pants/engine/intrinsics.py
+++ b/src/python/pants/engine/intrinsics.py
@@ -100,10 +100,15 @@ async def add_prefix(add_prefix: AddPrefix) -> Digest:
     return await native_engine.add_prefix(add_prefix)
 
 
+import dataclasses
+from pants.option.global_options import GlobalOptions
 @rule
 async def execute_process(
-    process: Process, process_execution_environment: ProcessExecutionEnvironment
+    process: Process,
+    process_execution_environment: ProcessExecutionEnvironment,
+    options: GlobalOptions,
 ) -> FallibleProcessResult:
+    process = dataclasses.replace(process, env={**process.env, **options.process_extra_env})
     return await native_engine.execute_process(process, process_execution_environment)
 
 

--- a/src/python/pants/engine/intrinsics.py
+++ b/src/python/pants/engine/intrinsics.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import logging
+import dataclasses
 
 from pants.engine.environment import EnvironmentName
 from pants.engine.fs import (
@@ -39,6 +40,7 @@ from pants.engine.process import (
     ProcessExecutionEnvironment,
 )
 from pants.engine.rules import _uncacheable_rule, collect_rules, implicitly, rule
+from pants.option.global_options import GlobalOptions
 from pants.util.docutil import git_url
 
 
@@ -100,8 +102,6 @@ async def add_prefix(add_prefix: AddPrefix) -> Digest:
     return await native_engine.add_prefix(add_prefix)
 
 
-import dataclasses
-from pants.option.global_options import GlobalOptions
 @rule
 async def execute_process(
     process: Process,

--- a/src/python/pants/engine/intrinsics.py
+++ b/src/python/pants/engine/intrinsics.py
@@ -108,7 +108,8 @@ async def execute_process(
     process_execution_environment: ProcessExecutionEnvironment,
     options: GlobalOptions,
 ) -> FallibleProcessResult:
-    process = dataclasses.replace(process, env={**process.env, **options.process_extra_env})
+    if options.process_extra_env:
+        process = dataclasses.replace(process, env={**process.env, **options.process_extra_env})
     return await native_engine.execute_process(process, process_execution_environment)
 
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1998,6 +1998,15 @@ class GlobalOptions(BootstrapOptions, Subsystem):
         default=[],
     )
 
+    process_extra_env = DictOption[str](
+        advanced=True,
+        help=softwrap(
+            """
+            Extra environment variables for every Process call.
+            """
+        )
+    )
+
     @classmethod
     def validate_instance(cls, opts):
         """Validates an instance of global options for cases that are not prohibited via


### PR DESCRIPTION
Precompiled binaries that were not created for NixOS usually have a so-called link-loader hardcoded into them. On Linux/x86_64 this is for example /lib64/ld-linux-x86-64.so.2. for glibc. NixOS, on the other hand, usually has its dynamic linker in the glibc package in the Nix store and therefore cannot run these binaries.

The solution is to use [`nix-ld`](https://github.com/nix-community/nix-ld), but it only works if you set `NIX_LD` env variable for every process call.

This pr adds a global option `process_extra_env` to set arbitrary env variables to every pants Process call.