### PR TITLE
use an `EnvironmentTarget` helper instead of direct `isinstance` checks

### DIFF
--- a/src/python/pants/core/util_rules/adhoc_binaries.py
+++ b/src/python/pants/core/util_rules/adhoc_binaries.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from textwrap import dedent  # noqa: PNT20
 
 from pants.core.subsystems.python_bootstrap import PythonBootstrapSubsystem
-from pants.core.util_rules.environments import EnvironmentTarget, LocalEnvironmentTarget
+from pants.core.util_rules.environments import EnvironmentTarget
 from pants.core.util_rules.system_binaries import BashBinary, SystemBinariesSubsystem, TarBinary
 from pants.engine.fs import DownloadFile
 from pants.engine.internals.native_engine import Digest, FileDigest
@@ -49,7 +49,7 @@ class _DownloadPythonBuildStandaloneBinaryRequest:
 
 @rule
 async def get_python_for_scripts(env_tgt: EnvironmentTarget) -> PythonBuildStandaloneBinary:
-    if env_tgt.val is None or isinstance(env_tgt.val, LocalEnvironmentTarget):
+    if env_tgt.can_access_local_system_paths:
         return PythonBuildStandaloneBinary(sys.executable)
 
     result = await Get(_PythonBuildStandaloneBinary, _DownloadPythonBuildStandaloneBinaryRequest())

--- a/src/python/pants/core/util_rules/asdf.py
+++ b/src/python/pants/core/util_rules/asdf.py
@@ -11,7 +11,7 @@ from typing import Collection
 
 from pants.base.build_environment import get_buildroot
 from pants.base.build_root import BuildRoot
-from pants.core.util_rules.environments import EnvironmentTarget, LocalEnvironmentTarget
+from pants.core.util_rules.environments import EnvironmentTarget
 from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.internals.selectors import Get
 from pants.engine.rules import _uncacheable_rule, collect_rules
@@ -97,7 +97,7 @@ async def _resolve_asdf_tool_paths(
     env: EnvironmentVars,
     local: bool,
 ) -> tuple[str, ...]:
-    if not (isinstance(env_tgt.val, LocalEnvironmentTarget) or env_tgt.val is None):
+    if not env_tgt.can_access_local_system_paths:
         return ()
 
     asdf_dir = get_asdf_data_dir(env)

--- a/src/python/pants/core/util_rules/environments.py
+++ b/src/python/pants/core/util_rules/environments.py
@@ -482,7 +482,7 @@ async def _warn_on_non_local_environments(specified_targets: Iterable[Target], s
     error_cases = [
         (env_name, tgts, env_tgt.val)
         for ((env_name, tgts), env_tgt) in zip(env_names_and_targets, env_tgts)
-        if env_tgt.val is not None and not isinstance(env_tgt.val, LocalEnvironmentTarget)
+        if env_tgt.val is not None and not env_tgt.can_access_local_system_paths
     ]
 
     for env_name, tgts, env_tgt in error_cases:
@@ -592,7 +592,7 @@ class EnvironmentTarget:
         return True
 
     @property
-    def can_use_system_path_metadata_requests(self) -> bool:
+    def can_access_local_system_paths(self) -> bool:
         tgt = self.val
         if not tgt:
             return True

--- a/src/python/pants/core/util_rules/system_binaries.py
+++ b/src/python/pants/core/util_rules/system_binaries.py
@@ -759,7 +759,7 @@ async def find_binary(
     env_target: EnvironmentTarget,
 ) -> BinaryPaths:
     found_paths: tuple[str, ...]
-    if env_target.can_use_system_path_metadata_requests:
+    if env_target.can_access_local_system_paths:
         found_paths = await _find_candidate_paths_via_path_metadata_lookups(request)
     else:
         found_paths = await _find_candidate_paths_via_subprocess_helper(request, env_target)


### PR DESCRIPTION
A user reported that Pants was generating a warning for the visibility lint rules because the target was running in an `experimental_workspace_environment`. As it turns out, several parts of the code were checking `EnvironmentTarget.val` directly to see if it was an instance of `LocalEnvironmentTarget`. This is an anti-pattern given that we can introduce new environment types.

This PR fixes the issue by using an existing helper method on `EnvironmentTarget`. The helper method is renamed to `can_access_local_system_paths` from `can_use_system_path_metadata_requests`.