### PR TITLE
Add information about workunit when failing to backtrack 

### DIFF
--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -871,8 +871,14 @@ impl SessionCore {
             } else {
                 // There are no live or invalidated sources of this Digest. Directly fail.
                 return result.map_err(|e| {
+                    let suffix = if let Some(workunit_data) = workunit.workunit() {
+                        &format!(", with workunit: {:?}", workunit_data)
+                    } else {
+                        ""
+                    };
+
                     throw(format!(
-                        "Could not identify a process to backtrack to for: {e}"
+                        "Could not identify a process to backtrack to for: {e}{suffix}"
                     ))
                 });
             }

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -889,6 +889,10 @@ impl RunningWorkunit {
         }
     }
 
+    pub fn workunit(&self) -> Option<&Workunit> {
+        self.workunit.as_ref()
+    }
+
     pub fn record_observation(&self, metric: ObservationMetric, value: u64) {
         self.store.record_observation(metric, value);
     }


### PR DESCRIPTION
I don't think there's much information to be had here, fundamentally, but on the off-chance there is it would be interesting. 

Relates to: https://github.com/pantsbuild/pants/issues/19748, which we've started seeing quite regularly at work.