### PR TITLE
mypy: lint scripts without extensions

### DIFF
--- a/docs/notes/2.24.x.md
+++ b/docs/notes/2.24.x.md
@@ -82,6 +82,7 @@ Version Updates:
 
 A new experimental [Python Provider](https://www.pantsbuild.org/blog/2023/03/31/two-hermetic-pythons) using [Python Build Standalone](https://gregoryszorc.com/docs/python-build-standalone/main/) is available as `pants.backend.python.providers.experimental.python_build_standalone`.  This joins the existing [pyenv provider](https://www.pantsbuild.org/stable/reference/subsystems/pyenv-python-provider) as a way for Pants to take care of providing an appropriate Python.
 
+Mypy will now typecheck previously-ignored python sources without a `.py` or `.pyi` extension.
 
 #### S3
 

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -127,6 +127,9 @@ def determine_python_files(files: Iterable[str]) -> Tuple[str, ...]:
             pyi_file = f + "i"
             if pyi_file not in result:
                 result.add(f)
+        else:
+            result.add(f)
+
     return tuple(result)
 
 

--- a/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
@@ -694,7 +694,7 @@ def test_determine_python_files() -> None:
     assert determine_python_files(["f.pyi"]) == ("f.pyi",)
     assert determine_python_files(["f.py", "f.pyi"]) == ("f.pyi",)
     assert determine_python_files(["f.pyi", "f.py"]) == ("f.pyi",)
-    assert determine_python_files(["f.json"]) == ()
+    assert determine_python_files(["script-without-extension"]) == ("script-without-extension",)
 
 
 def test_colors_and_formatting(rule_runner: PythonRuleRunner) -> None:


### PR DESCRIPTION
Closes #21572

As suggested by @huonw, I modified `determine_python_files` so that it does not exclude scripts without python extensions.

I also modified the test in `test_determine_python_files` to make it clear that this is intended. However I must admit that I am not sure of what the test's goal was. Could a `.json` file really make it to this function? My proposed change only works if the files considered here are python sources (and checking for the extension makes no sense because I should be allowed to name my python scripts with `.json` if I want).

I tested in my own project and it worked perfectly. It raised errors for scripts that were not typechecked before.

(By the way, me and the platform team at https://flare.io/ are huge fans of Pants. We are now about 9 months in and we have managed to transition our whole monorepo, implement distributed test caching, move to PEX for all services, and simplify many dev tools while getting rid of our home-made build system that kept getting more complex and slowing down. Pants was game-changing for Flare.)