### PR TITLE
Move native options parsing out of the legacy Parser

### DIFF
--- a/src/python/pants/option/options_test.py
+++ b/src/python/pants/option/options_test.py
@@ -353,8 +353,9 @@ def test_deprecated_options_error() -> None:
     def register(opts: Options) -> None:
         opts.register(GLOBAL_SCOPE, "--expired", removal_version="0.0.1.dev0")
 
+    opts = create_options([GLOBAL_SCOPE], register, [])
     with pytest.raises(CodeRemovedError):
-        create_options([GLOBAL_SCOPE], register, [])
+        opts.for_scope(scope=GLOBAL_SCOPE)
 
 
 @unittest.mock.patch("pants.base.deprecated.PANTS_SEMVER", Version(_FAKE_CUR_VERSION))

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -7,12 +7,11 @@ import copy
 import inspect
 import logging
 import typing
-from collections import defaultdict
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Mapping
 
-from pants.base.deprecated import validate_deprecation_semver, warn_or_error
+from pants.base.deprecated import validate_deprecation_semver
 from pants.option.custom_types import (
     DictValueComponent,
     ListValueComponent,
@@ -31,7 +30,6 @@ from pants.option.errors import (
     InvalidKwargNonGlobalScope,
     InvalidMemberType,
     MemberTypeNotAllowed,
-    MutuallyExclusiveOptionError,
     NoOptionNames,
     OptionAlreadyRegistered,
     OptionNameDoubleDash,
@@ -39,11 +37,9 @@ from pants.option.errors import (
     PassthroughType,
     RegistrationError,
 )
-from pants.option.native_options import NativeOptionParser, parse_dest
-from pants.option.option_value_container import OptionValueContainer, OptionValueContainerBuilder
-from pants.option.ranked_value import Rank, RankedValue
+from pants.option.native_options import parse_dest
+from pants.option.ranked_value import RankedValue
 from pants.option.scope import GLOBAL_SCOPE
-from pants.util.strutil import softwrap
 
 logger = logging.getLogger(__name__)
 
@@ -95,7 +91,7 @@ class Parser:
     def __init__(self, scope: str) -> None:
         """Create a Parser instance.
 
-        :param scope_info: the scope this parser acts for.
+        :param scope: the scope this parser acts for.
         """
         self._scope = scope
 
@@ -116,39 +112,6 @@ class Parser:
     def known_scoped_args(self) -> frozenset[str]:
         prefix = f"{self.scope}-" if self.scope != GLOBAL_SCOPE else ""
         return frozenset(f"--{prefix}{arg.lstrip('--')}" for arg in self._known_args)
-
-    def parse_args_native(
-        self,
-        native_parser: NativeOptionParser,
-    ) -> OptionValueContainer:
-        namespace = OptionValueContainerBuilder()
-        mutex_map = defaultdict(list)
-        for args, kwargs in self._option_registrations:
-            dest = parse_dest(*args, **kwargs)
-            val, rank = native_parser.get_value(
-                scope=self.scope, registration_args=args, registration_kwargs=kwargs
-            )
-
-            # If the option is explicitly given, check deprecation and mutual exclusion.
-            if rank > Rank.HARDCODED:
-                self._check_deprecated(dest, kwargs)
-                mutex_dest = kwargs.get("mutually_exclusive_group")
-                mutex_map_key = mutex_dest or dest
-                mutex_map[mutex_map_key].append(dest)
-                if len(mutex_map[mutex_map_key]) > 1:
-                    raise MutuallyExclusiveOptionError(
-                        softwrap(
-                            f"""
-                            Can only provide one of these mutually exclusive options in
-                            {self._scope_str()}, but multiple given:
-                            {', '.join(mutex_map[mutex_map_key])}
-                            """
-                        )
-                    )
-
-            setattr(namespace, dest, RankedValue(rank, val))
-
-        return namespace.build()
 
     def option_registrations_iter(self):
         """Returns an iterator over the normalized registration arguments of each option in this
@@ -181,8 +144,6 @@ class Parser:
     def register(self, *args, **kwargs) -> None:
         """Register an option."""
         self._validate(args, kwargs)
-        dest = parse_dest(*args, **kwargs)
-        self._check_deprecated(dest, kwargs, print_warning=False)
 
         if self.is_bool(kwargs):
             default = kwargs.get("default")
@@ -201,18 +162,6 @@ class Parser:
             if arg in self._known_args:
                 raise OptionAlreadyRegistered(self.scope, arg)
         self._known_args.update(args)
-
-    def _check_deprecated(self, dest: str, kwargs, print_warning: bool = True) -> None:
-        """Checks option for deprecation and issues a warning/error if necessary."""
-        removal_version = kwargs.get("removal_version", None)
-        if removal_version is not None:
-            warn_or_error(
-                removal_version=removal_version,
-                entity=f"option '{dest}' in {self._scope_str()}",
-                start_version=kwargs.get("deprecation_start_version", None),
-                hint=kwargs.get("removal_hint", None),
-                print_warning=print_warning,
-            )
 
     _allowed_registration_kwargs = {
         "type",
@@ -330,7 +279,7 @@ class Parser:
                 error(InvalidKwarg, kwarg=kwarg)
 
             # Ensure `daemon=True` can't be passed on non-global scopes.
-            if kwarg == "daemon" and self._scope != GLOBAL_SCOPE:
+            if kwarg == "daemon" and self.scope != GLOBAL_SCOPE:
                 error(InvalidKwargNonGlobalScope, kwarg=kwarg)
 
         removal_version = kwargs.get("removal_version")
@@ -358,8 +307,5 @@ class Parser:
                 f"Error applying type '{type_arg.__name__}' to option value '{val_str}': {e}"
             )
 
-    def _scope_str(self) -> str:
-        return "global scope" if self.scope == GLOBAL_SCOPE else f"scope '{self.scope}'"
-
     def __str__(self) -> str:
-        return f"Parser({self._scope})"
+        return f"Parser({self.scope})"


### PR DESCRIPTION
The Parser class had two jobs:
- A repository of option registrations
- Actual option parsing

This change removes the final vestiges of the second, by
inlining them in `options.py`.

A future change will rename Parser to, say, Registrar, as
befits its now single remaining role.