### PR TITLE
golang: support `all:` prefix for `go:embed` directives (Cherry-pick of #21559)

### DIFF
--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -124,6 +124,8 @@ Support for including additional binaries in the pants sandbox through the `--go
 
 Fix a bug where Pants raised an internal exception which occurred when compiling a Go package with coverage support when the package also had an external test which imported the base package.
 
+Add support for the `all:` prefix to patterns used with the `go:embed` directive. The `all:` prefix includes files which start with `_` or `.` which are ordinarilly excluded.
+
 #### JVM
 
 When [the `jvm.reproducible_jars` flag](https://www.pantsbuild.org/2.21/reference/subsystems/jvm#reproducible_jars) is set resources jars are now also made reproducible, previously it was assumed resources jars are reproducible without additional action.


### PR DESCRIPTION
Support the `all:` prefix for the `go:embed` directive. This directive includes files which start with `_` or `.` which are ordinarily excluded.

See Go commit https://github.com/golang/go/commit/36dbf7f7e63f3738795bb04593c3c011e987d1f3 which added this support for the details.

Closes https://github.com/pantsbuild/pants/issues/21554
