### PR TITLE
Use corepack to run package managers

### DIFF
--- a/src/python/pants/backend/javascript/package_manager.py
+++ b/src/python/pants/backend/javascript/package_manager.py
@@ -97,3 +97,6 @@ class PackageManager:
             pack_archive_format="{}-{}.tgz",
             extra_caches=FrozenDict(),
         )
+
+    def spec(self) -> str:
+        return self.name if self.version is None else f"{self.name}@{self.version}"

--- a/src/python/pants/backend/javascript/subsystems/nodejs_tool.py
+++ b/src/python/pants/backend/javascript/subsystems/nodejs_tool.py
@@ -14,7 +14,7 @@ from pants.backend.javascript.install_node_package import (
 from pants.backend.javascript.nodejs_project_environment import NodeJsProjectEnvironmentProcess
 from pants.backend.javascript.package_manager import PackageManager
 from pants.backend.javascript.resolve import FirstPartyNodePackageResolves, NodeJSProjectResolves
-from pants.backend.javascript.subsystems.nodejs import NodeJS, NodeJSToolProcess
+from pants.backend.javascript.subsystems.nodejs import NodeJS, NodeJSProcessEnvironment, NodeJSToolProcess
 from pants.engine.internals.native_engine import Digest, MergeDigests
 from pants.engine.internals.selectors import Get
 from pants.engine.process import Process
@@ -98,6 +98,7 @@ class NodeJSToolRequest:
 
 async def _run_tool_without_resolve(request: NodeJSToolRequest) -> Process:
     nodejs = await Get(NodeJS)
+    env = await Get(NodeJSProcessEnvironment)
 
     pkg_manager_version = nodejs.package_managers.get(nodejs.package_manager)
     pkg_manager_and_version = nodejs.default_package_manager
@@ -118,9 +119,9 @@ async def _run_tool_without_resolve(request: NodeJSToolRequest) -> Process:
     return await Get(
         Process,
         NodeJSToolProcess(
-            pkg_manager.name,
+            env.binaries.binary_dir + "/corepack",
             pkg_manager.version,
-            args=(*pkg_manager.download_and_execute_args, request.tool, *request.args),
+            args=(pkg_manager.name, *pkg_manager.download_and_execute_args, request.tool, *request.args),
             description=request.description,
             input_digest=request.input_digest,
             output_files=request.output_files,

--- a/src/python/pants/backend/javascript/subsystems/nodejs_tool.py
+++ b/src/python/pants/backend/javascript/subsystems/nodejs_tool.py
@@ -14,7 +14,11 @@ from pants.backend.javascript.install_node_package import (
 from pants.backend.javascript.nodejs_project_environment import NodeJsProjectEnvironmentProcess
 from pants.backend.javascript.package_manager import PackageManager
 from pants.backend.javascript.resolve import FirstPartyNodePackageResolves, NodeJSProjectResolves
-from pants.backend.javascript.subsystems.nodejs import NodeJS, NodeJSProcessEnvironment, NodeJSToolProcess
+from pants.backend.javascript.subsystems.nodejs import (
+    NodeJS,
+    NodeJSProcessEnvironment,
+    NodeJSToolProcess,
+)
 from pants.engine.internals.native_engine import Digest, MergeDigests
 from pants.engine.internals.selectors import Get
 from pants.engine.process import Process
@@ -121,7 +125,12 @@ async def _run_tool_without_resolve(request: NodeJSToolRequest) -> Process:
         NodeJSToolProcess(
             env.binaries.binary_dir + "/corepack",
             pkg_manager.version,
-            args=(pkg_manager.name, *pkg_manager.download_and_execute_args, request.tool, *request.args),
+            args=(
+                pkg_manager.name,
+                *pkg_manager.download_and_execute_args,
+                request.tool,
+                *request.args,
+            ),
             description=request.description,
             input_digest=request.input_digest,
             output_files=request.output_files,

--- a/src/python/pants/backend/javascript/subsystems/nodejs_tool.py
+++ b/src/python/pants/backend/javascript/subsystems/nodejs_tool.py
@@ -119,6 +119,10 @@ async def _run_tool_without_resolve(request: NodeJSToolRequest) -> Process:
             )
         )
     pkg_manager = PackageManager.from_string(pkg_manager_and_version)
+    if pkg_manager.name == PackageManager.yarn.__name__:
+        cmd = pkg_manager.name
+    else:
+        cmd = pkg_manager.spec()
 
     return await Get(
         Process,
@@ -126,7 +130,7 @@ async def _run_tool_without_resolve(request: NodeJSToolRequest) -> Process:
             env.binaries.binary_dir + "/corepack",
             pkg_manager.version,
             args=(
-                pkg_manager.name,
+                cmd,
                 *pkg_manager.download_and_execute_args,
                 request.tool,
                 *request.args,

--- a/src/python/pants/backend/javascript/subsystems/nodejs_tool_test.py
+++ b/src/python/pants/backend/javascript/subsystems/nodejs_tool_test.py
@@ -92,7 +92,7 @@ def test_execute_process_with_package_manager(
     [
         pytest.param("yarn", "1.22.22", id="yarn"),
         pytest.param("npm", "10.9.0", id="npm"),
-        pytest.param("pnpm", "9.12.1", id="pnpm"),
+        pytest.param("pnpm", "9.12.3", id="pnpm"),
     ],
 )
 def test_execute_process_with_package_manager_version_from_configuration(

--- a/src/python/pants/backend/javascript/subsystems/nodejs_tool_test.py
+++ b/src/python/pants/backend/javascript/subsystems/nodejs_tool_test.py
@@ -52,8 +52,8 @@ def test_version_option_overrides_default(rule_runner: RuleRunner):
     "package_manager, expected_argv",
     [
         pytest.param("yarn", ("yarn", "dlx", "--quiet"), id="yarn"),
-        pytest.param("npm", ("npm", "exec", "--yes", "--"), id="npm"),
-        pytest.param("pnpm", ("pnpm", "dlx"), id="pnpm"),
+        pytest.param("npm", ("npm@10.8.2", "exec", "--yes", "--"), id="npm"),
+        pytest.param("pnpm", ("pnpm@9.5.0", "dlx"), id="pnpm"),
     ],
 )
 def test_execute_process_with_package_manager(
@@ -91,8 +91,8 @@ def test_execute_process_with_package_manager(
     "package_manager, version",
     [
         pytest.param("yarn", "1.22.22", id="yarn"),
-        pytest.param("npm", "10.9.0", id="npm"),
-        pytest.param("pnpm", "9.12.3", id="pnpm"),
+        pytest.param("npm", "10.8.2", id="npm"),
+        pytest.param("pnpm", "9.5.0", id="pnpm"),
     ],
 )
 def test_execute_process_with_package_manager_version_from_configuration(
@@ -199,8 +199,12 @@ def request_package_manager_version_for_tool(
 ) -> str:
     request = tool.request((), EMPTY_DIGEST, "Inspect package manager version", LogLevel.DEBUG)
     process = rule_runner.request(Process, [request])
+    if process.argv[0].find("corepack") != -1:
+        args = process.argv[:2] + ("--version",)
+    else:
+        args = (package_manager, "--version")
     result = rule_runner.request(
         ProcessResult,
-        [dataclasses.replace(process, argv=(package_manager, "--version"))],
+        [dataclasses.replace(process, argv=args)],
     )
     return result.stdout.decode().strip()

--- a/src/python/pants/backend/javascript/subsystems/nodejs_tool_test.py
+++ b/src/python/pants/backend/javascript/subsystems/nodejs_tool_test.py
@@ -13,7 +13,7 @@ from pants.backend.javascript.package_json import PackageJsonTarget
 from pants.backend.javascript.subsystems import nodejs_tool
 from pants.backend.javascript.subsystems.nodejs_tool import NodeJSToolBase, NodeJSToolRequest
 from pants.engine.internals.native_engine import EMPTY_DIGEST
-from pants.engine.process import InteractiveProcess, InteractiveProcessResult, Process, ProcessResult
+from pants.engine.process import InteractiveProcess, Process, ProcessResult
 from pants.testutil.rule_runner import QueryRule, RuleRunner, mock_console
 from pants.util.logging import LogLevel
 
@@ -77,9 +77,7 @@ def test_execute_process_with_package_manager(
     ip = InteractiveProcess.from_process(to_run)
     with mock_console(rule_runner.options_bootstrapper) as mocked_console:
         interactive_result = rule_runner.run_interactive_process(ip)
-        assert interactive_result.exit_code == 0, mocked_console[
-            1
-        ].get_stderr()
+        assert interactive_result.exit_code == 0, mocked_console[1].get_stderr()
 
     # Remove the corepack binary path from argv.
     assert to_run.argv[1:] == expected_argv + ("cowsay@1.6.0", "--version")


### PR DESCRIPTION
This makes it possible to run NodeJSToolProcesses as interactive processes. Would be nice if we could setup aliases for each package manager instead perhaps as described [here](https://github.com/nodejs/corepack?tab=readme-ov-file#corepack-enable--name).

Do you have any pointers on how to solve it in another way than this?

Fixes https://github.com/pantsbuild/pants/issues/21205