### PR TITLE
Delete the legacy parse_args() method

### DIFF
--- a/src/python/pants/help/help_formatter_test.py
+++ b/src/python/pants/help/help_formatter_test.py
@@ -10,7 +10,6 @@ from pants.help.help_info_extracter import HelpInfoExtracter, OptionHelpInfo
 from pants.option.config import Config
 from pants.option.global_options import GlobalOptions
 from pants.option.native_options import NativeOptionParser
-from pants.option.option_value_container import OptionValueContainerBuilder
 from pants.option.parser import OptionValueHistory, Parser
 from pants.option.ranked_value import Rank, RankedValue
 
@@ -87,8 +86,6 @@ class TestOptionHelpFormatter:
         show_advanced: bool,
         show_deprecated: bool,
     ) -> list[str]:
-        # Force a parse to generate the derivation history.
-        parser.parse_args(Parser.ParseArgsRequest((), OptionValueContainerBuilder(), [], False))
         oshi = HelpInfoExtracter("").get_option_scope_help_info(
             "", parser, native_parser, False, "help.test"
         )

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -486,7 +486,6 @@ class HelpInfoExtracter:
             scope_info: ScopeInfo,
         ) -> Callable[[], OptionScopeHelpInfo]:
             def load() -> OptionScopeHelpInfo:
-                options.for_scope(scope_info.scope)  # Force parsing.
                 subsystem_cls = scope_info.subsystem_cls
                 if not scope_info.description:
                     cls_name = (


### PR DESCRIPTION
It is no longer used. And we no longer have to force-trigger
a parse in tests, so get rid of a case where we did that.