### PR TITLE
Copy-edit 2.24's release notes, add some highlights (Cherry-pick of #21672)

### DIFF
--- a/docs/notes/2.24.x.md
+++ b/docs/notes/2.24.x.md
@@ -12,7 +12,9 @@ We offer [formal sponsorship tiers for companies](https://www.pantsbuild.org/spo
 
 ### Highlights
 
-
+- Support for Python 3.13
+- `pants export --bin` allows exporting more tools for use outside Pants
+- A new options system unlocks future changes.
 
 ### Deprecations
 
@@ -26,7 +28,7 @@ We offer [formal sponsorship tiers for companies](https://www.pantsbuild.org/spo
 
 ### New Options System
 
-This release switches the Pants [options system](https://www.pantsbuild.org/2.22/docs/using-pants/key-concepts/options) to use the new "native" implementation written in Rust first introduced in the 2.22.x series.
+This release switches the Pants [options system](https://www.pantsbuild.org/2.24/docs/using-pants/key-concepts/options) to use the new "native" implementation written in Rust first introduced in the 2.22.x series.
 
 To ensure that this transition is not disruptive, this release will run the new system alongside the "legacy" options system, and compare their results, issuing a warning if they differ.
 
@@ -42,6 +44,16 @@ Many tools that Pants downloads can now be exported using [the new `export --bin
 
 ### Backends
 
+#### Go
+
+Fix a bug where Pants raised an internal exception which occurred when compiling a Go package with coverage support when the package also had an external test which imported the base package.
+
+Fix a bug where Pants sent a minor Go version instead of the major one to the Go toolchain during packaging.
+
+Recognize `-fullpath` as a test binary flag.
+
+Add support for the `all:` prefix to patterns used with the `go:embed` directive. The `all:` prefix includes files which start with `_` or `.` which are ordinarilly excluded .
+
 #### JVM
 
 Compression of class files into a jar file is not reading or writing from the remote cache. The size of jar files, combined with the low computational cost of compression, can outweigh the advantages of using a remote cache.
@@ -56,18 +68,15 @@ The kotlin linter, [ktlint](https://pinterest.github.io/ktlint/), has been updat
 
 #### Python
 
-**Breaking change**: the `pants.backend.experimental.python.lint.ruff.check` and `pants.backend.experimental.python.lint.ruff.format` subsystems now execute Ruff as a downloaded binary, directly from the Ruff releases, rather than using PEX to execute the PyPI `ruff` package. This has less overhead, and makes customising the version simpler. However, **options like [`[ruff].install_from_resolve`](https://www.pantsbuild.org/2.24/reference/subsystems/ruff#install_from_resolve) are now ignored** and will be removed in future. If you have customised the version, use [`[ruff].version`](https://www.pantsbuild.org/2.24/reference/subsystems/ruff#version) and [`[ruff].known_versions`](https://www.pantsbuild.org/2.24/reference/subsystems/ruff#known_versions) instead. This version of Pants includes built-in known-versions for the latest patch release (at time of development) of each `0.x` minor series (0.7.2, 0.6.9, 0.5.7, 0.4.10, 0.3.7, 0.2.2, 0.1.15): if you install from a resolve with a particular pinned version of Ruff, you may find setting `[ruff].version` to the closest matching version in that list is acceptable (if not, you may need to add to `[ruff].known_versions`).
+Pants' support for different Python versions has changed:
 
-User API Changes:
-- Update default package mapping for `pymupdf` to match imports from both `fitz` (the legacy name) and `pymupdf` (the [currently supported name](https://pymupdf.readthedocs.io/en/latest/installation.html#problems-after-installation).
+- The default lockfiles bundled with Pants for various tools (ex: to run `black`) now support Python 3.13.
 
-Deprecations:
+- **breaking change**: those lockfiles no longer support Python 3.7.  The minimum Python version is now 3.8.  Pants still supports running Python 3.7 (and earlier!) user code, but you will need to [generate your own lockfiles](https://www.pantsbuild.org/2.24/docs/python/overview/lockfiles#lockfiles-for-tools).  See the announcement at <https://www.pantsbuild.org/blog/2024/08/24/venerable-pythons> for further context.
 
 - Pants v2.24 and later are not proactively tested in CI with Python 2.7 since [Python 2.7 is no longer supported by its maintainers as of 1 January 2020](https://www.python.org/doc/sunset-python-2/). While Pants may continue to work with Python 2.7 in the near term, Pants no longer officially supports use of Python 2.7, and, consequently, any remaining support for Python 2.7 may "bit rot" and diverge over time. Contributions to fix issues with Python 2.7 support will continue to be accepted, but will depend on any community contributions and will not constitute continued official support for Python 2.7.
 
-- The default lockfiles bundled with Pants for various tools (ex: to run `black`) no longer support Python 3.7.  The minimum Python version is now 3.8.  Pants still supports running Python 3.7 (and earlier!) user code, but you will need to [generate your own lockfiles](https://www.pantsbuild.org/stable/docs/python/overview/lockfiles#lockfiles-for-tools).  See the announcement at <https://www.pantsbuild.org/blog/2024/08/24/venerable-pythons> for further context.
-
-- The deprecation of `resolve_local_platforms` (both a field of `pex_binary`, and a option of `[pex-binary-defaults]`) has expired and thus they have been removed.
+**Breaking change**: the `pants.backend.experimental.python.lint.ruff.check` and `pants.backend.experimental.python.lint.ruff.format` subsystems now execute Ruff as a downloaded binary, directly from the Ruff releases, rather than using PEX to execute the PyPI `ruff` package. This has less overhead, and makes customising the version simpler. However, **options like [`[ruff].install_from_resolve`](https://www.pantsbuild.org/2.24/reference/subsystems/ruff#install_from_resolve) are now ignored** and will be removed in future. If you have customised the version, use [`[ruff].version`](https://www.pantsbuild.org/2.24/reference/subsystems/ruff#version) and [`[ruff].known_versions`](https://www.pantsbuild.org/2.24/reference/subsystems/ruff#known_versions) instead. This version of Pants includes built-in known-versions for the latest patch release (at time of development) of each `0.x` minor series (0.7.2, 0.6.9, 0.5.7, 0.4.10, 0.3.7, 0.2.2, 0.1.15): if you install from a resolve with a particular pinned version of Ruff, you may find setting `[ruff].version` to the closest matching version in that list is acceptable (if not, you may need to add to `[ruff].known_versions`).
 
 Version Updates:
 
@@ -84,9 +93,16 @@ Version Updates:
 - The default version of the [Ruff](https://docs.astral.sh/ruff/) tool has been updated from 0.4.9 to [0.7.2](https://github.com/astral-sh/ruff/releases/tag/0.7.2). (As discussed above, one can pin to particular versions, including 0.4.9, via the new `[ruff].version` and `[ruff].known_versions` options.)
 
 
-A new experimental [Python Provider](https://www.pantsbuild.org/blog/2023/03/31/two-hermetic-pythons) using [Python Build Standalone](https://gregoryszorc.com/docs/python-build-standalone/main/) is available as `pants.backend.python.providers.experimental.python_build_standalone`.  This joins the existing [pyenv provider](https://www.pantsbuild.org/stable/reference/subsystems/pyenv-python-provider) as a way for Pants to take care of providing an appropriate Python.
+A new experimental [Python Provider](https://www.pantsbuild.org/blog/2023/03/31/two-hermetic-pythons) using [Python Build Standalone](https://gregoryszorc.com/docs/python-build-standalone/main/) is available as `pants.backend.python.providers.experimental.python_build_standalone`.  This joins the existing [pyenv provider](https://www.pantsbuild.org/2.24/reference/subsystems/pyenv-python-provider) as a way for Pants to take care of providing an appropriate Python.
 
-Mypy will now typecheck previously-ignored python sources without a `.py` or `.pyi` extension.
+Other changes:
+
+- Mypy will now typecheck previously-ignored python sources without a `.py` or `.pyi` extension.
+
+- Update default package mapping for `pymupdf` to match imports from both `fitz` (the legacy name) and `pymupdf` (the [currently supported name](https://pymupdf.readthedocs.io/en/latest/installation.html#problems-after-installation).
+
+- The deprecation of `resolve_local_platforms` (both a field of `pex_binary`, and a option of `[pex-binary-defaults]`) has expired and thus they have been removed.
+
 
 #### S3
 
@@ -98,21 +114,9 @@ The default version of [the semgrep tool](https://www.pantsbuild.org/2.24/refere
 
 #### Shell
 
-Pants will now warn if any errors are encountered while fingerprinting candidate binaries for the `system_binary` target type. The warnings may be disabled by setting the new `log_fingerprinting_errors` field on `system_binary` to `False`.
+Pants will now warn if any errors are encountered while fingerprinting candidate binaries for the `system_binary` target type. The warnings may be disabled by setting the [new `log_fingerprinting_errors` field](https://www.pantsbuild.org/2.24/reference/targets/system_binary#log_fingerprinting_errors) on `system_binary` to `False`.
 
-#### Shell
-
-Added a new `cache_scope` field to `adhoc_tool` and `shell_command` targets to allow configuration of the "cache scope" of the invoked process. The cache scope determines how long Pants will cache the result of the invoked process absent any other invalidation of the result via source or dependency changes.
-
-#### Go
-
-Fix a bug where Pants raised an internal exception which occurred when compiling a Go package with coverage support when the package also had an external test which imported the base package.
-
-Fix a bug where Pants sent a minor Go version instead of the major one to the Go toolchain during packaging.
-
-Recognize `-fullpath` as a test binary flag.
-
-Add support for the `all:` prefix to patterns used with the `go:embed` directive. The `all:` prefix includes files which start with `_` or `.` which are ordinarilly excluded .
+Added a new `cache_scope` field to [`adhoc_tool`](https://www.pantsbuild.org/2.24/reference/targets/adhoc_tool#cache_scope) and [`shell_command`](https://www.pantsbuild.org/2.24/reference/targets/shell_command#cache_scope) targets to allow configuration of the "cache scope" of the invoked process. The cache scope determines how long Pants will cache the result of the invoked process absent any other invalidation of the result via source or dependency changes.
 
 ### Plugin API changes
 


### PR DESCRIPTION
This does some copy-edits to the 2.24.x release notes, e.g.:

- shuffle the backends to be alphabetical
- include Python 3.13 support (and shuffle how the Python version support is discussed)
- tweak/add some links
- pull out some highlights

This is in preparation for the eventual 2.24.0 release.
