### PR TITLE
Test on newer macOS 13, not deprecated macOS 12 (partial cherry-pick of #21655)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -206,16 +206,16 @@ jobs:
 
         ./cargo doc'
     timeout-minutes: 60
-  bootstrap_pants_macos12_x86_64:
+  bootstrap_pants_macos13_x86_64:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
     if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only != 'true')
-    name: Bootstrap Pants, test Rust (macOS12-x86_64)
+    name: Bootstrap Pants, test Rust (macOS13-x86_64)
     needs:
     - classify_changes
     runs-on:
-    - macos-12
+    - macos-13
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -235,7 +235,7 @@ jobs:
     - name: Cache Rust toolchain
       uses: actions/cache@v4
       with:
-        key: macOS12-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
+        key: macOS13-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
         path: '~/.rustup/toolchains/1.78.0-*
 
           ~/.rustup/update-hashes
@@ -256,7 +256,7 @@ jobs:
     - name: Cache native engine
       uses: actions/cache@v4
       with:
-        key: macOS12-x86_64-engine-${{ steps.get-engine-hash.outputs.hash }}-v1
+        key: macOS13-x86_64-engine-${{ steps.get-engine-hash.outputs.hash }}-v1
         path: 'src/python/pants/bin/native_client
 
           src/python/pants/engine/internals/native_engine.so
@@ -281,13 +281,13 @@ jobs:
       name: Upload pants.log
       uses: actions/upload-artifact@v4
       with:
-        name: logs-bootstrap-macOS12-x86_64
+        name: logs-bootstrap-macOS13-x86_64
         overwrite: 'true'
         path: .pants.d/workdir/*.log
     - name: Upload native binaries
       uses: actions/upload-artifact@v4
       with:
-        name: native_binaries.${{ matrix.python-version }}.macOS12-x86_64
+        name: native_binaries.${{ matrix.python-version }}.macOS13-x86_64
         path: 'src/python/pants/bin/native_client
 
           src/python/pants/engine/internals/native_engine.so
@@ -697,7 +697,7 @@ jobs:
     - check_release_notes
     - bootstrap_pants_linux_arm64
     - bootstrap_pants_linux_x86_64
-    - bootstrap_pants_macos12_x86_64
+    - bootstrap_pants_macos13_x86_64
     - build_wheels_linux_arm64
     - build_wheels_linux_x86_64
     - build_wheels_macos10_15_x86_64
@@ -717,7 +717,7 @@ jobs:
     - test_python_linux_x86_64_7
     - test_python_linux_x86_64_8
     - test_python_linux_x86_64_9
-    - test_python_macos12_x86_64
+    - test_python_macos13_x86_64
     outputs:
       merge_ok: ${{ steps.set_merge_ok.outputs.merge_ok }}
     runs-on:
@@ -1701,16 +1701,16 @@ jobs:
         overwrite: 'true'
         path: .pants.d/workdir/*.log
     timeout-minutes: 90
-  test_python_macos12_x86_64:
+  test_python_macos13_x86_64:
     env:
       ARCHFLAGS: -arch x86_64
     if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only != 'true')
-    name: Test Python (macOS12-x86_64)
+    name: Test Python (macOS13-x86_64)
     needs:
-    - bootstrap_pants_macos12_x86_64
+    - bootstrap_pants_macos13_x86_64
     - classify_changes
     runs-on:
-    - macos-12
+    - macos-13
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -1730,7 +1730,7 @@ jobs:
     - name: Download native binaries
       uses: actions/download-artifact@v4
       with:
-        name: native_binaries.${{ matrix.python-version }}.macOS12-x86_64
+        name: native_binaries.${{ matrix.python-version }}.macOS13-x86_64
         path: src/python/pants
     - name: Make native-client runnable
       run: chmod +x src/python/pants/bin/native_client
@@ -1744,7 +1744,7 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: 'export S3_DST=s3://logs.pantsbuild.org/test/reports/macOS12-x86_64/$(git show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}
+      run: 'export S3_DST=s3://logs.pantsbuild.org/test/reports/macOS13-x86_64/$(git show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}
 
         echo "Uploading test reports to ${S3_DST}"
 
@@ -1756,7 +1756,7 @@ jobs:
       name: Upload pants.log
       uses: actions/upload-artifact@v4
       with:
-        name: logs-python-test-macOS12-x86_64
+        name: logs-python-test-macOS13-x86_64
         overwrite: 'true'
         path: .pants.d/workdir/*.log
     timeout-minutes: 90

--- a/src/python/pants/base/exception_sink_test.py
+++ b/src/python/pants/base/exception_sink_test.py
@@ -55,6 +55,7 @@ def test_set_invalid_log_location():
         Platform.macos_x86_64: (
             "The provided log location path at '/' is not writable or could not be created: "
             "[Errno 21] Is a directory: '/'.",
+            "Error opening fatal error log streams for log location '/': [Errno 30] Read-only file system",
         ),
         Platform.linux_arm64: (
             "Error opening fatal error log streams for log location '/': [Errno 13] Permission "

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -77,12 +77,12 @@ class Platform(Enum):
     LINUX_X86_64 = "Linux-x86_64"
     LINUX_ARM64 = "Linux-ARM64"
     MACOS10_15_X86_64 = "macOS10-15-x86_64"
-    # the oldest version of macOS supported by GitHub self-hosted runners
-    MACOS12_X86_64 = "macOS12-x86_64"
     MACOS11_ARM64 = "macOS11-ARM64"
+    MACOS13_X86_64 = "macOS13-x86_64"
+    MACOS14_ARM64 = "macOS14-ARM64"
 
 
-GITHUB_HOSTED = {Platform.LINUX_X86_64, Platform.MACOS12_X86_64}
+GITHUB_HOSTED = {Platform.LINUX_X86_64, Platform.MACOS13_X86_64, Platform.MACOS14_ARM64}
 SELF_HOSTED = {Platform.LINUX_ARM64, Platform.MACOS10_15_X86_64, Platform.MACOS11_ARM64}
 # We control these runners, so we preinstall and expose python on them.
 HAS_PYTHON = {Platform.LINUX_ARM64, Platform.MACOS10_15_X86_64, Platform.MACOS11_ARM64}
@@ -443,12 +443,14 @@ class Helper:
         # any platform-specific labels, so we don't run on future GH-hosted
         # platforms without realizing it.
         ret = ["self-hosted"] if self.platform in SELF_HOSTED else []
-        if self.platform == Platform.MACOS12_X86_64:
-            ret += ["macos-12"]
-        elif self.platform == Platform.MACOS11_ARM64:
+        if self.platform == Platform.MACOS11_ARM64:
             ret += ["macOS-11-ARM64"]
         elif self.platform == Platform.MACOS10_15_X86_64:
             ret += ["macOS-10.15-X64"]
+        elif self.platform == Platform.MACOS13_X86_64:
+            ret += ["macos-13"]
+        elif self.platform == Platform.MACOS14_ARM64:
+            ret += ["macos-14"]
         elif self.platform == Platform.LINUX_X86_64:
             ret += ["ubuntu-20.04"]
         elif self.platform == Platform.LINUX_ARM64:
@@ -464,11 +466,11 @@ class Helper:
 
     def platform_env(self):
         ret = {}
-        if self.platform in {Platform.MACOS10_15_X86_64, Platform.MACOS12_X86_64}:
+        if self.platform in {Platform.MACOS10_15_X86_64, Platform.MACOS13_X86_64}:
             # Works around bad `-arch arm64` flag embedded in Xcode 12.x Python interpreters on
             # intel machines. See: https://github.com/giampaolo/psutil/issues/1832
             ret["ARCHFLAGS"] = "-arch x86_64"
-        if self.platform == Platform.MACOS11_ARM64:
+        if self.platform in {Platform.MACOS11_ARM64, Platform.MACOS14_ARM64}:
             ret["ARCHFLAGS"] = "-arch arm64"
         if self.platform == Platform.LINUX_X86_64:
             # Currently we run Linux x86_64 CI on GitHub Actions-hosted hardware, and
@@ -838,8 +840,8 @@ def linux_arm64_test_jobs() -> Jobs:
     return jobs
 
 
-def macos12_x86_64_test_jobs() -> Jobs:
-    helper = Helper(Platform.MACOS12_X86_64)
+def macos13_x86_64_test_jobs() -> Jobs:
+    helper = Helper(Platform.MACOS13_X86_64)
     jobs = {
         helper.job_name("bootstrap_pants"): bootstrap_jobs(
             helper,
@@ -1033,7 +1035,7 @@ def test_workflow_jobs() -> Jobs:
     }
     jobs.update(**linux_x86_64_test_jobs())
     jobs.update(**linux_arm64_test_jobs())
-    jobs.update(**macos12_x86_64_test_jobs())
+    jobs.update(**macos13_x86_64_test_jobs())
     jobs.update(**build_wheels_jobs())
     jobs.update(
         {


### PR DESCRIPTION
The macOS-12 runners are disappearing (see #21333), and thus our CI jobs that run on the macos-12 need to stop using it.

This PR cherrypicks just that part of #21655: upgrading the test job, leaving the release jobs running on macOS 10.15 & 11.