### PR TITLE
Constrain the ICs in the coverage py integration tests.

### DIFF
--- a/src/python/pants/backend/python/goals/coverage_py_integration_test.py
+++ b/src/python/pants/backend/python/goals/coverage_py_integration_test.py
@@ -152,7 +152,9 @@ def run_coverage(tmpdir: str, *extra_args: str) -> PantsResult:
 def test_coverage(major_minor_interpreter: str) -> None:
     with setup_tmpdir(sources(False)) as tmpdir:
         result = run_coverage(
-            tmpdir, f"--coverage-py-interpreter-constraints=['=={major_minor_interpreter}.*']"
+            tmpdir,
+            f"--python-interpreter-constraints=['=={major_minor_interpreter}.*']",
+            f"--coverage-py-interpreter-constraints=['=={major_minor_interpreter}.*']",
         )
     assert (
         dedent(


### PR DESCRIPTION
They are failing on release branches on the new ARM64 AMIs that
have Python 3.7-3.13 on them, because there is no pip that can be
installed on all those versions.