### PR TITLE
Don't munge types in Docker registry config values.

### DIFF
--- a/docs/notes/2.25.x.md
+++ b/docs/notes/2.25.x.md
@@ -23,6 +23,11 @@ The "legacy" options system is removed in this release. All options parsing is n
 
 ### Backends
 
+#### Docker
+
+Strict adherence to the [schema of Docker registry configuration](https://www.pantsbuild.org/2.25/reference/subsystems/docker#registries) is now required.
+Previously we did ad-hoc coercion of some field values, so that, e.g., you could provide a "true"/"false" string as a boolean value. Now we require actual booleans.
+
 ### Plugin API changes
 
 ## Full Changelog

--- a/src/python/pants/backend/docker/registries.py
+++ b/src/python/pants/backend/docker/registries.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Iterator
 
-from pants.option.parser import Parser
 from pants.util.frozendict import FrozenDict
 from pants.util.strutil import softwrap
 
@@ -52,13 +51,13 @@ class DockerRegistryOptions:
         return cls(
             alias=alias,
             address=d["address"],
-            default=Parser.ensure_bool(d.get("default", alias == "default")),
-            skip_push=Parser.ensure_bool(d.get("skip_push", DockerRegistryOptions.skip_push)),
+            default=d.get("default", alias == "default"),
+            skip_push=d.get("skip_push", DockerRegistryOptions.skip_push),
             extra_image_tags=tuple(
                 d.get("extra_image_tags", DockerRegistryOptions.extra_image_tags)
             ),
-            repository=Parser.to_value_type(d.get("repository"), str, None),
-            use_local_alias=Parser.ensure_bool(d.get("use_local_alias", False)),
+            repository=d.get("repository"),
+            use_local_alias=d.get("use_local_alias", False),
         )
 
     def register(self, registries: dict[str, DockerRegistryOptions]) -> None:

--- a/src/python/pants/backend/docker/registries_test.py
+++ b/src/python/pants/backend/docker/registries_test.py
@@ -42,9 +42,9 @@ def test_docker_registries() -> None:
     # Test defaults.
     registries = DockerRegistries.from_dict(
         {
-            "reg1": {"address": "myregistry1domain:port", "default": "false"},
-            "reg2": {"address": "myregistry2domain:port", "default": "true"},
-            "reg3": {"address": "myregistry3domain:port", "default": "true"},
+            "reg1": {"address": "myregistry1domain:port", "default": False},
+            "reg2": {"address": "myregistry2domain:port", "default": True},
+            "reg3": {"address": "myregistry3domain:port", "default": True},
         }
     )
 
@@ -65,7 +65,7 @@ def test_skip_push() -> None:
         {
             "reg1": {"address": "registry1"},
             "reg2": {"address": "registry2", "skip_push": True},
-            "reg3": {"address": "registry3", "skip_push": "false"},
+            "reg3": {"address": "registry3", "skip_push": False},
         }
     )
 


### PR DESCRIPTION
We document a schema for the registries dict, including
specifying that certain fields should be bool-valued.

I see no need to coerce those values into bools if they
were actually strings, especially since we don't document
that we do that (AFAICT). 

We should require users to adhere to the published schema.
If this "breaks" users, well, they were accidentally relying on
unadvertised leniency, and the fix is extremely easy. 

Note that this coercion was very ad hoc. We don't apply it
uniformly across all fields in the docker registry config, 
and we certainly don't do this in other dict-valued options
across the repo.

This gets rid of a spurious dependency of the Docker backend
on internal code of the legacy options parser.

