### PR TITLE
Upgrade `docformatter` to 1.7.0 to support Python 3.13

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -15,3 +15,6 @@ dc8227b9841a1057b6ca8629c430f072dd9a190f
 
 # This commit formatted all Rust code
 3632a66bc7918ace25c0aa6f05b4b6a4253d908e
+
+# This commit ran docformatter over the whole codebase.
+ce5abb018207202bf9b80583890a6d85dfc2be47

--- a/docs/notes/2.24.x.md
+++ b/docs/notes/2.24.x.md
@@ -17,7 +17,7 @@ We offer [formal sponsorship tiers for companies](https://www.pantsbuild.org/spo
 ### Deprecations
 
 - **Python 2.7**: As announced in the v2.23.x release series, Pants v2.24 and later are not proactively tested in CI with Python 2.7 since [Python 2.7 is no longer supported by its maintainers as of 1 January 2020](https://www.python.org/doc/sunset-python-2/). While Pants may continue to work with Python 2.7 in the near term, Pants no longer officially supports use of Python 2.7, and, consequently, any remaining support for Python 2.7 may "bit rot" and diverge over time. Contributions to fix issues with Python 2.7 support will continue to be accepted, but will depend on any community contributions and will not constitute continued official support for Python 2.7.
-- **macOS verisons**: as announced in the v2.23.x release series, Pants v2.24 is built on macOS 12 and so may not work on versions of macOS 10.15 and 11 (which Apple no longer supports).
+- **macOS versions**: as announced in the v2.23.x release series, Pants v2.24 is built on macOS 12 and so may not work on versions of macOS 10.15 and 11 (which Apple no longer supports).
 
 
 ### General
@@ -78,6 +78,8 @@ Version Updates:
 - The default version of the [Pex](https://docs.pex-tool.org/) tool has been updated from 2.16.2 to [2.20.3](https://github.com/pex-tool/pex/releases/tag/v2.20.3).
 
 - The default version of the [Pyright](https://microsoft.github.io/pyright/#/) tool has been updated from 1.1.365 to [1.1.383](https://github.com/microsoft/pyright/releases/tag/1.1.383).
+
+- The default version of the [docformatter](https://github.com/PyCQA/docformatter) tool has been updated from 1.4 to 1.7.0. This adds support for Python 3.13.
 
 
 A new experimental [Python Provider](https://www.pantsbuild.org/blog/2023/03/31/two-hermetic-pythons) using [Python Build Standalone](https://gregoryszorc.com/docs/python-build-standalone/main/) is available as `pants.backend.python.providers.experimental.python_build_standalone`.  This joins the existing [pyenv provider](https://www.pantsbuild.org/stable/reference/subsystems/pyenv-python-provider) as a way for Pants to take care of providing an appropriate Python.

--- a/src/python/pants/backend/awslambda/python/register.py
+++ b/src/python/pants/backend/awslambda/python/register.py
@@ -1,6 +1,5 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
 """Create AWS Lambdas from Python code.
 
 See https://www.pantsbuild.org/docs/awslambda-python.

--- a/src/python/pants/backend/cc/lint/clangformat/subsystem.py
+++ b/src/python/pants/backend/cc/lint/clangformat/subsystem.py
@@ -38,7 +38,7 @@ class ClangFormat(PythonToolBase):
     default_lockfile_resource = ("pants.backend.cc.lint.clangformat", "clangformat.lock")
 
     def config_request(self, dirs: Iterable[str]) -> ConfigFilesRequest:
-        """clang-format will use the closest configuration file to the file currently being
+        """Clang-format will use the closest configuration file to the file currently being
         formatted, so add all of them."""
         config_files = (
             ".clang-format",

--- a/src/python/pants/backend/codegen/protobuf/python/register.py
+++ b/src/python/pants/backend/codegen/protobuf/python/register.py
@@ -1,6 +1,5 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
 """Generate Python sources from Protocol Buffers (Protobufs).
 
 See https://www.pantsbuild.org/docs/protobuf.

--- a/src/python/pants/backend/docker/goals/package_image.py
+++ b/src/python/pants/backend/docker/goals/package_image.py
@@ -152,12 +152,12 @@ class DockerPackageFieldSet(PackageFieldSet):
         separated with a colon. By introducing the image `ref` we can retain the use of `tag` for
         the version part of the image name.
 
-        This function returns all image refs to apply to the Docker image, grouped by
-        registry. Within each registry, the `tags` attribute contains a metadata about each tag in
-        the context of that registry, and the `full_name` attribute of each `ImageRefTag` provides
-        the image ref, of the following form:
+        This function returns all image refs to apply to the Docker image, grouped by registry.
+        Within each registry, the `tags` attribute contains a metadata about each tag in the context
+        of that registry, and the `full_name` attribute of each `ImageRefTag` provides the image
+        ref, of the following form:
 
-            [<registry>/]<repository-name>[:<tag>]
+        [<registry>/]<repository-name>[:<tag>]
 
         Where the `<repository-name>` may contain any number of separating slashes `/`, depending on
         the `default_repository` from configuration or the `repository` field on the target

--- a/src/python/pants/backend/experimental/cc/lint/clangformat/register.py
+++ b/src/python/pants/backend/experimental/cc/lint/clangformat/register.py
@@ -1,6 +1,5 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
 """A formatter for C/C++ (and several other languages).
 
 See https://clang.llvm.org/docs/ClangFormat.html for details.

--- a/src/python/pants/backend/experimental/javascript/lint/prettier/register.py
+++ b/src/python/pants/backend/experimental/javascript/lint/prettier/register.py
@@ -1,6 +1,5 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
 """A formatter for JS/TS (and several other languages).
 
 See https://prettier.io/ for details.

--- a/src/python/pants/backend/experimental/nfpm/register.py
+++ b/src/python/pants/backend/experimental/nfpm/register.py
@@ -1,6 +1,5 @@
 # Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
 """Create apk, archlinux, deb, and rpm system packages.
 
 See https://nfpm.goreleaser.com/ for details on nFPM, including these descriptions of it:

--- a/src/python/pants/backend/experimental/python/framework/stevedore/register.py
+++ b/src/python/pants/backend/experimental/python/framework/stevedore/register.py
@@ -1,6 +1,5 @@
 # Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
 """A python "framework" for apps to dynamically load plugins.
 
 See https://github.com/openstack/stevedore for details.

--- a/src/python/pants/backend/experimental/python/lint/add_trailing_comma/register.py
+++ b/src/python/pants/backend/experimental/python/lint/add_trailing_comma/register.py
@@ -1,6 +1,5 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
 """Autoformatter to automatically add trailing commas to calls and literals.
 
 See https://github.com/asottile/add-trailing-comma for details.

--- a/src/python/pants/backend/experimental/python/lint/ruff/check/register.py
+++ b/src/python/pants/backend/experimental/python/lint/ruff/check/register.py
@@ -1,6 +1,5 @@
 # Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
 """Linter & formatter for Python.
 
 See https://www.pantsbuild.org/docs/python-linters-and-formatters and https://docs.astral.sh/ruff/

--- a/src/python/pants/backend/experimental/python/lint/ruff/format/register.py
+++ b/src/python/pants/backend/experimental/python/lint/ruff/format/register.py
@@ -1,6 +1,5 @@
 # Copyright 2024 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
 """Linter & formatter for Python.
 
 See https://www.pantsbuild.org/docs/python-linters-and-formatters and https://docs.astral.sh/ruff/

--- a/src/python/pants/backend/experimental/python/typecheck/pyright/register.py
+++ b/src/python/pants/backend/experimental/python/typecheck/pyright/register.py
@@ -1,6 +1,5 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
 """Static type checker for Python, running on NodeJS.
 
 See https://github.com/Microsoft/pyright for details.

--- a/src/python/pants/backend/experimental/tools/semgrep/register.py
+++ b/src/python/pants/backend/experimental/tools/semgrep/register.py
@@ -1,6 +1,5 @@
 # Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
 """Lightweight static analysis for many languages. Find bug variants with patterns that look like
 source code.
 

--- a/src/python/pants/backend/experimental/tools/yamllint/register.py
+++ b/src/python/pants/backend/experimental/tools/yamllint/register.py
@@ -1,6 +1,5 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
 """A configurable linter for YAML files.
 
 See https://yamllint.readthedocs.io/ for details.

--- a/src/python/pants/backend/google_cloud_function/python/register.py
+++ b/src/python/pants/backend/google_cloud_function/python/register.py
@@ -1,6 +1,5 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
 """Create Google Cloud Functions from Python code.
 
 See https://www.pantsbuild.org/docs/google-cloud-function-python.

--- a/src/python/pants/backend/helm/util_rules/renderer.py
+++ b/src/python/pants/backend/helm/util_rules/renderer.py
@@ -97,7 +97,8 @@ class _HelmDeploymentProcessWrapper(EngineAwareParameter, EngineAwareReturnType)
     """Intermediate representation of a `HelmProcess` that will produce a fully rendered set of
     manifests from a given chart.
 
-    The encapsulated `process` will be side-effecting depending on the `cmd` that was originally requested.
+    The encapsulated `process` will be side-effecting depending on the `cmd` that was originally
+    requested.
 
     This is meant to only be used internally by this module.
     """

--- a/src/python/pants/backend/helm/utils/yaml.py
+++ b/src/python/pants/backend/helm/utils/yaml.py
@@ -215,8 +215,8 @@ class FrozenYamlIndex(Generic[T]):
 
         The items that map to `None` in the given function are not included in the result.
 
-        This is a combination of the `map` and `filter` higher-order functions into one so
-        both operations are performed in a single pass.
+        This is a combination of the `map` and `filter` higher-order functions into one so both
+        operations are performed in a single pass.
         """
 
         mutable_index: MutableYamlIndex[R] = MutableYamlIndex()

--- a/src/python/pants/backend/java/compile/javac_test.py
+++ b/src/python/pants/backend/java/compile/javac_test.py
@@ -310,16 +310,16 @@ def test_compile_with_cycle(rule_runner: RuleRunner) -> None:
     """Test that javac can handle source-level cycles--even across build target boundaries--via
     graph coarsening.
 
-    This test has to set up a contrived dependency since build-target cycles are forbidden by the graph.  However,
-    file-target cycles are not forbidden, so we configure the graph like so:
+    This test has to set up a contrived dependency since build-target cycles are forbidden by the
+    graph.  However, file-target cycles are not forbidden, so we configure the graph like so:
 
     a:a has a single source file, which has file-target address a/A.java, and which inherits a:a's
-    explicit dependency on b/B.java.
-    b:b depends directly on a:a, and its source b/B.java inherits that dependency.
+    explicit dependency on b/B.java. b:b depends directly on a:a, and its source b/B.java inherits
+    that dependency.
 
     Therefore, after target expansion via Get(Targets, Addresses(...)), we get the cycle of:
 
-        a/A.java -> b/B.java -> a/A.java
+    a/A.java -> b/B.java -> a/A.java
     """
 
     rule_runner.write_files(

--- a/src/python/pants/backend/project_info/count_loc_test.py
+++ b/src/python/pants/backend/project_info/count_loc_test.py
@@ -84,7 +84,7 @@ def test_passthrough_args(rule_runner: RuleRunner) -> None:
 
 
 def test_files_without_owners(rule_runner: RuleRunner) -> None:
-    """cloc works on any readable file in the build root, regardless of whether it's declared in a
+    """Cloc works on any readable file in the build root, regardless of whether it's declared in a
     BUILD file."""
     rule_runner.write_files(
         {

--- a/src/python/pants/backend/project_info/register.py
+++ b/src/python/pants/backend/project_info/register.py
@@ -1,6 +1,5 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
 """Information on your project, such as listing the targets in your project."""
 
 from pants.backend.project_info import (

--- a/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
+++ b/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
@@ -52,7 +52,7 @@ def two_groups_hyphens_two_replacements_with_suffix(
     second_group_replacement: PackageSeparator = PackageSeparator.NONE,
     custom_suffix: str = "",
 ) -> str:
-    """take two groups, and by default, the first will have '-' replaced with '.', the second will
+    """Take two groups, and by default, the first will have '-' replaced with '.', the second will
     have '-' replaced with '' e.g. google-cloud-foo-bar -> group1(google.cloud.)group2(foobar)
 
     >>> two_groups_hyphens_two_replacements_with_suffix(re.match(r"^(google-cloud-)([^.]+)", "google-cloud-foo-bar"))
@@ -74,14 +74,12 @@ first_group_hyphen_to_dot = partial(first_group_hyphen_to_separator, separator=P
 first_group_hyphen_to_underscore = partial(
     first_group_hyphen_to_separator, separator=PackageSeparator.UNDERSCORE
 )
+"""A mapping of Patterns and their replacements. will be used with `re.sub`. The match is either a
+string or a function`(str) -> str`; that takes a re.Match and returns the replacement. see re.sub
+for more information.
 
-"""
-A mapping of Patterns and their replacements. will be used with `re.sub`.
-The match is either a string or a function`(str) -> str`; that takes a re.Match and returns
-the replacement. see re.sub for more information
-
-then if an import in the python code is google.cloud.foo, then the package of
-google-cloud-foo will be used.
+then if an import in the python code is google.cloud.foo, then the package of google-cloud-foo will
+be used.
 """
 DEFAULT_MODULE_PATTERN_MAPPING: Dict[re.Pattern, List[Callable[[Match[str]], str]]] = {
     re.compile(r"""^azure-.+"""): [all_hyphen_to_dot],

--- a/src/python/pants/backend/python/dependency_inference/module_mapper.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper.py
@@ -145,7 +145,6 @@ class FirstPartyPythonModuleMapping:
     resolves_to_modules_to_providers: FrozenDict[
         ResolveName, FrozenDict[str, Tuple[ModuleProvider, ...]]
     ]
-
     """A merged mapping of each resolve name to the first-party module names contained and their
     owning addresses.
 

--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -210,12 +210,7 @@ def _remove_ignored_imports(
 ) -> frozenset[str]:
     """Remove unowned imports given a list of paths to ignore.
 
-    E.g. having
-    ```
-    import foo.bar
-    from foo.bar import baz
-    import foo.barley
-    ```
+    E.g. having ``` import foo.bar from foo.bar import baz import foo.barley ```
 
     and passing `ignored-paths=["foo.bar"]`, only `foo.bar` and `foo.bar.baz` will be ignored.
     """

--- a/src/python/pants/backend/python/lint/autoflake/register.py
+++ b/src/python/pants/backend/python/lint/autoflake/register.py
@@ -1,6 +1,5 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
 """Autoformatter for removing unused Python imports.
 
 See https://github.com/myint/autoflake for details.

--- a/src/python/pants/backend/python/lint/bandit/register.py
+++ b/src/python/pants/backend/python/lint/bandit/register.py
@@ -1,6 +1,5 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
 """Security linter for Python.
 
 See https://www.pantsbuild.org/docs/python-linters-and-formatters and

--- a/src/python/pants/backend/python/lint/black/register.py
+++ b/src/python/pants/backend/python/lint/black/register.py
@@ -1,6 +1,5 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
 """Autoformatter for Python.
 
 See https://www.pantsbuild.org/docs/python-linters-and-formatters and

--- a/src/python/pants/backend/python/lint/docformatter/docformatter.lock
+++ b/src/python/pants/backend/python/lint/docformatter/docformatter.lock
@@ -9,7 +9,7 @@
 //     "CPython<4,>=3.8"
 //   ],
 //   "generated_with_requirements": [
-//     "docformatter<1.5,>=1.4"
+//     "docformatter==1.7.0"
 //   ],
 //   "manylinux": "manylinux2014",
 //   "requirement_constraints": [],
@@ -32,16 +32,431 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "064e6d81f04ac96bc0d176cbaae953a0332482b22d3ad70d47c8a7f2732eef6f",
-              "url": "https://files.pythonhosted.org/packages/8a/7b/b32b3952ee4e9fd76c7a9b18d4bafb70ed65ac6426d1802103c2eaf1d0de/docformatter-1.4.tar.gz"
+              "hash": "fe9f97feb71aa9896b81973a7bbada8c49501dc73e58a10fcef6663af95e5079",
+              "url": "https://files.pythonhosted.org/packages/bf/9b/08c0432272d77b04803958a4598a51e2a4b51c06640af8b8f0f908c18bf2/charset_normalizer-3.4.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "aa41e526a5d4a9dfcfbab0716c7e8a1b215abd3f3df5a45cf18a12721d31cb5d",
+              "url": "https://files.pythonhosted.org/packages/04/4f/b3961ba0c664989ba63e30595a3ed0875d6790ff26671e2aae2fdc28a399/charset_normalizer-3.4.0-cp313-cp313-musllinux_1_2_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "aa693779a8b50cd97570e5a0f343538a8dbd3e496fa5dcb87e29406ad0299654",
+              "url": "https://files.pythonhosted.org/packages/0b/11/ca7786f7e13708687443082af20d8341c02e01024275a28bc75032c5ce5d/charset_normalizer-3.4.0-cp38-cp38-musllinux_1_2_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "285e96d9d53422efc0d7a17c60e59f37fbf3dfa942073f666db4ac71e8d726d0",
+              "url": "https://files.pythonhosted.org/packages/0c/48/0050550275fea585a6e24460b42465020b53375017d8596c96be57bfabca/charset_normalizer-3.4.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "92db3c28b5b2a273346bebb24857fda45601aef6ae1c011c0a997106581e8a88",
+              "url": "https://files.pythonhosted.org/packages/0c/75/1ed813c3ffd200b1f3e71121c95da3f79e6d2a96120163443b3ad1057505/charset_normalizer-3.4.0-cp313-cp313-musllinux_1_2_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "2006769bd1640bdf4d5641c69a3d63b71b81445473cac5ded39740a226fa88ab",
+              "url": "https://files.pythonhosted.org/packages/0e/dd/7f6fec09a1686446cee713f38cf7d5e0669e0bcc8288c8e2924e998cf87d/charset_normalizer-3.4.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "8ff4e7cdfdb1ab5698e675ca622e72d58a6fa2a8aa58195de0c0061288e6e3ea",
+              "url": "https://files.pythonhosted.org/packages/13/bc/87c2c9f2c144bedfa62f894c3007cd4530ba4b5351acb10dc786428a50f0/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "8cda06946eac330cbe6598f77bb54e690b4ca93f593dee1568ad22b04f347c15",
+              "url": "https://files.pythonhosted.org/packages/16/92/92a76dc2ff3a12e69ba94e7e05168d37d0345fa08c87e1fe24d0c2a42223/charset_normalizer-3.4.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "3d59d125ffbd6d552765510e3f31ed75ebac2c7470c7274195b9161a32350284",
+              "url": "https://files.pythonhosted.org/packages/1a/cf/f1f50c2f295312edb8a548d3fa56a5c923b146cd3f24114d5adb7e7be558/charset_normalizer-3.4.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "4ec9dd88a5b71abfc74e9df5ebe7921c35cbb3b641181a531ca65cdb5e8e4dea",
+              "url": "https://files.pythonhosted.org/packages/1e/70/17b1b9202531a33ed7ef41885f0d2575ae42a1e330c67fddda5d99ad1208/charset_normalizer-3.4.0-cp38-cp38-musllinux_1_2_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "5ed2e36c3e9b4f21dd9422f6893dec0abf2cca553af509b10cd630f878d3eb99",
+              "url": "https://files.pythonhosted.org/packages/21/67/b4564d81f48042f520c948abac7079356e94b30cb8ffb22e747532cf469d/charset_normalizer-3.4.0-cp310-cp310-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "0de7b687289d3c1b3e8660d0741874abe7888100efe14bd0f9fd7141bcbda92b",
+              "url": "https://files.pythonhosted.org/packages/23/81/d7eef6a99e42c77f444fdd7bc894b0ceca6c3a95c51239e74a722039521c/charset_normalizer-3.4.0-cp310-cp310-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "309a7de0a0ff3040acaebb35ec45d18db4b28232f21998851cfa709eeff49d62",
+              "url": "https://files.pythonhosted.org/packages/28/89/60f51ad71f63aaaa7e51a2a2ad37919985a341a1d267070f212cdf6c2d22/charset_normalizer-3.4.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "4796efc4faf6b53a18e3d46343535caed491776a22af773f366534056c4e1fbc",
+              "url": "https://files.pythonhosted.org/packages/2b/c9/1c8fe3ce05d30c87eff498592c89015b19fade13df42850aafae09e94f35/charset_normalizer-3.4.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "6fd30dc99682dc2c603c2b315bded2799019cea829f8bf57dc6b61efde6611c8",
+              "url": "https://files.pythonhosted.org/packages/32/c8/0bc558f7260db6ffca991ed7166494a7da4fda5983ee0b0bfc8ed2ac6ff9/charset_normalizer-3.4.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "136815f06a3ae311fae551c3df1f998a1ebd01ddd424aa5603a4336997629e95",
+              "url": "https://files.pythonhosted.org/packages/3a/a4/8633b0fc1a2d1834d5393dafecce4a1cc56727bfd82b4dc18fc92f0d3cc3/charset_normalizer-3.4.0-cp310-cp310-musllinux_1_2_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "82357d85de703176b5587dbe6ade8ff67f9f69a41c0733cf2425378b49954de5",
+              "url": "https://files.pythonhosted.org/packages/3b/a0/a68980ab8a1f45a36d9745d35049c1af57d27255eff8c907e3add84cf68f/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "79983512b108e4a164b9c8d34de3992f76d48cadc9554c9e60b43f308988aabe",
+              "url": "https://files.pythonhosted.org/packages/3b/fd/e60a9d9fd967f4ad5a92810138192f825d77b4fa2a557990fd575a47695b/charset_normalizer-3.4.0-cp310-cp310-musllinux_1_2_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "43193c5cda5d612f247172016c4bb71251c784d7a4d9314677186a838ad34858",
+              "url": "https://files.pythonhosted.org/packages/44/30/574b5b5933d77ecb015550aafe1c7d14a8cd41e7e6c4dcea5ae9e8d496c3/charset_normalizer-3.4.0-cp38-cp38-musllinux_1_2_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "bf4475b82be41b07cc5e5ff94810e6a01f276e37c2d55571e3fe175e467a1a1c",
+              "url": "https://files.pythonhosted.org/packages/4c/92/97509850f0d00e9f14a46bc751daabd0ad7765cff29cdfb66c68b6dad57f/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "dc15e99b2d8a656f8e666854404f1ba54765871104e50c8e9813af8a7db07f12",
+              "url": "https://files.pythonhosted.org/packages/4c/a8/440f1926d6d8740c34d3ca388fbd718191ec97d3d457a0677eb3aa718fce/charset_normalizer-3.4.0-cp38-cp38-musllinux_1_2_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "e9e3c4c9e1ed40ea53acf11e2a386383c3304212c965773704e4603d589343ed",
+              "url": "https://files.pythonhosted.org/packages/4f/cd/8947fe425e2ab0aa57aceb7807af13a0e4162cd21eee42ef5b053447edf5/charset_normalizer-3.4.0-cp313-cp313-macosx_10_13_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "de7376c29d95d6719048c194a9cf1a1b0393fbe8488a22008610b0361d834ecf",
+              "url": "https://files.pythonhosted.org/packages/50/89/354cc56cf4dd2449715bc9a0f54f3aef3dc700d2d62d1fa5bbea53b13426/charset_normalizer-3.4.0-cp312-cp312-macosx_10_13_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "980b4f289d1d90ca5efcf07958d3eb38ed9c0b7676bf2831a54d4f66f9c27dfa",
+              "url": "https://files.pythonhosted.org/packages/54/2f/28659eee7f5d003e0f5a3b572765bf76d6e0fe6601ab1f1b1dd4cba7e4f1/charset_normalizer-3.4.0-cp39-cp39-macosx_10_9_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "7782afc9b6b42200f7362858f9e73b1f8316afb276d316336c0ec3bd73312742",
+              "url": "https://files.pythonhosted.org/packages/54/9a/acfa96dc4ea8c928040b15822b59d0863d6e1757fba8bd7de3dc4f761c13/charset_normalizer-3.4.0-cp39-cp39-musllinux_1_2_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "44aeb140295a2f0659e113b31cfe92c9061622cadbc9e2a2f7b8ef6b1e29ef4b",
+              "url": "https://files.pythonhosted.org/packages/5a/bb/3d8bc22bacb9eb89785e83e6723f9888265f3a0de3b9ce724d66bd49884e/charset_normalizer-3.4.0-cp312-cp312-musllinux_1_2_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "92a7e36b000bf022ef3dbb9c46bfe2d52c047d5e3f3343f43204263c5addc250",
+              "url": "https://files.pythonhosted.org/packages/5b/f0/b5263e8668a4ee9becc2b451ed909e9c27058337fda5b8c49588183c267a/charset_normalizer-3.4.0-cp313-cp313-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "14215b71a762336254351b00ec720a8e85cada43b987da5a042e4ce3e82bd68e",
+              "url": "https://files.pythonhosted.org/packages/64/ea/69af161062166b5975ccbb0961fd2384853190c70786f288684490913bf5/charset_normalizer-3.4.0-cp310-cp310-musllinux_1_2_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "1110e22af8ca26b90bd6364fe4c763329b0ebf1ee213ba32b68c73de5752323d",
+              "url": "https://files.pythonhosted.org/packages/67/56/fa28c2c3e31217c4c52158537a2cf5d98a6c1e89d31faf476c89391cd16b/charset_normalizer-3.4.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "4f9fc98dad6c2eaa32fc3af1417d95b5e3d08aff968df0cd320066def971f9a6",
+              "url": "https://files.pythonhosted.org/packages/69/8b/825cc84cf13a28bfbcba7c416ec22bf85a9584971be15b21dd8300c65b7f/charset_normalizer-3.4.0-cp310-cp310-macosx_10_9_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ee803480535c44e7f5ad00788526da7d85525cfefaf8acf8ab9a310000be4b03",
+              "url": "https://files.pythonhosted.org/packages/6b/e3/9f73e779315a54334240353eaea75854a9a690f3f580e4bd85d977cb2204/charset_normalizer-3.4.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "6b493a043635eb376e50eedf7818f2f322eabbaa974e948bd8bdd29eb7ef2a51",
+              "url": "https://files.pythonhosted.org/packages/70/de/1538bb2f84ac9940f7fa39945a5dd1d22b295a89c98240b262fc4b9fcfe0/charset_normalizer-3.4.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "27623ba66c183eca01bf9ff833875b459cad267aeeb044477fedac35e19ba907",
+              "url": "https://files.pythonhosted.org/packages/73/8b/2102692cb6d7e9f03b9a33a710e0164cadfce312872e3efc7cfe22ed26b4/charset_normalizer-3.4.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "f1a2f519ae173b5b6a2c9d5fa3116ce16e48b3462c8b96dfdded11055e3d6365",
+              "url": "https://files.pythonhosted.org/packages/75/d2/0ab54463d3410709c09266dfb416d032a08f97fd7d60e94b8c6ef54ae14b/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "c57516e58fd17d03ebe67e181a4e4e2ccab1168f8c2976c6a334d4f819fe5944",
+              "url": "https://files.pythonhosted.org/packages/77/d5/8c982d58144de49f59571f940e329ad6e8615e1e82ef84584c5eeb5e1d72/charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "e91f541a85298cf35433bf66f3fab2a4a2cff05c127eeca4af174f6d497f0d4b",
+              "url": "https://files.pythonhosted.org/packages/7b/ab/f47b0159a69eab9bd915591106859f49670c75f9a19082505ff16f50efc0/charset_normalizer-3.4.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ab973df98fc99ab39080bfb0eb3a925181454d7c3ac8a1e695fddfae696d9e90",
+              "url": "https://files.pythonhosted.org/packages/7d/0d/6f32255c1979653b448d3c709583557a4d24ff97ac4f3a5be156b2e6a210/charset_normalizer-3.4.0-cp313-cp313-musllinux_1_2_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "20587d20f557fe189b7947d8e7ec5afa110ccf72a3128d61a2a387c3313f46be",
+              "url": "https://files.pythonhosted.org/packages/84/79/5c731059ebab43e80bf61fa51666b9b18167974b82004f18c76378ed31a3/charset_normalizer-3.4.0-cp39-cp39-musllinux_1_2_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "af73657b7a68211996527dbfeffbb0864e043d270580c5aef06dc4b659a4b578",
+              "url": "https://files.pythonhosted.org/packages/86/f4/ccab93e631e7293cca82f9f7ba39783c967f823a0000df2d8dd743cad74f/charset_normalizer-3.4.0-cp38-cp38-macosx_10_9_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "63bc5c4ae26e4bc6be6469943b8253c0fd4e4186c43ad46e713ea61a0ba49129",
+              "url": "https://files.pythonhosted.org/packages/8d/c9/27e41d481557be53d51e60750b85aa40eaf52b841946b3cdeff363105737/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "cab5d0b79d987c67f3b9e9c53f54a61360422a5a0bc075f43cab5621d530c3b6",
+              "url": "https://files.pythonhosted.org/packages/94/d4/2b21cb277bac9605026d2d91a4a8872bc82199ed11072d035dc674c27223/charset_normalizer-3.4.0-cp38-cp38-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "9289fd5dddcf57bab41d044f1756550f9e7cf0c8e373b8cdf0ce8773dc4bd417",
+              "url": "https://files.pythonhosted.org/packages/9a/e0/a7c1fcdff20d9c667342e0391cfeb33ab01468d7d276b2c7914b371667cc/charset_normalizer-3.4.0-cp38-cp38-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "0d99dd8ff461990f12d6e42c7347fd9ab2532fb70e9621ba520f9e8637161d7c",
+              "url": "https://files.pythonhosted.org/packages/9c/61/73589dcc7a719582bf56aae309b6103d2762b526bffe189d635a7fcfd998/charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "84450ba661fb96e9fd67629b93d2941c871ca86fc38d835d19d4225ff946a631",
+              "url": "https://files.pythonhosted.org/packages/9d/be/5708ad18161dee7dc6a0f7e6cf3a88ea6279c3e8484844c0590e50e803ef/charset_normalizer-3.4.0-cp312-cp312-musllinux_1_2_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "b295729485b06c1a0683af02a9e42d2caa9db04a373dc38a6a58cdd1e8abddf1",
+              "url": "https://files.pythonhosted.org/packages/9d/e4/9263b8240ed9472a2ae7ddc3e516e71ef46617fe40eaa51221ccd4ad9a27/charset_normalizer-3.4.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "1ffd9493de4c922f2a38c2bf62b831dcec90ac673ed1ca182fe11b4d8e9f2a64",
+              "url": "https://files.pythonhosted.org/packages/a1/b2/4af9993b532d93270538ad4926c8e37dc29f2111c36f9c629840c57cd9b3/charset_normalizer-3.4.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "07afec21bbbbf8a5cc3651aa96b980afe2526e7f048fdfb7f1014d84acc8b6d8",
+              "url": "https://files.pythonhosted.org/packages/a4/01/2117ff2b1dfc61695daf2babe4a874bca328489afa85952440b59819e9d7/charset_normalizer-3.4.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "bd7af3717683bea4c87acd8c0d3d5b44d56120b26fd3f8a692bdd2d5260c620a",
+              "url": "https://files.pythonhosted.org/packages/a4/23/65af317914a0308495133b2d654cf67b11bbd6ca16637c4e8a38f80a5a69/charset_normalizer-3.4.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "a8e538f46104c815be19c975572d74afb53f29650ea2025bbfaef359d2de2f7f",
+              "url": "https://files.pythonhosted.org/packages/aa/75/58374fdaaf8406f373e508dab3486a31091f760f99f832d3951ee93313e8/charset_normalizer-3.4.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "b8dcd239c743aa2f9c22ce674a145e0a25cb1566c495928440a181ca1ccf6719",
+              "url": "https://files.pythonhosted.org/packages/ab/f6/7ac4a01adcdecbc7a7587767c776d53d369b8b971382b91211489535acf0/charset_normalizer-3.4.0-cp312-cp312-musllinux_1_2_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "4b67fdab07fdd3c10bb21edab3cbfe8cf5696f453afce75d815d9d7223fbe88b",
+              "url": "https://files.pythonhosted.org/packages/ac/a0/c1b5298de4670d997101fef95b97ac440e8c8d8b4efa5a4d1ef44af82f0d/charset_normalizer-3.4.0-cp313-cp313-musllinux_1_2_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "6dba5d19c4dfab08e58d5b36304b3f92f3bd5d42c1a3fa37b5ba5cdf6dfcbcee",
+              "url": "https://files.pythonhosted.org/packages/bf/19/411a64f01ee971bed3231111b69eb56f9331a769072de479eae7de52296d/charset_normalizer-3.4.0-cp311-cp311-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "40d3ff7fc90b98c637bda91c89d51264a3dcf210cade3a2c6f838c7268d7a4ca",
+              "url": "https://files.pythonhosted.org/packages/c2/72/12a7f0943dd71fb5b4e7b55c41327ac0a1663046a868ee4d0d8e9c369b85/charset_normalizer-3.4.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "0b309d1747110feb25d7ed6b01afdec269c647d382c857ef4663bbe6ad95a912",
+              "url": "https://files.pythonhosted.org/packages/c9/27/cde291783715b8ec30a61c810d0120411844bc4c23b50189b81188b273db/charset_normalizer-3.4.0-cp310-cp310-musllinux_1_2_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "130272c698667a982a5d0e626851ceff662565379baf0ff2cc58067b81d4f11d",
+              "url": "https://files.pythonhosted.org/packages/ca/f3/0719cd09fc4dc42066f239cb3c48ced17fc3316afca3e2a30a4756fe49ab/charset_normalizer-3.4.0-cp39-cp39-musllinux_1_2_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "f28f891ccd15c514a0981f3b9db9aa23d62fe1a99997512b0491d2ed323d229a",
+              "url": "https://files.pythonhosted.org/packages/d1/18/92869d5c0057baa973a3ee2af71573be7b084b3c3d428fe6463ce71167f8/charset_normalizer-3.4.0-cp39-cp39-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "0713f3adb9d03d49d365b70b84775d0a0d18e4ab08d12bc46baa6132ba78aaf6",
+              "url": "https://files.pythonhosted.org/packages/d3/0b/4b7a70987abf9b8196845806198975b6aab4ce016632f817ad758a5aa056/charset_normalizer-3.4.0-cp312-cp312-macosx_10_13_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "a8aacce6e2e1edcb6ac625fb0f8c3a9570ccc7bfba1f63419b3769ccf6a00ed0",
+              "url": "https://files.pythonhosted.org/packages/d6/27/327904c5a54a7796bb9f36810ec4173d2df5d88b401d2b95ef53111d214e/charset_normalizer-3.4.0-cp39-cp39-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "47334db71978b23ebcf3c0f9f5ee98b8d65992b65c9c4f2d34c2eaf5bcaf0594",
+              "url": "https://files.pythonhosted.org/packages/d7/a1/493919799446464ed0299c8eef3c3fad0daf1c3cd48bff9263c731b0d9e2/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ffc519621dce0c767e96b9c53f09c5d215578e10b02c285809f76509a3931482",
+              "url": "https://files.pythonhosted.org/packages/d8/90/6af4cd042066a4adad58ae25648a12c09c879efa4849c705719ba1b23d8c/charset_normalizer-3.4.0-cp313-cp313-musllinux_1_2_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "f606a1881d2663630ea5b8ce2efe2111740df4b687bd78b34a8131baa007f79b",
+              "url": "https://files.pythonhosted.org/packages/d8/96/cc2c1b5d994119ce9f088a9a0c3ebd489d360a2eb058e2c8049f27092847/charset_normalizer-3.4.0-cp310-cp310-musllinux_1_2_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "5d447056e2ca60382d460a604b6302d8db69476fd2015c81e7c35417cfabe4cd",
+              "url": "https://files.pythonhosted.org/packages/dc/b5/47f8ee91455946f745e6c9ddbb0f8f50314d2416dd922b213e7d5551ad09/charset_normalizer-3.4.0-cp39-cp39-musllinux_1_2_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ce031db0408e487fd2775d745ce30a7cd2923667cf3b69d48d219f1d8f5ddeb6",
+              "url": "https://files.pythonhosted.org/packages/e2/29/d227805bff72ed6d6cb1ce08eec707f7cfbd9868044893617eb331f16295/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ab2e5bef076f5a235c3774b4f4028a680432cded7cad37bba0fd90d64b187d19",
+              "url": "https://files.pythonhosted.org/packages/e9/7f/4b71e350a3377ddd70b980bea1e2cc0983faf45ba43032b24b2578c14314/charset_normalizer-3.4.0-cp38-cp38-musllinux_1_2_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "9fa2566ca27d67c86569e8c85297aaf413ffab85a8960500f12ea34ff98e4c41",
+              "url": "https://files.pythonhosted.org/packages/e9/ca/288bb1a6bc2b74fb3990bdc515012b47c4bc5925c8304fc915d03f94b027/charset_normalizer-3.4.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "3710a9751938947e6327ea9f3ea6332a09bf0ba0c09cae9cb1f250bd1f1549bc",
+              "url": "https://files.pythonhosted.org/packages/eb/5b/6f10bad0f6461fa272bfbbdf5d0023b5fb9bc6217c92bf068fa5a99820f5/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "bcb4f8ea87d03bc51ad04add8ceaf9b0f085ac045ab4d74e73bbc2dc033f0236",
+              "url": "https://files.pythonhosted.org/packages/ee/44/4f62042ca8cdc0cabf87c0fc00ae27cd8b53ab68be3605ba6d071f742ad3/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "e7fdd52961feb4c96507aa649550ec2a0d527c086d284749b2f582f2d40a2e0d",
+              "url": "https://files.pythonhosted.org/packages/ee/68/efad5dcb306bf37db7db338338e7bb8ebd8cf38ee5bbd5ceaaaa46f257e6/charset_normalizer-3.4.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "5ff2ed8194587faf56555927b3aa10e6fb69d931e33953943bc4f837dfee2242",
+              "url": "https://files.pythonhosted.org/packages/f2/41/6190102ad521a8aa888519bb014a74251ac4586cde9b38e790901684f9ab/charset_normalizer-3.4.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "223217c3d4f82c3ac5e29032b3f1c2eb0fb591b72161f86d93f5719079dae93e",
+              "url": "https://files.pythonhosted.org/packages/f2/4f/e1808dc01273379acc506d18f1504eb2d299bd4131743b9fc54d7be4df1e/charset_normalizer-3.4.0.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "dd4eda173a9fcccb5f2e2bd2a9f423d180194b1bf17cf59e3269899235b2a114",
+              "url": "https://files.pythonhosted.org/packages/f3/89/68a4c86f1a0002810a27f12e9a7b22feb198c59b2f05231349fbce5c06f4/charset_normalizer-3.4.0-cp313-cp313-macosx_10_13_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "6b40e8d38afe634559e398cc32b1472f376a4099c75fe6299ae607e404c033b2",
+              "url": "https://files.pythonhosted.org/packages/f6/9b/93a332b8d25b347f6839ca0a61b7f0287b0930216994e8bf67a75d050255/charset_normalizer-3.4.0-cp312-cp312-musllinux_1_2_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ab22fbd9765e6954bc0bcff24c25ff71dcbfdb185fcdaca49e81bac68fe724d3",
+              "url": "https://files.pythonhosted.org/packages/f7/0e/c6357297f1157c8e8227ff337e93fd0a90e498e3d6ab96b2782204ecae48/charset_normalizer-3.4.0-cp39-cp39-musllinux_1_2_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "1db4e7fefefd0f548d73e2e2e041f9df5c59e178b4c72fbac4cc6f535cfb1565",
+              "url": "https://files.pythonhosted.org/packages/f7/fa/d3fc622de05a86f30beea5fc4e9ac46aead4731e73fd9055496732bcc0a4/charset_normalizer-3.4.0-cp312-cp312-musllinux_1_2_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "7f683ddc7eedd742e2889d2bfb96d69573fde1d92fcb811979cdb7165bb9c7d3",
+              "url": "https://files.pythonhosted.org/packages/f8/01/344ec40cf5d85c1da3c1f57566c59e0c9b56bcc5566c08804a95a6cc8257/charset_normalizer-3.4.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "86f4e8cca779080f66ff4f191a685ced73d2f72d50216f7112185dc02b90b9b7",
+              "url": "https://files.pythonhosted.org/packages/f9/d2/466a9be1f32d89eb1554cf84073a5ed9262047acee1ab39cbaefc19635d2/charset_normalizer-3.4.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "4a51b48f42d9358460b78725283f04bddaf44a9358197b889657deba38f329db",
+              "url": "https://files.pythonhosted.org/packages/fa/44/b730e2a2580110ced837ac083d8ad222343c96bb6b66e9e4e706e4d0b6df/charset_normalizer-3.4.0-cp312-cp312-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "35c404d74c2926d0287fbd63ed5d27eb911eb9e4a3bb2c6d294f3cfd4a9e0c23",
+              "url": "https://files.pythonhosted.org/packages/fb/6f/4e78c3b97686b871db9be6f31d64e9264e889f8c9d7ab33c771f847f79b7/charset_normalizer-3.4.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "8ce7fd6767a1cc5a92a639b391891bf1c268b03ec7e021c7d6d902285259685c",
+              "url": "https://files.pythonhosted.org/packages/fb/9d/9c13753a5a6e0db4a0a6edb1cef7aee39859177b64e1a1e748a6e3ba62c2/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "54b6a92d009cbe2fb11054ba694bc9e284dad30a26757b1e372a1fdddaf21920",
+              "url": "https://files.pythonhosted.org/packages/ff/6e/e445afe4f7fda27a533f3234b627b3e515a1b9429bc981c9a5e2aa5d97b6/charset_normalizer-3.4.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            }
+          ],
+          "project_name": "charset-normalizer",
+          "requires_dists": [],
+          "requires_python": ">=3.7.0",
+          "version": "3.4.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "8099de46392970f63eacfc69143b23dd78f6d6511ff8e9f474aba70f80d2e312",
+              "url": "https://files.pythonhosted.org/packages/67/13/258f94a8e20f975a27a243c860591aeeb5f8a34bdc5be82e8d68be87ddc1/docformatter-1.7.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "13bc8805b3bf4f8a0911fe87c3ea58c7bfc0d5739a2d86bb339efab3932ae49b",
+              "url": "https://files.pythonhosted.org/packages/eb/e0/194b10a4697569d242fd3f8b71477664fcb7e89c8bf7e30ece387a34432d/docformatter-1.7.0.tar.gz"
             }
           ],
           "project_name": "docformatter",
           "requires_dists": [
-            "untokenize"
+            "charset_normalizer<4.0.0,>=3.0.0",
+            "tomli<3.0.0,>=2.0.0; extra == \"tomli\"",
+            "untokenize<0.2.0,>=0.1.1"
           ],
-          "requires_python": null,
-          "version": "1.4"
+          "requires_python": "<4.0,>=3.7",
+          "version": "1.7.0"
         },
         {
           "artifacts": [
@@ -64,11 +479,11 @@
   "only_wheels": [],
   "overridden": [],
   "path_mappings": {},
-  "pex_version": "2.16.2",
+  "pex_version": "2.20.3",
   "pip_version": "24.2",
   "prefer_older_binary": false,
   "requirements": [
-    "docformatter<1.5,>=1.4"
+    "docformatter==1.7.0"
   ],
   "requires_python": [
     "<4,>=3.8"
@@ -80,5 +495,6 @@
     "mac"
   ],
   "transitive": true,
-  "use_pep517": null
+  "use_pep517": null,
+  "use_system_time": false
 }

--- a/src/python/pants/backend/python/lint/docformatter/register.py
+++ b/src/python/pants/backend/python/lint/docformatter/register.py
@@ -1,6 +1,5 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
 """Python autoformatter for PEP257 docstring conventions.
 
 See https://www.pantsbuild.org/docs/python-linters-and-formatters and

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -61,8 +61,6 @@ async def docformatter_fmt(
     # (All versions return 3 in check mode if any files would have changed, but that is
     # not an issue here).
     if result.exit_code not in [0, 3]:
-        # TODO(#12725):It would be more straightforward to force the exception with:
-        # result = await Get(ProcessResult, FallibleProcessResult, result)
         raise ProcessExecutionFailure(
             result.exit_code,
             result.stdout,

--- a/src/python/pants/backend/python/lint/docformatter/subsystem.py
+++ b/src/python/pants/backend/python/lint/docformatter/subsystem.py
@@ -16,7 +16,10 @@ class Docformatter(PythonToolBase):
     help_short = "The Python docformatter tool (https://github.com/myint/docformatter)."
 
     default_main = ConsoleScript("docformatter")
-    default_requirements = ["docformatter>=1.4,<1.5"]
+    # Upper bound requirement set because there is a bug in docformatter 1.7.1 that causes issues
+    # with Sphinx-style :param tags.
+    # https://github.com/PyCQA/docformatter/issues/264
+    default_requirements = ["docformatter==1.7.0"]
 
     register_interpreter_constraints = True
 

--- a/src/python/pants/backend/python/lint/flake8/register.py
+++ b/src/python/pants/backend/python/lint/flake8/register.py
@@ -1,6 +1,5 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
 """Linter for Python.
 
 See https://www.pantsbuild.org/docs/python-linters-and-formatters and

--- a/src/python/pants/backend/python/lint/isort/register.py
+++ b/src/python/pants/backend/python/lint/isort/register.py
@@ -1,6 +1,5 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
 """Autoformatter for Python import statements.
 
 See https://www.pantsbuild.org/docs/python-linters-and-formatters and

--- a/src/python/pants/backend/python/lint/pydocstyle/register.py
+++ b/src/python/pants/backend/python/lint/pydocstyle/register.py
@@ -1,6 +1,5 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
 """Static analysis tool for checking compliance with Python docstring conventions.
 
 See https://www.pantsbuild.org/docs/python-linters-and-formatters and

--- a/src/python/pants/backend/python/lint/pylint/register.py
+++ b/src/python/pants/backend/python/lint/pylint/register.py
@@ -1,6 +1,5 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
 """Linter for Python.
 
 See https://www.pantsbuild.org/docs/python-linters-and-formatters and https://www.pylint.org.

--- a/src/python/pants/backend/python/lint/pyupgrade/register.py
+++ b/src/python/pants/backend/python/lint/pyupgrade/register.py
@@ -1,6 +1,5 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
 """https://github.com/asottile/pyupgrade.
 
 A tool  to automatically upgrade syntax for newer versions of the language.

--- a/src/python/pants/backend/python/lint/yapf/register.py
+++ b/src/python/pants/backend/python/lint/yapf/register.py
@@ -1,6 +1,5 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
 """Autoformatter for Python.
 
 See https://www.pantsbuild.org/docs/python-linters-and-formatters and

--- a/src/python/pants/backend/python/providers/pyenv/rules.py
+++ b/src/python/pants/backend/python/providers/pyenv/rules.py
@@ -105,8 +105,8 @@ class PyenvPythonProviderSubsystem(TemplatedExternalTool):
 
         If the downloaded artifact is the executable itself, you can leave this unimplemented.
 
-        If the downloaded artifact is an archive, this should be overridden to provide a
-        relative path in the downloaded archive, e.g. `./bin/protoc`.
+        If the downloaded artifact is an archive, this should be overridden to provide a relative
+        path in the downloaded archive, e.g. `./bin/protoc`.
         """
         return f"./pyenv-{self.version}/bin/pyenv"
 

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -1,6 +1,5 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
 """Support for Python.
 
 See https://www.pantsbuild.org/docs/python-backend.

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -1547,11 +1547,11 @@ class ResolvePythonDistributionEntryPointsRequest:
     """Looks at the entry points to see if it is a setuptools entry point, or a BUILD target address
     that should be resolved into a setuptools entry point.
 
-    If the `entry_points_field` is present, inspect the specified entry points.
-    If the `provides_field` is present, inspect the `provides_field.kwargs["entry_points"]`.
+    If the `entry_points_field` is present, inspect the specified entry points. If the
+    `provides_field` is present, inspect the `provides_field.kwargs["entry_points"]`.
 
-    This is to support inspecting one or the other depending on use case, using the same
-    logic for resolving pex_binary addresses etc.
+    This is to support inspecting one or the other depending on use case, using the same logic for
+    resolving pex_binary addresses etc.
     """
 
     entry_points_field: Optional[PythonDistributionEntryPointsField] = None

--- a/src/python/pants/backend/python/target_types_rules.py
+++ b/src/python/pants/backend/python/target_types_rules.py
@@ -1,6 +1,5 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
 """Rules for the core Python target types.
 
 This is a separate module to avoid circular dependencies. Note that all types used by call sites are

--- a/src/python/pants/backend/python/typecheck/mypy/register.py
+++ b/src/python/pants/backend/python/typecheck/mypy/register.py
@@ -1,6 +1,5 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
 """Type checker for Python.
 
 See https://www.pantsbuild.org/docs/python-linters-and-formatters and

--- a/src/python/pants/backend/python/typecheck/pyright/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/pyright/subsystem.py
@@ -43,8 +43,8 @@ class Pyright(NodeJSToolBase):
         """Pyright will look for a `pyrightconfig.json` or a `pyproject.toml` (with a
         `[tool.pyright]` section) in the project root.
 
-        `pyrightconfig.json` takes precedence if both are present.
-        Pyright's configuration content is specified here:
+        `pyrightconfig.json` takes precedence if both are present. Pyright's configuration content
+        is specified here:
         https://github.com/microsoft/pyright/blob/main/docs/configuration.md.
 
         In order for Pants to work with Pyright, we modify the config file before

--- a/src/python/pants/backend/python/typecheck/pytype/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/pytype/subsystem.py
@@ -45,7 +45,8 @@ class Pytype(PythonToolBase):
         """Pytype will look for a  `pyproject.toml` (with a `[tool.pytype]` section) in the project
         root.
 
-        Pytype's configuration content is specified here: https://github.com/google/pytype#config-
+        Pytype's configuration content is specified here:
+        https://github.com/google/pytype#config-
         file.
         """
 

--- a/src/python/pants/backend/python/util_rules/local_dists.py
+++ b/src/python/pants/backend/python/util_rules/local_dists.py
@@ -135,7 +135,8 @@ class LocalDistsPex:
     `setup.py` / `pyproject.toml`, the dependencies will be included in the standard resolve process
     that the locally-built dists PEX is adjoined to via PEX_PATH. For hand-made `setup.py` /
     `pyproject.toml` with 3rdparty dependencies not hand-mirrored into BUILD file dependencies, this
-    will lead to issues. See https://github.com/pantsbuild/pants/issues/13587#issuecomment-974863636
+    will lead to issues. See
+    https://github.com/pantsbuild/pants/issues/13587#issuecomment-974863636
     for one way to fix this corner which is intentionally punted on for now.
 
     Lists the files provided by the dists on sys.path, so they can be subtracted from

--- a/src/python/pants/backend/python/util_rules/local_dists_pep660.py
+++ b/src/python/pants/backend/python/util_rules/local_dists_pep660.py
@@ -378,13 +378,12 @@ class EditableLocalDistsRequest:
 class EditableLocalDists:
     """A Digest populated by editable (PEP660) wheels of local dists.
 
-    According to PEP660, these wheels should not be exported to users and must be discarded
-    after install. Anything that uses this should ensure that these wheels get installed and
-    then deleted.
+    According to PEP660, these wheels should not be exported to users and must be discarded after
+    install. Anything that uses this should ensure that these wheels get installed and then deleted.
 
-    Installing PEP660 wheels creates an "editable" install such that the sys.path gets
-    adjusted to include source directories from the build root (not from the sandbox).
-    This is decidedly not hermetic or portable and should only be used locally.
+    Installing PEP660 wheels creates an "editable" install such that the sys.path gets adjusted to
+    include source directories from the build root (not from the sandbox). This is decidedly not
+    hermetic or portable and should only be used locally.
 
     PEP660 wheels have .dist-info metadata and the .pth files (or similar) that adjust sys.path.
     """

--- a/src/python/pants/backend/python/util_rules/package_dists.py
+++ b/src/python/pants/backend/python/util_rules/package_dists.py
@@ -168,8 +168,8 @@ class OwnedDependency:
 
     Code in this target is published in the owner's distribution.
 
-    The owner of a target T is T's closest filesystem ancestor among the python_distribution
-    targets that directly or indirectly depend on it (including T itself).
+    The owner of a target T is T's closest filesystem ancestor among the python_distribution targets
+    that directly or indirectly depend on it (including T itself).
     """
 
     target: Target

--- a/src/python/pants/backend/python/util_rules/python_sources.py
+++ b/src/python/pants/backend/python/util_rules/python_sources.py
@@ -25,16 +25,16 @@ from pants.util.logging import LogLevel
 class PythonSourceFiles:
     """Sources that can be introspected by Python, relative to a set of source roots.
 
-    Specifically, this will filter out to only have Python, and, optionally, resource and
-    file targets; and will add any missing `__init__.py` files to ensure that modules are
-    recognized correctly.
+    Specifically, this will filter out to only have Python, and, optionally, resource and file
+    targets; and will add any missing `__init__.py` files to ensure that modules are recognized
+    correctly.
 
-    Use-cases that introspect Python source code (e.g., the `test, `lint`, `fmt` goals) can
-    request this type to get relevant sources that are still relative to their source roots.
-    That way the paths they report are the unstripped ones the user is familiar with.
+    Use-cases that introspect Python source code (e.g., the `test, `lint`, `fmt` goals) can request
+    this type to get relevant sources that are still relative to their source roots. That way the
+    paths they report are the unstripped ones the user is familiar with.
 
-    The sources can also be imported and used by Python (e.g., for the `test` goal), but only
-    if sys.path is modified to include the source roots.
+    The sources can also be imported and used by Python (e.g., for the `test` goal), but only if
+    sys.path is modified to include the source roots.
     """
 
     source_files: SourceFiles

--- a/src/python/pants/backend/visibility/glob.py
+++ b/src/python/pants/backend/visibility/glob.py
@@ -178,11 +178,11 @@ class TargetGlob:
     def __str__(self) -> str:
         """Full syntax:
 
-            <target-type>[path:target-name](tag-1, tag-2)
+        <target-type>[path:target-name](tag-1, tag-2)
 
         If no target-type nor tags:
 
-            path:target-name
+        path:target-name
         """
         type_ = f"<{self.type_}>" if self.type_ else ""
         name = f":{self.name}" if self.name else ""

--- a/src/python/pants/backend/visibility/rule_types.py
+++ b/src/python/pants/backend/visibility/rule_types.py
@@ -209,8 +209,8 @@ class BuildFileVisibilityRules(BuildFileDependencyRules):
     ) -> DependencyRuleApplication:
         """Check all rules for any that apply to the relation between the two targets.
 
-        The `__dependencies_rules__` are the rules applicable for the origin target.
-        The `__dependents_rules__` are the rules applicable for the dependency target.
+        The `__dependencies_rules__` are the rules applicable for the origin target. The
+        `__dependents_rules__` are the rules applicable for the dependency target.
 
         Return dependency rule application describing the resulting action to take: ALLOW, DENY or
         WARN. WARN is effectively the same as ALLOW, but with a logged warning.

--- a/src/python/pants/base/deprecated.py
+++ b/src/python/pants/base/deprecated.py
@@ -46,8 +46,8 @@ class CodeRemovedError(Exception):
 
     I.e., that the option/function/module with that removal_version has already been removed.
 
-    Note that the code in question may not actually have been excised from the codebase yet, but
-    it may be at any time.
+    Note that the code in question may not actually have been excised from the codebase yet, but it
+    may be at any time.
     """
 
 

--- a/src/python/pants/base/exception_sink.py
+++ b/src/python/pants/base/exception_sink.py
@@ -26,9 +26,9 @@ class SignalHandler:
     """A specification for how to handle a fixed set of nonfatal signals.
 
     This is subclassed and registered with ExceptionSink.reset_signal_handler() whenever the signal
-    handling behavior is modified for different pants processes, for example in the remote client when
-    pantsd is enabled. The default behavior is to exit "gracefully" by leaving a detailed log of which
-    signal was received, then exiting with failure.
+    handling behavior is modified for different pants processes, for example in the remote client
+    when pantsd is enabled. The default behavior is to exit "gracefully" by leaving a detailed log
+    of which signal was received, then exiting with failure.
 
     Note that the terminal converts a ctrl-c from the user into a SIGINT.
     """

--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -239,8 +239,8 @@ class RawSpecs:
     Unlike `Specs`, this does not consider include vs. ignore specs. It simply matches all relevant
     targets/files.
 
-    When you want to operate on what the user specified, use `Specs`. Otherwise, you can use
-    either `Specs` or `RawSpecs` in rules, e.g. to find what targets exist in a directory.
+    When you want to operate on what the user specified, use `Specs`. Otherwise, you can use either
+    `Specs` or `RawSpecs` in rules, e.g. to find what targets exist in a directory.
     """
 
     description_of_origin: str

--- a/src/python/pants/core/goals/export.py
+++ b/src/python/pants/core/goals/export.py
@@ -89,8 +89,8 @@ class ExportedBinary:
     be used to abstract details from the name of the tool and avoid the other files in the tool's
     digest.
 
-    For example, "my-tool" might have a downloaded file of
-    "my_tool/my_tool_linux_x86-64.bin" and a readme. We would use `ExportedBinary(name="my-tool",
+    For example, "my-tool" might have a downloaded file of "my_tool/my_tool_linux_x86-64.bin" and a
+    readme. We would use `ExportedBinary(name="my-tool",
     path_in_export=my_tool/my_tool_linux_x86-64.bin"`
     """
 

--- a/src/python/pants/core/goals/generate_lockfiles.py
+++ b/src/python/pants/core/goals/generate_lockfiles.py
@@ -46,11 +46,11 @@ class GenerateLockfile:
     """A union base for generating ecosystem-specific lockfiles.
 
     Each language ecosystem should set up a subclass of `GenerateLockfile`, like
-    `GeneratePythonLockfile` and `GenerateJVMLockfile`, and register a union rule. They should
-    also set up a simple rule that goes from that class -> `WrappedGenerateLockfile`.
+    `GeneratePythonLockfile` and `GenerateJVMLockfile`, and register a union rule. They should also
+    set up a simple rule that goes from that class -> `WrappedGenerateLockfile`.
 
-    Subclasses will usually want to add additional properties, such as what requirements to
-    install and Python interpreter constraints.
+    Subclasses will usually want to add additional properties, such as what requirements to install
+    and Python interpreter constraints.
     """
 
     resolve_name: str

--- a/src/python/pants/core/goals/package.py
+++ b/src/python/pants/core/goals/package.py
@@ -220,12 +220,12 @@ async def package_asset(workspace: Workspace, dist_dir: DistDir) -> Package:
 class TraverseIfNotPackageTarget(ShouldTraverseDepsPredicate):
     """This predicate stops dep traversal after package targets.
 
-    When traversing deps, such as when collecting a list of transitive deps,
-    this predicate effectively turns any package targets into graph leaf nodes.
-    The package targets are included, but the deps of package targets are not.
+    When traversing deps, such as when collecting a list of transitive deps, this predicate
+    effectively turns any package targets into graph leaf nodes. The package targets are included,
+    but the deps of package targets are not.
 
-    Also, this excludes dependencies from any SpecialCasedDependencies fields,
-    which mirrors the behavior of the default predicate: TraverseIfDependenciesField.
+    Also, this excludes dependencies from any SpecialCasedDependencies fields, which mirrors the
+    behavior of the default predicate: TraverseIfDependenciesField.
     """
 
     package_field_set_types: FrozenOrderedSet[PackageFieldSet]

--- a/src/python/pants/core/goals/run.py
+++ b/src/python/pants/core/goals/run.py
@@ -150,9 +150,9 @@ class RunInSandboxRequest(RunRequest):
 
     Presently, implementors can opt to use the existing as not guaranteeing hermeticity, which will
     internally mark the rule as uncacheable. In such a case, non-safe APIs can be used, however,
-    this behavior can result in poorer performance, and only exists as a stop-gap while
-    implementors work to make sure their `RunRequest`-generating rules can be used in a hermetic
-    context, or writing new custom rules. (See the Plugin Upgrade Guide for details).
+    this behavior can result in poorer performance, and only exists as a stop-gap while implementors
+    work to make sure their `RunRequest`-generating rules can be used in a hermetic context, or
+    writing new custom rules. (See the Plugin Upgrade Guide for details).
     """
 
 

--- a/src/python/pants/core/register.py
+++ b/src/python/pants/core/register.py
@@ -1,6 +1,5 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
 """Core rules for Pants to operate correctly.
 
 These are always activated and cannot be disabled.

--- a/src/python/pants/core/util_rules/adhoc_binaries.py
+++ b/src/python/pants/core/util_rules/adhoc_binaries.py
@@ -25,7 +25,8 @@ from pants.util.logging import LogLevel
 class PythonBuildStandaloneBinary:
     """A Python interpreter for use by `@rule` code as an alternative to BashBinary scripts.
 
-    This interpreter is provided by Python Build Standalone https://gregoryszorc.com/docs/python-build-standalone/main/,
+    This interpreter is provided by Python Build Standalone
+    https://gregoryszorc.com/docs/python-build-standalone/main/,
     which has a few caveats. Namely it doesn't play nicely with third-party sdists. Meaning Pants'
     scripts being run by Python Build Standalone should avoid third-party sdists.
     """

--- a/src/python/pants/core/util_rules/environments.py
+++ b/src/python/pants/core/util_rules/environments.py
@@ -547,8 +547,9 @@ class EnvironmentTarget:
         session (i.e. Pants run), but we instead settle for every Pantsd lifetime to have more
         acceptable performance.
 
-        Meanwhile, when running with Docker, we already invalidate whenever the image changes
-        thanks to https://github.com/pantsbuild/pants/pull/17101.
+        Meanwhile, when running with Docker, we already invalidate whenever the image changes thanks
+        to
+        https://github.com/pantsbuild/pants/pull/17101.
 
         Remote execution often is safe to cache, but depends on the remote execution server.
         So, we rely on the user telling us what is safe.

--- a/src/python/pants/core/util_rules/external_tool.py
+++ b/src/python/pants/core/util_rules/external_tool.py
@@ -228,8 +228,8 @@ class ExternalTool(Subsystem, ExportableTool, ExternalToolOptionsMixin, metaclas
 
         If the downloaded artifact is the executable itself, you can leave this unimplemented.
 
-        If the downloaded artifact is an archive, this should be overridden to provide a
-        relative path in the downloaded archive, e.g. `./bin/protoc`.
+        If the downloaded artifact is an archive, this should be overridden to provide a relative
+        path in the downloaded archive, e.g. `./bin/protoc`.
         """
         return f"./{self.generate_url(plat).rsplit('/', 1)[-1]}"
 

--- a/src/python/pants/core/util_rules/lockfile_metadata.py
+++ b/src/python/pants/core/util_rules/lockfile_metadata.py
@@ -75,9 +75,9 @@ class NoLockfileMetadataBlock(InvalidLockfileError):
 class LockfileMetadata:
     """Base class for metadata that is attached to a given lockfile.
 
-    This class provides the external API for serializing, deserializing, and validating the
-    contents of individual lockfiles. New versions of metadata implement a concrete subclass and
-    provide deserialization and validation logic, along with specialist serialization logic.
+    This class provides the external API for serializing, deserializing, and validating the contents
+    of individual lockfiles. New versions of metadata implement a concrete subclass and provide
+    deserialization and validation logic, along with specialist serialization logic.
 
     To construct an instance of the most recent concrete subclass, call `LockfileMetadata.new()`.
     """

--- a/src/python/pants/core/util_rules/partitions.py
+++ b/src/python/pants/core/util_rules/partitions.py
@@ -1,6 +1,5 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
 """Contains the "base" code for plugin APIs which require partitioning."""
 
 from __future__ import annotations
@@ -29,7 +28,7 @@ class PartitionerType(Enum):
     """The plugin author has a rule to go from `RequestType.PartitionRequest` -> `Partitions`."""
 
     DEFAULT_SINGLE_PARTITION = "default_single_partition"
-    """Registers a partitioner which returns the inputs as a single partition
+    """Registers a partitioner which returns the inputs as a single partition.
 
     The returned partition will have no metadata.
     """

--- a/src/python/pants/engine/addresses.py
+++ b/src/python/pants/engine/addresses.py
@@ -41,21 +41,21 @@ class UnparsedAddressInputs:
 
     You can convert these into fully normalized `Addresses` and `Targets` like this:
 
-        await Get(Addresses, UnparsedAddressInputs(["//:tgt1", "//:tgt2"], owning_address=None)
-        await Get(Targets, UnparsedAddressInputs([...], owning_address=Address("original"))
+    await Get(Addresses, UnparsedAddressInputs(["//:tgt1", "//:tgt2"], owning_address=None) await
+    Get(Targets, UnparsedAddressInputs([...], owning_address=Address("original"))
 
     This is intended for contexts where the user specifies addresses outside of the `dependencies`
     field, such as through an option or a special field on a target that is not normal
-    `dependencies`. You should not use this to resolve the `dependencies` field; use
-    `await Get(Addresses, DependenciesRequest)` for that.
+    `dependencies`. You should not use this to resolve the `dependencies` field; use `await
+    Get(Addresses, DependenciesRequest)` for that.
 
     If the addresses are coming from a target's fields, set `owning_address` so that relative
     references like `:sibling` work properly.
 
     Unlike the `dependencies` field, this type does not work with `!` and `!!` ignores.
 
-    Set `description_of_origin` to a value like "CLI arguments" or "the `dependencies` field
-    from {tgt.address}". It is used for better error messages.
+    Set `description_of_origin` to a value like "CLI arguments" or "the `dependencies` field from
+    {tgt.address}". It is used for better error messages.
     """
 
     values: tuple[str, ...]

--- a/src/python/pants/engine/download_file.py
+++ b/src/python/pants/engine/download_file.py
@@ -51,7 +51,8 @@ class URLDownloadHandler:
     """
 
     match_authority: ClassVar[Optional[str]] = None
-    """The authority to match (e.g. 'pantsbuild.org' or 's3.amazonaws.com') or `None` to match all authorities.
+    """The authority to match (e.g. 'pantsbuild.org' or 's3.amazonaws.com') or `None` to match all
+    authorities.
 
     The authority is matched using `fnmatch`, see https://docs.python.org/3/library/fnmatch.html for more
     information.

--- a/src/python/pants/engine/env_vars.py
+++ b/src/python/pants/engine/env_vars.py
@@ -26,12 +26,12 @@ class CompleteEnvironmentVars(FrozenDict):
     ) -> FrozenDict[str, str]:
         """Extract a subset of named env vars.
 
-        Given a list of extra environment variable specifiers as strings, filter the contents of
-        the Pants environment to only those variables.
+        Given a list of extra environment variable specifiers as strings, filter the contents of the
+        Pants environment to only those variables.
 
-        Each variable can be specified either as a name or as a name=value pair.
-        In the former case, the value for that name is taken from this env. In the latter
-        case the specified value overrides the value in this env.
+        Each variable can be specified either as a name or as a name=value pair. In the former case,
+        the value for that name is taken from this env. In the latter case the specified value
+        overrides the value in this env.
 
         If `allowed` is specified, the requested variable names must be in that list, or an error
         will be raised.
@@ -86,8 +86,8 @@ class EnvironmentVars(FrozenDict[str, str]):
     environment should use APIs from this module instead.
 
     Wherever possible, the `EnvironmentVars` type should be consumed rather than the
-    `CompleteEnvironmentVars`, as it represents a filtered/relevant subset of the environment, rather
-    than the entire unfiltered environment.
+    `CompleteEnvironmentVars`, as it represents a filtered/relevant subset of the environment,
+    rather than the entire unfiltered environment.
     """
 
 

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -135,8 +135,8 @@ class CreateDigest(Collection[Union[FileContent, FileEntry, SymlinkEntry, Direct
     values.
 
     The engine will create any parent directories necessary, e.g. `FileContent('a/b/c.txt')` will
-    result in `a/`, `a/b`, and `a/b/c.txt` being created. You only need to use `Directory` to
-    create an empty directory.
+    result in `a/`, `a/b`, and `a/b/c.txt` being created. You only need to use `Directory` to create
+    an empty directory.
 
     This does _not_ actually materialize the digest to the build root. You must use
     `engine.fs.Workspace` in a `@goal_rule` to save the resulting digest to disk.
@@ -259,13 +259,13 @@ class DownloadFile:
 class NativeDownloadFile:
     """Retrieve the contents of a file via an HTTP GET request or directly for local file:// URLs.
 
-    This request is handled directly by the native engine without any additional coercion by plugins,
-    and therefore should only be used in cases where the URL is known to be publicly accessible.
-    Otherwise, callers should use `DownloadFile`.
+    This request is handled directly by the native engine without any additional coercion by
+    plugins, and therefore should only be used in cases where the URL is known to be publicly
+    accessible. Otherwise, callers should use `DownloadFile`.
 
-    The auth_headers are part of this nodes' cache key for memoization (changing a header invalidates
-    prior results) but are not part of the underlying cache key for the local/remote cache (changing
-    a header won't re-download a file if the file was previously downloaded).
+    The auth_headers are part of this nodes' cache key for memoization (changing a header
+    invalidates prior results) but are not part of the underlying cache key for the local/remote
+    cache (changing a header won't re-download a file if the file was previously downloaded).
     """
 
     url: str

--- a/src/python/pants/engine/goal.py
+++ b/src/python/pants/engine/goal.py
@@ -90,7 +90,6 @@ class Goal:
         """
 
         LOCAL_ONLY = 2
-
         f""" Indicates that the goal chooses the environments to use to execute rules within the goal.
 
         This requires migration work to be done by the goal author. See
@@ -100,7 +99,6 @@ class Goal:
 
     exit_code: int
     subsystem_cls: ClassVar[Type[GoalSubsystem]]
-
     f"""Indicates that a Goal has been migrated to compute EnvironmentNames to build targets in.
 
     All goals in `pantsbuild/pants` should be migrated before the 2.15.x branch is cut, but end
@@ -125,7 +123,8 @@ class Outputting:
 
     Allows output to go to a file or to stdout.
 
-    Useful for goals whose purpose is to emit output to the end user (as distinct from incidental logging to stderr).
+    Useful for goals whose purpose is to emit output to the end user (as distinct from incidental
+    logging to stderr).
     """
 
     output_file = StrOption(

--- a/src/python/pants/engine/internals/dep_rules.py
+++ b/src/python/pants/engine/internals/dep_rules.py
@@ -106,8 +106,8 @@ class BuildFileDependencyRules(ABC):
     ) -> DependencyRuleApplication:
         """Check all rules for any that apply to the relation between the two targets.
 
-        The `__dependencies_rules__` are the rules applicable for the origin target.
-        The `__dependents_rules__` are the rules applicable for the dependency target.
+        The `__dependencies_rules__` are the rules applicable for the origin target. The
+        `__dependents_rules__` are the rules applicable for the dependency target.
 
         Return dependency rule application describing the resulting action to take: ALLOW, DENY or
         WARN. WARN is effectively the same as ALLOW, but with a logged warning.

--- a/src/python/pants/engine/internals/native_engine.pyi
+++ b/src/python/pants/engine/internals/native_engine.pyi
@@ -412,8 +412,8 @@ class Snapshot:
     You can lift a `Digest` to a `Snapshot` with `await Get(Snapshot, Digest, my_digest)`.
 
     The `files` and `dirs` properties are symlink oblivious. If you require knowing about symlinks,
-    you can use the `digest` property to request the `DigestEntries`:
-    `await Get(DigestEntries, Digest, snapshot.digest)`.
+    you can use the `digest` property to request the `DigestEntries`: `await Get(DigestEntries,
+    Digest, snapshot.digest)`.
     """
 
     @classmethod

--- a/src/python/pants/engine/internals/synthetic_targets.py
+++ b/src/python/pants/engine/internals/synthetic_targets.py
@@ -122,8 +122,7 @@ class SyntheticTargetsRequest:
     SINGLE_REQUEST_FOR_ALL_TARGETS: ClassVar[str] = ""
 
     path: str = REQUEST_TARGETS_PER_DIRECTORY
-    """
-    The default field value is used to filter which paths to request targets for, and should be
+    """The default field value is used to filter which paths to request targets for, and should be
     declared as appropriate by union members subclassing `SyntheticTargetsRequest`. The
     SINGLE_REQUEST_FOR_ALL_TARGETS will make a single request for all targets at once, while
     REQUEST_TARGETS_PER_DIRECTORY will request all targets for a particular path at a time. Any

--- a/src/python/pants/engine/internals/target_adaptor.py
+++ b/src/python/pants/engine/internals/target_adaptor.py
@@ -22,8 +22,8 @@ class SourceBlock:
 
     Lines are 1 indexed, `start` is inclusive, `end` is exclusive.
 
-    SourceBlock is used to describe a set of source lines that are owned by a Target,
-    thus it can't be empty, i.e. `start` must be less than `end`.
+    SourceBlock is used to describe a set of source lines that are owned by a Target, thus it can't
+    be empty, i.e. `start` must be less than `end`.
     """
 
     start: int

--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -401,12 +401,12 @@ class InteractiveProcess(SideEffecting):
 
         Unlike `Process`, the result will not be cached.
 
-        To run the process, use `await Effect(InteractiveProcessResult, InteractiveProcess(..))`
-        in a `@goal_rule`.
+        To run the process, use `await Effect(InteractiveProcessResult, InteractiveProcess(..))` in
+        a `@goal_rule`.
 
-        `forward_signals_to_process` controls whether pants will allow a SIGINT signal
-        sent to a process by hitting Ctrl-C in the terminal to actually reach the process,
-        or capture that signal itself, blocking it from the process.
+        `forward_signals_to_process` controls whether pants will allow a SIGINT signal sent to a
+        process by hitting Ctrl-C in the terminal to actually reach the process, or capture that
+        signal itself, blocking it from the process.
         """
         object.__setattr__(
             self,

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -507,12 +507,12 @@ class Target:
     def __getitem__(self, field: Type[_F]) -> _F:
         """Get the requested `Field` instance belonging to this target.
 
-        If the `Field` is not registered on this `Target` type, this method will raise a
-        `KeyError`. To avoid this, you should first call `tgt.has_field()` or `tgt.has_fields()`
-        to ensure that the field is registered, or, alternatively, use `Target.get()`.
+        If the `Field` is not registered on this `Target` type, this method will raise a `KeyError`.
+        To avoid this, you should first call `tgt.has_field()` or `tgt.has_fields()` to ensure that
+        the field is registered, or, alternatively, use `Target.get()`.
 
-        See the docstring for `Target.get()` for how this method handles subclasses of the
-        requested Field and for tips on how to use the returned value.
+        See the docstring for `Target.get()` for how this method handles subclasses of the requested
+        Field and for tips on how to use the returned value.
         """
         result = self._maybe_get(field)
         if result is not None:
@@ -529,19 +529,19 @@ class Target:
         """Get the requested `Field` instance belonging to this target.
 
         This will return an instance of the requested field type, e.g. an instance of
-        `InterpreterConstraints`, `SourcesField`, `EntryPoint`, etc. Usually, you will want to
-        grab the `Field`'s inner value, e.g. `tgt.get(Compatibility).value`. (For async fields like
+        `InterpreterConstraints`, `SourcesField`, `EntryPoint`, etc. Usually, you will want to grab
+        the `Field`'s inner value, e.g. `tgt.get(Compatibility).value`. (For async fields like
         `SourcesField`, you may need to hydrate the value.).
 
-        This works with subclasses of `Field`. For example, if you subclass `Tags`
-        to define a custom subclass `CustomTags`, both `tgt.get(Tags)` and
-        `tgt.get(CustomTags)` will return the same `CustomTags` instance.
+        This works with subclasses of `Field`. For example, if you subclass `Tags` to define a
+        custom subclass `CustomTags`, both `tgt.get(Tags)` and `tgt.get(CustomTags)` will return the
+        same `CustomTags` instance.
 
-        If the `Field` is not registered on this `Target` type, this will return an instance of
-        the requested Field by using `default_raw_value` to create the instance. Alternatively,
-        first call `tgt.has_field()` or `tgt.has_fields()` to ensure that the field is registered,
-        or, alternatively, use indexing (e.g. `tgt[Compatibility]`) to raise a KeyError when the
-        field is not registered.
+        If the `Field` is not registered on this `Target` type, this will return an instance of the
+        requested Field by using `default_raw_value` to create the instance. Alternatively, first
+        call `tgt.has_field()` or `tgt.has_fields()` to ensure that the field is registered, or,
+        alternatively, use indexing (e.g. `tgt[Compatibility]`) to raise a KeyError when the field
+        is not registered.
         """
         result = self._maybe_get(field)
         if result is not None:
@@ -1289,16 +1289,15 @@ def _generate_file_level_targets(
     Set `add_dependencies_on_all_siblings` to True so that each file-level target depends on all
     other generated targets from the target generator. This is useful if both are true:
 
-        a) file-level targets usually need their siblings to be present to work. Most target types
-          (Python, Java, Shell, etc) meet this, except for `files` and `resources` which have no
-          concept of "imports"
-        b) dependency inference cannot infer dependencies on sibling files.
+    a) file-level targets usually need their siblings to be present to work. Most target types
+    (Python, Java, Shell, etc) meet this, except for `files` and `resources` which have no   concept
+    of "imports" b) dependency inference cannot infer dependencies on sibling files.
 
-    Otherwise, set `add_dependencies_on_all_siblings` to `False` so that dependencies are
-    finer-grained.
+    Otherwise, set `add_dependencies_on_all_siblings` to `False` so that dependencies are finer-
+    grained.
 
-    `overrides` allows changing the fields for particular targets. It expects the full file path
-     as the key.
+    `overrides` allows changing the fields for particular targets. It expects the full file path  as
+    the key.
     """
 
     # Paths will have already been globbed, so they should be escaped. See
@@ -1619,7 +1618,7 @@ class InvalidTargetException(Exception):
 
     Suggested template:
 
-         f"The `{alias!r}` target {address} ..."
+    f"The `{alias!r}` target {address} ..."
     """
 
     def __init__(self, message: Any, *, description_of_origin: str | None = None) -> None:
@@ -1646,7 +1645,7 @@ class InvalidFieldException(Exception):
 
     Suggested template:
 
-         f"The {alias!r} field in target {address} must ..., but ..."
+    f"The {alias!r} field in target {address} must ..., but ..."
     """
 
     def __init__(self, message: Any, *, description_of_origin: str | None = None) -> None:
@@ -2267,17 +2266,11 @@ class SourcesField(AsyncFieldMixin, Field):
         and the engine will generate the sources if possible or will return an instance of
         HydratedSources with an empty snapshot if not possible:
 
-            await Get(
-                HydratedSources,
-                HydrateSourcesRequest(
-                    sources_field,
-                    for_sources_types=[FortranSources],
-                    enable_codegen=True,
-                )
-            )
+        await Get(     HydratedSources,     HydrateSourcesRequest(         sources_field,
+        for_sources_types=[FortranSources],         enable_codegen=True,     ) )
 
-        This method is useful when you need to filter targets before hydrating them, such as how
-        you may filter targets via `tgt.has_field(MyField)`.
+        This method is useful when you need to filter targets before hydrating them, such as how you
+        may filter targets via `tgt.has_field(MyField)`.
         """
         generate_request_types = union_membership.get(GenerateSourcesRequest)
         return any(
@@ -2723,9 +2716,8 @@ class ExplicitlyProvidedDependencies:
     """The literal addresses from a BUILD file `dependencies` field.
 
     Almost always, you should use `await Get(Addresses, DependenciesRequest)` instead, which will
-    consider dependency inference and apply ignores. However, this type can be
-    useful particularly within inference rules to see if a user already explicitly
-    provided a dependency.
+    consider dependency inference and apply ignores. However, this type can be useful particularly
+    within inference rules to see if a user already explicitly provided a dependency.
 
     Resolve using `await Get(ExplicitlyProvidedDependencies, DependenciesRequest)`.
 
@@ -2755,9 +2747,9 @@ class ExplicitlyProvidedDependencies:
     ) -> frozenset[Address]:
         """All addresses that remain after ineligible candidates are discarded.
 
-        Candidates are removed if they appear as ignores (`!` and `!!)` in the `dependencies`
-        field. Note that if the input addresses are generated targets, they will still be marked as
-        covered if their original target generator is in the explicitly provided ignores.
+        Candidates are removed if they appear as ignores (`!` and `!!)` in the `dependencies` field.
+        Note that if the input addresses are generated targets, they will still be marked as covered
+        if their original target generator is in the explicitly provided ignores.
 
         Candidates are also removed if `owners_must_be_ancestors` is True and the targets are not
         ancestors, e.g. `root2:tgt` is not a valid candidate for something defined in `root1`.
@@ -2982,13 +2974,12 @@ class SpecialCasedDependencies(StringSequenceField, AsyncFieldMixin):
     """Subclass this for fields that act similarly to the `dependencies` field, but are handled
     differently than normal dependencies.
 
-    For example, you might have a field for package/binary dependencies, which you will call
-    the equivalent of `./pants package` on. While you could put these in the normal
-    `dependencies` field, it is often clearer to the user to call out this magic through a
-    dedicated field.
+    For example, you might have a field for package/binary dependencies, which you will call the
+    equivalent of `./pants package` on. While you could put these in the normal `dependencies`
+    field, it is often clearer to the user to call out this magic through a dedicated field.
 
-    This type will ensure that the dependencies show up in project introspection,
-    like `dependencies` and `dependents`, but not show up when you call `Get(TransitiveTargets,
+    This type will ensure that the dependencies show up in project introspection, like
+    `dependencies` and `dependents`, but not show up when you call `Get(TransitiveTargets,
     TransitiveTargetsRequest)` and `Get(Addresses, DependenciesRequest)`.
 
     To hydrate this field's dependencies, use `await Get(Addresses, UnparsedAddressInputs,

--- a/src/python/pants/engine/unions.py
+++ b/src/python/pants/engine/unions.py
@@ -40,11 +40,12 @@ def union(
 
     By default, in order to provide a stable extension API, when a `@union` is used in a `Get`,
     _only_ the provided parameter is available to callees, But in order to expand its API, a
-    `@union` declaration may optionally include additional "in_scope_types", which are types
-    which must already be in scope at callsites where the `@union` is used in a `Get`, and
-    which are propagated to the callee.
+    `@union` declaration may optionally include additional "in_scope_types", which are types which
+    must already be in scope at callsites where the `@union` is used in a `Get`, and which are
+    propagated to the callee.
 
-    See https://www.pantsbuild.org/docs/rules-api-unions.
+    See
+    https://www.pantsbuild.org/docs/rules-api-unions.
     """
 
     def decorator(cls: _T) -> _T:

--- a/src/python/pants/goal/auxiliary_goal.py
+++ b/src/python/pants/goal/auxiliary_goal.py
@@ -34,13 +34,13 @@ class AuxiliaryGoal(ABC, GoalSubsystem):
     Only a single auxiliary goal is executed per run, any remaining goals/arguments are passed
     unaltered to the auxiliary goal. Auxiliary goals have precedence over regular goals.
 
-    When multiple auxiliary goals are presented, the first auxiliary goal will be used unless there is a
-    auxiliary goal that begin with a hyphen (`-`), in which case the last such "option goal" will be
-    prioritized. This is to support things like `./pants some-builtin-goal --help`.
+    When multiple auxiliary goals are presented, the first auxiliary goal will be used unless there
+    is a auxiliary goal that begin with a hyphen (`-`), in which case the last such "option goal"
+    will be prioritized. This is to support things like `./pants some-builtin-goal --help`.
 
-    The intended use for this API is rule code which runs a server (for example, a BSP server)
-    which provides an alternate interface to the Pants rule engine, or other kinds of goals
-    which must run "outside" of the usual engine processing to function.
+    The intended use for this API is rule code which runs a server (for example, a BSP server) which
+    provides an alternate interface to the Pants rule engine, or other kinds of goals which must run
+    "outside" of the usual engine processing to function.
     """
 
     # Used by `pants.option.arg_splitter.ArgSplitter()` to optionally allow aliasing auxiliary goals.

--- a/src/python/pants/jvm/compile_test.py
+++ b/src/python/pants/jvm/compile_test.py
@@ -1,6 +1,5 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
 """Tests of multi-language JVM compilation.
 
 Tests of individual compilers should generally be written directly against the relevant `@rules`,

--- a/src/python/pants/jvm/resolve/coordinate.py
+++ b/src/python/pants/jvm/resolve/coordinate.py
@@ -106,7 +106,8 @@ class Coordinate:
 
         The CLI input format uses trailing key-val attributes to specify `packaging`, `url`, etc.
 
-        See https://github.com/coursier/coursier/blob/b5d5429a909426f4465a9599d25c678189a54549/modules/coursier/shared/src/test/scala/coursier/parse/DependencyParserTests.scala#L7
+        See
+        https://github.com/coursier/coursier/blob/b5d5429a909426f4465a9599d25c678189a54549/modules/coursier/shared/src/test/scala/coursier/parse/DependencyParserTests.scala#L7
         """
         attrs = dict(extra_attrs or {})
         if self.packaging != "jar":

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -569,19 +569,18 @@ async def coursier_fetch_one_coord(
 ) -> ClasspathEntry:
     """Run `coursier fetch --intransitive` to fetch a single artifact.
 
-    This rule exists to permit efficient subsetting of a "global" classpath
-    in the form of a lockfile.  Callers can determine what subset of dependencies
-    from the lockfile are needed for a given target, then request those
-    lockfile entries individually.
+    This rule exists to permit efficient subsetting of a "global" classpath in the form of a
+    lockfile.  Callers can determine what subset of dependencies from the lockfile are needed for a
+    given target, then request those lockfile entries individually.
 
-    By fetching only one entry at a time, we maximize our cache efficiency.  If instead
-    we fetched the entire subset that the caller wanted, there would be a different cache
-    key for every possible subset.
+    By fetching only one entry at a time, we maximize our cache efficiency.  If instead we fetched
+    the entire subset that the caller wanted, there would be a different cache key for every
+    possible subset.
 
-    This rule also guarantees exact reproducibility.  If all caches have been
-    removed, `coursier fetch` will re-download the artifact, and this rule will
-    confirm that what was downloaded matches exactly (by content digest) what
-    was specified in the lockfile (what Coursier originally downloaded).
+    This rule also guarantees exact reproducibility.  If all caches have been removed, `coursier
+    fetch` will re-download the artifact, and this rule will confirm that what was downloaded
+    matches exactly (by content digest) what was specified in the lockfile (what Coursier originally
+    downloaded).
     """
 
     # Prepare any URL- or JAR-specifying entries for use with Coursier

--- a/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
@@ -548,11 +548,12 @@ def test_fetch_one_coord_with_bad_length(rule_runner: RuleRunner) -> None:
 def test_fetch_one_coord_with_mismatched_coord(rule_runner: RuleRunner) -> None:
     """This test demonstrates that fetch_one_coord is picky about inexact coordinates.
 
-    Even though the expected jar was downloaded, the coordinate in the lockfile entry was inexact, meaning
-    it wasn't an exact string match for the coordinate fetched and reported by Coursier, which is exact.
+    Even though the expected jar was downloaded, the coordinate in the lockfile entry was inexact,
+    meaning it wasn't an exact string match for the coordinate fetched and reported by Coursier,
+    which is exact.
 
-    This shouldn't happen in practice, because these lockfile entries are ultimately derived from Coursier
-    reports which always give exact coordinate strings.
+    This shouldn't happen in practice, because these lockfile entries are ultimately derived from
+    Coursier reports which always give exact coordinate strings.
     """
     expected_exception_msg = (
         r'Coursier resolved coord.*?"org.hamcrest:hamcrest-core:1.3".*?'

--- a/src/python/pants/jvm/resolve/lockfile_metadata.py
+++ b/src/python/pants/jvm/resolve/lockfile_metadata.py
@@ -66,8 +66,8 @@ class JVMLockfileMetadataV1(JVMLockfileMetadata):
     User validity is tested by the set of user requirements strings appearing as a subset of those
     in the metadata requirements.
 
-    Tool validity is tested by the set of user requirements strings being an exact match of those
-    in the metadata requirements.
+    Tool validity is tested by the set of user requirements strings being an exact match of those in
+    the metadata requirements.
     """
 
     requirements: FrozenOrderedSet[str]

--- a/src/python/pants/jvm/target_types.py
+++ b/src/python/pants/jvm/target_types.py
@@ -602,8 +602,8 @@ class JvmRequiredMainClassNameField(JvmMainClassNameField):
 class JvmShadingRule(ABC):
     """Base class for defining JAR shading rules as valid aliases in BUILD files.
 
-    Subclasses need to provide with an `alias` and a `help` message. The `alias` represents
-    the name that will be used in BUILD files to instantiate the given subclass.
+    Subclasses need to provide with an `alias` and a `help` message. The `alias` represents the name
+    that will be used in BUILD files to instantiate the given subclass.
 
     Set the `help` class property with a description, which will be used in `./pants help`. For the
     best rendering, use soft wrapping (e.g. implicit string concatenation) within paragraphs, but

--- a/src/python/pants/option/arg_splitter.py
+++ b/src/python/pants/option/arg_splitter.py
@@ -74,10 +74,8 @@ class ArgSplitter:
 
     Recognizes, e.g.:
 
-    pants check --foo lint target1: dir f.ext
-    pants --global-opt check target1: dir f.ext --check-flag
-    pants --check-flag check target1: dir f.ext
-    pants goal -- passthru foo
+    pants check --foo lint target1: dir f.ext pants --global-opt check target1: dir f.ext --check-
+    flag pants --check-flag check target1: dir f.ext pants goal -- passthru foo
     """
 
     def __init__(self, known_scope_infos: Iterable[ScopeInfo], buildroot: str) -> None:

--- a/src/python/pants/option/config.py
+++ b/src/python/pants/option/config.py
@@ -65,8 +65,8 @@ class Config:
     ) -> Config:
         """Loads config from the given string payloads, with later payloads overriding earlier ones.
 
-        A handful of seed values, plus the values in the DEFAULT section, will be available for use in
-        substitutions.  The caller may override some of these seed values.
+        A handful of seed values, plus the values in the DEFAULT section, will be available for use
+        in substitutions.  The caller may override some of these seed values.
 
         If an `env` is supplied, it is exposed as `env` object available for interpolation via dot
         access of the environment variable names (e.g.: `env.HOME`).

--- a/src/python/pants/option/custom_types.py
+++ b/src/python/pants/option/custom_types.py
@@ -207,8 +207,8 @@ class ListValueComponent:
     A component consists of values to append and values to filter while constructing the final list.
 
     Each component may either replace or modify the preceding component.  So that, e.g., a config
-    file can append to and/or filter the default value list, instead of having to repeat most
-    of the contents of the default value list.
+    file can append to and/or filter the default value list, instead of having to repeat most of the
+    contents of the default value list.
     """
 
     REPLACE = "REPLACE"

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -258,9 +258,9 @@ class AuthPluginResult:
     """The return type for a function specified via `[GLOBAL].remote_auth_plugin`.
 
     The returned `store_headers` and `execution_headers` will replace whatever headers Pants would
-    have used normally, e.g. what is set with `[GLOBAL].remote_store_headers`. This allows you to control
-    the merge strategy if your plugin sets conflicting headers. Usually, you will want to preserve
-    the `initial_store_headers` and `initial_execution_headers` passed to the plugin.
+    have used normally, e.g. what is set with `[GLOBAL].remote_store_headers`. This allows you to
+    control the merge strategy if your plugin sets conflicting headers. Usually, you will want to
+    preserve the `initial_store_headers` and `initial_execution_headers` passed to the plugin.
 
     If set, the returned `instance_name` will override `[GLOBAL].remote_instance_name`,
     `store_address` will override `[GLOBAL].remote_store_address`, and `execution_address` will
@@ -2003,9 +2003,9 @@ class GlobalOptions(BootstrapOptions, Subsystem):
         """Validates an instance of global options for cases that are not prohibited via
         registration.
 
-        For example: mutually exclusive options may be registered by passing a `mutually_exclusive_group`,
-        but when multiple flags must be specified together, it can be necessary to specify post-parse
-        checks.
+        For example: mutually exclusive options may be registered by passing a
+        `mutually_exclusive_group`, but when multiple flags must be specified together, it can be
+        necessary to specify post-parse checks.
 
         Raises pants.option.errors.OptionsError on validation failure.
         """

--- a/src/python/pants/option/option_types.py
+++ b/src/python/pants/option/option_types.py
@@ -219,8 +219,8 @@ class _ListOptionBase(
 
     Don't use this class directly, instead use one of the concrete classes below.
 
-    The default value will always be set as an empty list, and the Python property always returns
-    a tuple (for immutability).
+    The default value will always be set as an empty list, and the Python property always returns a
+    tuple (for immutability).
     """
 
     option_type = list

--- a/src/python/pants/option/option_value_container.py
+++ b/src/python/pants/option/option_value_container.py
@@ -51,13 +51,13 @@ class OptionValueContainer:
 
     Implements "value ranking":
 
-       Attribute values can be ranked, so that a given attribute's value can only be changed if
-       the new value has at least as high a rank as the old value. This allows an option value in
-       an outer scope to override that option's value in an inner scope, when the outer scope's
-       value comes from a higher ranked source (e.g., the outer value comes from an env var and
-       the inner one from config).
+    Attribute values can be ranked, so that a given attribute's value can only be changed if the new
+    value has at least as high a rank as the old value. This allows an option value in an outer
+    scope to override that option's value in an inner scope, when the outer scope's value comes from
+    a higher ranked source (e.g., the outer value comes from an env var and the inner one from
+    config).
 
-       See ranked_value.py for more details.
+    See ranked_value.py for more details.
     """
 
     _value_map: dict[Key, RankedValue]

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -339,11 +339,11 @@ class Options:
     def _check_and_apply_deprecations(self, scope, values):
         """Checks whether a ScopeInfo has options specified in a deprecated scope.
 
-        There are two related cases here. Either:
-          1) The ScopeInfo has an associated deprecated_scope that was replaced with a non-deprecated
-             scope, meaning that the options temporarily live in two locations.
-          2) The entire ScopeInfo is deprecated (as in the case of deprecated SubsystemDependencies),
-             meaning that the options live in one location.
+        There are two related cases here. Either:   1) The ScopeInfo has an associated
+        deprecated_scope that was replaced with a non-deprecated      scope, meaning that the
+        options temporarily live in two locations.   2) The entire ScopeInfo is deprecated (as in
+        the case of deprecated SubsystemDependencies),      meaning that the options live in one
+        location.
 
         In the first case, this method has the side effect of merging options values from deprecated
         scopes into the given values.

--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -53,11 +53,11 @@ class OptionsBootstrapper:
         """Get the location of the config files.
 
         The locations are specified by the --pants-config-files option.  However we need to load the
-        config in order to process the options.  This method special-cases --pants-config-files
-        in order to solve this chicken-and-egg problem.
+        config in order to process the options.  This method special-cases --pants-config-files in
+        order to solve this chicken-and-egg problem.
 
-        Note that, obviously, it's not possible to set the location of config files in a config file.
-        Doing so will have no effect.
+        Note that, obviously, it's not possible to set the location of config files in a config
+        file. Doing so will have no effect.
         """
         # This exactly mirrors the logic applied in Option to all regular options.  Note that we'll
         # also parse --pants-config as a regular option later, but there's no harm in that.  In fact,
@@ -232,11 +232,11 @@ class OptionsBootstrapper:
     def bootstrap_options(self) -> Options:
         """The post-bootstrap options, computed from the env, args, and fully discovered Config.
 
-        Re-computing options after Config has been fully expanded allows us to pick up bootstrap values
-        (such as backends) from a config override file, for example.
+        Re-computing options after Config has been fully expanded allows us to pick up bootstrap
+        values (such as backends) from a config override file, for example.
 
-        Because this can be computed from the in-memory representation of these values, it is not part
-        of the object's identity.
+        Because this can be computed from the in-memory representation of these values, it is not
+        part of the object's identity.
         """
         return self.parse_bootstrap_options(self.env, self.bootstrap_args, self.config)
 

--- a/src/python/pants/option/options_test.py
+++ b/src/python/pants/option/options_test.py
@@ -197,7 +197,7 @@ def test_bool_invalid_value(val: Any, err: str) -> None:
 
 @contextmanager
 def no_exception():
-    """use in tests as placeholder for a pytest.raises, when no exception is expected."""
+    """Use in tests as placeholder for a pytest.raises, when no exception is expected."""
     yield None
 
 

--- a/src/python/pants/option/subsystem.py
+++ b/src/python/pants/option/subsystem.py
@@ -56,8 +56,8 @@ class _SubsystemMeta(ABCMeta):
 class Subsystem(metaclass=_SubsystemMeta):
     """A separable piece of functionality that may be reused across multiple tasks or other code.
 
-    Subsystems encapsulate the configuration and initialization of things like JVMs,
-    Python interpreters, SCMs and so on.
+    Subsystems encapsulate the configuration and initialization of things like JVMs, Python
+    interpreters, SCMs and so on.
 
     Set the `help` class property with a description, which will be used in `./pants help`. For the
     best rendering, use soft wrapping (e.g. implicit string concatenation) within paragraphs, but
@@ -83,14 +83,14 @@ class Subsystem(metaclass=_SubsystemMeta):
         """A separate container for options that may be redefined by the runtime environment.
 
         To define environment-aware options, create an inner class in the `Subsystem` called
-        `EnvironmentAware`. Option fields share their scope with their enclosing `Subsystem`,
-        and the values of fields will default to the values set through Pants' configuration.
+        `EnvironmentAware`. Option fields share their scope with their enclosing `Subsystem`, and
+        the values of fields will default to the values set through Pants' configuration.
 
-        To consume environment-aware options, inject the `EnvironmentAware` inner class into
-        your rule.
+        To consume environment-aware options, inject the `EnvironmentAware` inner class into your
+        rule.
 
-        Optionally, it is possible to specify environment variables that are required when
-        post-processing raw values provided by users (e.g. `<PATH>` special strings) by specifying
+        Optionally, it is possible to specify environment variables that are required when post-
+        processing raw values provided by users (e.g. `<PATH>` special strings) by specifying
         `env_vars_used_by_options`, and consuming `_options_env` in your post-processing property.
         These environment variables will be requested at construction time.
         """

--- a/src/python/pants/pantsd/service/pants_service.py
+++ b/src/python/pants/pantsd/service/pants_service.py
@@ -15,15 +15,15 @@ class PantsService(ABC):
     """Pants daemon service base class.
 
     The service lifecycle is made up of states described in the _ServiceState class, and controlled
-    by a calling thread that is holding the Service `lifecycle_lock`. Under that lock, a caller
-    can signal a service to "pause", "run", or "terminate" (see _ServiceState for more details).
+    by a calling thread that is holding the Service `lifecycle_lock`. Under that lock, a caller can
+    signal a service to "pause", "run", or "terminate" (see _ServiceState for more details).
 
-    pantsd pauses all Services before forking a pantsd in order to ensure that no "relevant"
-    locks are held (or awaited: see #6565) by threads that might not survive the fork. While paused,
-    a Service must not have any threads running that might interact with any non-private locks.
+    pantsd pauses all Services before forking a pantsd in order to ensure that no "relevant" locks
+    are held (or awaited: see #6565) by threads that might not survive the fork. While paused, a
+    Service must not have any threads running that might interact with any non-private locks.
 
-    After forking, the pantsd (child) process should call `terminate()` to finish shutting down
-    the service, and the parent process should call `resume()` to cause the service to resume running.
+    After forking, the pantsd (child) process should call `terminate()` to finish shutting down the
+    service, and the parent process should call `resume()` to cause the service to resume running.
     """
 
     class ServiceError(Exception):
@@ -74,12 +74,8 @@ class PantsService(ABC):
 class _ServiceState:
     """A threadsafe state machine for controlling a service running in another thread.
 
-    The state machine represents two stable states:
-      Running
-      Paused
-    And two transitional states:
-      Pausing
-      Terminating
+    The state machine represents two stable states:   Running   Paused And two transitional states:
+    Pausing   Terminating
 
     The methods of this class allow a caller to ask the Service to transition states, and then wait
     for those transitions to occur.
@@ -90,8 +86,8 @@ class _ServiceState:
 
     A complicating assumption is that while a service thread is `Paused`, it must be in a position
     where it could safely disappear and never come back. This is accounted for by having the service
-    thread wait on a Condition variable while Paused: testing indicates that for multiple Pythons
-    on both OSX and Linux, this does not result in poisoning of the associated Lock.
+    thread wait on a Condition variable while Paused: testing indicates that for multiple Pythons on
+    both OSX and Linux, this does not result in poisoning of the associated Lock.
     """
 
     _RUNNING = "Running"
@@ -114,8 +110,8 @@ class _ServiceState:
     def await_paused(self, timeout=None):
         """Blocks until the service is in the Paused state, then returns True.
 
-        If a timeout is specified, the method may return False to indicate a timeout: with no timeout
-        it will always (eventually) return True.
+        If a timeout is specified, the method may return False to indicate a timeout: with no
+        timeout it will always (eventually) return True.
 
         Raises if the service is not currently in the Pausing state.
         """
@@ -138,8 +134,8 @@ class _ServiceState:
     def maybe_pause(self, timeout=None):
         """Called by the service to indicate that it is pausable.
 
-        If the service calls this method while the state is `Pausing`, the state will transition
-        to `Paused`, and the service will block here until it is marked `Running` or `Terminating`.
+        If the service calls this method while the state is `Pausing`, the state will transition to
+        `Paused`, and the service will block here until it is marked `Running` or `Terminating`.
 
         If the state is not currently `Pausing`, and a timeout is not passed, this method returns
         immediately. If a timeout is passed, this method blocks up to that number of seconds to wait

--- a/src/python/pants/testutil/debug_adapter_util.py
+++ b/src/python/pants/testutil/debug_adapter_util.py
@@ -9,8 +9,8 @@ def debugadapter_port_for_testing() -> int:
 
     Use this in Pants's (and plugins') own tests to avoid collisions.
 
-    Assumes that the env var TEST_EXECUTION_SLOT has been set. If not, all tests
-    will use the same port, and collisions may occur.
+    Assumes that the env var TEST_EXECUTION_SLOT has been set. If not, all tests will use the same
+    port, and collisions may occur.
     """
     execution_slot = os.environ.get("TEST_EXECUTION_SLOT", "0")
     return 22000 + int(execution_slot)

--- a/src/python/pants/testutil/pants_integration_test.py
+++ b/src/python/pants/testutil/pants_integration_test.py
@@ -263,11 +263,10 @@ def setup_tmpdir(
     with the tmpdir. The file content can use `{tmpdir}` to have it substituted with the actual
     tmpdir via a format string.
 
-    The `raw_files` parameter can be used to write binary files. These
-    files will not go through formatting in any way.
+    The `raw_files` parameter can be used to write binary files. These files will not go through
+    formatting in any way.
 
-
-    This is useful to set up controlled test environments, such as setting up source files and
+     This is useful to set up controlled test environments, such as setting up source files and
     BUILD files.
     """
 

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -125,8 +125,7 @@ def engine_error(
 
     Use like this:
 
-        with engine_error(ValueError, contains="foo"):
-            rule_runner.request(OutputType, [input])
+    with engine_error(ValueError, contains="foo"):     rule_runner.request(OutputType, [input])
 
     Will raise AssertionError if no ExecutionError occurred.
 
@@ -476,8 +475,8 @@ class RuleRunner:
         to read arbitrary env vars. Any options that start with `PANTS_` will also be used to set
         options.
 
-        Environment variables listed in `env_inherit` and not in `env` will be inherited from the test
-        runner's environment (os.environ)
+        Environment variables listed in `env_inherit` and not in `env` will be inherited from the
+        test runner's environment (os.environ)
 
         This will override any previously configured values.
         """

--- a/src/python/pants/util/collections.py
+++ b/src/python/pants/util/collections.py
@@ -109,8 +109,8 @@ def partition_sequentially(
     """Stably partitions the given items into batches of around `size_target` items.
 
     The "stability" property refers to avoiding adjusting all batches when a single item is added,
-    which could happen if the items were trivially windowed using `itertools.islice` and an
-    item was added near the front of the list.
+    which could happen if the items were trivially windowed using `itertools.islice` and an item was
+    added near the front of the list.
 
     Batches will optionally be capped to `size_max`, but note that this can weaken the stability
     properties of the bucketing, by forcing bucket boundaries to be created where they otherwise

--- a/src/python/pants/util/meta.py
+++ b/src/python/pants/util/meta.py
@@ -14,8 +14,7 @@ class SingletonMetaclass(type):
 
     Example class definition:
 
-      class Unicorn(metaclass=SingletonMetaclass):
-        pass
+    class Unicorn(metaclass=SingletonMetaclass):   pass
     """
 
     def __call__(cls, *args: Any, **kwargs: Any) -> Any:

--- a/src/python/pants/util/ordered_set.py
+++ b/src/python/pants/util/ordered_set.py
@@ -1,6 +1,5 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
 """An OrderedSet is a set that remembers its insertion order, and a FrozenOrderedSet is one that is
 also immutable.
 

--- a/src/python/pants/util/strutil.py
+++ b/src/python/pants/util/strutil.py
@@ -148,9 +148,9 @@ class Simplifier:
 
     # it's only rarely useful to show a chroot path to a user, hence they're stripped by default
     strip_chroot_path: bool = True
-    """remove all instances of the chroot tmpdir path"""
+    """Remove all instances of the chroot tmpdir path."""
     strip_formatting: bool = False
-    """remove ANSI formatting commands (colors, bold, etc)"""
+    """Remove ANSI formatting commands (colors, bold, etc)"""
 
     def simplify(self, v: bytes | str) -> str:
         chroot = (

--- a/src/python/pants/vcs/changed.py
+++ b/src/python/pants/vcs/changed.py
@@ -137,7 +137,8 @@ class ChangedOptions:
     ) -> dict[str, tuple[Hunk, ...]]:
         """Determines the unified diff hunks changed according to SCM/workspace and options.
 
-        More info on unified diff: https://www.gnu.org/software/diffutils/manual/html_node/Detailed-Unified.html
+        More info on unified diff:
+        https://www.gnu.org/software/diffutils/manual/html_node/Detailed-Unified.html
         """
         changes_since = self.since or git_worktree.current_rev_identifier
         return git_worktree.changed_files_lines(

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -1374,44 +1374,31 @@ class Repo:
     """
 
     name: str
-    """
-    `user/repo`, referring to `https://github.com/user/repo`. (This can be expanded to other services, if required.)
+    """`user/repo`, referring to `https://github.com/user/repo`.
+
+    (This can be expanded to other services, if required.)
     """
 
     python_version: str = "3.10"
-    """
-    The Python version to install system-wide for user code to use.
-    """
+    """The Python version to install system-wide for user code to use."""
 
     env: dict[str, str] = field(default_factory=dict)
-    """
-    Any extra environment variables to provide to all pants steps
-    """
+    """Any extra environment variables to provide to all pants steps."""
 
     install_go: bool = False
-    """
-    Whether to install Go system-wide
-    """
+    """Whether to install Go system-wide."""
 
     install_thrift: bool = False
-    """
-    Whether to install Thrift system-wide
-    """
+    """Whether to install Thrift system-wide."""
 
     node_version: None | str = None
-    """
-    Whether to install Node/NPM system-wide, and which version if so
-    """
+    """Whether to install Node/NPM system-wide, and which version if so."""
 
     checkout_options: dict[str, Any] = field(default_factory=dict)
-    """
-    Any additional options to provide to actions/checkout
-    """
+    """Any additional options to provide to actions/checkout."""
 
     setup_commands: str = ""
-    """
-    Any additional set-up commands to run before pants (e.g. `sudo apt install ...`)
-    """
+    """Any additional set-up commands to run before pants (e.g. `sudo apt install ...`)"""
 
     goals: Sequence[str] = tuple(DefaultGoals)
     """


### PR DESCRIPTION
The current version of `docformatter` in the Pants codebase does not support Python 3.13, due to the use of the [lib2to3](https://github.com/python/cpython/issues/104780) module which was removed. The most recent release of `docformatter` was in July 2023, and it's the release that is used here.

Related Slack discussion: https://pantsbuild.slack.com/archives/C046T6T9U/p1728393944035549?thread_ts=1728386679.902609&cid=C046T6T9U

# Process

This PR is specifically split out into 3 steps/commits:

1. Upgrading the lockfile + setting the new version + release notes
2. Formatting the whole codebase
3. Updating `.git-blame-ignore-revs` with the new changes from step 2

> [!IMPORTANT]  
> If merging, this PR should be merged via rebase-and-merge rather than squash-and-merge so that the changes to `git-blame-ignore-revs` remain intact.