### PR TITLE
tests: make cas testutil functions async

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -2292,6 +2292,7 @@ dependencies = [
  "clap",
  "mock",
  "protos",
+ "tokio",
 ]
 
 [[package]]

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -2282,6 +2282,7 @@ dependencies = [
  "clap",
  "env_logger",
  "mock",
+ "tokio",
 ]
 
 [[package]]

--- a/src/rust/engine/fs/store/src/remote_tests.rs
+++ b/src/rust/engine/fs/store/src/remote_tests.rs
@@ -27,7 +27,7 @@ async fn smoke_test_from_options_reapi_provider() {
     let roland = TestData::roland();
     let empty = TestData::empty();
 
-    let cas = new_cas(10);
+    let cas = new_cas(10).await;
 
     let store = ByteStore::from_options(RemoteStoreOptions {
         provider: RemoteProvider::Reapi,

--- a/src/rust/engine/process_execution/remote/src/remote_cache_tests.rs
+++ b/src/rust/engine/process_execution/remote/src/remote_cache_tests.rs
@@ -96,7 +96,7 @@ struct StoreSetup {
 
 impl StoreSetup {
     pub async fn new() -> Self {
-        Self::new_with_stub_cas(StubCAS::builder().build()).await
+        Self::new_with_stub_cas(StubCAS::builder().build().await).await
     }
 
     pub async fn new_with_stub_cas(cas: StubCAS) -> Self {
@@ -358,7 +358,8 @@ async fn cache_read_speculation() {
         let store_setup = StoreSetup::new_with_stub_cas(
             StubCAS::builder()
                 .ac_read_delay(Duration::from_millis(remote_delay_ms))
-                .build(),
+                .build()
+                .await,
         )
         .await;
         let (local_runner, local_runner_call_counter) = create_local_runner(1, local_delay_ms);
@@ -560,7 +561,8 @@ async fn cache_write_does_not_block() {
     let store_setup = StoreSetup::new_with_stub_cas(
         StubCAS::builder()
             .ac_write_delay(Duration::from_millis(100))
-            .build(),
+            .build()
+            .await,
     )
     .await;
     let (local_runner, local_runner_call_counter) = create_local_runner(0, 100);
@@ -750,7 +752,7 @@ async fn make_action_result_basic() {
         .expect("Error saving directory");
 
     let mock_command_runner = Arc::new(MockCommandRunner);
-    let cas = StubCAS::builder().build();
+    let cas = StubCAS::builder().build().await;
     let runner = crate::remote_cache::CommandRunner::from_provider_options(
         RemoteCacheRunnerOptions {
             inner: mock_command_runner.clone(),
@@ -859,7 +861,8 @@ async fn no_remote_cache_on_scope_local() {
         let store_setup = StoreSetup::new_with_stub_cas(
             StubCAS::builder()
                 .ac_read_delay(Duration::from_millis(100))
-                .build(),
+                .build()
+                .await,
         )
         .await;
         let (local_runner, local_runner_call_counter) = create_local_runner(1, 500);

--- a/src/rust/engine/process_execution/remote/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/remote/src/remote_tests.rs
@@ -941,6 +941,7 @@ async fn successful_with_only_call_to_execute() {
             }]),
             None,
         )
+        .await
     };
 
     let result = run_command_remote(mock_server.address(), execute_request)
@@ -989,6 +990,7 @@ async fn successful_after_reconnect_with_wait_execution() {
             ]),
             None,
         )
+        .await
     };
 
     let result = run_command_remote(mock_server.address(), execute_request)
@@ -1046,6 +1048,7 @@ async fn successful_after_reconnect_from_retryable_error() {
             ]),
             None,
         )
+        .await
     };
 
     let result = run_command_remote(mock_server.address(), execute_request)
@@ -1108,6 +1111,7 @@ async fn creates_executing_workunit() {
             }]),
             None,
         )
+        .await
     };
 
     let result =
@@ -1172,12 +1176,14 @@ async fn dropped_request_cancels() {
             }]),
             None,
         )
+        .await
     };
 
     let cas = mock::StubCAS::builder()
         .file(&TestData::roland())
         .directory(&TestDirectory::containing_roland())
-        .build();
+        .build()
+        .await;
     let (command_runner, _store) = create_command_runner(mock_server.address(), &cas).await;
 
     let context = Context {
@@ -1228,7 +1234,8 @@ async fn server_rejecting_execute_request_gives_error() {
             stream_responses: Err(Status::invalid_argument("".to_owned())),
         }]),
         None,
-    );
+    )
+    .await;
 
     let error = run_command_remote(mock_server.address(), execute_request)
         .await
@@ -1260,6 +1267,7 @@ async fn server_sending_triggering_timeout_with_deadline_exceeded() {
             }]),
             None,
         )
+        .await
     };
 
     let result = run_command_remote(mock_server.address(), execute_request)
@@ -1287,7 +1295,7 @@ fn remote_options_for_cas(cas: &mock::StubCAS) -> RemoteStoreOptions {
 async fn sends_headers() {
     let (_, mut workunit) = WorkunitStore::setup_for_tests();
 
-    let cas = mock::StubCAS::empty();
+    let cas = mock::StubCAS::empty().await;
     let runtime = task_executor::Executor::new();
     let store_dir = TempDir::new().unwrap();
     let store = Store::local_only(runtime.clone(), store_dir)
@@ -1321,6 +1329,7 @@ async fn sends_headers() {
             }]),
             None,
         )
+        .await
     };
 
     let command_runner = CommandRunner::new(
@@ -1443,7 +1452,7 @@ async fn ensure_inline_stdio_is_stored() {
     let store_dir = TempDir::new().unwrap();
     let store_dir_path = store_dir.path();
 
-    let cas = mock::StubCAS::empty();
+    let cas = mock::StubCAS::empty().await;
     let store = Store::local_only(runtime.clone(), store_dir_path)
         .unwrap()
         .into_with_remote(remote_options_for_cas(&cas))
@@ -1483,6 +1492,7 @@ async fn ensure_inline_stdio_is_stored() {
             }]),
             None,
         )
+        .await
     };
 
     let cmd_runner = CommandRunner::new(
@@ -1571,6 +1581,7 @@ async fn bad_result_bytes() {
             }]),
             None,
         )
+        .await
     };
 
     run_command_remote(mock_server.address(), execute_request)
@@ -1616,6 +1627,7 @@ async fn initial_response_error() {
             }]),
             None,
         )
+        .await
     };
 
     let result = run_command_remote(mock_server.address(), execute_request)
@@ -1658,6 +1670,7 @@ async fn initial_response_missing_response_and_error() {
             }]),
             None,
         )
+        .await
     };
 
     let result = run_command_remote(mock_server.address(), execute_request)
@@ -1714,6 +1727,7 @@ async fn fails_after_retry_limit_exceeded() {
             ]),
             None,
         )
+        .await
     };
 
     let result = run_command_remote(mock_server.address(), execute_request)
@@ -1772,6 +1786,7 @@ async fn fails_after_retry_limit_exceeded_with_stream_close() {
             ]),
             None,
         )
+        .await
     };
 
     let result = run_command_remote(mock_server.address(), execute_request)
@@ -1792,7 +1807,8 @@ async fn execute_missing_file_uploads_if_known() {
     let store_dir = TempDir::new().unwrap();
     let cas = mock::StubCAS::builder()
         .directory(&TestDirectory::containing_roland())
-        .build();
+        .build()
+        .await;
     let store = Store::local_only(runtime.clone(), store_dir)
         .unwrap()
         .into_with_remote(remote_options_for_cas(&cas))
@@ -1851,6 +1867,7 @@ async fn execute_missing_file_uploads_if_known() {
             ]),
             None,
         )
+        .await
     };
 
     store
@@ -1901,10 +1918,14 @@ async fn execute_missing_file_errors_if_unknown() {
             mock::execution_server::MockExecution::new(vec![]),
             None,
         )
+        .await
     };
 
     let store_dir = TempDir::new().unwrap();
-    let cas = mock::StubCAS::builder().file(&TestData::roland()).build();
+    let cas = mock::StubCAS::builder()
+        .file(&TestData::roland())
+        .build()
+        .await;
     let runtime = task_executor::Executor::new();
     let store = Store::local_only(runtime.clone(), store_dir)
         .unwrap()
@@ -2127,7 +2148,8 @@ async fn remote_workunits_are_stored() {
     let cas = mock::StubCAS::builder()
         .file(&TestData::roland())
         .directory(&TestDirectory::containing_roland())
-        .build();
+        .build()
+        .await;
     // TODO: This CommandRunner is only used for parsing, add so intentionally passes a CAS/AC
     // address rather than an Execution address.
     let (command_runner, _store) = create_command_runner(cas.address(), &cas).await;
@@ -2658,7 +2680,8 @@ async fn run_command_remote_in_workunit(
         .file(&TestData::roland())
         .directory(&TestDirectory::containing_roland())
         .tree(&TestTree::roland_at_root())
-        .build();
+        .build()
+        .await;
     let (command_runner, store) = create_command_runner(execution_address, &cas).await;
     let original = command_runner
         .run(Context::default(), workunit, request)
@@ -2696,7 +2719,9 @@ async fn extract_execute_response(
     let cas = mock::StubCAS::builder()
         .file(&TestData::roland())
         .directory(&TestDirectory::containing_roland())
-        .build();
+        .build()
+        .await;
+
     // TODO: This CommandRunner is only used for parsing, add so intentionally passes a CAS/AC
     // address rather than an Execution address.
     let (command_runner, store) = create_command_runner(cas.address(), &cas).await;
@@ -2734,7 +2759,8 @@ async fn extract_output_files_from_response(
         .directory(&TestDirectory::containing_roland())
         .tree(&TestTree::roland_at_root())
         .tree(&TestTree::robin_at_root())
-        .build();
+        .build()
+        .await;
     let executor = task_executor::Executor::new();
     let store_dir = TempDir::new().unwrap();
     let store = make_store(store_dir.path(), &cas, executor.clone()).await;

--- a/src/rust/engine/remote_provider/remote_provider_reapi/src/action_cache_tests.rs
+++ b/src/rust/engine/remote_provider/remote_provider_reapi/src/action_cache_tests.rs
@@ -28,7 +28,7 @@ async fn new_provider(cas: &StubCAS) -> Provider {
 
 #[tokio::test]
 async fn get_action_result_existing() {
-    let cas = StubCAS::empty();
+    let cas = StubCAS::empty().await;
     let provider = new_provider(&cas).await;
 
     let action_digest = Digest::of_bytes(b"get_action_cache test");
@@ -49,7 +49,7 @@ async fn get_action_result_existing() {
 
 #[tokio::test]
 async fn get_action_result_missing() {
-    let cas = StubCAS::empty();
+    let cas = StubCAS::empty().await;
     let provider = new_provider(&cas).await;
 
     let action_digest = Digest::of_bytes(b"update_action_cache test");
@@ -62,7 +62,7 @@ async fn get_action_result_missing() {
 
 #[tokio::test]
 async fn get_action_result_grpc_error() {
-    let cas = StubCAS::builder().ac_always_errors().build();
+    let cas = StubCAS::builder().ac_always_errors().build().await;
     let provider = new_provider(&cas).await;
 
     let action_digest = Digest::of_bytes(b"get_action_result_grpc_error test");
@@ -80,7 +80,7 @@ async fn get_action_result_grpc_error() {
 
 #[tokio::test]
 async fn update_action_cache() {
-    let cas = StubCAS::empty();
+    let cas = StubCAS::empty().await;
     let provider = new_provider(&cas).await;
 
     let action_digest = Digest::of_bytes(b"update_action_cache test");
@@ -102,7 +102,7 @@ async fn update_action_cache() {
 
 #[tokio::test]
 async fn update_action_cache_grpc_error() {
-    let cas = StubCAS::builder().ac_always_errors().build();
+    let cas = StubCAS::builder().ac_always_errors().build().await;
     let provider = new_provider(&cas).await;
 
     let action_digest = Digest::of_bytes(b"update_action_cache_grpc_error test");

--- a/src/rust/engine/remote_provider/remote_provider_reapi/src/byte_store_tests.rs
+++ b/src/rust/engine/remote_provider/remote_provider_reapi/src/byte_store_tests.rs
@@ -54,7 +54,8 @@ async fn load_test(chunk_size: usize) {
     let cas = StubCAS::builder()
         .chunk_size_bytes(chunk_size)
         .file(&testdata)
-        .build();
+        .build()
+        .await;
 
     let provider = new_provider(&cas).await;
     let mut destination = Vec::new();
@@ -91,7 +92,7 @@ async fn load_existing_multiple_chunks_nonfactor() {
 #[tokio::test]
 async fn load_missing() {
     let testdata = TestData::roland();
-    let cas = StubCAS::empty();
+    let cas = StubCAS::empty().await;
     let provider = new_provider(&cas).await;
     let mut destination: Vec<u8> = Vec::new();
 
@@ -107,7 +108,7 @@ async fn load_missing() {
 #[tokio::test]
 async fn load_grpc_error() {
     let testdata = TestData::roland();
-    let cas = StubCAS::cas_always_errors();
+    let cas = StubCAS::cas_always_errors().await;
 
     let provider = new_provider(&cas).await;
     let mut destination = Vec::new();
@@ -136,7 +137,8 @@ async fn load_existing_wrong_digest_error() {
             TestData::roland().fingerprint(),
             Bytes::from_static(b"not roland"),
         )
-        .build();
+        .build()
+        .await;
 
     let provider = new_provider(&cas).await;
     let mut destination = Vec::new();
@@ -171,7 +173,7 @@ fn assert_cas_store(cas: &StubCAS, testdata: &TestData, chunks: usize, chunk_siz
 #[tokio::test]
 async fn store_file_one_chunk() {
     let testdata = TestData::roland();
-    let cas = StubCAS::empty();
+    let cas = StubCAS::empty().await;
     let provider = new_provider(&cas).await;
 
     provider
@@ -188,7 +190,7 @@ async fn store_file_one_chunk() {
 async fn store_file_multiple_chunks() {
     let testdata = TestData::all_the_henries();
 
-    let cas = StubCAS::empty();
+    let cas = StubCAS::empty().await;
     let chunk_size = 10 * 1024;
     let provider = Provider::new(remote_options(
         cas.address(),
@@ -212,7 +214,7 @@ async fn store_file_multiple_chunks() {
 #[tokio::test]
 async fn store_file_empty_file() {
     let testdata = TestData::empty();
-    let cas = StubCAS::empty();
+    let cas = StubCAS::empty().await;
     let provider = new_provider(&cas).await;
 
     provider
@@ -229,7 +231,7 @@ async fn store_file_empty_file() {
 #[tokio::test]
 async fn store_file_grpc_error() {
     let testdata = TestData::roland();
-    let cas = StubCAS::cas_always_errors();
+    let cas = StubCAS::cas_always_errors().await;
     let provider = new_provider(&cas).await;
 
     let error = provider
@@ -278,7 +280,7 @@ async fn store_file_connection_error() {
 #[tokio::test]
 async fn store_file_source_read_error_immediately() {
     let testdata = TestData::roland();
-    let cas = StubCAS::empty();
+    let cas = StubCAS::empty().await;
     let provider = new_provider(&cas).await;
 
     let temp_dir = TempDir::new().unwrap();
@@ -314,7 +316,7 @@ async fn store_bytes_one_chunk() {
 async fn store_bytes_multiple_chunks() {
     let testdata = TestData::all_the_henries();
 
-    let cas = StubCAS::empty();
+    let cas = StubCAS::empty().await;
     let chunk_size = 10 * 1024;
     let provider = Provider::new(remote_options(
         cas.address(),
@@ -335,7 +337,7 @@ async fn store_bytes_multiple_chunks() {
 #[tokio::test]
 async fn store_bytes_empty_file() {
     let testdata = TestData::empty();
-    let cas = StubCAS::empty();
+    let cas = StubCAS::empty().await;
     let provider = new_provider(&cas).await;
 
     provider
@@ -349,7 +351,7 @@ async fn store_bytes_empty_file() {
 #[tokio::test]
 async fn store_bytes_batch_grpc_error() {
     let testdata = TestData::roland();
-    let cas = StubCAS::cas_always_errors();
+    let cas = StubCAS::cas_always_errors().await;
     let provider = new_provider(&cas).await;
 
     let error = provider
@@ -373,7 +375,7 @@ async fn store_bytes_batch_grpc_error() {
 #[tokio::test]
 async fn store_bytes_write_stream_grpc_error() {
     let testdata = TestData::all_the_henries();
-    let cas = StubCAS::cas_always_errors();
+    let cas = StubCAS::cas_always_errors().await;
     let chunk_size = 10 * 1024;
     let provider = Provider::new(remote_options(
         cas.address(),
@@ -424,7 +426,7 @@ async fn store_bytes_connection_error() {
 async fn list_missing_digests_none_missing() {
     let testdata = TestData::roland();
     let _ = WorkunitStore::setup_for_tests();
-    let cas = StubCAS::builder().file(&testdata).build();
+    let cas = StubCAS::builder().file(&testdata).build().await;
 
     let provider = new_provider(&cas).await;
 
@@ -438,7 +440,7 @@ async fn list_missing_digests_none_missing() {
 
 #[tokio::test]
 async fn list_missing_digests_some_missing() {
-    let cas = StubCAS::empty();
+    let cas = StubCAS::empty().await;
 
     let provider = new_provider(&cas).await;
     let digest = TestData::roland().digest();
@@ -456,7 +458,7 @@ async fn list_missing_digests_some_missing() {
 
 #[tokio::test]
 async fn list_missing_digests_grpc_error() {
-    let cas = StubCAS::cas_always_errors();
+    let cas = StubCAS::cas_always_errors().await;
     let provider = new_provider(&cas).await;
 
     let error = provider

--- a/src/rust/engine/remote_provider/remote_provider_reapi/src/byte_store_tests.rs
+++ b/src/rust/engine/remote_provider/remote_provider_reapi/src/byte_store_tests.rs
@@ -302,7 +302,7 @@ async fn store_file_source_read_error_immediately() {
 #[tokio::test]
 async fn store_bytes_one_chunk() {
     let testdata = TestData::roland();
-    let cas = StubCAS::empty();
+    let cas = StubCAS::empty().await;
     let provider = new_provider(&cas).await;
 
     provider

--- a/src/rust/engine/src/externs/testutil.rs
+++ b/src/rust/engine/src/externs/testutil.rs
@@ -50,7 +50,7 @@ impl PyStubCASBuilder {
         py_executor
             .borrow()
             .0
-            .enter(|| Ok(PyStubCAS(builder.build())))
+            .block_on(async move { Ok(PyStubCAS(builder.build().await)) })
     }
 }
 

--- a/src/rust/engine/testutil/local_cas/Cargo.toml
+++ b/src/rust/engine/testutil/local_cas/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 mock = { path = "../mock" }
 clap = { workspace = true }
 env_logger = { workspace = true }
+tokio = { workspace = true }
 
 [lints]
 workspace = true

--- a/src/rust/engine/testutil/local_cas/src/main.rs
+++ b/src/rust/engine/testutil/local_cas/src/main.rs
@@ -6,7 +6,8 @@ use mock::StubCAS;
 use std::io;
 use std::io::Read;
 
-fn main() -> Result<(), String> {
+#[tokio::main]
+async fn main() -> Result<(), String> {
     env_logger::init();
     let mut stdin = io::stdin();
 
@@ -40,7 +41,8 @@ fn main() -> Result<(), String> {
                 .expect("port must be a non-negative number"),
         )
         .instance_name(matches.value_of("instance-name").unwrap().to_owned())
-        .build();
+        .build()
+        .await;
     println!("Started CAS at address: {}", cas.address());
     println!("Press enter to exit.");
     let _ = stdin.read(&mut [0_u8]).unwrap();

--- a/src/rust/engine/testutil/local_execution_server/Cargo.toml
+++ b/src/rust/engine/testutil/local_execution_server/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 protos = { path = "../../protos" }
 mock = { path = "../mock" }
 clap = { workspace = true, features = ["derive"] }
+tokio = { workspace = true }
 
 [lints]
 workspace = true

--- a/src/rust/engine/testutil/local_execution_server/src/main.rs
+++ b/src/rust/engine/testutil/local_execution_server/src/main.rs
@@ -30,7 +30,8 @@ struct Options {
     request_size: i64,
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let options = Options::from_args();
 
     // When the request is executed, perform this operation
@@ -54,7 +55,7 @@ fn main() {
     }]);
 
     // Start the server
-    let server = TestServer::new(execution, options.port);
+    let server = TestServer::new(execution, options.port).await;
     println!("Started execution server at address: {}", server.address());
 
     // Wait for the user to kill us

--- a/src/rust/engine/testutil/mock/src/cas.rs
+++ b/src/rust/engine/testutil/mock/src/cas.rs
@@ -177,7 +177,7 @@ impl StubCASBuilder {
         self
     }
 
-    pub fn build(self) -> StubCAS {
+    pub async fn build(self) -> StubCAS {
         let request_counts = Arc::new(Mutex::new(HashMap::new()));
         let write_message_sizes = Arc::new(Mutex::new(Vec::new()));
         let blobs = Arc::new(Mutex::new(self.content));
@@ -202,10 +202,8 @@ impl StubCASBuilder {
 
         // TODO: Refactor to just use `tokio::net::TcpListener` directly (but requries the method be async and
         // all call sites updated).
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-        listener.set_nonblocking(true).unwrap();
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let local_addr = listener.local_addr().unwrap();
-        let listener = TcpListener::from_std(listener).unwrap();
 
         let (shutdown_sender, shutdown_receiver) = tokio::sync::oneshot::channel();
 
@@ -243,12 +241,12 @@ impl StubCAS {
         StubCASBuilder::new()
     }
 
-    pub fn empty() -> StubCAS {
-        StubCAS::builder().build()
+    pub async fn empty() -> StubCAS {
+        StubCAS::builder().build().await
     }
 
-    pub fn cas_always_errors() -> StubCAS {
-        StubCAS::builder().cas_always_errors().build()
+    pub async fn cas_always_errors() -> StubCAS {
+        StubCAS::builder().cas_always_errors().build().await
     }
 
     ///

--- a/src/rust/engine/testutil/mock/src/execution_server.rs
+++ b/src/rust/engine/testutil/mock/src/execution_server.rs
@@ -123,7 +123,7 @@ impl TestServer {
     ///                      If a GetOperation request is received whose name is not equal to this
     ///                      MockExecution's name, or more requests are received than stub responses
     ///                      are available for, an error will be returned.
-    pub fn new(mock_execution: MockExecution, port: Option<u16>) -> TestServer {
+    pub async fn new(mock_execution: MockExecution, port: Option<u16>) -> TestServer {
         let mock_responder = MockResponder::new(mock_execution);
         let mock_responder2 = mock_responder.clone();
 


### PR DESCRIPTION
During the most recent Tonic upgrade, there was a need to use Tokio's `TcpListener` instead of `std::net::TcpListener` because that is what is acccepted by Tonic. Unfortunately, using Tokio's `TcpListener` directly at that time would have required making several CAS testutil functions be `async` with the corresponding mass refactor changes to call `.await` on the returned `Future`'s.

I opted to not do those async / await changes at the time to avoid making the PRs longer to review. Instead, the Tonic refactor created a `std::net::TcpListener` and wrapped it with the Tokio `TcpListener`. This is prone to error because the developer needs to remember to make the `std::net::TcpListener` non-blocking. But it worked to keep the upgrade PR simpler.

This PR now performs the refactor which was deferred during the Tonic upgrade.