### PR TITLE
remove category label requirement from PRs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -560,22 +560,6 @@ jobs:
         overwrite: 'true'
         path: .pants.d/workdir/*.log
     timeout-minutes: 90
-  check_labels:
-    if: github.repository_owner == 'pantsbuild'
-    name: Ensure PR has a category label
-    runs-on:
-    - ubuntu-22.04
-    steps:
-    - env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      if: github.event_name == 'pull_request'
-      name: Ensure category label
-      uses: mheap/github-action-required-labels@v4.0.0
-      with:
-        count: 1
-        labels: category:new feature, category:user api change, category:plugin api change, category:performance, category:bugfix,
-          category:documentation, category:internal
-        mode: exactly
   check_release_notes:
     if: github.repository_owner == 'pantsbuild'
     name: Ensure PR has release notes
@@ -694,7 +678,6 @@ jobs:
     name: Set Merge OK
     needs:
     - classify_changes
-    - check_labels
     - check_release_notes
     - bootstrap_pants_linux_arm64
     - bootstrap_pants_linux_x86_64
@@ -703,7 +686,6 @@ jobs:
     - build_wheels_linux_x86_64
     - build_wheels_macos11_arm64
     - build_wheels_macos12_x86_64
-    - check_labels
     - check_release_notes
     - classify_changes
     - lint_python

--- a/docs/docs/contributions/index.mdx
+++ b/docs/docs/contributions/index.mdx
@@ -104,20 +104,6 @@ Bad titles:
 
 Then, include a description. You can use the default template if you'd like, or use a normal description instead. Link to any corresponding GitHub issues.
 
-Finally—if you have the permissions—add exactly one of the following labels to your PR. Otherwise, a maintainer will do this for you:
-
-- `category:new feature` for new features
-- `category:user api change` for changes that affect how end-users interact with Pants
-- `category:plugin api change` for changes that affect how plugin authors interact with Pants internals
-- `category:performance` for changes focused on improving performance
-- `category:bugfix` for bugfixes
-- `category:documentation` for documentation changes, including logging and help messages
-- `category:internal` for miscellaneous, internal-facing changes
-
-Pick the first of these that applies to your change. I.e., if you have modified the user API in a change that also improves performance, use `category:user api change`.
-
-These labels are used to generate the changelist for each release.
-
 :::note Tip: Review your own PR
 It is often helpful to other reviewers if you proactively review your own code. Specifically, add comments to parts where you want extra attention.
 
@@ -175,3 +161,5 @@ We have guidance to walk us through this, so it's not a problem to forget. Pull 
 
 - the PR release notes, by having changes in `docs/notes/`
 - someone has opted out, by labelling the PR with `release-notes:not-required` or `category:internal` (the latter means that release notes are optional for all `category:internal` PRs).
+
+For minor releases, all GitHub release description will simply list all the commits save those with `release-notes:not-required` or `category:internal`.

--- a/src/python/pants_release/changelog_test.py
+++ b/src/python/pants_release/changelog_test.py
@@ -4,15 +4,15 @@
 from __future__ import annotations
 
 import pytest
-from pants_release.changelog import Category, Entry, format_notes
+from pants_release.changelog import Category, Entry, format_notes, format_notes_by_category
 
 
 @pytest.mark.parametrize("category", [*(c for c in Category if c is not Category.Internal), None])
-def test_format_notes(category: None | Category) -> None:
+def test_format_notes_by_category(category: None | Category) -> None:
     entries = [Entry(category=category, text="some entry")]
     heading = "Uncategorized" if category is None else category.heading()
 
-    formatted = format_notes(entries)
+    formatted = format_notes_by_category(entries)
 
     # we're testing the exact formatting, so no softwrap/dedent:
     assert (
@@ -20,5 +20,16 @@ def test_format_notes(category: None | Category) -> None:
         == f"""\
 ## {heading}
 
+some entry"""
+    )
+
+
+def test_format_notes() -> None:
+    entries = [Entry(category=None, text="some entry")]
+    formatted = format_notes(entries)
+    # we're testing the exact formatting, so no softwrap/dedent:
+    assert (
+        formatted
+        == """\
 some entry"""
     )

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -188,29 +188,6 @@ def classify_changes() -> Jobs:
     }
 
 
-def ensure_category_label() -> Sequence[Step]:
-    """Check that exactly one category label is present on a pull request."""
-    return [
-        {
-            "if": "github.event_name == 'pull_request'",
-            "name": "Ensure category label",
-            "uses": action("github-action-required-labels"),
-            "env": {"GITHUB_TOKEN": gha_expr("secrets.GITHUB_TOKEN")},
-            "with": {
-                "mode": "exactly",
-                "count": 1,
-                "labels": softwrap(
-                    """
-                    category:new feature, category:user api change,
-                    category:plugin api change, category:performance, category:bugfix,
-                    category:documentation, category:internal
-                    """
-                ),
-            },
-        }
-    ]
-
-
 def ensure_release_notes() -> Sequence[Step]:
     """Check that a PR either has release notes, or a category:internal or release-notes:not-
     required label."""
@@ -1014,12 +991,6 @@ def build_wheels_jobs(*, for_deploy_ref: str | None = None, needs: list[str] | N
 def test_workflow_jobs() -> Jobs:
     linux_x86_64_helper = Helper(Platform.LINUX_X86_64)
     jobs: dict[str, Any] = {
-        "check_labels": {
-            "name": "Ensure PR has a category label",
-            "runs-on": linux_x86_64_helper.runs_on(),
-            "if": IS_PANTS_OWNER,
-            "steps": ensure_category_label(),
-        },
         "check_release_notes": {
             "name": "Ensure PR has release notes",
             "runs-on": linux_x86_64_helper.runs_on(),
@@ -1713,7 +1684,7 @@ def merge_ok(pr_jobs: list[str]) -> Jobs:
             # NB: This always() condition is critical, as it ensures that this job is run even if
             #   jobs it depends on are skipped.
             "if": "always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')",
-            "needs": ["classify_changes", "check_labels", "check_release_notes"] + sorted(pr_jobs),
+            "needs": ["classify_changes", "check_release_notes"] + sorted(pr_jobs),
             "outputs": {"merge_ok": f"{gha_expr('steps.set_merge_ok.outputs.merge_ok')}"},
             "steps": [
                 {
@@ -1755,7 +1726,7 @@ def generate() -> dict[Path, str]:
     pr_jobs = test_workflow_jobs()
     pr_jobs.update(**classify_changes())
     for key, val in pr_jobs.items():
-        if key in {"check_labels", "classify_changes", "check_release_notes"}:
+        if key in {"classify_changes", "check_release_notes"}:
             continue
         needs = val.get("needs", [])
         if isinstance(needs, str):

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -17,8 +17,6 @@ import toml
 import yaml
 from pants_release.common import die
 
-from pants.util.strutil import softwrap
-
 
 def action(name: str, node16_compat: bool = False) -> str:
     # Versions of actions compatible with node16 and the `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION` setting.


### PR DESCRIPTION
The category label used to be used as part of release notes generation, but now that we a spiffy new releases notes process <https://github.com/pantsbuild/pants/discussions/20888> and they are no longer used for "major" releases.

They were still part of the GitHub patch releases notes but:
 * Bugfix releases ought to be all bug fixes already
 * It is a point of friction for contributors; every first time contributor is likely to get a red X and it is hard for reviewers to tell at a glance from the PR list which failures are real.

So on net, the benefit is no longer worth the friction.

This diff renders them optional by:
 * Removing the Action check.
 * Defaulting to not using them for headings in the GitHub release notes
 * Removing from docs.
  
 After using this for a bit we can see if it feels right and if omitting `internal` changes from the GitHub release description is worth the vestigial support.