### PR TITLE
Ensure deterministic `jvm` lockfiles

### DIFF
--- a/docs/notes/2.24.x.md
+++ b/docs/notes/2.24.x.md
@@ -50,6 +50,8 @@ Fixed a coursier fetch wrapper script bug on nixos.
 
 Fixed a jvm.sh script bug on nixos.
 
+Lockfiles are now deterministic as the dependency coordinates to be resolved are sorted before being passed to couriser.
+
 #### Kotlin
 
 The kotlin linter, [ktlint](https://pinterest.github.io/ktlint/), has been updated to version 1.3.1.

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -12,7 +12,7 @@ import os
 from collections import defaultdict
 from dataclasses import dataclass
 from itertools import chain
-from typing import TYPE_CHECKING, Any, FrozenSet, Iterable, Iterator, List, Tuple
+from typing import TYPE_CHECKING, Any, Iterable, Iterator, List, Tuple
 
 import toml
 
@@ -65,6 +65,7 @@ from pants.jvm.target_types import (
 from pants.jvm.util_rules import ExtractFileDigest
 from pants.util.docutil import bin_name, doc_url
 from pants.util.logging import LogLevel
+from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
 from pants.util.strutil import bullet_list, pluralize
 
 if TYPE_CHECKING:
@@ -302,8 +303,8 @@ def classpath_dest_filename(coord: str, src_filename: str) -> str:
 
 @dataclass(frozen=True)
 class CoursierResolveInfo:
-    coord_arg_strings: FrozenSet[str]
-    force_version_coord_arg_strings: FrozenSet[str]
+    coord_arg_strings: FrozenOrderedSet[str]
+    force_version_coord_arg_strings: FrozenOrderedSet[str]
     extra_args: tuple[str, ...]
     digest: Digest
 
@@ -394,17 +395,17 @@ async def prepare_coursier_resolve_info(
         ),
     )
 
-    coord_arg_strings = set()
-    force_version_coord_arg_strings = set()
-    for req in to_resolve:
+    coord_arg_strings: OrderedSet[str] = OrderedSet()
+    force_version_coord_arg_strings: OrderedSet[str] = OrderedSet()
+    for req in sorted(to_resolve, key=lambda ar: ar.coordinate):
         coord_arg_str = req.to_coord_arg_str()
         coord_arg_strings.add(coord_arg_str)
         if req.force_version:
             force_version_coord_arg_strings.add(coord_arg_str)
 
     return CoursierResolveInfo(
-        coord_arg_strings=frozenset(coord_arg_strings),
-        force_version_coord_arg_strings=frozenset(force_version_coord_arg_strings),
+        coord_arg_strings=FrozenOrderedSet(coord_arg_strings),
+        force_version_coord_arg_strings=FrozenOrderedSet(force_version_coord_arg_strings),
         digest=digest,
         extra_args=tuple(extra_args),
     )


### PR DESCRIPTION
This change will make lockfile generation for `jvm` deterministic by sorting the dependency coordinates that is passed into `coursier`. The sorted dependencies produces smaller diffs of the lockfile even tho environmental differences (e.g. cached packages) might be present.

I would really like to see this cherry-picked to `2.22.x` because it currently breaks our deployment-pipelines.

**Important**: 
This modification constitutes a breaking change. The initial execution of `generate-lockfiles` after implementing this change will generate a lockfile that differs from the existing one, even if no dependencies have been altered.
This one-time discrepancy is a necessary trade-off for achieving deterministic lockfiles and more stable diffs in subsequent runs.

Thanks to @jgranstrom for helping me with this!