### PR TITLE
upgrade `rustversion` crate to v1.0.17

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -3740,9 +3740,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.14"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "ryu"


### PR DESCRIPTION
Upgrade the `rustversion` crate to v1.0.17 in the hopes of forcing Cargo in CI to re-download the `rustversion` crate into the cache. See discussion at https://pantsbuild.slack.com/archives/C0D7TNJHL/p1728089970443699 for details on release failures and Cargo not finding this crate in its cache.