### PR TITLE
Move option registration validation earlier

### DIFF
--- a/src/python/pants/help/help_formatter_test.py
+++ b/src/python/pants/help/help_formatter_test.py
@@ -60,7 +60,7 @@ class TestOptionHelpFormatter:
     @classmethod
     def _get_parser(cls) -> Tuple[Parser, NativeOptionParser]:
         return Parser(
-            scope_info=GlobalOptions.get_scope_info(),
+            scope=GlobalOptions.options_scope,
         ), NativeOptionParser(
             args=[], env={}, config_sources=[], allow_pantsrc=False, include_derivation=True
         )

--- a/src/python/pants/help/help_info_extracter_test.py
+++ b/src/python/pants/help/help_info_extracter_test.py
@@ -101,7 +101,7 @@ def test_default() -> None:
         # Defaults are computed in the parser and added into the kwargs, so we
         # must jump through this hoop in this test.
         parser = Parser(
-            scope_info=GlobalOptions.get_scope_info(),
+            scope=GlobalOptions.options_scope,
         )
         native_parser = NativeOptionParser([], {}, [], allow_pantsrc=False, include_derivation=True)
         parser.register(*args, **kwargs)
@@ -198,9 +198,7 @@ def test_grouping():
         def exp_to_len(exp):
             return int(exp)  # True -> 1, False -> 0.
 
-        parser = Parser(
-            scope_info=GlobalOptions.get_scope_info(),
-        )
+        parser = Parser(scope=GlobalOptions.options_scope)
         native_parser = NativeOptionParser([], {}, [], allow_pantsrc=False, include_derivation=True)
         parser.register("--foo", **kwargs)
         oshi = HelpInfoExtracter("").get_option_scope_help_info(

--- a/src/python/pants/help/help_tools_test.py
+++ b/src/python/pants/help/help_tools_test.py
@@ -16,9 +16,7 @@ from pants.option.parser import Parser
 
 @pytest.fixture
 def parser() -> Parser:
-    return Parser(
-        scope_info=GlobalOptions.get_scope_info(),
-    )
+    return Parser(scope=GlobalOptions.options_scope)
 
 
 @pytest.fixture

--- a/src/python/pants/help/help_tools_test.py
+++ b/src/python/pants/help/help_tools_test.py
@@ -31,8 +31,8 @@ def extracter() -> HelpInfoExtracter:
 
 @pytest.fixture
 def tool_info(extracter, parser, native_parser) -> ToolHelpInfo:
-    parser.register("version", typ=str, default="1.0")
-    parser.register("url-template", typ=str, default="https://download/{version}")
+    parser.register("--version", type=str, default="1.0")
+    parser.register("--url-template", type=str, default="https://download/{version}")
     oshi = extracter.get_option_scope_help_info("Test description.", parser, native_parser, False)
     tool_info = ToolHelpInfo.from_option_scope_help_info(oshi)
     assert tool_info is not None

--- a/src/python/pants/option/native_options.py
+++ b/src/python/pants/option/native_options.py
@@ -23,7 +23,7 @@ from pants.util.strutil import get_strict_env, softwrap
 logger = logging.getLogger()
 
 
-def parse_dest(*args, **kwargs):
+def parse_dest(*args: str, **kwargs) -> str:
     """Return the dest for an option registration.
 
     If an explicit `dest` is specified, returns that and otherwise derives a default from the
@@ -36,7 +36,7 @@ def parse_dest(*args, **kwargs):
     """
     dest = kwargs.get("dest")
     if dest:
-        return dest
+        return str(dest)
     # No explicit dest, so compute one based on the first long arg, or the short arg
     # if that's all there is.
     arg = next((a for a in args if a.startswith("--")), args[0])

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -15,7 +15,7 @@ from pants.option.config import Config
 from pants.option.errors import ConfigValidationError, UnknownFlagsError
 from pants.option.native_options import NativeOptionParser
 from pants.option.option_util import is_list_option
-from pants.option.option_value_container import OptionValueContainer, OptionValueContainerBuilder
+from pants.option.option_value_container import OptionValueContainer
 from pants.option.parser import Parser
 from pants.option.scope import GLOBAL_SCOPE, GLOBAL_SCOPE_CONFIG_SECTION, ScopeInfo
 from pants.util.memo import memoized_method
@@ -164,7 +164,7 @@ class Options:
                             [line for line in [line.strip() for line in f] if line]
                         )
 
-        parser_by_scope = {si.scope: Parser(si) for si in complete_known_scope_infos}
+        parser_by_scope = {si.scope: Parser(si.scope) for si in complete_known_scope_infos}
         known_scope_to_info = {s.scope: s for s in complete_known_scope_infos}
 
         config_to_pass = None if native_options_config_discovery else config.sources()
@@ -391,16 +391,6 @@ class Options:
                     entity=f"scope {deprecated_scope}",
                     hint=f"Use scope {scope} instead (options: {', '.join(explicit_keys)})",
                 )
-
-    def _make_parse_args_request(
-        self, flags_in_scope, namespace: OptionValueContainerBuilder
-    ) -> Parser.ParseArgsRequest:
-        return Parser.ParseArgsRequest(
-            flags_in_scope=flags_in_scope,
-            namespace=namespace,
-            passthrough_args=self._passthru,
-            allow_unknown_flags=self._allow_unknown_options,
-        )
 
     # TODO: Eagerly precompute backing data for this?
     @memoized_method

--- a/src/python/pants/option/options_test.py
+++ b/src/python/pants/option/options_test.py
@@ -1014,7 +1014,7 @@ def test_parse_dest() -> None:
 
 
 def test_validation() -> None:
-    def assertError(expected_error, *args, **kwargs):
+    def assert_error(expected_error, *args, **kwargs):
         with pytest.raises(expected_error):
             options = Options.create(
                 args=["./pants"],
@@ -1025,17 +1025,17 @@ def test_validation() -> None:
             options.register(GLOBAL_SCOPE, *args, **kwargs)
             options.for_global_scope()
 
-    assertError(NoOptionNames)
-    assertError(OptionNameDoubleDash, "badname")
-    assertError(OptionNameDoubleDash, "-badname")
-    assertError(InvalidKwarg, "--foo", badkwarg=42)
-    assertError(BooleanOptionNameWithNo, "--no-foo", type=bool)
-    assertError(MemberTypeNotAllowed, "--foo", member_type=int)
-    assertError(MemberTypeNotAllowed, "--foo", type=dict, member_type=int)
-    assertError(InvalidMemberType, "--foo", type=list, member_type=set)
-    assertError(InvalidMemberType, "--foo", type=list, member_type=list)
-    assertError(HelpType, "--foo", help=())
-    assertError(HelpType, "--foo", help=("Help!",))
+    assert_error(NoOptionNames)
+    assert_error(OptionNameDoubleDash, "badname")
+    assert_error(OptionNameDoubleDash, "-badname")
+    assert_error(InvalidKwarg, "--foo", badkwarg=42)
+    assert_error(BooleanOptionNameWithNo, "--no-foo", type=bool)
+    assert_error(MemberTypeNotAllowed, "--foo", member_type=int)
+    assert_error(MemberTypeNotAllowed, "--foo", type=dict, member_type=int)
+    assert_error(InvalidMemberType, "--foo", type=list, member_type=set)
+    assert_error(InvalidMemberType, "--foo", type=list, member_type=list)
+    assert_error(HelpType, "--foo", help=())
+    assert_error(HelpType, "--foo", help=("Help!",))
 
 
 def test_shadowing() -> None:
@@ -1046,7 +1046,7 @@ def test_shadowing() -> None:
         args=["./pants"],
     )
     options.register("", "--opt1")
-    options.register("foo", "-o", "--opt2")
+    options.register("foo", "--opt2")
 
 
 def test_is_known_scope() -> None:


### PR DESCRIPTION
Previously we validated when parsing, now we do so at registration. 

This uncovered a couple of tests that were implicitly relying on
incorrect registration, so fixed those. 

Also removed more legacy parser cruft.