### PR TITLE
docs: getting started links to stable version docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Documentation: [www.pantsbuild.org](https://www.pantsbuild.org/).
 
 # Getting started
 
-See the [getting started](https://www.pantsbuild.org/docs/getting-started) documentation.
+See the [getting started](https://www.pantsbuild.org/stable/docs/getting-started) documentation.
 
 # Credits
 


### PR DESCRIPTION
Fixes issue where user was redirected to a deprecated version of the docs.

![IMG_0751](https://github.com/user-attachments/assets/54942f9d-61b1-4181-88e4-822d32037d05)
