### PR TITLE
Align 2.23's release notes on main to those on 2.23.x branch

### DIFF
--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -177,6 +177,10 @@ Added [new `--docker-optional-tools` option](https://www.pantsbuild.org/2.23/ref
 
 Support for including additional binaries in the Pants sandbox through [the `--golang-extra-tools` option](https://www.pantsbuild.org/2.23/reference/subsystems/golang#extra_tools). The `go` tools may require other binaries in certain cases. E.g. When using `go` modules from a private git repository, `go mod download` will invoke `git`. See the [documentation on Go Private Modules](https://www.pantsbuild.org/2.23/docs/go/private-modules) for details
 
+Fix a bug where Pants raised an internal exception which occurred when compiling a Go package with coverage support when the package also had an external test which imported the base package.
+
+Add support for the `all:` prefix to patterns used with the `go:embed` directive. The `all:` prefix includes files which start with `_` or `.` which are ordinarilly excluded.
+
 #### Helm
 
 Fixed pulling `helm_artifact`s from OCI repositories.

--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -368,8 +368,6 @@ Several intrinsics have been renamed more succinctly, to make them more readable
 An execute_process_or_raise() alias has been added for the fallible_to_exec_result_or_raise rule, so that
 code that calls it by name on an implicitly executed process will be more readable.
 
-Previously `SetupKwargs` took `_allow_banned_keys` which would allow one to pass in certain critical setuptools args (ex: `install_requires`) that Pants calculates for you.  If you Really Really know what you are doing you can know also use `_overwrite_banned_keys` to exclusively use your  own values and ignore the Pants calculated ones.
-
 Metadata for paths in the repository can now be requested via the `PathMetadataRequest` and `PathMetadataResult` types. This API is intended for rules which need access to the "full" metadata for a path.
 
 ## Full Changelog

--- a/docs/notes/2.24.x.md
+++ b/docs/notes/2.24.x.md
@@ -116,6 +116,8 @@ PyO3, the interface crate between Rust and Python, has been upgraded to v0.22.x.
 
 `GenerateToolLockfileSentinel` is removed. See the [porting guide details](https://www.pantsbuild.org/2.24/docs/writing-plugins/common-plugin-tasks/plugin-upgrade-guide#deprecated-generatetoollockfilesentinel) for instructions on migrating.
 
+Previously `SetupKwargs` took `_allow_banned_keys` which would allow one to pass in certain critical setuptools args (ex: `install_requires`) that Pants calculates for you.  If you Really Really know what you are doing you can know also use `_overwrite_banned_keys` to exclusively use your  own values and ignore the Pants calculated ones.
+
 ## Full Changelog
 
 For the full changelog, see the individual GitHub Releases for this series: <https://github.com/pantsbuild/pants/releases>


### PR DESCRIPTION
There's some slight differences in the `2.23.x.md` release notes file on `main` vs on the `2.23.x` branch:

- #21394 had notes in 2.23, but only landed for 2.24 and was not cherrypicked, so the notes are moved to `2.24.x.md`
- #21452 and #21559 were cherry picked to 2.23 and appear in the `2.23.x.md` file on the `2.23.x` branch, but not in that file on `main` (until this PR)
