### PR TITLE
restore string borrowing logic for `AddressInput::parse`

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -2975,9 +2975,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
 dependencies = [
  "unicode-ident",
 ]


### PR DESCRIPTION
Restore the string borrowing logic that had been originally used in `AddressInput::parse` prior to the PyO3 v0.22.x upgrade. I figured out how to use the new `PyBackedStr` type and actually get the code to compile.