### PR TITLE
Revert "Replace macOS 10.15 x86-64 self-hosted runner with 12 GH-hosted (#21417)"

### DIFF
--- a/.github/workflows/clear_self_hosted_persistent_caches.yaml
+++ b/.github/workflows/clear_self_hosted_persistent_caches.yaml
@@ -26,6 +26,25 @@ jobs:
       run: du -sh ~/.pex || true; rm -rf ~/.pex || true
     - name: df after
       run: df -h
+  clean_macos10_15_x86_64:
+    runs-on:
+    - self-hosted
+    - macOS-10.15-X64
+    steps:
+    - name: df before
+      run: df -h
+    - name: Deleting ~/Library/Caches
+      run: du -sh ~/Library/Caches || true; rm -rf ~/Library/Caches || true
+    - name: Deleting ~/.cache
+      run: du -sh ~/.cache || true; rm -rf ~/.cache || true
+    - name: Deleting ~/.nce
+      run: du -sh ~/.nce || true; rm -rf ~/.nce || true
+    - name: Deleting ~/.rustup
+      run: du -sh ~/.rustup || true; rm -rf ~/.rustup || true
+    - name: Deleting ~/.pex
+      run: du -sh ~/.pex || true; rm -rf ~/.pex || true
+    - name: df after
+      run: df -h
   clean_macos11_arm64:
     runs-on:
     - self-hosted

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -167,6 +167,92 @@ jobs:
         \ needs.release_info.outputs.release-asset-upload-url }}?name=$(basename $WHL)\"\
         \ \\\n    --data-binary \"@$WHL\";\n"
     timeout-minutes: 90
+  build_wheels_macos10_15_x86_64:
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: false
+      PANTS_REMOTE_CACHE_READ: 'false'
+      PANTS_REMOTE_CACHE_WRITE: 'false'
+    if: github.repository_owner == 'pantsbuild'
+    name: Build wheels (macOS10-15-x86_64)
+    needs:
+    - release_info
+    runs-on:
+    - self-hosted
+    - macOS-10.15-X64
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 10
+        ref: ${{ needs.release_info.outputs.build-ref }}
+    - name: Install Protoc
+      uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        version: 23.x
+    - name: Set rustup profile
+      run: rustup set profile default
+    - name: Cache Rust toolchain
+      uses: actions/cache@v4
+      with:
+        key: macOS10-15-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain')
+          }}-v2
+        path: '~/.rustup/toolchains/1.82.0-*
+
+          ~/.rustup/update-hashes
+
+          ~/.rustup/settings.toml
+
+          '
+    - name: Cache Cargo
+      uses: benjyw/rust-cache@5ed697a6894712d2854c80635bb00a2496ea307a
+      with:
+        cache-bin: 'false'
+        shared-key: engine
+        workspaces: src/rust/engine
+    - name: Install Protoc
+      uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        version: 23.x
+    - name: Install Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: 1.19.5
+    - env:
+        ARCHFLAGS: -arch x86_64
+      name: Build wheels
+      run: ./pants run src/python/pants_release/release.py -- build-wheels
+    - env:
+        ARCHFLAGS: -arch x86_64
+      name: Build Pants PEX
+      run: ./pants package src/python/pants:pants-pex
+    - continue-on-error: true
+      if: always()
+      name: Upload pants.log
+      uses: actions/upload-artifact@v4
+      with:
+        name: logs-wheels-and-pex-macOS10-15-x86_64
+        overwrite: 'true'
+        path: .pants.d/workdir/*.log
+    - if: needs.release_info.outputs.is-release == 'true'
+      name: Upload Wheel and Pex
+      run: "PANTS_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c \"\
+        import pants.version;print(pants.version.VERSION)\")\nPY_VER=$(PEX_INTERPRETER=1\
+        \ dist/src.python.pants/pants-pex.pex -c \"import sys;print(f'cp{sys.version_info[0]}{sys.version_info[1]}')\"\
+        )\nPLAT=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c \"import\
+        \ os;print(f'{os.uname().sysname.lower()}_{os.uname().machine.lower()}')\"\
+        )\nPEX_FILENAME=pants.$PANTS_VER-$PY_VER-$PLAT.pex\n\nmv dist/src.python.pants/pants-pex.pex\
+        \ dist/src.python.pants/$PEX_FILENAME\n\ncurl -L --fail \\\n    -X POST \\\
+        \n    -H \"Authorization: Bearer ${{ github.token }}\" \\\n    -H \"Content-Type:\
+        \ application/octet-stream\" \\\n    ${{ needs.release_info.outputs.release-asset-upload-url\
+        \ }}?name=$PEX_FILENAME \\\n    --data-binary \"@dist/src.python.pants/$PEX_FILENAME\"\
+        \n\nWHL=$(find dist/deploy/wheels/pantsbuild.pants -type f -name \"pantsbuild.pants-*.whl\"\
+        )\ncurl -L --fail \\\n    -X POST \\\n    -H \"Authorization: Bearer ${{ github.token\
+        \ }}\" \\\n    -H \"Content-Type: application/octet-stream\" \\\n    \"${{\
+        \ needs.release_info.outputs.release-asset-upload-url }}?name=$(basename $WHL)\"\
+        \ \\\n    --data-binary \"@$WHL\";\n"
+    timeout-minutes: 90
   build_wheels_macos11_arm64:
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: false
@@ -253,107 +339,6 @@ jobs:
         \ needs.release_info.outputs.release-asset-upload-url }}?name=$(basename $WHL)\"\
         \ \\\n    --data-binary \"@$WHL\";\n"
     timeout-minutes: 90
-  build_wheels_macos12_x86_64:
-    env:
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: false
-      PANTS_REMOTE_CACHE_READ: 'false'
-      PANTS_REMOTE_CACHE_WRITE: 'false'
-    if: github.repository_owner == 'pantsbuild'
-    name: Build wheels (macOS12-x86_64)
-    needs:
-    - release_info
-    runs-on:
-    - macos-12
-    steps:
-    - name: Check out code
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 10
-        ref: ${{ needs.release_info.outputs.build-ref }}
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.7
-
-          3.8
-
-          3.9
-
-          3.10
-
-          3.12
-
-          3.13
-
-          3.11'
-    - name: Install Protoc
-      uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        version: 23.x
-    - name: Set rustup profile
-      run: rustup set profile default
-    - name: Cache Rust toolchain
-      uses: actions/cache@v4
-      with:
-        key: macOS12-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain')
-          }}-v2
-        path: '~/.rustup/toolchains/1.82.0-*
-
-          ~/.rustup/update-hashes
-
-          ~/.rustup/settings.toml
-
-          '
-    - name: Cache Cargo
-      uses: benjyw/rust-cache@5ed697a6894712d2854c80635bb00a2496ea307a
-      with:
-        cache-bin: 'false'
-        shared-key: engine
-        workspaces: src/rust/engine
-    - name: Install Protoc
-      uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        version: 23.x
-    - name: Install Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: 1.19.5
-    - env:
-        ARCHFLAGS: -arch x86_64
-      name: Build wheels
-      run: ./pants run src/python/pants_release/release.py -- build-wheels
-    - env:
-        ARCHFLAGS: -arch x86_64
-      name: Build Pants PEX
-      run: ./pants package src/python/pants:pants-pex
-    - continue-on-error: true
-      if: always()
-      name: Upload pants.log
-      uses: actions/upload-artifact@v4
-      with:
-        name: logs-wheels-and-pex-macOS12-x86_64
-        overwrite: 'true'
-        path: .pants.d/workdir/*.log
-    - if: needs.release_info.outputs.is-release == 'true'
-      name: Upload Wheel and Pex
-      run: "PANTS_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c \"\
-        import pants.version;print(pants.version.VERSION)\")\nPY_VER=$(PEX_INTERPRETER=1\
-        \ dist/src.python.pants/pants-pex.pex -c \"import sys;print(f'cp{sys.version_info[0]}{sys.version_info[1]}')\"\
-        )\nPLAT=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c \"import\
-        \ os;print(f'{os.uname().sysname.lower()}_{os.uname().machine.lower()}')\"\
-        )\nPEX_FILENAME=pants.$PANTS_VER-$PY_VER-$PLAT.pex\n\nmv dist/src.python.pants/pants-pex.pex\
-        \ dist/src.python.pants/$PEX_FILENAME\n\ncurl -L --fail \\\n    -X POST \\\
-        \n    -H \"Authorization: Bearer ${{ github.token }}\" \\\n    -H \"Content-Type:\
-        \ application/octet-stream\" \\\n    ${{ needs.release_info.outputs.release-asset-upload-url\
-        \ }}?name=$PEX_FILENAME \\\n    --data-binary \"@dist/src.python.pants/$PEX_FILENAME\"\
-        \n\nWHL=$(find dist/deploy/wheels/pantsbuild.pants -type f -name \"pantsbuild.pants-*.whl\"\
-        )\ncurl -L --fail \\\n    -X POST \\\n    -H \"Authorization: Bearer ${{ github.token\
-        \ }}\" \\\n    -H \"Content-Type: application/octet-stream\" \\\n    \"${{\
-        \ needs.release_info.outputs.release-asset-upload-url }}?name=$(basename $WHL)\"\
-        \ \\\n    --data-binary \"@$WHL\";\n"
-    timeout-minutes: 90
   publish:
     env:
       MODE: debug
@@ -362,7 +347,7 @@ jobs:
     needs:
     - build_wheels_linux_x86_64
     - build_wheels_linux_arm64
-    - build_wheels_macos12_x86_64
+    - build_wheels_macos10_15_x86_64
     - build_wheels_macos11_arm64
     - release_info
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -445,6 +445,75 @@ jobs:
         overwrite: 'true'
         path: .pants.d/workdir/*.log
     timeout-minutes: 90
+  build_wheels_macos10_15_x86_64:
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: false
+      MODE: debug
+      PANTS_REMOTE_CACHE_READ: 'false'
+      PANTS_REMOTE_CACHE_WRITE: 'false'
+    if: ((github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.release == 'true')) && (needs.classify_changes.outputs.docs_only
+      != 'true')
+    name: Build wheels (macOS10-15-x86_64)
+    needs:
+    - classify_changes
+    runs-on:
+    - self-hosted
+    - macOS-10.15-X64
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 10
+    - name: Install Protoc
+      uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        version: 23.x
+    - name: Set rustup profile
+      run: rustup set profile default
+    - name: Cache Rust toolchain
+      uses: actions/cache@v4
+      with:
+        key: macOS10-15-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
+        path: '~/.rustup/toolchains/1.82.0-*
+
+          ~/.rustup/update-hashes
+
+          ~/.rustup/settings.toml
+
+          '
+    - name: Cache Cargo
+      uses: benjyw/rust-cache@5ed697a6894712d2854c80635bb00a2496ea307a
+      with:
+        cache-bin: 'false'
+        shared-key: engine
+        workspaces: src/rust/engine
+    - name: Install Protoc
+      uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        version: 23.x
+    - name: Install Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: 1.19.5
+    - env:
+        ARCHFLAGS: -arch x86_64
+      name: Build wheels
+      run: ./pants run src/python/pants_release/release.py -- build-wheels
+    - env:
+        ARCHFLAGS: -arch x86_64
+      name: Build Pants PEX
+      run: ./pants package src/python/pants:pants-pex
+    - continue-on-error: true
+      if: always()
+      name: Upload pants.log
+      uses: actions/upload-artifact@v4
+      with:
+        name: logs-wheels-and-pex-macOS10-15-x86_64
+        overwrite: 'true'
+        path: .pants.d/workdir/*.log
+    timeout-minutes: 90
   build_wheels_macos11_arm64:
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: false
@@ -511,90 +580,6 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: logs-wheels-and-pex-macOS11-ARM64
-        overwrite: 'true'
-        path: .pants.d/workdir/*.log
-    timeout-minutes: 90
-  build_wheels_macos12_x86_64:
-    env:
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: false
-      MODE: debug
-      PANTS_REMOTE_CACHE_READ: 'false'
-      PANTS_REMOTE_CACHE_WRITE: 'false'
-    if: ((github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.release == 'true')) && (needs.classify_changes.outputs.docs_only
-      != 'true')
-    name: Build wheels (macOS12-x86_64)
-    needs:
-    - classify_changes
-    runs-on:
-    - macos-12
-    steps:
-    - name: Check out code
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 10
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.7
-
-          3.8
-
-          3.9
-
-          3.10
-
-          3.12
-
-          3.13
-
-          3.11'
-    - name: Install Protoc
-      uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        version: 23.x
-    - name: Set rustup profile
-      run: rustup set profile default
-    - name: Cache Rust toolchain
-      uses: actions/cache@v4
-      with:
-        key: macOS12-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.82.0-*
-
-          ~/.rustup/update-hashes
-
-          ~/.rustup/settings.toml
-
-          '
-    - name: Cache Cargo
-      uses: benjyw/rust-cache@5ed697a6894712d2854c80635bb00a2496ea307a
-      with:
-        cache-bin: 'false'
-        shared-key: engine
-        workspaces: src/rust/engine
-    - name: Install Protoc
-      uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        version: 23.x
-    - name: Install Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: 1.19.5
-    - env:
-        ARCHFLAGS: -arch x86_64
-      name: Build wheels
-      run: ./pants run src/python/pants_release/release.py -- build-wheels
-    - env:
-        ARCHFLAGS: -arch x86_64
-      name: Build Pants PEX
-      run: ./pants package src/python/pants:pants-pex
-    - continue-on-error: true
-      if: always()
-      name: Upload pants.log
-      uses: actions/upload-artifact@v4
-      with:
-        name: logs-wheels-and-pex-macOS12-x86_64
         overwrite: 'true'
         path: .pants.d/workdir/*.log
     timeout-minutes: 90
@@ -734,8 +719,8 @@ jobs:
     - bootstrap_pants_macos12_x86_64
     - build_wheels_linux_arm64
     - build_wheels_linux_x86_64
+    - build_wheels_macos10_15_x86_64
     - build_wheels_macos11_arm64
-    - build_wheels_macos12_x86_64
     - check_release_notes
     - classify_changes
     - lint_python

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -73,15 +73,16 @@ Env = Dict[str, str]
 class Platform(Enum):
     LINUX_X86_64 = "Linux-x86_64"
     LINUX_ARM64 = "Linux-ARM64"
+    MACOS10_15_X86_64 = "macOS10-15-x86_64"
     # the oldest version of macOS supported by GitHub self-hosted runners
     MACOS12_X86_64 = "macOS12-x86_64"
     MACOS11_ARM64 = "macOS11-ARM64"
 
 
 GITHUB_HOSTED = {Platform.LINUX_X86_64, Platform.MACOS12_X86_64}
-SELF_HOSTED = {Platform.LINUX_ARM64, Platform.MACOS11_ARM64}
+SELF_HOSTED = {Platform.LINUX_ARM64, Platform.MACOS10_15_X86_64, Platform.MACOS11_ARM64}
 # We control these runners, so we preinstall and expose python on them.
-HAS_PYTHON = {Platform.LINUX_ARM64, Platform.MACOS11_ARM64}
+HAS_PYTHON = {Platform.LINUX_ARM64, Platform.MACOS10_15_X86_64, Platform.MACOS11_ARM64}
 CARGO_AUDIT_IGNORED_ADVISORY_IDS = (
     "RUSTSEC-2020-0128",  # returns a false positive on the cache crate, which is a local crate not a 3rd party crate
 )
@@ -424,6 +425,8 @@ class Helper:
             ret += ["macos-12"]
         elif self.platform == Platform.MACOS11_ARM64:
             ret += ["macOS-11-ARM64"]
+        elif self.platform == Platform.MACOS10_15_X86_64:
+            ret += ["macOS-10.15-X64"]
         elif self.platform == Platform.LINUX_X86_64:
             ret += ["ubuntu-22.04"]
         elif self.platform == Platform.LINUX_ARM64:
@@ -439,7 +442,7 @@ class Helper:
 
     def platform_env(self):
         ret = {}
-        if self.platform in {Platform.MACOS12_X86_64}:
+        if self.platform in {Platform.MACOS10_15_X86_64, Platform.MACOS12_X86_64}:
             # Works around bad `-arch arm64` flag embedded in Xcode 12.x Python interpreters on
             # intel machines. See: https://github.com/giampaolo/psutil/issues/1832
             ret["ARCHFLAGS"] = "-arch x86_64"
@@ -972,7 +975,7 @@ def build_wheels_jobs(*, for_deploy_ref: str | None = None, needs: list[str] | N
     return {
         **build_wheels_job(Platform.LINUX_X86_64, for_deploy_ref, needs),
         **build_wheels_job(Platform.LINUX_ARM64, for_deploy_ref, needs),
-        **build_wheels_job(Platform.MACOS12_X86_64, for_deploy_ref, needs),
+        **build_wheels_job(Platform.MACOS10_15_X86_64, for_deploy_ref, needs),
         **build_wheels_job(Platform.MACOS11_ARM64, for_deploy_ref, needs),
     }
 


### PR DESCRIPTION
This reverts commit ae20980b59f529ba5bde97ded3aca712ddfbc75e / #21417 to restore current-`main`/version 2.24.x to using our self-hosted macOS 10.15 runner, rather than the Github-hosted macOS 12 runner that is being deprecated on 2024-12-03.

This ensures we'll be able to do the 2.24.0 release and patch releases after that. This doesn't change the deprecation of macOS versions 10.15, 11 (in 2.23, #21326) and 12 (in 2.24, #21569). We'll be "unnecessarily" building on 10.15 for 2.24 even though it's not actually supported. The warnings/errors about the lack of support will still occur, though.

Once we branch for 2.24 and `main` switches over to 2.25, we can switch this over to using the GitHub hosted macOS 13 runner (not 12).

See https://github.com/pantsbuild/pants/issues/21333#issuecomment-2460869204 for more discussion.