### PR TITLE
Don't coerce the option default to a RankedValue.

### DIFF
--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -621,18 +621,14 @@ class HelpInfoExtracter:
         if default_help_repr is not None:
             return str(default_help_repr)  # Should already be a string, but might as well be safe.
 
-        ranked_default = kwargs.get("default")
-        fallback: Any = None
+        default = kwargs.get("default")
+        if default is not None:
+            return default
         if is_list_option(kwargs):
-            fallback = []
+            return []
         elif is_dict_option(kwargs):
-            fallback = {}
-        default = (
-            ranked_default.value
-            if ranked_default and ranked_default.value is not None
-            else fallback
-        )
-        return default
+            return {}
+        return None
 
     @staticmethod
     def stringify_type(t: type) -> str:

--- a/src/python/pants/help/help_info_extracter_test.py
+++ b/src/python/pants/help/help_info_extracter_test.py
@@ -17,7 +17,7 @@ from pants.option.global_options import GlobalOptions, LogLevelOption
 from pants.option.option_types import BoolOption, IntOption, StrListOption
 from pants.option.options import Options
 from pants.option.parser import Parser
-from pants.option.ranked_value import Rank, RankedValue
+from pants.option.ranked_value import Rank
 from pants.option.scope import GLOBAL_SCOPE
 from pants.option.subsystem import Subsystem
 from pants.util.logging import LogLevel
@@ -127,7 +127,6 @@ def test_default() -> None:
 
 def test_compute_default():
     def do_test(expected_default: Optional[Any], **kwargs):
-        kwargs["default"] = RankedValue(Rank.HARDCODED, kwargs["default"])
         assert expected_default == HelpInfoExtracter.compute_default(**kwargs)
 
     do_test(False, type=bool, default=False)

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -344,22 +344,20 @@ class Parser:
         Useful for generating help and other documentation.
 
         Each yielded item is an (args, kwargs) pair, as passed to register(), except that kwargs
-        will be normalized in the following ways:
-          - It will always have 'dest' explicitly set.
-          - It will always have 'default' explicitly set, and the value will be a RankedValue.
+        will be normalized to always have 'dest' and 'default' explicitly set.
         """
 
         def normalize_kwargs(orig_args, orig_kwargs):
             nkwargs = copy.copy(orig_kwargs)
             dest = self.parse_dest(*orig_args, **nkwargs)
             nkwargs["dest"] = dest
-            if not ("default" in nkwargs and isinstance(nkwargs["default"], RankedValue)):
+            if "default" not in nkwargs:
                 type_arg = nkwargs.get("type", str)
                 member_type = nkwargs.get("member_type", str)
                 default_val = self.to_value_type(nkwargs.get("default"), type_arg, member_type)
                 if isinstance(default_val, (ListValueComponent, DictValueComponent)):
                     default_val = default_val.val
-                nkwargs["default"] = RankedValue(Rank.HARDCODED, default_val)
+                nkwargs["default"] = default_val
             return nkwargs
 
         # Yield our directly-registered options.


### PR DESCRIPTION
This is unnecessary (and I don't recall if or why it ever was necessary), 
and complicates switching to using value derivation history from the
native parser. 

At the only site where we consumed this coerced value we immediately
took its inner value, so we might as well just have that be the default
kwarg all along.

Note that this coercion was only happening in the iterator over registration
kwargs, which isn't actually used during option parsing anyway. So all
this is only relevant to help generation.