### PR TITLE
Turn off the legacy options parser.

### DIFF
--- a/docs/notes/2.25.x.md
+++ b/docs/notes/2.25.x.md
@@ -15,6 +15,10 @@ established for this purpose. This non-profit's only source of revenue is
 
 ### General
 
+### New Options System
+
+The "legacy" options system is removed in this release. All options parsing is now handled by the new, native parser.
+
 ### Goals
 
 ### Backends

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -982,6 +982,8 @@ class BootstrapOptions:
     )
     native_options_validation = EnumOption(
         default=NativeOptionsValidation.warning,
+        removal_version="2.26.0.dev0",
+        removal_hint="The legacy parser has been removed so this option has no effect.",
         help=softwrap(
             """
             Pants is switching its option parsing system from a legacy parser written in Python

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -212,8 +212,9 @@ class Parser:
                 scope=self.scope, registration_args=args, registration_kwargs=kwargs
             )
 
-            # If the option is explicitly given, check mutual exclusion.
+            # If the option is explicitly given, check deprecation and mutual exclusion.
             if rank > Rank.HARDCODED:
+                self._check_deprecated(dest, kwargs)
                 mutex_dest = kwargs.get("mutually_exclusive_group")
                 mutex_map_key = mutex_dest or dest
                 mutex_map[mutex_map_key].append(dest)


### PR DESCRIPTION
Only use the native parser from now on.

Future changes will strip out the legacy parser's code.