### PR TITLE
Upgrade `pyright` to version 1.1.383

### DIFF
--- a/docs/notes/2.24.x.md
+++ b/docs/notes/2.24.x.md
@@ -56,19 +56,22 @@ Deprecations:
 
 - The default lockfiles bundled with Pants for various tools (ex: to run `black`) no longer support Python 3.7.  The minimum Python version is now 3.8.  Pants still supports running Python 3.7 (and earlier!) user code, but you will need to [generate your own lockfiles](https://www.pantsbuild.org/stable/docs/python/overview/lockfiles#lockfiles-for-tools).  See the announcement at <https://www.pantsbuild.org/blog/2024/08/24/venerable-pythons> for further context.
 
-As a consequence of the lockfile generation, newer versions of many tools are now included in the default lockfiles.
+- The deprecation of `resolve_local_platforms` (both a field of `pex_binary`, and a option of `[pex-binary-defaults]`) has expired and thus they have been removed.
 
-The default version of pip is now [24.2](https://pip.pypa.io/en/stable/news/#v24-2) bringing performance improvements to dependency resolution and support or the upcoming Python 3.13 release.
+Version Updates:
 
-The versions of `setuptools` and `wheel` used in Pants have been upgraded to `74.1.2` and `0.44.0` to address a remote code execution vulnerability in versions before setuptools `70.0`. This forces the minimum Python version to 3.8, in line with the changes mentioned above.
+- As a consequence of the lockfile generation, newer versions of many tools are now included in the default lockfiles.
 
-The default version of the [Pex](https://docs.pex-tool.org/) tool has been updated from 2.16.2 to [2.19.1](https://github.com/pex-tool/pex/releases/tag/v2.19.1).
+- The default version of pip is now [24.2](https://pip.pypa.io/en/stable/news/#v24-2) bringing performance improvements to dependency resolution and support or the upcoming Python 3.13 release.
+
+- The versions of `setuptools` and `wheel` used in Pants have been upgraded to `74.1.2` and `0.44.0` to address a remote code execution vulnerability in versions before setuptools `70.0`. This forces the minimum Python version to 3.8, in line with the changes mentioned above.
+
+- The default version of the [Pex](https://docs.pex-tool.org/) tool has been updated from 2.16.2 to [2.19.1](https://github.com/pex-tool/pex/releases/tag/v2.19.1).
+
+- The default version of the [Pyright](https://microsoft.github.io/pyright/#/) tool has been updated from 1.1.365 to [1.1.383](https://github.com/microsoft/pyright/releases/tag/1.1.383).
 
 
-
-The deprecation of `resolve_local_platforms` (both a field of `pex_binary`, and a option of `[pex-binary-defaults]`) has expired and thus they have been removed.
-
-A new experimental [Python Provider](https://www.pantsbuild.org/blog/2023/03/31/two-hermetic-pythons) using [Python Build Standlone](https://gregoryszorc.com/docs/python-build-standalone/main/) is available as `pants.backend.python.providers.experimental.python_build_standalone`.  This joins the existing [pyenv provider](https://www.pantsbuild.org/stable/reference/subsystems/pyenv-python-provider) as a way for Pants to take care of providing an appropriate Python.
+A new experimental [Python Provider](https://www.pantsbuild.org/blog/2023/03/31/two-hermetic-pythons) using [Python Build Standalone](https://gregoryszorc.com/docs/python-build-standalone/main/) is available as `pants.backend.python.providers.experimental.python_build_standalone`.  This joins the existing [pyenv provider](https://www.pantsbuild.org/stable/reference/subsystems/pyenv-python-provider) as a way for Pants to take care of providing an appropriate Python.
 
 
 #### S3

--- a/src/python/pants/backend/python/typecheck/pyright/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/pyright/rules_integration_test.py
@@ -92,8 +92,8 @@ UNDEFINED_VARIABLE_TOML_CONFIG = dedent(
     """
 )
 
-PYRIGHT_VERSION = "1.1.365"
-PYRIGHT_INTEGRITY_HASH = "sha512-A5RHXB782m2wCeazfrPGSvFUd1WAjpHrD83M/Umc/tcAhyC5pzhrh23US1yv9DH/GMilQeWdJ4W8pGxmgej4DQ=="
+PYRIGHT_VERSION = "1.1.383"
+PYRIGHT_INTEGRITY_HASH = "sha512-b540vUDWGXFlVwhxREgCrvKYT9bnUUPiDtSv5s7sUGxIokTxc06bPC2vfnGunUqaUu6hgIqlv1GRFdOKIEb09A=="
 PYRIGHT_LOCKFILE = json.dumps(
     {
         "name": "@the-company/project",

--- a/src/python/pants/backend/python/typecheck/pyright/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/pyright/subsystem.py
@@ -20,7 +20,7 @@ class Pyright(NodeJSToolBase):
         """
     )
 
-    default_version = "pyright@1.1.365"
+    default_version = "pyright@1.1.383"
 
     skip = SkipOption("check")
     args = ArgsListOption(example="--version")


### PR DESCRIPTION
Upgrading Pyright should [fix a wide range of bugs](https://github.com/microsoft/pyright/compare/1.1.365...1.1.383). This PR also rearranges the `Python` heading of the release notes to group version upgrades together and make it a bit simpler to read.