### PR TITLE
use `GILProtected` to synchronize access to various `pyclass` types

### DIFF
--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -286,8 +286,8 @@ pub(crate) enum GeneratorInput {
 /// - we will `send` back a single value or tupled values to the coroutine, or `throw` an exception.
 /// - a coroutine will eventually return a single return value.
 ///
-pub(crate) fn generator_send<'py>(
-    py: Python<'py>,
+pub(crate) fn generator_send(
+    py: Python<'_>,
     generator_type: &TypeId,
     generator: &Value,
     input: GeneratorInput,
@@ -497,7 +497,7 @@ impl PyGeneratorResponseNativeCall {
         }))))
     }
 
-    fn take<'py>(&self, py: Python<'py>) -> Result<NativeCall, String> {
+    fn take(&self, py: Python<'_>) -> Result<NativeCall, String> {
         self.0
             .get(py)
             .borrow_mut()
@@ -593,7 +593,7 @@ impl PyGeneratorResponseCall {
     }
 
     #[getter]
-    fn inputs<'py>(&self, py: Python<'py>) -> PyResult<Vec<PyObject>> {
+    fn inputs(&self, py: Python<'_>) -> PyResult<Vec<PyObject>> {
         let inner = self.borrow_inner(py)?;
         let args: Vec<PyObject> = inner.args.as_ref().map_or_else(
             || Ok(Vec::default()),
@@ -607,7 +607,7 @@ impl PyGeneratorResponseCall {
 }
 
 impl PyGeneratorResponseCall {
-    fn take<'py>(&self, py: Python<'py>) -> Result<Call, String> {
+    fn take(&self, py: Python<'_>) -> Result<Call, String> {
         self.0
             .get(py)
             .borrow_mut()
@@ -621,7 +621,7 @@ impl PyGeneratorResponseCall {
 pub struct PyGeneratorResponseGet(GILProtected<RefCell<Option<Get>>>);
 
 impl PyGeneratorResponseGet {
-    fn take<'py>(&self, py: Python<'py>) -> Result<Get, String> {
+    fn take(&self, py: Python<'_>) -> Result<Get, String> {
         self.0
             .get(py)
             .borrow_mut()
@@ -693,7 +693,7 @@ impl PyGeneratorResponseGet {
     }
 
     #[getter]
-    fn inputs<'py>(&self, py: Python<'py>) -> PyResult<Vec<PyObject>> {
+    fn inputs(&self, py: Python<'_>) -> PyResult<Vec<PyObject>> {
         Ok(self
             .0
             .get(py)
@@ -710,7 +710,7 @@ impl PyGeneratorResponseGet {
             .collect())
     }
 
-    fn __repr__<'py>(&self, py: Python<'py>) -> PyResult<String> {
+    fn __repr__(&self, py: Python<'_>) -> PyResult<String> {
         Ok(format!(
             "{}",
             self.0.get(py).borrow().as_ref().ok_or_else(|| {


### PR DESCRIPTION
As part of [upgrading to PyO3 v0.23.x](https://github.com/pantsbuild/pants/issues/21671), access to`pyclass`-annotated types will no longer be implicitly synchronized against the Python GIL. Those `pyclass`-annotated types [must now be `Sync`](https://pyo3.rs/v0.23.1/class/thread-safety) and provide that synchronization explicitly.

Several places in Pants use `RefCell` which is not Send/Sync by itself. This PR uses `pyo3::sync::GILProtected` to provide explicit synchronization against the GIL for those use cases. (Eventually, we may wish to not use `GILProtected` to enable use of the Python 3.13 "no GIL" free threaded build, but that day is not today.)

[Migration guide](https://pyo3.rs/v0.23.1/migration.html#free-threaded-python-support)