### PR TITLE
go: recognize `-fullpath` test binary option

### DIFF
--- a/docs/notes/2.24.x.md
+++ b/docs/notes/2.24.x.md
@@ -87,6 +87,8 @@ Added a new `cache_scope` field to `adhoc_tool` and `shell_command` targets to a
 
 Fix a bug where Pants raised an internal exception which occurred when compiling a Go package with coverage support when the package also had an external test which imported the base package.
 
+Recognize `-fullpath` as a test binary flag.
+
 ### Plugin API changes
 
 The `path_metadata_request` intrinsic rule can now access metadata for paths in the local system outside of the build root. Use the new `namespace` field on `PathMetadataRequest` to request metdata on local system paths using namespace `PathNamespace.SYSTEM`.

--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -87,6 +87,7 @@ TEST_FLAGS = {
     "cpu": True,
     "cpuprofile": True,
     "failfast": False,
+    "fullpath": False,
     "fuzz": True,
     "fuzzminimizetime": True,
     "fuzztime": True,


### PR DESCRIPTION
Recognize the `-fullpath` Go test binary option.