### PR TITLE
Remove direct pex imports from the codebase

### DIFF
--- a/src/python/pants/backend/python/util_rules/BUILD
+++ b/src/python/pants/backend/python/util_rules/BUILD
@@ -13,7 +13,7 @@ python_tests(
     name="tests",
     overrides={
         "local_dists_test.py": {"timeout": 120},
-        "pex_from_targets_test.py": {"timeout": 200},
+        "pex_from_targets_test.py": {"timeout": 200, "dependencies": ["3rdparty/python#pex"]},
         "pex_test.py": {"timeout": 600, "dependencies": [":complete_platform_pex_test"]},
         "package_dists_test.py": {"timeout": 150},
         "vcs_versioning_test.py": {"timeout": 120},

--- a/tests/python/pants_test/init/test_plugin_resolver.py
+++ b/tests/python/pants_test/init/test_plugin_resolver.py
@@ -141,7 +141,7 @@ def plugin_resolution(
 
     # Default to resolving with whatever we're currently running with.
     interpreter_constraints = (
-        InterpreterConstraints([f"=={python_version}"]) if python_version else None
+        InterpreterConstraints([f"=={python_version}.*"]) if python_version else None
     )
     artifact_interpreter_constraints = interpreter_constraints or InterpreterConstraints(
         [f"=={'.'.join(map(str, sys.version_info[:3]))}"]


### PR DESCRIPTION
Closes #21401. This removes any direct imports of `pex` in the codebase but retains it as a dependency, because certain tests depend on it.