### PR TITLE
Update the ARM64 CI AMI. (Cherry-pick of #21531)

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -1,6 +1,6 @@
 images:
-  ubuntu22-full-arm64-python3.7-python3.8-python3.9:
+  ubuntu22-full-arm64-python3.7-3.13:
     platform: "linux"
     arch: "arm64"
     owner: "408085265505"
-    ami: "ami-072f12824058aa801"
+    ami: "ami-0718bef309678bb83"


### PR DESCRIPTION
This AMI will have all pythons from 3.7 to 3.13 preinstalled.

Also update the docs on how to create it.

