### PR TITLE
Log the list of tests in a given batch

### DIFF
--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -95,7 +95,7 @@ from pants.util.ordered_set import OrderedSet
 from pants.util.pip_requirement import PipRequirement
 from pants.util.strutil import softwrap
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 # -----------------------------------------------------------------------------------------
@@ -445,6 +445,10 @@ async def setup_pytest_for_target(
     if len(request.field_sets) > 1:
         run_description = (
             f"batch of {run_description} and {len(request.field_sets) - 1} other files"
+        )
+        logger.debug(
+            f"{run_description} contains:\n"
+            + "\n".join(f"  {field_set.address.spec}" for field_set in request.field_sets)
         )
     process = await setup_venv_pex_process(
         VenvPexProcess(


### PR DESCRIPTION
This PR logs the list of test files in a given batch before tests execute.

The batch listing is logged at `debug` level using a named logger (`pants.backend.python.goals.pytest_runner`), which integrates with the existing `--log-levels-by-target` mechanism. To surface it in CI, add to `pants.toml`:

```toml
[GLOBAL]
log_levels_by_target = {"pants.backend.python.goals.pytest_runner" = "info"}
```

Example output when enabled:
```
09:59:41.68 [INFO] batch of a_test.py:tests and 3 other files contains:
  a_test.py:tests
  b_test.py:tests
  c_test.py:tests
  d_test.py:tests
```