### PR TITLE
use explicit setup-python versions over implicit expose- (Cherry-pick of #21568, #21582)

### DIFF
--- a/.github/workflows/cache_comparison.yaml
+++ b/.github/workflows/cache_comparison.yaml
@@ -11,12 +11,22 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 10
-    - name: Set up Python 3.9
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
-    - name: Expose Pythons
-      uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
+        python-version: '3.7
+
+          3.8
+
+          3.9
+
+          3.10
+
+          3.12
+
+          3.13
+
+          3.11'
     - env:
         BASE_REF: ${{ github.event.inputs.base_ref }}
         BUILD_COMMIT: ${{ github.event.inputs.build_commit }}

--- a/.github/workflows/cache_comparison.yaml
+++ b/.github/workflows/cache_comparison.yaml
@@ -11,7 +11,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 10
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.11
       uses: actions/setup-python@v5
       with:
         python-version: '3.7
@@ -23,8 +23,6 @@ jobs:
           3.10
 
           3.12
-
-          3.13
 
           3.11'
     - env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -185,22 +185,6 @@ jobs:
       with:
         fetch-depth: 10
         ref: ${{ needs.release_info.outputs.build-ref }}
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.7
-
-          3.8
-
-          3.9
-
-          3.10
-
-          3.12
-
-          3.13
-
-          3.11'
     - name: Install Protoc
       uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -358,12 +358,22 @@ jobs:
         fetch-depth: '0'
         fetch-tags: true
         ref: ${{ needs.release_info.outputs.build-ref }}
-    - name: Set up Python 3.9
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
-    - name: Expose Pythons
-      uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
+        python-version: '3.7
+
+          3.8
+
+          3.9
+
+          3.10
+
+          3.12
+
+          3.13
+
+          3.11'
     - name: Install Protoc
       uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -185,6 +185,22 @@ jobs:
       with:
         fetch-depth: 10
         ref: ${{ needs.release_info.outputs.build-ref }}
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.7
+
+          3.8
+
+          3.9
+
+          3.10
+
+          3.12
+
+          3.13
+
+          3.11'
     - name: Install Protoc
       uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -358,7 +358,7 @@ jobs:
         fetch-depth: '0'
         fetch-tags: true
         ref: ${{ needs.release_info.outputs.build-ref }}
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.11
       uses: actions/setup-python@v5
       with:
         python-version: '3.7
@@ -370,8 +370,6 @@ jobs:
           3.10
 
           3.12
-
-          3.13
 
           3.11'
     - name: Install Protoc

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -118,10 +118,22 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 10
-    - name: Set up Python 3.9
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.7
+
+          3.8
+
+          3.9
+
+          3.10
+
+          3.12
+
+          3.13
+
+          3.11'
     - name: Install Protoc
       uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
       with:
@@ -221,10 +233,22 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 10
-    - name: Set up Python 3.9
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.7
+
+          3.8
+
+          3.9
+
+          3.10
+
+          3.12
+
+          3.13
+
+          3.11'
     - name: Install Protoc
       uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
       with:
@@ -565,6 +589,43 @@ jobs:
     runs-on:
     - ubuntu-20.04
     steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 10
+    - name: Install Protoc
+      uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        version: 23.x
+    - name: Set rustup profile
+      run: rustup set profile default
+    - name: Cache Rust toolchain
+      uses: actions/cache@v4
+      with:
+        key: macOS12-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
+        path: '~/.rustup/toolchains/1.82.0-*
+
+          ~/.rustup/update-hashes
+
+          ~/.rustup/settings.toml
+
+          '
+    - name: Cache Cargo
+      uses: benjyw/rust-cache@61b5b2e17a28350779e9a535e353da2f8b00e832
+      with:
+        cache-bin: 'false'
+        shared-key: engine
+        workspaces: src/rust/engine
+    - name: Install Protoc
+      uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        version: 23.x
+    - name: Install Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: 1.19.5
     - env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       if: github.event_name == 'pull_request'
@@ -654,10 +715,22 @@ jobs:
         \                 --max_size 30\necho \"PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092\" >> \"$GITHUB_ENV\"\necho\
         \ \"PANTS_REMOTE_CACHE_READ=true\" >> \"$GITHUB_ENV\"\necho \"PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}\" >> \"$GITHUB_ENV\"\
         \n"
-    - name: Set up Python 3.9
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.7
+
+          3.8
+
+          3.9
+
+          3.10
+
+          3.12
+
+          3.13
+
+          3.11'
     - name: Download native binaries
       uses: actions/download-artifact@v4
       with:
@@ -834,12 +907,22 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.9
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
-    - name: Expose Pythons
-      uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
+        python-version: '3.7
+
+          3.8
+
+          3.9
+
+          3.10
+
+          3.12
+
+          3.13
+
+          3.11'
     - name: Download native binaries
       uses: actions/download-artifact@v4
       with:
@@ -926,12 +1009,22 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.9
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
-    - name: Expose Pythons
-      uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
+        python-version: '3.7
+
+          3.8
+
+          3.9
+
+          3.10
+
+          3.12
+
+          3.13
+
+          3.11'
     - name: Download native binaries
       uses: actions/download-artifact@v4
       with:
@@ -1018,12 +1111,22 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.9
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
-    - name: Expose Pythons
-      uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
+        python-version: '3.7
+
+          3.8
+
+          3.9
+
+          3.10
+
+          3.12
+
+          3.13
+
+          3.11'
     - name: Download native binaries
       uses: actions/download-artifact@v4
       with:
@@ -1110,12 +1213,22 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.9
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
-    - name: Expose Pythons
-      uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
+        python-version: '3.7
+
+          3.8
+
+          3.9
+
+          3.10
+
+          3.12
+
+          3.13
+
+          3.11'
     - name: Download native binaries
       uses: actions/download-artifact@v4
       with:
@@ -1202,12 +1315,22 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.9
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
-    - name: Expose Pythons
-      uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
+        python-version: '3.7
+
+          3.8
+
+          3.9
+
+          3.10
+
+          3.12
+
+          3.13
+
+          3.11'
     - name: Download native binaries
       uses: actions/download-artifact@v4
       with:
@@ -1294,12 +1417,22 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.9
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
-    - name: Expose Pythons
-      uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
+        python-version: '3.7
+
+          3.8
+
+          3.9
+
+          3.10
+
+          3.12
+
+          3.13
+
+          3.11'
     - name: Download native binaries
       uses: actions/download-artifact@v4
       with:
@@ -1386,12 +1519,22 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.9
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
-    - name: Expose Pythons
-      uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
+        python-version: '3.7
+
+          3.8
+
+          3.9
+
+          3.10
+
+          3.12
+
+          3.13
+
+          3.11'
     - name: Download native binaries
       uses: actions/download-artifact@v4
       with:
@@ -1478,12 +1621,22 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.9
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
-    - name: Expose Pythons
-      uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
+        python-version: '3.7
+
+          3.8
+
+          3.9
+
+          3.10
+
+          3.12
+
+          3.13
+
+          3.11'
     - name: Download native binaries
       uses: actions/download-artifact@v4
       with:
@@ -1570,12 +1723,22 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.9
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
-    - name: Expose Pythons
-      uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
+        python-version: '3.7
+
+          3.8
+
+          3.9
+
+          3.10
+
+          3.12
+
+          3.13
+
+          3.11'
     - name: Download native binaries
       uses: actions/download-artifact@v4
       with:
@@ -1662,12 +1825,22 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.9
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
-    - name: Expose Pythons
-      uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
+        python-version: '3.7
+
+          3.8
+
+          3.9
+
+          3.10
+
+          3.12
+
+          3.13
+
+          3.11'
     - name: Download native binaries
       uses: actions/download-artifact@v4
       with:
@@ -1721,12 +1894,22 @@ jobs:
       with:
         distribution: adopt
         java-version: '11'
-    - name: Set up Python 3.9
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
-    - name: Expose Pythons
-      uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
+        python-version: '3.7
+
+          3.8
+
+          3.9
+
+          3.10
+
+          3.12
+
+          3.13
+
+          3.11'
     - name: Download native binaries
       uses: actions/download-artifact@v4
       with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -464,6 +464,22 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 10
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.7
+
+          3.8
+
+          3.9
+
+          3.10
+
+          3.12
+
+          3.13
+
+          3.11'
     - name: Install Protoc
       uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
       with:
@@ -593,6 +609,22 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 10
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.7
+
+          3.8
+
+          3.9
+
+          3.10
+
+          3.12
+
+          3.13
+
+          3.11'
     - name: Install Protoc
       uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
       with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -118,7 +118,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 10
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.11
       uses: actions/setup-python@v5
       with:
         python-version: '3.7
@@ -130,8 +130,6 @@ jobs:
           3.10
 
           3.12
-
-          3.13
 
           3.11'
     - name: Install Protoc
@@ -233,7 +231,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 10
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.11
       uses: actions/setup-python@v5
       with:
         python-version: '3.7
@@ -245,8 +243,6 @@ jobs:
           3.10
 
           3.12
-
-          3.13
 
           3.11'
     - name: Install Protoc
@@ -678,7 +674,7 @@ jobs:
         \                 --max_size 30\necho \"PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092\" >> \"$GITHUB_ENV\"\necho\
         \ \"PANTS_REMOTE_CACHE_READ=true\" >> \"$GITHUB_ENV\"\necho \"PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}\" >> \"$GITHUB_ENV\"\
         \n"
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.11
       uses: actions/setup-python@v5
       with:
         python-version: '3.7
@@ -690,8 +686,6 @@ jobs:
           3.10
 
           3.12
-
-          3.13
 
           3.11'
     - name: Download native binaries
@@ -870,7 +864,7 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.11
       uses: actions/setup-python@v5
       with:
         python-version: '3.7
@@ -882,8 +876,6 @@ jobs:
           3.10
 
           3.12
-
-          3.13
 
           3.11'
     - name: Download native binaries
@@ -972,7 +964,7 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.11
       uses: actions/setup-python@v5
       with:
         python-version: '3.7
@@ -984,8 +976,6 @@ jobs:
           3.10
 
           3.12
-
-          3.13
 
           3.11'
     - name: Download native binaries
@@ -1074,7 +1064,7 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.11
       uses: actions/setup-python@v5
       with:
         python-version: '3.7
@@ -1086,8 +1076,6 @@ jobs:
           3.10
 
           3.12
-
-          3.13
 
           3.11'
     - name: Download native binaries
@@ -1176,7 +1164,7 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.11
       uses: actions/setup-python@v5
       with:
         python-version: '3.7
@@ -1188,8 +1176,6 @@ jobs:
           3.10
 
           3.12
-
-          3.13
 
           3.11'
     - name: Download native binaries
@@ -1278,7 +1264,7 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.11
       uses: actions/setup-python@v5
       with:
         python-version: '3.7
@@ -1290,8 +1276,6 @@ jobs:
           3.10
 
           3.12
-
-          3.13
 
           3.11'
     - name: Download native binaries
@@ -1380,7 +1364,7 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.11
       uses: actions/setup-python@v5
       with:
         python-version: '3.7
@@ -1392,8 +1376,6 @@ jobs:
           3.10
 
           3.12
-
-          3.13
 
           3.11'
     - name: Download native binaries
@@ -1482,7 +1464,7 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.11
       uses: actions/setup-python@v5
       with:
         python-version: '3.7
@@ -1494,8 +1476,6 @@ jobs:
           3.10
 
           3.12
-
-          3.13
 
           3.11'
     - name: Download native binaries
@@ -1584,7 +1564,7 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.11
       uses: actions/setup-python@v5
       with:
         python-version: '3.7
@@ -1596,8 +1576,6 @@ jobs:
           3.10
 
           3.12
-
-          3.13
 
           3.11'
     - name: Download native binaries
@@ -1686,7 +1664,7 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.11
       uses: actions/setup-python@v5
       with:
         python-version: '3.7
@@ -1698,8 +1676,6 @@ jobs:
           3.10
 
           3.12
-
-          3.13
 
           3.11'
     - name: Download native binaries
@@ -1788,7 +1764,7 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.11
       uses: actions/setup-python@v5
       with:
         python-version: '3.7
@@ -1800,8 +1776,6 @@ jobs:
           3.10
 
           3.12
-
-          3.13
 
           3.11'
     - name: Download native binaries
@@ -1857,7 +1831,7 @@ jobs:
       with:
         distribution: adopt
         java-version: '11'
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.11
       uses: actions/setup-python@v5
       with:
         python-version: '3.7
@@ -1869,8 +1843,6 @@ jobs:
           3.10
 
           3.12
-
-          3.13
 
           3.11'
     - name: Download native binaries

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -464,22 +464,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 10
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.7
-
-          3.8
-
-          3.9
-
-          3.10
-
-          3.12
-
-          3.13
-
-          3.11'
     - name: Install Protoc
       uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
       with:
@@ -605,59 +589,6 @@ jobs:
     runs-on:
     - ubuntu-20.04
     steps:
-    - name: Check out code
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 10
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.7
-
-          3.8
-
-          3.9
-
-          3.10
-
-          3.12
-
-          3.13
-
-          3.11'
-    - name: Install Protoc
-      uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        version: 23.x
-    - name: Set rustup profile
-      run: rustup set profile default
-    - name: Cache Rust toolchain
-      uses: actions/cache@v4
-      with:
-        key: macOS12-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.82.0-*
-
-          ~/.rustup/update-hashes
-
-          ~/.rustup/settings.toml
-
-          '
-    - name: Cache Cargo
-      uses: benjyw/rust-cache@61b5b2e17a28350779e9a535e353da2f8b00e832
-      with:
-        cache-bin: 'false'
-        shared-key: engine
-        workspaces: src/rust/engine
-    - name: Install Protoc
-      uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        version: 23.x
-    - name: Install Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: 1.19.5
     - env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       if: github.event_name == 'pull_request'

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -173,7 +173,7 @@ def test_pex_environment(rule_runner: RuleRunner, pex_type: type[Pex | VenvPex])
             "--subprocess-environment-env-vars=LANG",  # Value should come from environment.
             "--subprocess-environment-env-vars=ftp_proxy=dummyproxy",
         ),
-        interpreter_constraints=InterpreterConstraints(["CPython>=3.6"]),
+        interpreter_constraints=InterpreterConstraints(["CPython>=3.8"]),
         env={"LANG": "es_PY.UTF-8"},
     )
 
@@ -224,7 +224,7 @@ def test_pex_working_directory(rule_runner: RuleRunner, pex_type: type[Pex | Ven
         pex_type=pex_type,
         main=EntryPoint("main"),
         sources=sources,
-        interpreter_constraints=InterpreterConstraints(["CPython>=3.6"]),
+        interpreter_constraints=InterpreterConstraints(["CPython>=3.8"]),
     )
 
     pex_process_type = PexProcess if isinstance(pex_data.pex, Pex) else VenvPexProcess
@@ -418,7 +418,7 @@ def test_entry_point(rule_runner: RuleRunner) -> None:
 
 
 def test_interpreter_constraints(rule_runner: RuleRunner) -> None:
-    constraints = InterpreterConstraints(["CPython>=2.7,<3", "CPython>=3.6,<3.12"])
+    constraints = InterpreterConstraints(["CPython>=2.7,<3", "CPython>=3.8,<3.12"])
     pex_info = create_pex_and_get_pex_info(
         rule_runner, interpreter_constraints=constraints, internal_only=False
     )
@@ -434,7 +434,7 @@ def test_platforms(rule_runner: RuleRunner) -> None:
     # We use Python 2.7, rather than Python 3, to ensure that the specified platform is
     # actually used.
     platforms = PexPlatforms(["linux-x86_64-cp-27-cp27mu"])
-    constraints = InterpreterConstraints(["CPython>=2.7,<3", "CPython>=3.6"])
+    constraints = InterpreterConstraints(["CPython>=2.7,<3", "CPython>=3.8"])
     pex_data = create_pex_and_get_all_data(
         rule_runner,
         requirements=PexRequirements(["cryptography==2.9"]),

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -124,7 +124,7 @@ NATIVE_FILES = [
 # We don't specify a patch version so that we get the latest, which comes pre-installed:
 #  https://github.com/actions/setup-python#available-versions-of-python
 # NOTE: The last entry becomes the default
-PYTHON_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.12", "3.13", "3.11"]
+PYTHON_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.12", "3.11"]
 
 DONT_SKIP_RUST = "needs.classify_changes.outputs.rust == 'true'"
 DONT_SKIP_WHEELS = "needs.classify_changes.outputs.release == 'true'"

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -881,6 +881,7 @@ def build_wheels_job(
     else:
         initial_steps = [
             *checkout(ref=for_deploy_ref),
+            *helper.setup_pythons(),
             # NB: We only cache Rust, but not `native_engine.so` and the Pants
             # virtualenv. This is because we must build both these things with
             # multiple Python versions, whereas that caching assumes only one primary

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -36,7 +36,6 @@ def action(name: str, node16_compat: bool = False) -> str:
             "cache": "actions/cache@v4",
             "checkout": "actions/checkout@v4",
             "download-artifact": "actions/download-artifact@v4",
-            "expose-pythons": "pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe",
             "github-action-required-labels": "mheap/github-action-required-labels@v4.0.0",
             "rust-cache": "benjyw/rust-cache@461b9f8eee66b575bce78977bf649b8b7a8d53f1",
             "setup-go": "actions/setup-go@v5",
@@ -124,7 +123,8 @@ NATIVE_FILES = [
 
 # We don't specify a patch version so that we get the latest, which comes pre-installed:
 #  https://github.com/actions/setup-python#available-versions-of-python
-PYTHON_VERSION = "3.9"
+# NOTE: The last entry becomes the default
+PYTHON_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.12", "3.13", "3.11"]
 
 DONT_SKIP_RUST = "needs.classify_changes.outputs.rust == 'true'"
 DONT_SKIP_WHEELS = "needs.classify_changes.outputs.release == 'true'"
@@ -361,11 +361,14 @@ def install_rustup() -> Step:
     }
 
 
-def install_python(version: str) -> Step:
+def install_pythons(versions: list[str]) -> Step:
+    # See:
+    # https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#specifying-multiple-pythonpypy-versions
+    # This is a list expressed as a newline delimited string instead of a... list
     return {
-        "name": f"Set up Python {version}",
+        "name": f"Set up Python {', '.join(versions)}",
         "uses": action("setup-python"),
-        "with": {"python-version": version},
+        "with": {"python-version": "\n".join(versions)},
     }
 
 
@@ -568,27 +571,16 @@ class Helper:
             },
         ]
 
-    def setup_primary_python(self) -> Sequence[Step]:
+    def setup_pythons(self) -> Sequence[Step]:
         ret = []
         if self.platform not in HAS_PYTHON:
-            ret.append(install_python(PYTHON_VERSION))
-        return ret
-
-    def expose_all_pythons(self) -> Sequence[Step]:
-        ret = []
-        if self.platform not in HAS_PYTHON:
-            ret.append(
-                {
-                    "name": "Expose Pythons",
-                    "uses": action("expose-pythons"),
-                }
-            )
+            ret.append(install_pythons(PYTHON_VERSIONS))
         return ret
 
     def bootstrap_pants(self) -> Sequence[Step]:
         return [
             *checkout(),
-            *self.setup_primary_python(),
+            *self.setup_pythons(),
             *self.bootstrap_caches(),
             {
                 "name": "Bootstrap Pants",
@@ -783,8 +775,7 @@ def test_jobs(
                 # preinstalled on the self-hosted runners.
                 else []
             ),
-            *helper.setup_primary_python(),
-            *helper.expose_all_pythons(),
+            *helper.setup_pythons(),
             *helper.native_binaries_download(),
             {
                 "name": human_readable_step_name,
@@ -890,7 +881,6 @@ def build_wheels_job(
     else:
         initial_steps = [
             *checkout(ref=for_deploy_ref),
-            *helper.expose_all_pythons(),
             # NB: We only cache Rust, but not `native_engine.so` and the Pants
             # virtualenv. This is because we must build both these things with
             # multiple Python versions, whereas that caching assumes only one primary
@@ -1046,7 +1036,7 @@ def test_workflow_jobs() -> Jobs:
                 "steps": [
                     *checkout(),
                     *launch_bazel_remote(),
-                    *linux_x86_64_helper.setup_primary_python(),
+                    *linux_x86_64_helper.setup_pythons(),
                     *linux_x86_64_helper.native_binaries_download(),
                     {
                         "name": "Lint",
@@ -1122,8 +1112,7 @@ def cache_comparison_jobs_and_inputs() -> tuple[Jobs, dict[str, Any]]:
             "timeout-minutes": 90,
             "steps": [
                 *checkout(),
-                *helper.setup_primary_python(),
-                *helper.expose_all_pythons(),
+                *helper.setup_pythons(),
                 {
                     "name": "Prepare cache comparison",
                     "run": dedent(
@@ -1256,8 +1245,7 @@ def release_jobs_and_inputs() -> tuple[Jobs, dict[str, Any]]:
                         "fetch-tags": True,
                     },
                 },
-                *helper.setup_primary_python(),
-                *helper.expose_all_pythons(),
+                *helper.setup_pythons(),
                 *helper.bootstrap_caches(),
                 {
                     "name": "Generate announcement",
@@ -1594,7 +1582,7 @@ def public_repos() -> PublicReposOutput:
             "permissions": {},
             "steps": [
                 *checkout(repository=repo.name, **repo.checkout_options),
-                install_python(repo.python_version),
+                install_pythons([repo.python_version]),
                 *([install_go()] if repo.install_go else []),
                 *([install_node(repo.node_version)] if repo.node_version else []),
                 *([download_apache_thrift()] if repo.install_thrift else []),


### PR DESCRIPTION
The project is currently using a mix of the GitHub supplied `setup-python` action and `pantsbuild/actions/expose-pythons`.  On GitHub managed runners they behave similarly:
 * `setup-python` will install a version of Python if missing, or add it to the PATH if already present at the expected location (managed runners historically have multiple Pythons baked into the image)
 * `expose-pythons` will add all Python's at the expected GitHub location to the PATH.  (Which ones is up to GitHub.)

So today the invocation of `setup-python` followed by `expose-pythons` is redundant.

Consolidating on `setup-python` let's us be explicit about expected versions (more like the ARM image) and reduces the number of custom actions the project manages while still making multiple Python versions available.

NOTE: The awkward double newlines in the final yaml are a pre-existing issue
https://stackoverflow.com/questions/45004464/yaml-dump-adding-unwanted-newlines-in-multiline-strings

See #21552 for some history regarding the `setup-` vs `expose-` actions.
