### PR TITLE
Fix the remaining coverage py integration tests (Cherry-pick of #21544)

### DIFF
--- a/src/python/pants/backend/python/goals/coverage_py_integration_test.py
+++ b/src/python/pants/backend/python/goals/coverage_py_integration_test.py
@@ -186,7 +186,9 @@ def test_coverage(major_minor_interpreter: str) -> None:
 def test_coverage_batched(major_minor_interpreter: str) -> None:
     with setup_tmpdir(sources(True)) as tmpdir:
         result = run_coverage(
-            tmpdir, f"--coverage-py-interpreter-constraints=['=={major_minor_interpreter}.*']"
+            tmpdir,
+            f"--python-interpreter-constraints=['=={major_minor_interpreter}.*']",
+            f"--coverage-py-interpreter-constraints=['=={major_minor_interpreter}.*']",
         )
     assert (
         dedent(


### PR DESCRIPTION
Follow up to #21540, which alas only tackled half the tests
(and those do indeed pass on the new ARM images, so this
change should now cause the rest to pass).
