### PR TITLE
Allow python protobuf codegen export to coexist with namespace/host package (Cherry-pick of #21665)

### DIFF
--- a/docs/notes/2.24.x.md
+++ b/docs/notes/2.24.x.md
@@ -23,6 +23,7 @@ We offer [formal sponsorship tiers for companies](https://www.pantsbuild.org/spo
 ### General
 
 * Fixed bug where `pants peek --include-additional-info` was not actually displaying the additional info ([#21399](https://github.com/pantsbuild/pants/pull/21399)).
+* [Fixed](https://github.com/pantsbuild/pants/pull/21665) bug where `pants --export-resolve=<resolve> --export-py-generated-sources-in-resolve=<resolve>` fails (see [#21659](https://github.com/pantsbuild/pants/issues/21659) for more info).
 
 ### New Options System
 

--- a/src/python/pants/backend/python/goals/export.py
+++ b/src/python/pants/backend/python/goals/export.py
@@ -411,6 +411,7 @@ async def python_codegen_export_setup() -> _ExportPythonCodegenSetup:
                     content=textwrap.dedent(
                         f"""\
                         import os
+                        import shutil
                         import site
                         import sys
 
@@ -424,7 +425,10 @@ async def python_codegen_export_setup() -> _ExportPythonCodegenSetup:
                         for item in os.listdir(codegen_dir):
                             if item == "{_ExportPythonCodegenSetup.SCRIPT_NAME}":
                                 continue
-                            os.rename(os.path.join(codegen_dir, item), os.path.join(site_packages_dir, item))
+                            src = os.path.join(codegen_dir, item)
+                            dest = os.path.join(site_packages_dir, item)
+                            shutil.copytree(src, dest, dirs_exist_ok=True)
+                            shutil.rmtree(src)
                         """
                     ).encode(),
                 )

--- a/src/python/pants/backend/python/goals/export_test.py
+++ b/src/python/pants/backend/python/goals/export_test.py
@@ -251,12 +251,32 @@ def test_export_codegen_outputs():
     rule_runner.write_files(
         {
             "test-resolve.lock": "",
+            # Case #1
+            # `foo`` package exports `an-input.py` file as a generated source.
             "src/python/foo/BUILD": dedent(
-                """\
-            codegen_target(name="codegen", source="an-input", resolve="test-resolve")
-            """
+                """
+                codegen_target(
+                  name="codegen",
+                  source="an-input",
+                  resolve="test-resolve"
+                )
+                """
             ),
             "src/python/foo/an-input": "print('Hello World!')\n",
+            # Case #2
+            # The local `ansicolors`` package exports `ansicolors-input.py` file as a generated source.
+            # The local `ansicolors package clashes with the 3rd party dep `ansicolors``.
+            # This is an edge case.
+            "src/python/ansicolors/BUILD": dedent(
+                """
+                codegen_target(
+                  name="codegen",
+                  source="ansicolors-input",
+                  resolve="test-resolve"
+                )
+                """
+            ),
+            "src/python/ansicolors/ansicolors-input": "print('Hello World!')\n",
         }
     )
 
@@ -267,3 +287,7 @@ def test_export_codegen_outputs():
     export_snapshot = rule_runner.request(Snapshot, [export_result.digest])
     assert any(p.endswith("__pants_codegen__/codegen_setup.py") for p in export_snapshot.files)
     assert any(p.endswith("__pants_codegen__/foo/an-input.py") for p in export_snapshot.files)
+    assert any(
+        p.endswith("__pants_codegen__/ansicolors/ansicolors-input.py")
+        for p in export_snapshot.files
+    )


### PR DESCRIPTION
Before this change, if a codegen export clashes with an existing package in the venv the export halts completely. The current change skips the problematic exports. This is sub optimal because not all symbols are exported but better than halting the export.

See #21659 
