### PR TITLE
Mark PBS & pyenv provider test as "platform-specific behaviour"

### DIFF
--- a/src/python/pants/backend/python/providers/pyenv/BUILD
+++ b/src/python/pants/backend/python/providers/pyenv/BUILD
@@ -7,6 +7,7 @@ python_tests(
     overrides={
         "rules_integration_test.py": {
             "timeout": 600,
+            "tags": ["platform_specific_behavior"],
         }
     },
 )

--- a/src/python/pants/backend/python/providers/pyenv/rules_integration_test.py
+++ b/src/python/pants/backend/python/providers/pyenv/rules_integration_test.py
@@ -63,6 +63,7 @@ def run_run_request(
         return mocked_console[1].get_stdout().strip()
 
 
+@pytest.mark.platform_specific_behavior
 @pytest.mark.parametrize(
     "interpreter_constraints, expected_version_substring",
     [("2.7.*", "2.7"), ("3.9.*", "3.9"), ("3.10.4", "3.10.4")],

--- a/src/python/pants/backend/python/providers/python_build_standalone/BUILD
+++ b/src/python/pants/backend/python/providers/python_build_standalone/BUILD
@@ -8,6 +8,7 @@ python_tests(
     overrides={
         "rules_integration_test.py": {
             "timeout": 300,
+            "tags": ["platform_specific_behavior"],
         }
     },
 )

--- a/src/python/pants/backend/python/providers/python_build_standalone/rules_integration_test.py
+++ b/src/python/pants/backend/python/providers/python_build_standalone/rules_integration_test.py
@@ -72,6 +72,7 @@ def run_run_request(
         return mocked_console[1].get_stdout().strip()
 
 
+@pytest.mark.platform_specific_behavior
 @pytest.mark.parametrize("py_version", ["3.8.*", "3.9.*", "3.9.10"])
 def test_using_pbs(rule_runner, py_version):
     rule_runner.write_files(


### PR DESCRIPTION
Experiment to see whether our existing tests catch the bug in the PBS provider on macOS (see #21551).