### PR TITLE
provide a Knot of Pythons for testing for github-action provided jobs

### DIFF
--- a/.github/workflows/cache_comparison.yaml
+++ b/.github/workflows/cache_comparison.yaml
@@ -14,9 +14,7 @@ jobs:
     - name: Set up Python 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '|
-
-          3.9
+        python-version: '3.9
 
           3.10
 

--- a/.github/workflows/cache_comparison.yaml
+++ b/.github/workflows/cache_comparison.yaml
@@ -11,10 +11,20 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 10
-    - name: Set up Python 3.9
+    - name: Set up Python 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '|
+
+          3.9
+
+          3.10
+
+          3.12
+
+          3.13
+
+          3.11'
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@v9
     - env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -359,10 +359,20 @@ jobs:
         fetch-depth: '0'
         fetch-tags: true
         ref: ${{ needs.release_info.outputs.build-ref }}
-    - name: Set up Python 3.9
+    - name: Set up Python 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '|
+
+          3.9
+
+          3.10
+
+          3.12
+
+          3.13
+
+          3.11'
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@v9
     - name: Install Protoc

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -362,9 +362,7 @@ jobs:
     - name: Set up Python 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '|
-
-          3.9
+        python-version: '3.9
 
           3.10
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -121,9 +121,7 @@ jobs:
     - name: Set up Python 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '|
-
-          3.9
+        python-version: '3.9
 
           3.10
 
@@ -234,9 +232,7 @@ jobs:
     - name: Set up Python 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '|
-
-          3.9
+        python-version: '3.9
 
           3.10
 
@@ -678,9 +674,7 @@ jobs:
     - name: Set up Python 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '|
-
-          3.9
+        python-version: '3.9
 
           3.10
 
@@ -868,9 +862,7 @@ jobs:
     - name: Set up Python 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '|
-
-          3.9
+        python-version: '3.9
 
           3.10
 
@@ -970,9 +962,7 @@ jobs:
     - name: Set up Python 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '|
-
-          3.9
+        python-version: '3.9
 
           3.10
 
@@ -1072,9 +1062,7 @@ jobs:
     - name: Set up Python 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '|
-
-          3.9
+        python-version: '3.9
 
           3.10
 
@@ -1174,9 +1162,7 @@ jobs:
     - name: Set up Python 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '|
-
-          3.9
+        python-version: '3.9
 
           3.10
 
@@ -1276,9 +1262,7 @@ jobs:
     - name: Set up Python 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '|
-
-          3.9
+        python-version: '3.9
 
           3.10
 
@@ -1378,9 +1362,7 @@ jobs:
     - name: Set up Python 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '|
-
-          3.9
+        python-version: '3.9
 
           3.10
 
@@ -1480,9 +1462,7 @@ jobs:
     - name: Set up Python 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '|
-
-          3.9
+        python-version: '3.9
 
           3.10
 
@@ -1582,9 +1562,7 @@ jobs:
     - name: Set up Python 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '|
-
-          3.9
+        python-version: '3.9
 
           3.10
 
@@ -1684,9 +1662,7 @@ jobs:
     - name: Set up Python 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '|
-
-          3.9
+        python-version: '3.9
 
           3.10
 
@@ -1786,9 +1762,7 @@ jobs:
     - name: Set up Python 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '|
-
-          3.9
+        python-version: '3.9
 
           3.10
 
@@ -1855,9 +1829,7 @@ jobs:
     - name: Set up Python 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '|
-
-          3.9
+        python-version: '3.9
 
           3.10
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -118,10 +118,20 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 10
-    - name: Set up Python 3.9
+    - name: Set up Python 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '|
+
+          3.9
+
+          3.10
+
+          3.12
+
+          3.13
+
+          3.11'
     - name: Install Protoc
       uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
       with:
@@ -221,10 +231,20 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 10
-    - name: Set up Python 3.9
+    - name: Set up Python 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '|
+
+          3.9
+
+          3.10
+
+          3.12
+
+          3.13
+
+          3.11'
     - name: Install Protoc
       uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
       with:
@@ -655,10 +675,20 @@ jobs:
         \                 --max_size 30\necho \"PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092\" >> \"$GITHUB_ENV\"\necho\
         \ \"PANTS_REMOTE_CACHE_READ=true\" >> \"$GITHUB_ENV\"\necho \"PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}\" >> \"$GITHUB_ENV\"\
         \n"
-    - name: Set up Python 3.9
+    - name: Set up Python 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '|
+
+          3.9
+
+          3.10
+
+          3.12
+
+          3.13
+
+          3.11'
     - name: Download native binaries
       uses: actions/download-artifact@v4
       with:
@@ -835,10 +865,20 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.9
+    - name: Set up Python 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '|
+
+          3.9
+
+          3.10
+
+          3.12
+
+          3.13
+
+          3.11'
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@v9
     - name: Download native binaries
@@ -927,10 +967,20 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.9
+    - name: Set up Python 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '|
+
+          3.9
+
+          3.10
+
+          3.12
+
+          3.13
+
+          3.11'
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@v9
     - name: Download native binaries
@@ -1019,10 +1069,20 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.9
+    - name: Set up Python 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '|
+
+          3.9
+
+          3.10
+
+          3.12
+
+          3.13
+
+          3.11'
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@v9
     - name: Download native binaries
@@ -1111,10 +1171,20 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.9
+    - name: Set up Python 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '|
+
+          3.9
+
+          3.10
+
+          3.12
+
+          3.13
+
+          3.11'
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@v9
     - name: Download native binaries
@@ -1203,10 +1273,20 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.9
+    - name: Set up Python 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '|
+
+          3.9
+
+          3.10
+
+          3.12
+
+          3.13
+
+          3.11'
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@v9
     - name: Download native binaries
@@ -1295,10 +1375,20 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.9
+    - name: Set up Python 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '|
+
+          3.9
+
+          3.10
+
+          3.12
+
+          3.13
+
+          3.11'
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@v9
     - name: Download native binaries
@@ -1387,10 +1477,20 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.9
+    - name: Set up Python 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '|
+
+          3.9
+
+          3.10
+
+          3.12
+
+          3.13
+
+          3.11'
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@v9
     - name: Download native binaries
@@ -1479,10 +1579,20 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.9
+    - name: Set up Python 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '|
+
+          3.9
+
+          3.10
+
+          3.12
+
+          3.13
+
+          3.11'
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@v9
     - name: Download native binaries
@@ -1571,10 +1681,20 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.9
+    - name: Set up Python 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '|
+
+          3.9
+
+          3.10
+
+          3.12
+
+          3.13
+
+          3.11'
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@v9
     - name: Download native binaries
@@ -1663,10 +1783,20 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.9
+    - name: Set up Python 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '|
+
+          3.9
+
+          3.10
+
+          3.12
+
+          3.13
+
+          3.11'
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@v9
     - name: Download native binaries
@@ -1722,10 +1852,20 @@ jobs:
       with:
         distribution: adopt
         java-version: '11'
-    - name: Set up Python 3.9
+    - name: Set up Python 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '|
+
+          3.9
+
+          3.10
+
+          3.12
+
+          3.13
+
+          3.11'
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@v9
     - name: Download native binaries

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -365,14 +365,10 @@ def install_pythons(versions: list[str]) -> Step:
     # See:
     # https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#specifying-multiple-pythonpypy-versions
     # This is a list expressed as a newline delimited string instead of a... list
-    if len(versions) == 1:
-        version_yaml = versions[0]
-    else:
-        version_yaml = "|\n" + "\n".join(versions)
     return {
         "name": f"Set up Python {', '.join(versions)}",
         "uses": action("setup-python"),
-        "with": {"python-version": version_yaml},
+        "with": {"python-version": "\n".join(versions),
     }
 
 

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -368,7 +368,7 @@ def install_pythons(versions: list[str]) -> Step:
     return {
         "name": f"Set up Python {', '.join(versions)}",
         "uses": action("setup-python"),
-        "with": {"python-version": "\n".join(versions),
+        "with": {"python-version": "\n".join(versions)},
     }
 
 


### PR DESCRIPTION
On those platforms for which which we rely on GitHub Actions to provide the Pythons. This brings these platforms to closer parity with those images that have multiple Python pre-installed. This:
 * Provides more places we can run Python version specific tests.
 * Provides a Python > 3.9 that will :cross-fingers: will soon be the one used by Pants itself.

NOTE: The awkward double newlines in the final yaml are a pre-existing issue https://stackoverflow.com/questions/45004464/yaml-dump-adding-unwanted-newlines-in-multiline-strings