### PR TITLE
Mark one test from hadolint and golangci_lint backends as platform-specific behaviour, test on macOS

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -781,6 +781,10 @@ jobs:
       with:
         distribution: adopt
         java-version: '11'
+    - name: Install Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: 1.19.5
     - name: Download native binaries
       uses: actions/download-artifact@v4
       with:

--- a/src/python/pants/backend/docker/lint/hadolint/BUILD
+++ b/src/python/pants/backend/docker/lint/hadolint/BUILD
@@ -2,4 +2,11 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_sources()
-python_tests(name="tests")
+python_tests(
+    name="tests",
+    overrides={
+        "rules_integration_test.py": {
+            "tags": ["platform_specific_behavior"],
+        }
+    },
+)

--- a/src/python/pants/backend/docker/lint/hadolint/rules_integration_test.py
+++ b/src/python/pants/backend/docker/lint/hadolint/rules_integration_test.py
@@ -78,6 +78,7 @@ def test_passing(rule_runner: RuleRunner) -> None:
     assert_success(rule_runner, tgt)
 
 
+@pytest.mark.platform_specific_behavior
 def test_failing(rule_runner: RuleRunner) -> None:
     rule_runner.write_files({"Dockerfile": BAD_FILE, "BUILD": "docker_image(name='t')"})
     tgt = rule_runner.get_target(Address("", target_name="t"))

--- a/src/python/pants/backend/go/lint/golangci_lint/BUILD
+++ b/src/python/pants/backend/go/lint/golangci_lint/BUILD
@@ -2,4 +2,12 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_sources()
-python_tests(name="tests", timeout=120)
+python_tests(
+    name="tests",
+    timeout=120,
+    overrides={
+        "rules_integration_test.py": {
+            "tags": ["platform_specific_behavior"],
+        }
+    },
+)

--- a/src/python/pants/backend/go/lint/golangci_lint/rules_integration_test.py
+++ b/src/python/pants/backend/go/lint/golangci_lint/rules_integration_test.py
@@ -130,6 +130,7 @@ def test_passing(rule_runner: RuleRunner) -> None:
     assert lint_results[0].stderr == ""
 
 
+@pytest.mark.platform_specific_behavior
 def test_failing(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -82,6 +82,7 @@ GITHUB_HOSTED = {Platform.LINUX_X86_64, Platform.MACOS12_X86_64}
 SELF_HOSTED = {Platform.LINUX_ARM64, Platform.MACOS11_ARM64}
 # We control these runners, so we preinstall and expose python on them.
 HAS_PYTHON = {Platform.LINUX_ARM64, Platform.MACOS11_ARM64}
+HAS_GO = {Platform.MACOS12_X86_64, Platform.MACOS11_ARM64}
 CARGO_AUDIT_IGNORED_ADVISORY_IDS = (
     "RUSTSEC-2020-0128",  # returns a false positive on the cache crate, which is a local crate not a 3rd party crate
 )
@@ -740,8 +741,9 @@ def test_jobs(
             *checkout(),
             *(launch_bazel_remote() if with_remote_caching else []),
             install_jdk(),
+            *([install_go()] if helper.platform not in HAS_GO else []),
             *(
-                [install_go(), download_apache_thrift()]
+                [download_apache_thrift()]
                 if helper.platform == Platform.LINUX_X86_64
                 # Other platforms either don't run those tests, or have the binaries
                 # preinstalled on the self-hosted runners.


### PR DESCRIPTION
Continuing #21610, this adds the `platform_specific_behavior` flag to two additional backends (hadolint and golangci_lint), that require installing Go on the CI machines.

(I think Hadolint requires Go to build the `dockerfile` Python package on Linux arm64.)