### PR TITLE
Add platform_specific_behavior tag to test targets that use mark

### DIFF
--- a/src/python/pants/backend/build_files/fmt/black/BUILD
+++ b/src/python/pants/backend/build_files/fmt/black/BUILD
@@ -3,4 +3,11 @@
 
 python_sources()
 
-python_tests(name="tests")
+python_tests(
+    name="tests",
+    overrides={
+        "integration_test.py": {
+            "tags": ["platform_specific_behavior"],
+        }
+    },
+)

--- a/src/python/pants/backend/build_files/fmt/ruff/BUILD
+++ b/src/python/pants/backend/build_files/fmt/ruff/BUILD
@@ -3,4 +3,11 @@
 
 python_sources()
 
-python_tests(name="tests")
+python_tests(
+    name="tests",
+    overrides={
+        "integration_test.py": {
+            "tags": ["platform_specific_behavior"],
+        }
+    },
+)

--- a/src/python/pants/backend/build_files/fmt/yapf/BUILD
+++ b/src/python/pants/backend/build_files/fmt/yapf/BUILD
@@ -3,4 +3,11 @@
 
 python_sources()
 
-python_tests(name="tests")
+python_tests(
+    name="tests",
+    overrides={
+        "integration_test.py": {
+            "tags": ["platform_specific_behavior"],
+        }
+    },
+)

--- a/src/python/pants/backend/sql/lint/sqlfluff/BUILD
+++ b/src/python/pants/backend/sql/lint/sqlfluff/BUILD
@@ -8,4 +8,9 @@ python_sources(
 
 python_tests(
     name="tests",
+    overrides={
+        "rules_integration_test.py": {
+            "tags": ["platform_specific_behavior"],
+        }
+    },
 )


### PR DESCRIPTION
This PR adds the `platform_specific_behavior` tag to the `python_test` targets of 4 additional test files in this repo.

These test files use this repo's custom `pytest.mark.platform_specific_behavior` mark to indicate tests are high-value to test on non-Linux-x86_64 platforms. However, they were not being run in CI because the testing invocation uses both Pants-level tag and Pytest-level mark filtering: `./pants --tag=+platform_specific_behavior test :: -- -m platform_specific_behavior`.

This PR fixes the current problems identified in #21608, but doesn't stop us from making the same mistakes in future (and thus doesn't close that ticket).