### PR TITLE
"open" support for experimental-explorer on Linux

### DIFF
--- a/src/python/pants/core/util_rules/system_binaries.py
+++ b/src/python/pants/core/util_rules/system_binaries.py
@@ -1075,8 +1075,13 @@ async def find_mv(system_binaries: SystemBinariesSubsystem.EnvironmentAware) -> 
 
 
 @rule(desc="Finding the `open` binary", level=LogLevel.DEBUG)
-async def find_open(system_binaries: SystemBinariesSubsystem.EnvironmentAware) -> OpenBinary:
-    request = BinaryPathRequest(binary_name="open", search_path=system_binaries.system_binary_paths)
+async def find_open(
+    platform: Platform, system_binaries: SystemBinariesSubsystem.EnvironmentAware
+) -> OpenBinary:
+    request = BinaryPathRequest(
+        binary_name=("open" if platform.is_macos else "xdg-open"),
+        search_path=system_binaries.system_binary_paths,
+    )
     paths = await Get(BinaryPaths, BinaryPathRequest, request)
     first_path = paths.first_path_or_raise(request, rationale="open URLs with default browser")
     return OpenBinary(first_path.path, first_path.fingerprint)


### PR DESCRIPTION
`open` isn't a traditional Linux command, but
[xdg-open](https://wiki.archlinux.org/title/Default_applications) is a common part of many distros and exits to "open a file or URL in the user's preferred application".

NOTE: The intend here is limited to make experimental-explorer runnable without crashing on Linux, I have not done any testing of how various GUI applications work or not when invoked from the sandbox.