### PR TITLE
Add annotation to untyped function causing mypy note

### DIFF
--- a/src/python/pants/core/util_rules/external_tool_test.py
+++ b/src/python/pants/core/util_rules/external_tool_test.py
@@ -146,7 +146,7 @@ def rule_runner():
     )
 
 
-def test_export(rule_runner):
+def test_export(rule_runner) -> None:
     """Tests export_external_tool.
 
     Ensures we locate the class and prepare the Digest correctly


### PR DESCRIPTION
Running `pants check ::` currently gets a `note` level warning from mypy. This PR fixes it.

```
src/python/pants/core/util_rules/external_tool_test.py: note: In function "test_export":
src/python/pants/core/util_rules/external_tool_test.py:194:5: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
src/python/pants/core/util_rules/external_tool_test.py:215:5: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
```

This appears to be caused by a minor oversight in a test in #21258  (missing the `-> None`).