### PR TITLE
golang: support `all:` prefix for `go:embed` directives (Cherry-pick of #21559)

### DIFF
--- a/docs/notes/2.22.x.md
+++ b/docs/notes/2.22.x.md
@@ -141,6 +141,8 @@ Setting [the `orphan_files_behaviour = "ignore"` option](https://www.pantsbuild.
 
 Fix a bug where Pants raised an internal exception which occurred when compiling a Go package with coverage support when the package also had an external test which imported the base package.
 
+Add support for the `all:` prefix to patterns used with the `go:embed` directive. The `all:` prefix includes files which start with `_` or `.` which are ordinarilly excluded.
+
 ### Plugin API changes
 
 The `PythonToolRequirementsBase` and `PythonToolBase` classes now have a new `help_short` field. Subclasses should now use `help_short` instead of the `help` field. The `help` field will be automatically generated using `help_short`, and will include the tool's default package version and provide instructions on how to override this version using a custom lockfile.


### PR DESCRIPTION
Support the `all:` prefix for the `go:embed` directive. This directive includes files which start with `_` or `.` which are ordinarily excluded.

See Go commit https://github.com/golang/go/commit/36dbf7f7e63f3738795bb04593c3c011e987d1f3 which added this support for the details.

Closes https://github.com/pantsbuild/pants/issues/21554
