### PR TITLE
Upgrade Ruff to 0.7.2 by default, add known-versions for latest of all `0.x` series

### DIFF
--- a/docs/notes/2.24.x.md
+++ b/docs/notes/2.24.x.md
@@ -56,7 +56,7 @@ The kotlin linter, [ktlint](https://pinterest.github.io/ktlint/), has been updat
 
 #### Python
 
-**Breaking change**: the `pants.backend.experimental.python.lint.ruff.check` and `pants.backend.experimental.python.lint.ruff.format` subsystems now execute Ruff as a downloaded binary, directly from the Ruff releases, rather than using PEX to execute the PyPI `ruff` package. This has less overhead, and makes customising the version simpler. However, **options like [`[ruff].install_from_resolve`](https://www.pantsbuild.org/2.24/reference/subsystems/ruff#install_from_resolve) are now ignored** and will be removed in future. If you have customised the version, use [`[ruff].version`](https://www.pantsbuild.org/2.24/reference/subsystems/ruff#version) and [`[ruff].known_versions`](https://www.pantsbuild.org/2.24/reference/subsystems/ruff#known_versions) instead.
+**Breaking change**: the `pants.backend.experimental.python.lint.ruff.check` and `pants.backend.experimental.python.lint.ruff.format` subsystems now execute Ruff as a downloaded binary, directly from the Ruff releases, rather than using PEX to execute the PyPI `ruff` package. This has less overhead, and makes customising the version simpler. However, **options like [`[ruff].install_from_resolve`](https://www.pantsbuild.org/2.24/reference/subsystems/ruff#install_from_resolve) are now ignored** and will be removed in future. If you have customised the version, use [`[ruff].version`](https://www.pantsbuild.org/2.24/reference/subsystems/ruff#version) and [`[ruff].known_versions`](https://www.pantsbuild.org/2.24/reference/subsystems/ruff#known_versions) instead. This version of Pants includes built-in known-versions for the latest patch release (at time of development) of each `0.x` minor series (0.7.2, 0.6.9, 0.5.7, 0.4.10, 0.3.7, 0.2.2, 0.1.15): if you install from a resolve with a particular pinned version of Ruff, you may find setting `[ruff].version` to the closest matching version in that list is acceptable (if not, you may need to add to `[ruff].known_versions`).
 
 User API Changes:
 - Update default package mapping for `pymupdf` to match imports from both `fitz` (the legacy name) and `pymupdf` (the [currently supported name](https://pymupdf.readthedocs.io/en/latest/installation.html#problems-after-installation).
@@ -80,6 +80,8 @@ Version Updates:
 - The default version of the [Pex](https://docs.pex-tool.org/) tool has been updated from 2.16.2 to [2.20.3](https://github.com/pex-tool/pex/releases/tag/v2.20.3).
 
 - The default version of the [Pyright](https://microsoft.github.io/pyright/#/) tool has been updated from 1.1.365 to [1.1.383](https://github.com/microsoft/pyright/releases/tag/1.1.383).
+
+- The default version of the [Ruff](https://docs.astral.sh/ruff/) tool has been updated from 0.4.9 to [0.7.2](https://github.com/astral-sh/ruff/releases/tag/0.7.2). (As discussed above, one can pin to particular versions, including 0.4.9, via the new `[ruff].version` and `[ruff].known_versions` options.)
 
 
 A new experimental [Python Provider](https://www.pantsbuild.org/blog/2023/03/31/two-hermetic-pythons) using [Python Build Standalone](https://gregoryszorc.com/docs/python-build-standalone/main/) is available as `pants.backend.python.providers.experimental.python_build_standalone`.  This joins the existing [pyenv provider](https://www.pantsbuild.org/stable/reference/subsystems/pyenv-python-provider) as a way for Pants to take care of providing an appropriate Python.

--- a/src/python/pants/backend/python/lint/ruff/subsystem.py
+++ b/src/python/pants/backend/python/lint/ruff/subsystem.py
@@ -45,7 +45,7 @@ class Ruff(TemplatedExternalTool):
     name = "Ruff"
     help = "The Ruff Python formatter (https://github.com/astral-sh/ruff)."
 
-    default_version = "0.6.4"
+    default_version = "0.7.2"
     default_known_versions = [
         "0.7.2|macos_arm64|1c9f5a4fc815330d01fd8a56a7a70114ff3ed149bd997ff831524313705ba991|9802953",
         "0.7.2|macos_x86_64|5815756947d0a7b1d90805b07ffb2c376c8a9800e9462d545839dc0d79a091d2|10162492",

--- a/src/python/pants/backend/python/lint/ruff/subsystem.py
+++ b/src/python/pants/backend/python/lint/ruff/subsystem.py
@@ -47,15 +47,42 @@ class Ruff(TemplatedExternalTool):
 
     default_version = "0.6.4"
     default_known_versions = [
+        "0.7.2|macos_arm64|1c9f5a4fc815330d01fd8a56a7a70114ff3ed149bd997ff831524313705ba991|9802953",
+        "0.7.2|macos_x86_64|5815756947d0a7b1d90805b07ffb2c376c8a9800e9462d545839dc0d79a091d2|10162492",
+        "0.7.2|linux_arm64|f9342fcca6b58143f316ef3e617f39334edb4c3d15fced5220bd939685f6261d|10651691",
+        "0.7.2|linux_x86_64|b769e11a3e23a72692cb97ed762ff28e48534972a8ef447fd5b0d3178a56ffd8|11097578",
+        "0.6.9|macos_arm64|b94562393a4bf23f1a48521f5495a8e48de885b7c173bd7ea8206d6d09921633|9697031",
+        "0.6.9|macos_x86_64|34aa37643e30dcb81a3c0e011c3a8df552465ea7580ba92ca727a3b7c6de25d1|10018168",
+        "0.6.9|linux_arm64|73df3729a3381d0918e4640aac4b2653c542f74c7b7843dee8310e2c877e6f2e|10724239",
+        "0.6.9|linux_x86_64|39a1cd878962ebc88322b4f6d33cae2292454563028f93a3f1f8ce58e3025b07|11000553",
         "0.6.4|macos_arm64|2648dd09984c82db9f3163ce8762c89536e4bf0e198f17e06a01c0e32214273e|9167424",
         "0.6.4|macos_x86_64|4438cbc80c6aa0e839abc3abb2a869a27113631cb40aa26540572fb53752c432|9463378",
         "0.6.4|linux_arm64|a9157a0f062d62c1b1582284a8d10629503f38bc9b7126b614cb7569073180ff|10120541",
         "0.6.4|linux_x86_64|3ca04aabf7259c59193e4153a865618cad26f73be930ce5f6109e0e6097d037b|10373921",
+        "0.5.7|macos_arm64|b78a09f44dc60d8c894aba6cad55abd3b0eccc0992d60a86f74155fc459e227b|8256430",
+        "0.5.7|macos_x86_64|1f9a7d307f191781fc895947af21d32f8c810c5a5a4cdff16ac53d88a14acd69|8662539",
+        "0.5.7|linux_arm64|2509d20ef605fb1c8af37af1f46fefc85e1d72add6e87187cb6543420c05dfb1|9991080",
+        "0.5.7|linux_x86_64|9a5580536ef9cea7d8e56be8af712ac5cd152c081969ece2fbc3631b30bbb5e8|10263458",
         # Custom URLs because 0.5+ doesn't include the version
+        "0.4.10|macos_arm64|5a4ff81270eee1efa7901566719aca705a3e8d0f1abead96c01caa4678a7762e|8094319|https://github.com/astral-sh/ruff/releases/download/v0.4.10/ruff-0.4.10-aarch64-apple-darwin.tar.gz",
+        "0.4.10|macos_x86_64|6e96f288d13b68863e79c9f107a0c51660215829726c9d3dc4879c1801fa3140|8490153|https://github.com/astral-sh/ruff/releases/download/v0.4.10/ruff-0.4.10-x86_64-apple-darwin.tar.gz",
+        "0.4.10|linux_arm64|75332c97520233b5f95cb3d40bdef13b40e1aa5e6c82a078623993545771f55f|9851689|https://github.com/astral-sh/ruff/releases/download/v0.4.10/ruff-0.4.10-aarch64-unknown-linux-musl.tar.gz",
+        "0.4.10|linux_x86_64|332ba368c6e08afc3c5d1c7f6e4fb7bf238b7cbf007b400e6bdf01a0a36ae656|10130989|https://github.com/astral-sh/ruff/releases/download/v0.4.10/ruff-0.4.10-x86_64-unknown-linux-musl.tar.gz",
         "0.4.9|macos_arm64|5f4506d7ec2ae6ac5a48ba309218a4b825a00d4cad9967b7bbcec1724ef04930|8148128|https://github.com/astral-sh/ruff/releases/download/v0.4.9/ruff-0.4.9-aarch64-apple-darwin.tar.gz",
         "0.4.9|macos_x86_64|e4d745adb0f5a0b08f2c9ca71e57f451a9b8485ae35b5555d9f5d20fc93a6cb6|8510706|https://github.com/astral-sh/ruff/releases/download/v0.4.9/ruff-0.4.9-x86_64-apple-darwin.tar.gz",
         "0.4.9|linux_arm64|00c50563f9921a141ddd4ec0371149f3bbfa0369d9d238a143bcc3a932363785|8106747|https://github.com/astral-sh/ruff/releases/download/v0.4.9/ruff-0.4.9-aarch64-unknown-linux-musl.tar.gz",
         "0.4.9|linux_x86_64|5ceba21dad91e3fa05056ca62f278b0178516cfad8dbf08cf2433c6f1eeb92d3|8863118|https://github.com/astral-sh/ruff/releases/download/v0.4.9/ruff-0.4.9-x86_64-unknown-linux-musl.tar.gz",
+        "0.3.7|macos_x86_64|b1c961c1bed427e74ab72950c6debcb078c82aba0ee347183cc27a9fc8aaa43b|8615221|https://github.com/astral-sh/ruff/releases/download/v0.3.7/ruff-0.3.7-x86_64-apple-darwin.tar.gz",
+        "0.3.7|linux_arm64|0e79fbefcd813a10fa60250441bbe36978c95d010b64646848fada64b9af61f0|8180808|https://github.com/astral-sh/ruff/releases/download/v0.3.7/ruff-0.3.7-aarch64-unknown-linux-musl.tar.gz",
+        "0.3.7|linux_x86_64|3f8348096f7d9c0a9266c4a821dbc7599ef299983e456b61eb0d5290d8615df8|8905370|https://github.com/astral-sh/ruff/releases/download/v0.3.7/ruff-0.3.7-x86_64-unknown-linux-musl.tar.gz",
+        "0.2.2|macos_arm64|21454a77f0a5ff8ed23a43327f6de9c2f9f6bab1352ebe87fc03866889fa7fae|7262889|https://github.com/astral-sh/ruff/releases/download/v0.2.2/ruff-0.2.2-aarch64-apple-darwin.tar.gz",
+        "0.2.2|macos_x86_64|798a2028a783f10f21f11eb59763eabcff9961d4302cdcc37d186ab9f864ca82|7611899|https://github.com/astral-sh/ruff/releases/download/v0.2.2/ruff-0.2.2-x86_64-apple-darwin.tar.gz",
+        "0.2.2|linux_arm64|e73a37f41acf4a4f44cdb9b587316f0f9eb83b51c3c134d1401501e3f8d65dee|7247275|https://github.com/astral-sh/ruff/releases/download/v0.2.2/ruff-0.2.2-aarch64-unknown-linux-musl.tar.gz",
+        "0.2.2|linux_x86_64|044e4dbd46acc12de78a144c24fd9af86003eaba28e83244546d85076a9c7b04|7881552|https://github.com/astral-sh/ruff/releases/download/v0.2.2/ruff-0.2.2-x86_64-unknown-linux-musl.tar.gz",
+        "0.1.15|macos_arm64|373c648d693ddaf4f1936a05d3093aabd08553f585c3c3afbbdba41d16b70032|7025376|https://github.com/astral-sh/ruff/releases/download/v0.1.15/ruff-0.1.15-aarch64-apple-darwin.tar.gz",
+        "0.1.15|macos_x86_64|6d006dc427a74cba930717297b0c472856a2be4cfc37cd04309895c11329dc68|7308240|https://github.com/astral-sh/ruff/releases/download/v0.1.15/ruff-0.1.15-x86_64-apple-darwin.tar.gz",
+        "0.1.15|linux_arm64|e9ed3c353c4f2b801ed4d21fee2b6159883ad777e959fbbad0b2d2b22e1974c7|7049764|https://github.com/astral-sh/ruff/releases/download/v0.1.15/ruff-0.1.15-aarch64-unknown-linux-musl.tar.gz",
+        "0.1.15|linux_x86_64|d7389b9743b0b909c364d11bba94d13302171d751430b58c13dcdf248e924276|7605249|https://github.com/astral-sh/ruff/releases/download/v0.1.15/ruff-0.1.15-x86_64-unknown-linux-musl.tar.gz",
     ]
     version_constraints = ">=0.1.2,<1"
 


### PR DESCRIPTION
This does two related changes:

- adds known version configuration for the latest (at the time of writing) patch release of every minor series: 0.7.2, 0.6.9, 0.5.7, 0.4.10, 0.3.7, 0.2.2, 0.1.15 (I'm not sure the last three will work, but they're easy enough to include and someone can file bugs if they use them and find they don't)
- upgrades the default version to 0.7.2

My thinking:
- this adds all of the series so that it's very easy for someone with an existing repo using a specific version of Ruff to start using it within Pants (i.e. reduce the number of hurdles via this very simple configuration). 
- this just adds the latest patch release within each series (rather than every single patch release) to reduce quite how overwhelming it'll look in docs, assuming that Ruff is backwards compatible within a `0.x` series, i.e. someone using 0.7.0 can, hopefully, easily start using 0.7.2
- as we go forward, we just add new versions on demand (no particular rules about waiting for a series to finish, and not deleting old ones, e.g. we've got 0.4.9 and 0.4.10, and two 0.6s too, and that seems fine)