### PR TITLE
upgrade Rust to v1.82.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -197,7 +197,7 @@ jobs:
       with:
         key: macOS11-ARM64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain')
           }}-v2
-        path: '~/.rustup/toolchains/1.81.0-*
+        path: '~/.rustup/toolchains/1.82.0-*
 
           ~/.rustup/update-hashes
 
@@ -284,7 +284,7 @@ jobs:
       with:
         key: macOS12-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain')
           }}-v2
-        path: '~/.rustup/toolchains/1.81.0-*
+        path: '~/.rustup/toolchains/1.82.0-*
 
           ~/.rustup/update-hashes
 
@@ -376,7 +376,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.81.0-*
+        path: '~/.rustup/toolchains/1.82.0-*
 
           ~/.rustup/update-hashes
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,7 +40,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: Linux-ARM64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.81.0-*
+        path: '~/.rustup/toolchains/1.82.0-*
 
           ~/.rustup/update-hashes
 
@@ -133,7 +133,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.81.0-*
+        path: '~/.rustup/toolchains/1.82.0-*
 
           ~/.rustup/update-hashes
 
@@ -236,7 +236,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: macOS12-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.81.0-*
+        path: '~/.rustup/toolchains/1.82.0-*
 
           ~/.rustup/update-hashes
 
@@ -451,7 +451,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: macOS11-ARM64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.81.0-*
+        path: '~/.rustup/toolchains/1.82.0-*
 
           ~/.rustup/update-hashes
 
@@ -521,7 +521,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: macOS12-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.81.0-*
+        path: '~/.rustup/toolchains/1.82.0-*
 
           ~/.rustup/update-hashes
 

--- a/src/rust/engine/client/src/main.rs
+++ b/src/rust/engine/client/src/main.rs
@@ -96,10 +96,8 @@ fn try_execv_fallback_client(pants_server: OsString) -> Result<Infallible, i32> 
 }
 
 fn execv_fallback_client(pants_server: OsString) -> Infallible {
-    if let Err(exit_code) = try_execv_fallback_client(pants_server) {
-        std::process::exit(exit_code);
-    }
-    unreachable!()
+    let Err(exit_code) = try_execv_fallback_client(pants_server);
+    std::process::exit(exit_code);
 }
 
 // The value is taken from this C precedent:

--- a/src/rust/engine/rust-toolchain
+++ b/src/rust/engine/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.81.0"
+channel = "1.82.0"
 # NB: We don't list the components (namely `clippy` and `rustfmt`) and instead rely on either the
 #  the profile being "default" (by-and-large the default profile) or the nice error message from
 #  `cargo fmt` and `cargo clippy` if the required component isn't installed

--- a/src/rust/engine/stdio/src/lib.rs
+++ b/src/rust/engine/stdio/src/lib.rs
@@ -82,9 +82,9 @@ impl Console {
 impl Drop for Console {
     fn drop(&mut self) {
         // "Forget" about our file handles without closing them.
-        self.stdin_handle.take().unwrap().into_raw_fd();
-        self.stdout_handle.take().unwrap().into_raw_fd();
-        self.stderr_handle.take().unwrap().into_raw_fd();
+        let _ = self.stdin_handle.take().unwrap().into_raw_fd();
+        let _ = self.stdout_handle.take().unwrap().into_raw_fd();
+        let _ = self.stderr_handle.take().unwrap().into_raw_fd();
     }
 }
 


### PR DESCRIPTION
Upgrade Rust toolchain to v1.82.0.

As per the [blog announcement](https://blog.rust-lang.org/2024/10/17/Rust-1.82.0.html), the main interesting point is that macOS on 64-bit ARM is now a "Tier 1" platform for Rust.
- 