### PR TITLE
PyO3: migrate to using `IntoPyObject`

### DIFF
--- a/src/rust/engine/src/externs/dep_inference.rs
+++ b/src/rust/engine/src/externs/dep_inference.rs
@@ -6,7 +6,7 @@ use std::hash::{Hash, Hasher};
 use pyo3::basic::CompareOp;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
-use pyo3::{IntoPy, PyObject, Python};
+use pyo3::{PyObject, Python};
 
 use fs::DirectoryDigest;
 use protos::gen::pants::cache::{
@@ -59,12 +59,20 @@ impl PyInferenceMetadata {
         )))
     }
 
-    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python) -> PyObject {
-        match op {
-            CompareOp::Eq => (self == other).into_py(py),
-            CompareOp::Ne => (self != other).into_py(py),
+    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python) -> PyResult<PyObject> {
+        Ok(match op {
+            CompareOp::Eq => (self == other)
+                .into_pyobject(py)?
+                .to_owned()
+                .into_any()
+                .unbind(),
+            CompareOp::Ne => (self != other)
+                .into_pyobject(py)?
+                .to_owned()
+                .into_any()
+                .unbind(),
             _ => py.NotImplemented(),
-        }
+        })
     }
 
     fn __repr__(&self) -> String {
@@ -111,11 +119,19 @@ impl PyNativeDependenciesRequest {
         )
     }
 
-    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python) -> PyObject {
-        match op {
-            CompareOp::Eq => (self == other).into_py(py),
-            CompareOp::Ne => (self != other).into_py(py),
+    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python) -> PyResult<PyObject> {
+        Ok(match op {
+            CompareOp::Eq => (self == other)
+                .into_pyobject(py)?
+                .to_owned()
+                .into_any()
+                .unbind(),
+            CompareOp::Ne => (self != other)
+                .into_pyobject(py)?
+                .to_owned()
+                .into_any()
+                .unbind(),
             _ => py.NotImplemented(),
-        }
+        })
     }
 }

--- a/src/rust/engine/src/externs/fs.rs
+++ b/src/rust/engine/src/externs/fs.rs
@@ -1,9 +1,6 @@
 // Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-// Temporary: Allow deprecated items while we migrate to PyO3 v0.23.x.
-#![allow(deprecated)]
-
 use std::collections::hash_map::DefaultHasher;
 use std::fmt;
 use std::hash::{Hash, Hasher};
@@ -96,13 +93,26 @@ impl PyDigest {
         format!("{self}")
     }
 
-    fn __richcmp__(&self, other: &Bound<'_, PyDigest>, op: CompareOp, py: Python) -> PyObject {
+    fn __richcmp__(
+        &self,
+        other: &Bound<'_, PyDigest>,
+        op: CompareOp,
+        py: Python,
+    ) -> PyResult<PyObject> {
         let other_digest = other.borrow();
-        match op {
-            CompareOp::Eq => (*self == *other_digest).into_py(py),
-            CompareOp::Ne => (*self != *other_digest).into_py(py),
+        Ok(match op {
+            CompareOp::Eq => (*self == *other_digest)
+                .into_pyobject(py)?
+                .to_owned()
+                .into_any()
+                .unbind(),
+            CompareOp::Ne => (*self != *other_digest)
+                .into_pyobject(py)?
+                .to_owned()
+                .into_any()
+                .unbind(),
             _ => py.NotImplemented(),
-        }
+        })
     }
 
     #[getter]
@@ -141,13 +151,26 @@ impl PyFileDigest {
         )
     }
 
-    fn __richcmp__(&self, other: &Bound<'_, PyFileDigest>, op: CompareOp, py: Python) -> PyObject {
+    fn __richcmp__(
+        &self,
+        other: &Bound<'_, PyFileDigest>,
+        op: CompareOp,
+        py: Python,
+    ) -> PyResult<PyObject> {
         let other_file_digest = other.borrow();
-        match op {
-            CompareOp::Eq => (*self == *other_file_digest).into_py(py),
-            CompareOp::Ne => (*self != *other_file_digest).into_py(py),
+        Ok(match op {
+            CompareOp::Eq => (*self == *other_file_digest)
+                .into_pyobject(py)?
+                .to_owned()
+                .into_any()
+                .unbind(),
+            CompareOp::Ne => (*self != *other_file_digest)
+                .into_pyobject(py)?
+                .to_owned()
+                .into_any()
+                .unbind(),
             _ => py.NotImplemented(),
-        }
+        })
     }
 
     #[getter]
@@ -201,13 +224,26 @@ impl PySnapshot {
         ))
     }
 
-    fn __richcmp__(&self, other: &Bound<'_, PySnapshot>, op: CompareOp, py: Python) -> PyObject {
+    fn __richcmp__(
+        &self,
+        other: &Bound<'_, PySnapshot>,
+        op: CompareOp,
+        py: Python,
+    ) -> PyResult<PyObject> {
         let other_digest = other.borrow().0.digest;
-        match op {
-            CompareOp::Eq => (self.0.digest == other_digest).into_py(py),
-            CompareOp::Ne => (self.0.digest != other_digest).into_py(py),
+        Ok(match op {
+            CompareOp::Eq => (self.0.digest == other_digest)
+                .into_pyobject(py)?
+                .to_owned()
+                .into_any()
+                .unbind(),
+            CompareOp::Ne => (self.0.digest != other_digest)
+                .into_pyobject(py)?
+                .to_owned()
+                .into_any()
+                .unbind(),
             _ => py.NotImplemented(),
-        }
+        })
     }
 
     #[getter]
@@ -306,13 +342,21 @@ impl PyMergeDigests {
         other: &Bound<'_, PyMergeDigests>,
         op: CompareOp,
         py: Python,
-    ) -> PyObject {
+    ) -> PyResult<PyObject> {
         let other = other.borrow();
-        match op {
-            CompareOp::Eq => (*self == *other).into_py(py),
-            CompareOp::Ne => (*self != *other).into_py(py),
+        Ok(match op {
+            CompareOp::Eq => (*self == *other)
+                .into_pyobject(py)?
+                .to_owned()
+                .into_any()
+                .unbind(),
+            CompareOp::Ne => (*self != *other)
+                .into_pyobject(py)?
+                .to_owned()
+                .into_any()
+                .unbind(),
             _ => py.NotImplemented(),
-        }
+        })
     }
 }
 
@@ -348,13 +392,26 @@ impl PyAddPrefix {
         )
     }
 
-    fn __richcmp__(&self, other: &Bound<'_, PyAddPrefix>, op: CompareOp, py: Python) -> PyObject {
+    fn __richcmp__(
+        &self,
+        other: &Bound<'_, PyAddPrefix>,
+        op: CompareOp,
+        py: Python,
+    ) -> PyResult<PyObject> {
         let other = other.borrow();
-        match op {
-            CompareOp::Eq => (*self == *other).into_py(py),
-            CompareOp::Ne => (*self != *other).into_py(py),
+        Ok(match op {
+            CompareOp::Eq => (*self == *other)
+                .into_pyobject(py)?
+                .to_owned()
+                .into_any()
+                .unbind(),
+            CompareOp::Ne => (*self != *other)
+                .into_pyobject(py)?
+                .to_owned()
+                .into_any()
+                .unbind(),
             _ => py.NotImplemented(),
-        }
+        })
     }
 }
 
@@ -395,13 +452,21 @@ impl PyRemovePrefix {
         other: &Bound<'_, PyRemovePrefix>,
         op: CompareOp,
         py: Python,
-    ) -> PyObject {
+    ) -> PyResult<PyObject> {
         let other = other.borrow();
-        match op {
-            CompareOp::Eq => (*self == *other).into_py(py),
-            CompareOp::Ne => (*self != *other).into_py(py),
+        Ok(match op {
+            CompareOp::Eq => (*self == *other)
+                .into_pyobject(py)?
+                .to_owned()
+                .into_any()
+                .unbind(),
+            CompareOp::Ne => (*self != *other)
+                .into_pyobject(py)?
+                .to_owned()
+                .into_any()
+                .unbind(),
             _ => py.NotImplemented(),
-        }
+        })
     }
 }
 
@@ -486,17 +551,20 @@ impl PyFilespecMatcher {
         other: &Bound<'_, PyFilespecMatcher>,
         op: CompareOp,
         py: Python,
-    ) -> PyObject {
+    ) -> PyResult<PyObject> {
         let other = other.borrow();
-        match op {
-            CompareOp::Eq => (self.0.include_globs() == other.0.include_globs()
-                && self.0.exclude_globs() == other.0.exclude_globs())
-            .into_py(py),
-            CompareOp::Ne => (self.0.include_globs() != other.0.include_globs()
-                || self.0.exclude_globs() != other.0.exclude_globs())
-            .into_py(py),
-            _ => py.NotImplemented(),
-        }
+        let res = match op {
+            CompareOp::Eq => {
+                self.0.include_globs() == other.0.include_globs()
+                    && self.0.exclude_globs() == other.0.exclude_globs()
+            }
+            CompareOp::Ne => {
+                self.0.include_globs() != other.0.include_globs()
+                    || self.0.exclude_globs() != other.0.exclude_globs()
+            }
+            _ => return Ok(py.NotImplemented().into_any()),
+        };
+        Ok(res.into_pyobject(py)?.to_owned().into_any().unbind())
     }
 
     fn matches(&self, paths: Vec<String>, py: Python) -> PyResult<Vec<String>> {

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -3,8 +3,6 @@
 
 // File-specific allowances to silence internal warnings of `[pyclass]`.
 #![allow(clippy::used_underscore_binding)]
-// Temporary: Allow deprecated items while we migrate to PyO3 v0.23.x.
-#![allow(deprecated)]
 
 use futures::future::{BoxFuture, Future};
 use futures::FutureExt;
@@ -12,9 +10,9 @@ use lazy_static::lazy_static;
 use pyo3::exceptions::{PyAssertionError, PyException, PyStopIteration, PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::sync::GILProtected;
-use pyo3::types::{PyBytes, PyDict, PySequence, PyTuple, PyType};
+use pyo3::types::{PyBool, PyBytes, PyDict, PySequence, PyString, PyTuple, PyType};
+use pyo3::FromPyObject;
 use pyo3::{create_exception, import_exception, intern};
-use pyo3::{FromPyObject, ToPyObject};
 use smallvec::{smallvec, SmallVec};
 use std::cell::{Ref, RefCell};
 use std::collections::BTreeMap;
@@ -129,7 +127,7 @@ pub fn store_tuple(py: Python, values: Vec<Value>) -> PyResult<Value> {
         .into_iter()
         .map(|v| v.consume_into_py_object(py))
         .collect();
-    Ok(Value::from(PyTuple::new(py, &arg_handles)?.to_object(py)))
+    Ok(Value::from(PyTuple::new(py, &arg_handles)?.into_any()))
 }
 
 /// Store a slice containing 2-tuples of (key, value) as a Python dictionary.
@@ -141,29 +139,29 @@ pub fn store_dict(
     for (k, v) in keys_and_values {
         dict.set_item(k.consume_into_py_object(py), v.consume_into_py_object(py))?;
     }
-    Ok(Value::from(dict.to_object(py)))
+    Ok(Value::from(dict.into_any()))
 }
 
 /// Store an opaque buffer of bytes to pass to Python. This will end up as a Python `bytes`.
 pub fn store_bytes(py: Python, bytes: &[u8]) -> Value {
-    Value::from(PyBytes::new(py, bytes).to_object(py))
+    Value::from(PyBytes::new(py, bytes).into_any())
 }
 
 /// Store a buffer of utf8 bytes to pass to Python. This will end up as a Python `str`.
 pub fn store_utf8(py: Python, utf8: &str) -> Value {
-    Value::from(utf8.to_object(py))
+    Value::from(PyString::new(py, utf8).into_any())
 }
 
 pub fn store_u64(py: Python, val: u64) -> Value {
-    Value::from(val.to_object(py))
+    Value::from(val.into_pyobject(py).unwrap())
 }
 
 pub fn store_i64(py: Python, val: i64) -> Value {
-    Value::from(val.to_object(py))
+    Value::from(val.into_pyobject(py).unwrap())
 }
 
 pub fn store_bool(py: Python, val: bool) -> Value {
-    Value::from(val.to_object(py))
+    Value::from(PyBool::new(py, val))
 }
 
 ///
@@ -193,7 +191,7 @@ where
 pub fn collect_iterable_bound<'py>(
     value: &Bound<'py, PyAny>,
 ) -> Result<Vec<Bound<'py, PyAny>>, String> {
-    match value.iter() {
+    match value.try_iter() {
         Ok(py_iter) => py_iter
             .enumerate()
             .map(|(i, py_res)| {
@@ -270,7 +268,11 @@ pub fn doc_url(py: Python, slug: &str) -> String {
 }
 
 pub fn create_exception(py: Python, msg: String) -> Value {
-    Value::new(IntrinsicError::new_err(msg).into_py(py))
+    Value::from(
+        IntrinsicError::new_err(msg)
+            .into_pyobject(py)
+            .expect("Construct PyErr"),
+    )
 }
 
 pub(crate) enum GeneratorInput {
@@ -358,7 +360,7 @@ pub(crate) fn generator_send(
     } else if let Ok(get_multi) = response.downcast::<PySequence>() {
         // Was an `All` or `MultiGet`.
         let gogs = get_multi
-            .iter()?
+            .try_iter()?
             .map(|gog| {
                 let gog = gog?;
                 // TODO: Find a better way to check whether something is a coroutine... this seems
@@ -401,7 +403,7 @@ pub fn unsafe_call(py: Python, type_id: TypeId, args: &[Value]) -> Value {
             e
         );
     });
-    Value::new(res.into_py(py))
+    Value::from(&res)
 }
 
 lazy_static! {
@@ -522,10 +524,9 @@ impl PyGeneratorResponseNativeCall {
         Some(self_)
     }
 
-    fn send(&self, py: Python, value: PyObject) -> PyResult<()> {
-        Err(PyStopIteration::new_err(
-            PyTuple::new(py, [value])?.to_object(py),
-        ))
+    fn send(&self, py: Python<'_>, value: PyObject) -> PyResult<()> {
+        let args = PyTuple::new(py, [value])?.into_pyobject(py)?.unbind();
+        Err(PyStopIteration::new_err(args))
     }
 }
 

--- a/src/rust/engine/src/externs/options.rs
+++ b/src/rust/engine/src/externs/options.rs
@@ -1,8 +1,8 @@
 // Copyright 2024 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyDict, PyFloat, PyInt, PyList, PyString, PyTuple};
+use pyo3::{prelude::*, BoundObject};
 
 use options::{
     apply_dict_edits, apply_list_edits, Args, ConfigSource, DictEdit, DictEditAction, Env,
@@ -26,23 +26,23 @@ pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
 // This function converts them to equivalent Python types.
 fn val_to_py_object(py: Python, val: &Val) -> PyResult<PyObject> {
     let res = match val {
-        Val::Bool(b) => b.into_py(py),
-        Val::Int(i) => i.into_py(py),
-        Val::Float(f) => f.into_py(py),
-        Val::String(s) => s.into_py(py),
+        Val::Bool(b) => b.into_pyobject(py)?.into_any().unbind(),
+        Val::Int(i) => i.into_pyobject(py)?.into_any().unbind(),
+        Val::Float(f) => f.into_pyobject(py)?.into_any().unbind(),
+        Val::String(s) => s.into_pyobject(py)?.into_any().unbind(),
         Val::List(list) => {
             let pylist = PyList::empty(py);
             for m in list {
                 pylist.append(val_to_py_object(py, m)?)?;
             }
-            pylist.into_py(py)
+            pylist.into_pyobject(py)?.into_any().unbind()
         }
         Val::Dict(dict) => {
             let pydict = PyDict::new(py);
             for (k, v) in dict {
-                pydict.set_item(k.into_py(py), val_to_py_object(py, v)?)?;
+                pydict.set_item(k.into_pyobject(py)?, val_to_py_object(py, v)?)?;
             }
-            pydict.into_py(py)
+            pydict.into_pyobject(py)?.into_any().unbind()
         }
     };
     Ok(res)

--- a/src/rust/engine/src/externs/process.rs
+++ b/src/rust/engine/src/externs/process.rs
@@ -1,17 +1,15 @@
 // Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-// Temporary: Allow deprecated items while we migrate to PyO3 v0.23.x.
-#![allow(deprecated)]
-
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
 use pyo3::basic::CompareOp;
 use pyo3::exceptions::{PyAssertionError, PyValueError};
-use pyo3::prelude::*;
+use pyo3::{prelude::*, BoundObject};
 
 use process_execution::{Platform, ProcessExecutionEnvironment, ProcessExecutionStrategy};
+use pyo3::types::PyBool;
 
 pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyProcessExecutionEnvironment>()?;
@@ -90,8 +88,16 @@ impl PyProcessExecutionEnvironment {
     ) -> PyObject {
         let other = other.borrow();
         match op {
-            CompareOp::Eq => (*self == *other).into_py(py),
-            CompareOp::Ne => (*self != *other).into_py(py),
+            CompareOp::Eq => PyBool::new(py, *self == *other)
+                .into_bound()
+                .as_any()
+                .clone()
+                .unbind(),
+            CompareOp::Ne => PyBool::new(py, *self != *other)
+                .into_bound()
+                .as_any()
+                .clone()
+                .unbind(),
             _ => py.NotImplemented(),
         }
     }

--- a/src/rust/engine/src/externs/target.rs
+++ b/src/rust/engine/src/externs/target.rs
@@ -170,9 +170,9 @@ impl Field {
         ))
     }
 
-    fn __richcmp__(
-        self_: &Bound<'_, Self>,
-        other: &Bound<'_, PyAny>,
+    fn __richcmp__<'py>(
+        self_: &Bound<'py, Self>,
+        other: &Bound<'py, PyAny>,
         op: CompareOp,
         py: Python,
     ) -> PyResult<PyObject> {
@@ -182,11 +182,11 @@ impl Field {
                 .value
                 .bind(py)
                 .eq(&other.extract::<PyRef<Field>>()?.value)?;
-        match op {
-            CompareOp::Eq => Ok(is_eq.into_py(py)),
-            CompareOp::Ne => Ok((!is_eq).into_py(py)),
-            _ => Ok(py.NotImplemented()),
-        }
+        Ok(match op {
+            CompareOp::Eq => is_eq.into_pyobject(py)?.to_owned().into_any().unbind(),
+            CompareOp::Ne => (!is_eq).into_pyobject(py)?.to_owned().into_any().unbind(),
+            _ => py.NotImplemented(),
+        })
     }
 }
 

--- a/src/rust/engine/src/intrinsics/dep_inference.rs
+++ b/src/rust/engine/src/intrinsics/dep_inference.rs
@@ -1,9 +1,6 @@
 // Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-// Temporary: Allow deprecated items while we migrate to PyO3 v0.23.x.
-#![allow(deprecated)]
-
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -18,9 +15,9 @@ use hashing::Digest;
 use protos::gen::pants::cache::{
     dependency_inference_request, CacheKey, CacheKeyType, DependencyInferenceRequest,
 };
-use pyo3::prelude::{pyfunction, wrap_pyfunction, PyModule, PyResult, Python, ToPyObject};
+use pyo3::prelude::{pyfunction, wrap_pyfunction, PyModule, PyResult, Python};
 use pyo3::types::{PyAnyMethods, PyModuleMethods};
-use pyo3::{Bound, IntoPy};
+use pyo3::{Bound, IntoPyObject, PyErr};
 use store::Store;
 use workunit_store::{in_workunit, Level};
 
@@ -148,26 +145,35 @@ fn parse_dockerfile_info(deps_request: Value) -> PyGeneratorResponseNativeCall {
                 )
                 .await?;
 
-                let result = Python::with_gil(|py| {
-                    externs::unsafe_call(
+                let result = Python::with_gil(|py| -> Result<_, PyErr> {
+                    Ok(externs::unsafe_call(
                         py,
                         core.types.parsed_dockerfile_info_result,
                         &[
-                            result.path.to_object(py).into(),
-                            result.build_args.to_object(py).into(),
-                            result.copy_source_paths.to_object(py).into(),
-                            result.copy_build_args.to_object(py).into(),
-                            result.from_image_build_args.to_object(py).into(),
+                            result.path.into_pyobject(py)?.into_any().into(),
+                            result.build_args.into_pyobject(py)?.into_any().into(),
+                            result
+                                .copy_source_paths
+                                .into_pyobject(py)?
+                                .into_any()
+                                .into(),
+                            result.copy_build_args.into_pyobject(py)?.into_any().into(),
+                            result
+                                .from_image_build_args
+                                .into_pyobject(py)?
+                                .into_any()
+                                .into(),
                             result
                                 .version_tags
                                 .into_iter()
                                 .map(|(stage, tag)| format!("{stage} {tag}"))
                                 .collect::<Vec<_>>()
-                                .to_object(py)
+                                .into_pyobject(py)?
+                                .into_any()
                                 .into(),
                         ],
-                    )
-                });
+                    ))
+                })?;
 
                 Ok::<_, Failure>(result)
             }
@@ -204,16 +210,20 @@ fn parse_python_deps(deps_request: Value) -> PyGeneratorResponseNativeCall {
                 )
                 .await?;
 
-                let result = Python::with_gil(|py| {
-                    externs::unsafe_call(
+                let result = Python::with_gil(|py| -> Result<_, PyErr> {
+                    Ok(externs::unsafe_call(
                         py,
                         core.types.parsed_python_deps_result,
                         &[
-                            result.imports.to_object(py).into(),
-                            result.string_candidates.to_object(py).into(),
+                            result.imports.into_pyobject(py)?.into_any().into(),
+                            result
+                                .string_candidates
+                                .into_pyobject(py)?
+                                .into_any()
+                                .into(),
                         ],
-                    )
-                });
+                    ))
+                })?;
 
                 Ok::<_, Failure>(result)
             }
@@ -268,27 +278,31 @@ fn parse_javascript_deps(deps_request: Value) -> PyGeneratorResponseNativeCall {
                 )
                 .await?;
 
-                Python::with_gil(|py| {
+                Python::with_gil(|py| -> Result<_, Failure> {
+                    let import_items = result
+                        .imports
+                        .into_iter()
+                        .map(|(string, info)| -> Result<_, PyErr> {
+                            Ok((
+                                string.into_pyobject(py)?.into_any().into(),
+                                externs::unsafe_call(
+                                    py,
+                                    core.types.parsed_javascript_deps_candidate_result,
+                                    &[
+                                        info.file_imports.into_pyobject(py)?.into_any().into(),
+                                        info.package_imports.into_pyobject(py)?.into_any().into(),
+                                    ],
+                                ),
+                            ))
+                        })
+                        .collect::<Result<Vec<_>, PyErr>>()
+                        .map_err(|e| Failure::from_py_err_with_gil(py, e))?;
+
                     Ok(externs::unsafe_call(
                         py,
                         core.types.parsed_javascript_deps_result,
-                        &[store_dict(
-                            py,
-                            result.imports.into_iter().map(|(string, info)| {
-                                (
-                                    string.into_py(py).into(),
-                                    externs::unsafe_call(
-                                        py,
-                                        core.types.parsed_javascript_deps_candidate_result,
-                                        &[
-                                            info.file_imports.into_py(py).into(),
-                                            info.package_imports.into_py(py).into(),
-                                        ],
-                                    ),
-                                )
-                            }),
-                        )
-                        .map_err(|e| Failure::from_py_err_with_gil(py, e))?],
+                        &[store_dict(py, import_items)
+                            .map_err(|e| Failure::from_py_err_with_gil(py, e))?],
                     ))
                 })
             }

--- a/src/rust/engine/src/intrinsics/process.rs
+++ b/src/rust/engine/src/intrinsics/process.rs
@@ -1,15 +1,12 @@
 // Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-// Temporary: Allow deprecated items while we migrate to PyO3 v0.23.x.
-#![allow(deprecated)]
-
 use std::time::Duration;
 
 use futures::future::TryFutureExt;
 use futures::try_join;
 use pyo3::types::{PyAnyMethods, PyModule, PyModuleMethods};
-use pyo3::{pyfunction, wrap_pyfunction, Bound, IntoPy, PyResult, Python};
+use pyo3::{pyfunction, wrap_pyfunction, Bound, IntoPyObject, PyResult, Python};
 
 use crate::externs::{self, PyGeneratorResponseNativeCall};
 use crate::nodes::{task_get_context, ExecuteProcess, NodeResult, Snapshot};
@@ -70,7 +67,7 @@ fn execute_process(process: Value, process_config: Value) -> PyGeneratorResponse
                                 externs::process::PyProcessExecutionEnvironment {
                                     environment: result.metadata.environment,
                                 }
-                                .into_py(py),
+                                .into_pyobject(py)?,
                             ),
                             externs::store_utf8(py, result.metadata.source.into()),
                             externs::store_u64(py, result.metadata.source_run_id.0.into()),

--- a/src/rust/engine/src/nodes/snapshot.rs
+++ b/src/rust/engine/src/nodes/snapshot.rs
@@ -1,9 +1,6 @@
 // Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-// Temporary: Allow deprecated items while we migrate to PyO3 v0.23.x.
-#![allow(deprecated)]
-
 use std::path::Path;
 
 use deepsize::DeepSizeOf;
@@ -14,7 +11,7 @@ use fs::{
 use futures::TryFutureExt;
 use graph::CompoundNode;
 use pyo3::prelude::{Py, PyAny, Python};
-use pyo3::{Bound, IntoPy};
+use pyo3::Bound;
 
 use super::{unmatched_globs_additional_context, NodeKey, NodeOutput, NodeResult};
 use crate::context::Context;
@@ -73,18 +70,18 @@ impl Snapshot {
 
     pub fn store_directory_digest(py: Python, item: DirectoryDigest) -> Result<Value, String> {
         let py_digest = Py::new(py, externs::fs::PyDigest(item)).map_err(|e| format!("{e}"))?;
-        Ok(Value::new(py_digest.into_py(py)))
+        Ok(Value::new(py_digest.into_any()))
     }
 
     pub fn store_file_digest(py: Python, item: hashing::Digest) -> Result<Value, String> {
         let py_file_digest =
             Py::new(py, externs::fs::PyFileDigest(item)).map_err(|e| format!("{e}"))?;
-        Ok(Value::new(py_file_digest.into_py(py)))
+        Ok(Value::new(py_file_digest.into_any()))
     }
 
     pub fn store_snapshot(py: Python, item: store::Snapshot) -> Result<Value, String> {
         let py_snapshot = Py::new(py, externs::fs::PySnapshot(item)).map_err(|e| format!("{e}"))?;
-        Ok(Value::new(py_snapshot.into_py(py)))
+        Ok(Value::new(py_snapshot.into_any()))
     }
 
     pub fn store_path(py: Python, item: &Path) -> Result<Value, String> {

--- a/src/rust/engine/src/python.rs
+++ b/src/rust/engine/src/python.rs
@@ -1,9 +1,6 @@
 // Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-// Temporary: Allow deprecated items while we migrate to PyO3 v0.23.x.
-#![allow(deprecated)]
-
 use std::convert::Infallible;
 use std::sync::Arc;
 use std::{fmt, hash};
@@ -11,7 +8,7 @@ use std::{fmt, hash};
 use deepsize::{known_deep_size, DeepSizeOf};
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyType};
-use pyo3::{FromPyObject, IntoPy, ToPyObject};
+use pyo3::FromPyObject;
 use smallvec::SmallVec;
 
 use hashing::Digest;
@@ -261,7 +258,7 @@ impl fmt::Display for Key {
 impl<'py> FromPyObject<'py> for Key {
     fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
         let py = obj.py();
-        externs::INTERNS.key_insert(py, obj.into_py(py))
+        externs::INTERNS.key_insert(py, obj.to_owned().unbind())
     }
 }
 
@@ -352,14 +349,7 @@ impl fmt::Display for Value {
 
 impl<'py> FromPyObject<'py> for Value {
     fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
-        let py = obj.py();
-        Ok(obj.into_py(py).into())
-    }
-}
-
-impl ToPyObject for &Value {
-    fn to_object(&self, py: Python) -> PyObject {
-        self.0.clone_ref(py)
+        Ok(Value::new(obj.to_owned().unbind()))
     }
 }
 
@@ -391,7 +381,14 @@ impl From<PyObject> for Value {
 
 impl<'py, T> From<&Bound<'py, T>> for Value {
     fn from(value: &Bound<'py, T>) -> Self {
-        Value::new(value.clone().into_py(value.py()))
+        Value::new(
+            value
+                .clone()
+                .into_pyobject(value.py())
+                .unwrap()
+                .into_any()
+                .unbind(),
+        )
     }
 }
 
@@ -401,9 +398,9 @@ impl<'py, T> From<Bound<'py, T>> for Value {
     }
 }
 
-impl IntoPy<PyObject> for &Value {
-    fn into_py(self, py: Python) -> PyObject {
-        (*self.0).bind(py).into_py(py)
+impl<'a, 'py, T> From<Borrowed<'a, 'py, T>> for Value {
+    fn from(value: Borrowed<'a, 'py, T>) -> Self {
+        Value::from(value.as_any())
     }
 }
 
@@ -499,8 +496,8 @@ impl Failure {
 
         let maybe_ptraceback = py_err
             .traceback(py)
-            .map(|traceback| traceback.to_object(py));
-        let val = Value::from(py_err.into_py(py));
+            .map(|traceback| traceback.into_pyobject(py).unwrap());
+        let val = Value::from(py_err.into_pyobject(py).unwrap());
         let python_traceback = if let Some(tb) = maybe_ptraceback {
             let locals = PyDict::new(py);
             locals

--- a/src/rust/engine/src/python.rs
+++ b/src/rust/engine/src/python.rs
@@ -395,6 +395,12 @@ impl<'py, T> From<&Bound<'py, T>> for Value {
     }
 }
 
+impl<'py, T> From<Bound<'py, T>> for Value {
+    fn from(py_value: Bound<'py, T>) -> Self {
+        Value::from(&py_value)
+    }
+}
+
 impl IntoPy<PyObject> for &Value {
     fn into_py(self, py: Python) -> PyObject {
         (*self.0).bind(py).into_py(py)

--- a/src/rust/engine/src/python.rs
+++ b/src/rust/engine/src/python.rs
@@ -381,14 +381,7 @@ impl From<PyObject> for Value {
 
 impl<'py, T> From<&Bound<'py, T>> for Value {
     fn from(value: &Bound<'py, T>) -> Self {
-        Value::new(
-            value
-                .clone()
-                .into_pyobject(value.py())
-                .unwrap()
-                .into_any()
-                .unbind(),
-        )
+        Value::new(value.to_owned().into_any().unbind())
     }
 }
 


### PR DESCRIPTION
As part of [upgrading to PyO3 v2.23.x](https://github.com/pantsbuild/pants/issues/21671), migrate to using the new `IntoPyObject` conversion trait instead of the now deprecated `IntoPy` and `ToPyObject` traits. Deprecation warnings are no longer disabled for the affected files.