### PR TITLE
PyO3: Rename Pants-specific helper methods to remove "bound" from the name

### DIFF
--- a/src/rust/engine/src/externs/engine_aware.rs
+++ b/src/rust/engine/src/externs/engine_aware.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use crate::externs;
 use crate::externs::fs::PyFileDigest;
-use crate::nodes::{lift_directory_digest_bound, lift_file_digest_bound};
+use crate::nodes::{lift_directory_digest, lift_file_digest_bound};
 use crate::Value;
 
 use pyo3::prelude::*;
@@ -76,7 +76,7 @@ impl EngineAwareReturnType {
                 lift_file_digest_bound(&value).map(ArtifactOutput::FileDigest)
             } else {
                 let digest_value = value.getattr("digest").ok()?;
-                lift_directory_digest_bound(&digest_value)
+                lift_directory_digest(&digest_value)
                     .map(|dd| ArtifactOutput::Snapshot(Arc::new(dd)))
             }
             .ok()?;

--- a/src/rust/engine/src/externs/engine_aware.rs
+++ b/src/rust/engine/src/externs/engine_aware.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use crate::externs;
 use crate::externs::fs::PyFileDigest;
-use crate::nodes::{lift_directory_digest, lift_file_digest_bound};
+use crate::nodes::{lift_directory_digest, lift_file_digest};
 use crate::Value;
 
 use pyo3::prelude::*;
@@ -73,7 +73,7 @@ impl EngineAwareReturnType {
         for kv_pair in artifacts_dict.items().into_iter() {
             let (key, value): (String, Bound<'_, PyAny>) = kv_pair.extract().ok()?;
             let artifact_output = if value.is_instance_of::<PyFileDigest>() {
-                lift_file_digest_bound(&value).map(ArtifactOutput::FileDigest)
+                lift_file_digest(&value).map(ArtifactOutput::FileDigest)
             } else {
                 let digest_value = value.getattr("digest").ok()?;
                 lift_directory_digest(&digest_value)

--- a/src/rust/engine/src/externs/engine_aware.rs
+++ b/src/rust/engine/src/externs/engine_aware.rs
@@ -50,7 +50,7 @@ impl EngineAwareReturnType {
         if level_val.is_none() {
             return None;
         }
-        externs::val_to_log_level_bound(&level_val).ok()
+        externs::val_to_log_level(&level_val).ok()
     }
 
     fn message(obj: &Bound<'_, PyAny>) -> Option<String> {

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -1532,7 +1532,7 @@ fn rule_graph_consumed_types<'py>(
         Ok(subgraph
             .consumed_types()
             .into_iter()
-            .map(|type_id| type_id.as_py_type_bound(py))
+            .map(|type_id| type_id.as_py_type(py))
             .collect())
     })
 }
@@ -1564,10 +1564,10 @@ fn rule_graph_rule_gets<'py>(
                 let provided_params = dependency_key
                     .provided_params
                     .iter()
-                    .map(|p| p.as_py_type_bound(py))
+                    .map(|p| p.as_py_type(py))
                     .collect::<Vec<_>>();
                 dependencies.push((
-                    dependency_key.product.as_py_type_bound(py),
+                    dependency_key.product.as_py_type(py),
                     provided_params,
                     function.0.value.into_py(py),
                 ));

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -1775,7 +1775,7 @@ fn ensure_remote_has_recursive(
             .map(|value| {
                 crate::nodes::lift_directory_digest(&value)
                     .map(|dd| dd.as_digest())
-                    .or_else(|_| crate::nodes::lift_file_digest_bound(&value))
+                    .or_else(|_| crate::nodes::lift_file_digest(&value))
             })
             .collect::<Result<Vec<Digest>, _>>()
             .map_err(PyException::new_err)?;

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -1713,7 +1713,7 @@ fn capture_snapshots(
         // TODO: A parent_id should be an explicit argument.
         session.workunit_store().init_thread_state(None);
 
-        let values = externs::collect_iterable_bound(path_globs_and_root_tuple_wrapper).unwrap();
+        let values = externs::collect_iterable(path_globs_and_root_tuple_wrapper).unwrap();
         let path_globs_and_roots = values
             .into_iter()
             .map(|value| {

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -1728,7 +1728,7 @@ fn capture_snapshots(
                     if maybe_digest.is_none() {
                         None
                     } else {
-                        Some(nodes::lift_directory_digest_bound(&maybe_digest)?)
+                        Some(nodes::lift_directory_digest(&maybe_digest)?)
                     }
                 };
                 path_globs.map(|path_globs| (path_globs, root, digest_hint))
@@ -1773,7 +1773,7 @@ fn ensure_remote_has_recursive(
         let digests: Vec<Digest> = py_digests
             .iter()
             .map(|value| {
-                crate::nodes::lift_directory_digest_bound(&value)
+                crate::nodes::lift_directory_digest(&value)
                     .map(|dd| dd.as_digest())
                     .or_else(|_| crate::nodes::lift_file_digest_bound(&value))
             })
@@ -1798,7 +1798,7 @@ fn ensure_directory_digest_persisted(
     let core = &py_scheduler.borrow().0.core;
     core.executor.enter(|| {
         let digest =
-            crate::nodes::lift_directory_digest_bound(py_digest).map_err(PyException::new_err)?;
+            crate::nodes::lift_directory_digest(py_digest).map_err(PyException::new_err)?;
 
         py.allow_threads(|| {
             core.executor
@@ -1868,8 +1868,7 @@ fn write_digest(
         // TODO: A parent_id should be an explicit argument.
         session.workunit_store().init_thread_state(None);
 
-        let lifted_digest =
-            nodes::lift_directory_digest_bound(digest).map_err(PyValueError::new_err)?;
+        let lifted_digest = nodes::lift_directory_digest(digest).map_err(PyValueError::new_err)?;
 
         // Python will have already validated that path_prefix is a relative path.
         let path_prefix = Path::new(&path_prefix);

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -1721,7 +1721,7 @@ fn capture_snapshots(
                 let path_globs = {
                     let path_globs_py_value =
                         externs::getattr::<Bound<'_, PyAny>>(&value, "path_globs")?;
-                    nodes::Snapshot::lift_prepared_path_globs_bound(&path_globs_py_value)
+                    nodes::Snapshot::lift_prepared_path_globs(&path_globs_py_value)
                 };
                 let digest_hint = {
                     let maybe_digest: Bound<'_, PyAny> = externs::getattr(&value, "digest_hint")?;

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -1717,15 +1717,14 @@ fn capture_snapshots(
         let path_globs_and_roots = values
             .into_iter()
             .map(|value| {
-                let root: PathBuf = externs::getattr_bound(&value, "root")?;
+                let root: PathBuf = externs::getattr(&value, "root")?;
                 let path_globs = {
                     let path_globs_py_value =
-                        externs::getattr_bound::<Bound<'_, PyAny>>(&value, "path_globs")?;
+                        externs::getattr::<Bound<'_, PyAny>>(&value, "path_globs")?;
                     nodes::Snapshot::lift_prepared_path_globs_bound(&path_globs_py_value)
                 };
                 let digest_hint = {
-                    let maybe_digest: Bound<'_, PyAny> =
-                        externs::getattr_bound(&value, "digest_hint")?;
+                    let maybe_digest: Bound<'_, PyAny> = externs::getattr(&value, "digest_hint")?;
                     if maybe_digest.is_none() {
                         None
                     } else {

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -216,7 +216,7 @@ pub fn collect_iterable_bound<'py>(
 }
 
 /// Read a `FrozenDict[str, T]`.
-pub fn getattr_from_str_frozendict_bound<'py, T: FromPyObject<'py>>(
+pub fn getattr_from_str_frozendict<'py, T: FromPyObject<'py>>(
     value: &Bound<'py, PyAny>,
     field: &str,
 ) -> BTreeMap<String, T> {

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -200,7 +200,7 @@ pub fn collect_iterable<'py>(
                 py_res.map_err(|py_err| {
                     format!(
                         "Could not iterate {}, failed to extract {}th item: {:?}",
-                        val_to_str_bound(value),
+                        val_to_str(value),
                         i,
                         py_err
                     )
@@ -209,7 +209,7 @@ pub fn collect_iterable<'py>(
             .collect(),
         Err(py_err) => Err(format!(
             "Could not iterate {}: {:?}",
-            val_to_str_bound(value),
+            val_to_str(value),
             py_err
         )),
     }
@@ -241,7 +241,7 @@ pub fn getattr_as_optional_string(
 /// Call the equivalent of `str()` on an arbitrary Python object.
 ///
 /// Converts `None` to the empty string.
-pub fn val_to_str_bound(obj: &Bound<'_, PyAny>) -> String {
+pub fn val_to_str(obj: &Bound<'_, PyAny>) -> String {
     if obj.is_none() {
         return "".to_string();
     }
@@ -254,7 +254,7 @@ pub fn val_to_log_level(obj: &Bound<'_, PyAny>) -> Result<log::Level, String> {
             .map_err(|e: num_enum::TryFromPrimitiveError<_>| {
                 format!(
                     "Could not parse {:?} as a LogLevel: {}",
-                    val_to_str_bound(obj),
+                    val_to_str(obj),
                     e
                 )
             })

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -190,7 +190,7 @@ where
 ///
 /// Collect the Values contained within an outer Python Iterable PyObject.
 ///
-pub fn collect_iterable_bound<'py>(
+pub fn collect_iterable<'py>(
     value: &Bound<'py, PyAny>,
 ) -> Result<Vec<Bound<'py, PyAny>>, String> {
     match value.iter() {

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -363,7 +363,7 @@ pub(crate) fn generator_send(
                 let gog = gog?;
                 // TODO: Find a better way to check whether something is a coroutine... this seems
                 // unnecessarily awkward.
-                if gog.is_instance(&generator_type.as_py_type_bound(py))? {
+                if gog.is_instance(&generator_type.as_py_type(py))? {
                     Ok(GetOrGenerator::Generator(Value::new(gog.unbind())))
                 } else if let Ok(get) = gog.extract::<PyRef<PyGeneratorResponseGet>>() {
                     Ok(GetOrGenerator::Get(
@@ -390,7 +390,7 @@ pub(crate) fn generator_send(
 /// NB: Panics on failure. Only recommended for use with built-in types, such as
 /// those configured in types::Types.
 pub fn unsafe_call(py: Python, type_id: TypeId, args: &[Value]) -> Value {
-    let py_type = type_id.as_py_type_bound(py);
+    let py_type = type_id.as_py_type(py);
     let args_tuple = PyTuple::new(py, args.iter().map(|v| v.bind(py))).unwrap_or_else(|e| {
         panic!("Core type constructor `PyTuple` failed: {e:?}",);
     });
@@ -581,7 +581,7 @@ impl PyGeneratorResponseCall {
 
     #[getter]
     fn output_type<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyType>> {
-        Ok(self.borrow_inner(py)?.output_type.as_py_type_bound(py))
+        Ok(self.borrow_inner(py)?.output_type.as_py_type(py))
     }
 
     #[getter]
@@ -590,7 +590,7 @@ impl PyGeneratorResponseCall {
             .borrow_inner(py)?
             .input_types
             .iter()
-            .map(|t| t.as_py_type_bound(py))
+            .map(|t| t.as_py_type(py))
             .collect())
     }
 
@@ -673,7 +673,7 @@ impl PyGeneratorResponseGet {
                 )
             })?
             .output
-            .as_py_type_bound(py))
+            .as_py_type(py))
     }
 
     #[getter]
@@ -690,7 +690,7 @@ impl PyGeneratorResponseGet {
             })?
             .input_types
             .iter()
-            .map(|t| t.as_py_type_bound(py))
+            .map(|t| t.as_py_type(py))
             .collect())
     }
 

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -248,7 +248,7 @@ pub fn val_to_str_bound(obj: &Bound<'_, PyAny>) -> String {
     obj.str().unwrap().extract().unwrap()
 }
 
-pub fn val_to_log_level_bound(obj: &Bound<'_, PyAny>) -> Result<log::Level, String> {
+pub fn val_to_log_level(obj: &Bound<'_, PyAny>) -> Result<log::Level, String> {
     let res: Result<PythonLogLevel, String> = getattr(obj, "_level").and_then(|n: u64| {
         n.try_into()
             .map_err(|e: num_enum::TryFromPrimitiveError<_>| {

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -229,7 +229,7 @@ pub fn getattr_from_str_frozendict_bound<'py, T: FromPyObject<'py>>(
         .collect()
 }
 
-pub fn getattr_as_optional_string_bound(
+pub fn getattr_as_optional_string(
     value: &Bound<'_, PyAny>,
     field: &str,
 ) -> PyResult<Option<String>> {

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -190,9 +190,7 @@ where
 ///
 /// Collect the Values contained within an outer Python Iterable PyObject.
 ///
-pub fn collect_iterable<'py>(
-    value: &Bound<'py, PyAny>,
-) -> Result<Vec<Bound<'py, PyAny>>, String> {
+pub fn collect_iterable<'py>(value: &Bound<'py, PyAny>) -> Result<Vec<Bound<'py, PyAny>>, String> {
     match value.iter() {
         Ok(py_iter) => py_iter
             .enumerate()
@@ -252,11 +250,7 @@ pub fn val_to_log_level(obj: &Bound<'_, PyAny>) -> Result<log::Level, String> {
     let res: Result<PythonLogLevel, String> = getattr(obj, "_level").and_then(|n: u64| {
         n.try_into()
             .map_err(|e: num_enum::TryFromPrimitiveError<_>| {
-                format!(
-                    "Could not parse {:?} as a LogLevel: {}",
-                    val_to_str(obj),
-                    e
-                )
+                format!("Could not parse {:?} as a LogLevel: {}", val_to_str(obj), e)
             })
     });
     res.map(|py_level| py_level.into())

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -169,7 +169,7 @@ pub fn store_bool(py: Python, val: bool) -> Value {
 ///
 /// Gets an attribute of the given value as the given type.
 ///
-pub fn getattr_bound<'py, T>(value: &Bound<'py, PyAny>, field: &str) -> Result<T, String>
+pub fn getattr<'py, T>(value: &Bound<'py, PyAny>, field: &str) -> Result<T, String>
 where
     T: FromPyObject<'py>,
 {
@@ -220,8 +220,8 @@ pub fn getattr_from_str_frozendict_bound<'py, T: FromPyObject<'py>>(
     value: &Bound<'py, PyAny>,
     field: &str,
 ) -> BTreeMap<String, T> {
-    let frozendict: Bound<PyAny> = getattr_bound(value, field).unwrap();
-    let pydict: Bound<PyDict> = getattr_bound(&frozendict, "_data").unwrap();
+    let frozendict: Bound<PyAny> = getattr(value, field).unwrap();
+    let pydict: Bound<PyDict> = getattr(&frozendict, "_data").unwrap();
     pydict
         .items()
         .into_iter()
@@ -249,7 +249,7 @@ pub fn val_to_str_bound(obj: &Bound<'_, PyAny>) -> String {
 }
 
 pub fn val_to_log_level_bound(obj: &Bound<'_, PyAny>) -> Result<log::Level, String> {
-    let res: Result<PythonLogLevel, String> = getattr_bound(obj, "_level").and_then(|n: u64| {
+    let res: Result<PythonLogLevel, String> = getattr(obj, "_level").and_then(|n: u64| {
         n.try_into()
             .map_err(|e: num_enum::TryFromPrimitiveError<_>| {
                 format!(

--- a/src/rust/engine/src/intrinsics/digests.rs
+++ b/src/rust/engine/src/intrinsics/digests.rs
@@ -258,7 +258,7 @@ fn create_digest(py: Python, create_digest: Value) -> PyGeneratorResponseNativeC
         let items: Vec<CreateDigestItem> = {
             Python::with_gil(|py| {
                 let py_create_digest = create_digest.bind(py);
-                externs::collect_iterable_bound(py_create_digest)
+                externs::collect_iterable(py_create_digest)
                     .unwrap()
                     .into_iter()
                     .map(|obj| {

--- a/src/rust/engine/src/intrinsics/digests.rs
+++ b/src/rust/engine/src/intrinsics/digests.rs
@@ -397,7 +397,7 @@ fn path_metadata_request(single_path: Value) -> PyGeneratorResponseNativeCall {
                 None => py.None(),
             };
 
-            let py_type = context.core.types.path_metadata_result.as_py_type_bound(py);
+            let py_type = context.core.types.path_metadata_result.as_py_type(py);
             let args_tuple = PyTuple::new(py, &[path_metadata_opt]).unwrap_or_else(|e| {
                 panic!("Core type constructor `PyTuple` failed: {e:?}");
             });

--- a/src/rust/engine/src/intrinsics/digests.rs
+++ b/src/rust/engine/src/intrinsics/digests.rs
@@ -23,8 +23,8 @@ use crate::externs::fs::{
 };
 use crate::externs::PyGeneratorResponseNativeCall;
 use crate::nodes::{
-    lift_directory_digest_bound, task_get_context, unmatched_globs_additional_context,
-    DownloadedFile, NodeResult, PathMetadataNode, Snapshot, SubjectPath,
+    lift_directory_digest, task_get_context, unmatched_globs_additional_context, DownloadedFile,
+    NodeResult, PathMetadataNode, Snapshot, SubjectPath,
 };
 use crate::python::{throw, Key, Value};
 use crate::Failure;
@@ -53,7 +53,7 @@ fn get_digest_contents(digest: Value) -> PyGeneratorResponseNativeCall {
 
         let digest = Python::with_gil(|py| {
             let py_digest = digest.bind(py);
-            lift_directory_digest_bound(py_digest)
+            lift_directory_digest(py_digest)
         })?;
 
         let digest_contents = context.core.store().contents_for_directory(digest).await?;
@@ -71,7 +71,7 @@ fn get_digest_entries(digest: Value) -> PyGeneratorResponseNativeCall {
 
         let digest = Python::with_gil(|py| {
             let py_digest = digest.bind(py);
-            lift_directory_digest_bound(py_digest)
+            lift_directory_digest(py_digest)
         })?;
         let digest_entries = context.core.store().entries_for_directory(digest).await?;
         Ok::<_, Failure>(Python::with_gil(|py| {
@@ -133,7 +133,7 @@ fn digest_to_snapshot(digest: Value) -> PyGeneratorResponseNativeCall {
 
         let digest = Python::with_gil(|py| {
             let py_digest = digest.bind(py);
-            lift_directory_digest_bound(py_digest)
+            lift_directory_digest(py_digest)
         })?;
         let snapshot = store::Snapshot::from_digest(store, digest).await?;
         Ok::<_, Failure>(Python::with_gil(|py| {
@@ -350,7 +350,7 @@ fn digest_subset_to_digest(digest_subset: Value) -> PyGeneratorResponseNativeCal
             let py_digest: Bound<'_, PyAny> = externs::getattr(py_digest_subset, "digest").unwrap();
             let res: NodeResult<_> = Ok((
                 Snapshot::lift_prepared_path_globs(&py_path_globs)?,
-                lift_directory_digest_bound(&py_digest)?,
+                lift_directory_digest(&py_digest)?,
             ));
             res
         })?;

--- a/src/rust/engine/src/intrinsics/digests.rs
+++ b/src/rust/engine/src/intrinsics/digests.rs
@@ -349,7 +349,7 @@ fn digest_subset_to_digest(digest_subset: Value) -> PyGeneratorResponseNativeCal
                 externs::getattr(py_digest_subset, "globs").unwrap();
             let py_digest: Bound<'_, PyAny> = externs::getattr(py_digest_subset, "digest").unwrap();
             let res: NodeResult<_> = Ok((
-                Snapshot::lift_prepared_path_globs_bound(&py_path_globs)?,
+                Snapshot::lift_prepared_path_globs(&py_path_globs)?,
                 lift_directory_digest_bound(&py_digest)?,
             ));
             res

--- a/src/rust/engine/src/intrinsics/digests.rs
+++ b/src/rust/engine/src/intrinsics/digests.rs
@@ -184,7 +184,7 @@ fn path_globs_to_digest(path_globs: Value) -> PyGeneratorResponseNativeCall {
 
         let path_globs = Python::with_gil(|py| {
             let py_path_globs = path_globs.bind(py);
-            Snapshot::lift_path_globs_bound(py_path_globs)
+            Snapshot::lift_path_globs(py_path_globs)
         })
         .map_err(|e| throw(format!("Failed to parse PathGlobs: {e}")))?;
         let snapshot = context.get(Snapshot::from_path_globs(path_globs)).await?;
@@ -202,7 +202,7 @@ fn path_globs_to_paths(path_globs: Value) -> PyGeneratorResponseNativeCall {
 
         let path_globs = Python::with_gil(|py| {
             let py_path_globs = path_globs.bind(py);
-            Snapshot::lift_path_globs_bound(py_path_globs)
+            Snapshot::lift_path_globs(py_path_globs)
         })
         .map_err(|e| throw(format!("Failed to parse PathGlobs: {e}")))?;
 

--- a/src/rust/engine/src/intrinsics/digests.rs
+++ b/src/rust/engine/src/intrinsics/digests.rs
@@ -262,24 +262,24 @@ fn create_digest(py: Python, create_digest: Value) -> PyGeneratorResponseNativeC
                     .unwrap()
                     .into_iter()
                     .map(|obj| {
-                        let raw_path: String = externs::getattr_bound(&obj, "path").unwrap();
+                        let raw_path: String = externs::getattr(&obj, "path").unwrap();
                         let path = RelativePath::new(PathBuf::from(raw_path)).unwrap();
                         if obj.hasattr("content").unwrap() {
                             let bytes = bytes::Bytes::from(
-                                externs::getattr_bound::<Vec<u8>>(&obj, "content").unwrap(),
+                                externs::getattr::<Vec<u8>>(&obj, "content").unwrap(),
                             );
                             let is_executable: bool =
-                                externs::getattr_bound(&obj, "is_executable").unwrap();
+                                externs::getattr(&obj, "is_executable").unwrap();
                             new_file_count += 1;
                             CreateDigestItem::FileContent(path, bytes, is_executable)
                         } else if obj.hasattr("file_digest").unwrap() {
                             let py_file_digest: PyFileDigest =
-                                externs::getattr_bound(&obj, "file_digest").unwrap();
+                                externs::getattr(&obj, "file_digest").unwrap();
                             let is_executable: bool =
-                                externs::getattr_bound(&obj, "is_executable").unwrap();
+                                externs::getattr(&obj, "is_executable").unwrap();
                             CreateDigestItem::FileEntry(path, py_file_digest.0, is_executable)
                         } else if obj.hasattr("target").unwrap() {
-                            let target: String = externs::getattr_bound(&obj, "target").unwrap();
+                            let target: String = externs::getattr(&obj, "target").unwrap();
                             CreateDigestItem::SymlinkEntry(path, PathBuf::from(target))
                         } else {
                             CreateDigestItem::Dir(path)
@@ -346,9 +346,8 @@ fn digest_subset_to_digest(digest_subset: Value) -> PyGeneratorResponseNativeCal
         let (path_globs, original_digest) = Python::with_gil(|py| {
             let py_digest_subset = digest_subset.bind(py);
             let py_path_globs: Bound<'_, PyAny> =
-                externs::getattr_bound(py_digest_subset, "globs").unwrap();
-            let py_digest: Bound<'_, PyAny> =
-                externs::getattr_bound(py_digest_subset, "digest").unwrap();
+                externs::getattr(py_digest_subset, "globs").unwrap();
+            let py_digest: Bound<'_, PyAny> = externs::getattr(py_digest_subset, "digest").unwrap();
             let res: NodeResult<_> = Ok((
                 Snapshot::lift_prepared_path_globs_bound(&py_path_globs)?,
                 lift_directory_digest_bound(&py_digest)?,
@@ -372,7 +371,7 @@ fn path_metadata_request(single_path: Value) -> PyGeneratorResponseNativeCall {
                 .map_err(|e| format!("Failed to get `path` for field: {e}"))?;
             let path = path.ok_or_else(|| "Path must not be `None`.".to_string())?;
 
-            let namespace: PyPathNamespace = externs::getattr_bound(arg, "namespace")
+            let namespace: PyPathNamespace = externs::getattr(arg, "namespace")
                 .map_err(|e| format!("Failed to get `namespace` for field: {e}"))?;
             match namespace {
                 PyPathNamespace::Workspace => SubjectPath::new_workspace(&path).map_err(|_| {

--- a/src/rust/engine/src/intrinsics/digests.rs
+++ b/src/rust/engine/src/intrinsics/digests.rs
@@ -367,7 +367,7 @@ fn path_metadata_request(single_path: Value) -> PyGeneratorResponseNativeCall {
     PyGeneratorResponseNativeCall::new(async move {
         let subject_path = Python::with_gil(|py| -> Result<_, String> {
             let arg = single_path.bind(py);
-            let path = externs::getattr_as_optional_string_bound(arg, "path")
+            let path = externs::getattr_as_optional_string(arg, "path")
                 .map_err(|e| format!("Failed to get `path` for field: {e}"))?;
             let path = path.ok_or_else(|| "Path must not be `None`.".to_string())?;
 

--- a/src/rust/engine/src/intrinsics/docker.rs
+++ b/src/rust/engine/src/intrinsics/docker.rs
@@ -27,9 +27,8 @@ fn docker_resolve_image(docker_request: Value) -> PyGeneratorResponseNativeCall 
 
         let (image_name, platform) = Python::with_gil(|py| {
             let py_docker_request = docker_request.bind(py);
-            let image_name: String =
-                externs::getattr_bound(py_docker_request, "image_name").unwrap();
-            let platform: String = externs::getattr_bound(py_docker_request, "platform").unwrap();
+            let image_name: String = externs::getattr(py_docker_request, "image_name").unwrap();
+            let platform: String = externs::getattr(py_docker_request, "platform").unwrap();
             (image_name, platform)
         });
 

--- a/src/rust/engine/src/intrinsics/interactive_process.rs
+++ b/src/rust/engine/src/intrinsics/interactive_process.rs
@@ -58,7 +58,7 @@ pub async fn interactive_process_inner(
         externs::process::PyProcessExecutionEnvironment,
     ) = Python::with_gil(|py| {
         let py_interactive_process = interactive_process.bind(py);
-        let py_process: Value = externs::getattr_bound(py_interactive_process, "process").unwrap();
+        let py_process: Value = externs::getattr(py_interactive_process, "process").unwrap();
         let process_config = process_config.bind(py).extract().unwrap();
         (
             py_interactive_process.extract().unwrap(),
@@ -84,11 +84,11 @@ pub async fn interactive_process_inner(
     let (run_in_workspace, keep_sandboxes) = Python::with_gil(|py| {
         let py_interactive_process = py_interactive_process.bind(py);
         let run_in_workspace: bool =
-            externs::getattr_bound(py_interactive_process, "run_in_workspace").unwrap();
+            externs::getattr(py_interactive_process, "run_in_workspace").unwrap();
         let keep_sandboxes_value: Bound<'_, PyAny> =
-            externs::getattr_bound(py_interactive_process, "keep_sandboxes").unwrap();
+            externs::getattr(py_interactive_process, "keep_sandboxes").unwrap();
         let keep_sandboxes = KeepSandboxes::from_str(
-            externs::getattr_bound::<PyBackedStr>(&keep_sandboxes_value, "value")
+            externs::getattr::<PyBackedStr>(&keep_sandboxes_value, "value")
                 .unwrap()
                 .as_ref(),
         )

--- a/src/rust/engine/src/nodes/downloaded_file.rs
+++ b/src/rust/engine/src/nodes/downloaded_file.rs
@@ -99,16 +99,16 @@ impl DownloadedFile {
             Python::with_gil(|py| {
                 let py_download_file_val = self.0.to_value();
                 let py_download_file = py_download_file_val.bind(py);
-                let url_str: String = externs::getattr_bound(py_download_file, "url")
+                let url_str: String = externs::getattr(py_download_file, "url")
                     .map_err(|e| format!("Failed to get `url` for field: {e}"))?;
                 let auth_headers =
                     externs::getattr_from_str_frozendict_bound(py_download_file, "auth_headers");
                 let py_file_digest: PyFileDigest =
-                    externs::getattr_bound(py_download_file, "expected_digest")?;
+                    externs::getattr(py_download_file, "expected_digest")?;
                 let retry_delay_duration: Duration =
-                    externs::getattr_bound(py_download_file, "retry_error_duration")?;
+                    externs::getattr(py_download_file, "retry_error_duration")?;
                 let max_attempts: NonZeroUsize =
-                    externs::getattr_bound(py_download_file, "max_attempts")?;
+                    externs::getattr(py_download_file, "max_attempts")?;
                 Ok::<_, String>((
                     url_str,
                     py_file_digest.0,

--- a/src/rust/engine/src/nodes/downloaded_file.rs
+++ b/src/rust/engine/src/nodes/downloaded_file.rs
@@ -102,7 +102,7 @@ impl DownloadedFile {
                 let url_str: String = externs::getattr(py_download_file, "url")
                     .map_err(|e| format!("Failed to get `url` for field: {e}"))?;
                 let auth_headers =
-                    externs::getattr_from_str_frozendict_bound(py_download_file, "auth_headers");
+                    externs::getattr_from_str_frozendict(py_download_file, "auth_headers");
                 let py_file_digest: PyFileDigest =
                     externs::getattr(py_download_file, "expected_digest")?;
                 let retry_delay_duration: Duration =

--- a/src/rust/engine/src/nodes/execute_process.rs
+++ b/src/rust/engine/src/nodes/execute_process.rs
@@ -82,11 +82,10 @@ impl ExecuteProcess {
     ) -> Result<Process, StoreError> {
         let env = externs::getattr_from_str_frozendict_bound(value, "env");
 
-        let working_directory =
-            externs::getattr_as_optional_string_bound(value, "working_directory")
-                .map_err(|e| format!("Failed to get `working_directory` from field: {e}"))?
-                .map(RelativePath::new)
-                .transpose()?;
+        let working_directory = externs::getattr_as_optional_string(value, "working_directory")
+            .map_err(|e| format!("Failed to get `working_directory` from field: {e}"))?
+            .map(RelativePath::new)
+            .transpose()?;
 
         let output_files = externs::getattr::<Vec<String>>(value, "output_files")?
             .into_iter()
@@ -121,12 +120,12 @@ impl ExecuteProcess {
                 })
                 .collect::<Result<_, String>>()?;
 
-        let jdk_home = externs::getattr_as_optional_string_bound(value, "jdk_home")
+        let jdk_home = externs::getattr_as_optional_string(value, "jdk_home")
             .map_err(|e| format!("Failed to get `jdk_home` from field: {e}"))?
             .map(PathBuf::from);
 
         let execution_slot_variable =
-            externs::getattr_as_optional_string_bound(value, "execution_slot_variable")
+            externs::getattr_as_optional_string(value, "execution_slot_variable")
                 .map_err(|e| format!("Failed to get `execution_slot_variable` for field: {e}"))?;
 
         let concurrency_available: usize = externs::getattr(value, "concurrency_available")?;

--- a/src/rust/engine/src/nodes/execute_process.rs
+++ b/src/rust/engine/src/nodes/execute_process.rs
@@ -45,7 +45,7 @@ impl ExecuteProcess {
                 lift_directory_digest_bound(&input_files_py_value)
                     .map_err(|err| format!("Error parsing input_digest {err}"))?
             };
-            let immutable_inputs = externs::getattr_from_str_frozendict_bound::<Bound<PyAny>>(
+            let immutable_inputs = externs::getattr_from_str_frozendict::<Bound<PyAny>>(
                 value,
                 "immutable_input_digests",
             )
@@ -80,7 +80,7 @@ impl ExecuteProcess {
         input_digests: InputDigests,
         process_config: externs::process::PyProcessExecutionEnvironment,
     ) -> Result<Process, StoreError> {
-        let env = externs::getattr_from_str_frozendict_bound(value, "env");
+        let env = externs::getattr_from_str_frozendict(value, "env");
 
         let working_directory = externs::getattr_as_optional_string(value, "working_directory")
             .map_err(|e| format!("Failed to get `working_directory` from field: {e}"))?
@@ -112,7 +112,7 @@ impl ExecuteProcess {
         let level = externs::val_to_log_level(&py_level)?;
 
         let append_only_caches =
-            externs::getattr_from_str_frozendict_bound::<PyBackedStr>(value, "append_only_caches")
+            externs::getattr_from_str_frozendict::<PyBackedStr>(value, "append_only_caches")
                 .into_iter()
                 .map(|(name, dest)| {
                     let path: &str = dest.as_ref();

--- a/src/rust/engine/src/nodes/execute_process.rs
+++ b/src/rust/engine/src/nodes/execute_process.rs
@@ -41,7 +41,7 @@ impl ExecuteProcess {
             let value = value.bind(py);
             let input_files = {
                 let input_files_py_value: Bound<'_, PyAny> =
-                    externs::getattr_bound(value, "input_digest")?;
+                    externs::getattr(value, "input_digest")?;
                 lift_directory_digest_bound(&input_files_py_value)
                     .map_err(|err| format!("Error parsing input_digest {err}"))?
             };
@@ -57,7 +57,7 @@ impl ExecuteProcess {
                 ))
             })
             .collect::<Result<BTreeMap<_, _>, String>>()?;
-            let use_nailgun = externs::getattr_bound::<Vec<String>>(value, "use_nailgun")?
+            let use_nailgun = externs::getattr::<Vec<String>>(value, "use_nailgun")?
                 .into_iter()
                 .map(RelativePath::new)
                 .collect::<Result<BTreeSet<_>, _>>()?;
@@ -88,18 +88,17 @@ impl ExecuteProcess {
                 .map(RelativePath::new)
                 .transpose()?;
 
-        let output_files = externs::getattr_bound::<Vec<String>>(value, "output_files")?
+        let output_files = externs::getattr::<Vec<String>>(value, "output_files")?
             .into_iter()
             .map(RelativePath::new)
             .collect::<Result<_, _>>()?;
 
-        let output_directories =
-            externs::getattr_bound::<Vec<String>>(value, "output_directories")?
-                .into_iter()
-                .map(RelativePath::new)
-                .collect::<Result<_, _>>()?;
+        let output_directories = externs::getattr::<Vec<String>>(value, "output_directories")?
+            .into_iter()
+            .map(RelativePath::new)
+            .collect::<Result<_, _>>()?;
 
-        let timeout_in_seconds: f64 = externs::getattr_bound(value, "timeout_seconds")?;
+        let timeout_in_seconds: f64 = externs::getattr(value, "timeout_seconds")?;
 
         let timeout = if timeout_in_seconds < 0.0 {
             None
@@ -107,9 +106,9 @@ impl ExecuteProcess {
             Some(Duration::from_millis((timeout_in_seconds * 1000.0) as u64))
         };
 
-        let description: String = externs::getattr_bound(value, "description")?;
+        let description: String = externs::getattr(value, "description")?;
 
-        let py_level = externs::getattr_bound(value, "level")?;
+        let py_level = externs::getattr(value, "level")?;
 
         let level = externs::val_to_log_level_bound(&py_level)?;
 
@@ -130,22 +129,22 @@ impl ExecuteProcess {
             externs::getattr_as_optional_string_bound(value, "execution_slot_variable")
                 .map_err(|e| format!("Failed to get `execution_slot_variable` for field: {e}"))?;
 
-        let concurrency_available: usize = externs::getattr_bound(value, "concurrency_available")?;
+        let concurrency_available: usize = externs::getattr(value, "concurrency_available")?;
 
         let cache_scope: ProcessCacheScope = {
-            let cache_scope_enum: Bound<'_, PyAny> = externs::getattr_bound(value, "cache_scope")?;
-            externs::getattr_bound::<String>(&cache_scope_enum, "name")?.try_into()?
+            let cache_scope_enum: Bound<'_, PyAny> = externs::getattr(value, "cache_scope")?;
+            externs::getattr::<String>(&cache_scope_enum, "name")?.try_into()?
         };
 
         let remote_cache_speculation_delay = std::time::Duration::from_millis(
-            externs::getattr_bound::<i32>(value, "remote_cache_speculation_delay_millis")
+            externs::getattr::<i32>(value, "remote_cache_speculation_delay_millis")
                 .map_err(|e| format!("Failed to get `name` for field: {e}"))? as u64,
         );
 
-        let attempt = externs::getattr_bound(value, "attempt").unwrap_or(0);
+        let attempt = externs::getattr(value, "attempt").unwrap_or(0);
 
         Ok(Process {
-            argv: externs::getattr_bound(value, "argv").unwrap(),
+            argv: externs::getattr(value, "argv").unwrap(),
             env,
             working_directory,
             input_digests,

--- a/src/rust/engine/src/nodes/execute_process.rs
+++ b/src/rust/engine/src/nodes/execute_process.rs
@@ -109,7 +109,7 @@ impl ExecuteProcess {
 
         let py_level = externs::getattr(value, "level")?;
 
-        let level = externs::val_to_log_level_bound(&py_level)?;
+        let level = externs::val_to_log_level(&py_level)?;
 
         let append_only_caches =
             externs::getattr_from_str_frozendict_bound::<PyBackedStr>(value, "append_only_caches")

--- a/src/rust/engine/src/nodes/mod.rs
+++ b/src/rust/engine/src/nodes/mod.rs
@@ -220,7 +220,7 @@ fn select_reentry(
     .boxed()
 }
 
-pub fn lift_directory_digest_bound(digest: &Bound<'_, PyAny>) -> Result<DirectoryDigest, String> {
+pub fn lift_directory_digest(digest: &Bound<'_, PyAny>) -> Result<DirectoryDigest, String> {
     let py_digest: externs::fs::PyDigest = digest.extract().map_err(|e| format!("{e}"))?;
     Ok(py_digest.0)
 }

--- a/src/rust/engine/src/nodes/mod.rs
+++ b/src/rust/engine/src/nodes/mod.rs
@@ -470,11 +470,7 @@ impl NodeKey {
         py: Python<'a>,
         params: &'a Params,
     ) -> impl Iterator<Item = &'a Key> + 'a {
-        let engine_aware_param_ty = context
-            .core
-            .types
-            .engine_aware_parameter
-            .as_py_type(py);
+        let engine_aware_param_ty = context.core.types.engine_aware_parameter.as_py_type(py);
         params.keys().filter(move |key| {
             key.type_id()
                 .as_py_type(py)

--- a/src/rust/engine/src/nodes/mod.rs
+++ b/src/rust/engine/src/nodes/mod.rs
@@ -474,10 +474,10 @@ impl NodeKey {
             .core
             .types
             .engine_aware_parameter
-            .as_py_type_bound(py);
+            .as_py_type(py);
         params.keys().filter(move |key| {
             key.type_id()
-                .as_py_type_bound(py)
+                .as_py_type(py)
                 .is_subclass(&engine_aware_param_ty)
                 .unwrap_or(false)
         })

--- a/src/rust/engine/src/nodes/mod.rs
+++ b/src/rust/engine/src/nodes/mod.rs
@@ -225,7 +225,7 @@ pub fn lift_directory_digest(digest: &Bound<'_, PyAny>) -> Result<DirectoryDiges
     Ok(py_digest.0)
 }
 
-pub fn lift_file_digest_bound(digest: &Bound<'_, PyAny>) -> Result<hashing::Digest, String> {
+pub fn lift_file_digest(digest: &Bound<'_, PyAny>) -> Result<hashing::Digest, String> {
     let py_file_digest: externs::fs::PyFileDigest = digest.extract().map_err(|e| format!("{e}"))?;
     Ok(py_file_digest.0)
 }

--- a/src/rust/engine/src/nodes/snapshot.rs
+++ b/src/rust/engine/src/nodes/snapshot.rs
@@ -34,7 +34,7 @@ impl Snapshot {
         Snapshot { path_globs }
     }
 
-    pub fn lift_path_globs_bound(item: &Bound<'_, PyAny>) -> Result<PathGlobs, String> {
+    pub fn lift_path_globs(item: &Bound<'_, PyAny>) -> Result<PathGlobs, String> {
         let globs: Vec<String> = externs::getattr(item, "globs")
             .map_err(|e| format!("Failed to get `globs` for field: {e}"))?;
 
@@ -63,7 +63,7 @@ impl Snapshot {
     }
 
     pub fn lift_prepared_path_globs(item: &Bound<'_, PyAny>) -> Result<PreparedPathGlobs, String> {
-        let path_globs = Snapshot::lift_path_globs_bound(item)?;
+        let path_globs = Snapshot::lift_path_globs(item)?;
         path_globs
             .parse()
             .map_err(|e| format!("Failed to parse PathGlobs for globs({item:?}): {e}"))

--- a/src/rust/engine/src/nodes/snapshot.rs
+++ b/src/rust/engine/src/nodes/snapshot.rs
@@ -35,7 +35,7 @@ impl Snapshot {
     }
 
     pub fn lift_path_globs_bound(item: &Bound<'_, PyAny>) -> Result<PathGlobs, String> {
-        let globs: Vec<String> = externs::getattr_bound(item, "globs")
+        let globs: Vec<String> = externs::getattr(item, "globs")
             .map_err(|e| format!("Failed to get `globs` for field: {e}"))?;
 
         let description_of_origin =
@@ -43,19 +43,19 @@ impl Snapshot {
                 .map_err(|e| format!("Failed to get `description_of_origin` for field: {e}"))?;
 
         let glob_match_error_behavior: Bound<'_, PyAny> =
-            externs::getattr_bound(item, "glob_match_error_behavior")
+            externs::getattr(item, "glob_match_error_behavior")
                 .map_err(|e| format!("Failed to get `glob_match_error_behavior` for field: {e}"))?;
 
-        let failure_behavior: String = externs::getattr_bound(&glob_match_error_behavior, "value")
+        let failure_behavior: String = externs::getattr(&glob_match_error_behavior, "value")
             .map_err(|e| format!("Failed to get `value` for field: {e}"))?;
 
         let strict_glob_matching =
             StrictGlobMatching::create(failure_behavior.as_str(), description_of_origin)?;
 
-        let conjunction_obj: Bound<'_, PyAny> = externs::getattr_bound(item, "conjunction")
+        let conjunction_obj: Bound<'_, PyAny> = externs::getattr(item, "conjunction")
             .map_err(|e| format!("Failed to get `conjunction` for field: {e}"))?;
 
-        let conjunction_string: String = externs::getattr_bound(&conjunction_obj, "value")
+        let conjunction_string: String = externs::getattr(&conjunction_obj, "value")
             .map_err(|e| format!("Failed to get `value` for field: {e}"))?;
 
         let conjunction = GlobExpansionConjunction::create(&conjunction_string)?;

--- a/src/rust/engine/src/nodes/snapshot.rs
+++ b/src/rust/engine/src/nodes/snapshot.rs
@@ -39,7 +39,7 @@ impl Snapshot {
             .map_err(|e| format!("Failed to get `globs` for field: {e}"))?;
 
         let description_of_origin =
-            externs::getattr_as_optional_string_bound(item, "description_of_origin")
+            externs::getattr_as_optional_string(item, "description_of_origin")
                 .map_err(|e| format!("Failed to get `description_of_origin` for field: {e}"))?;
 
         let glob_match_error_behavior: Bound<'_, PyAny> =

--- a/src/rust/engine/src/nodes/snapshot.rs
+++ b/src/rust/engine/src/nodes/snapshot.rs
@@ -62,9 +62,7 @@ impl Snapshot {
         Ok(PathGlobs::new(globs, strict_glob_matching, conjunction))
     }
 
-    pub fn lift_prepared_path_globs_bound(
-        item: &Bound<'_, PyAny>,
-    ) -> Result<PreparedPathGlobs, String> {
+    pub fn lift_prepared_path_globs(item: &Bound<'_, PyAny>) -> Result<PreparedPathGlobs, String> {
         let path_globs = Snapshot::lift_path_globs_bound(item)?;
         path_globs
             .parse()

--- a/src/rust/engine/src/python.rs
+++ b/src/rust/engine/src/python.rs
@@ -137,7 +137,7 @@ impl TypeId {
         Self(py_type.as_type_ptr())
     }
 
-    pub fn as_py_type_bound<'py>(&self, py: Python<'py>) -> Bound<'py, PyType> {
+    pub fn as_py_type<'py>(&self, py: Python<'py>) -> Bound<'py, PyType> {
         // SAFETY: Dereferencing a pointer to a PyTypeObject is safe as long as the module defining the
         // type is not unloaded. That is true today, but would not be if we implemented support for hot
         // reloading of plugins.
@@ -149,12 +149,12 @@ impl TypeId {
     }
 
     pub fn is_union(&self) -> bool {
-        Python::with_gil(|py| externs::is_union(py, &self.as_py_type_bound(py)).unwrap())
+        Python::with_gil(|py| externs::is_union(py, &self.as_py_type(py)).unwrap())
     }
 
     pub fn union_in_scope_types(&self) -> Option<Vec<TypeId>> {
         Python::with_gil(|py| {
-            externs::union_in_scope_types(py, &self.as_py_type_bound(py))
+            externs::union_in_scope_types(py, &self.as_py_type(py))
                 .unwrap()
                 .map(|types| {
                     types
@@ -169,7 +169,7 @@ impl TypeId {
 impl fmt::Debug for TypeId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         Python::with_gil(|py| {
-            let type_bound = self.as_py_type_bound(py);
+            let type_bound = self.as_py_type(py);
             let name = type_bound.name().unwrap();
             write!(f, "{name}")
         })

--- a/src/rust/engine/src/python.rs
+++ b/src/rust/engine/src/python.rs
@@ -338,7 +338,7 @@ impl fmt::Debug for Value {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let repr = Python::with_gil(|py| {
             let obj = self.0.bind(py);
-            externs::val_to_str_bound(obj)
+            externs::val_to_str(obj)
         });
         write!(f, "{repr}")
     }
@@ -511,7 +511,7 @@ impl Failure {
             .extract::<String>()
             .unwrap()
         } else {
-            Self::native_traceback(&externs::val_to_str_bound(val.bind(py)))
+            Self::native_traceback(&externs::val_to_str(val.bind(py)))
         };
         Failure::Throw {
             val,
@@ -551,7 +551,7 @@ impl fmt::Display for Failure {
             Failure::Throw { val, .. } => {
                 let repr = Python::with_gil(|py| {
                     let obj = val.0.bind(py);
-                    externs::val_to_str_bound(obj)
+                    externs::val_to_str(obj)
                 });
                 write!(f, "{repr}")
             }

--- a/src/rust/engine/src/python.rs
+++ b/src/rust/engine/src/python.rs
@@ -201,11 +201,11 @@ impl Function {
     pub fn full_name(&self) -> String {
         let (module, name, line_no) = Python::with_gil(|py| {
             let obj = self.0.value.bind(py);
-            let module: String = externs::getattr_bound(obj, "__module__").unwrap();
-            let name: String = externs::getattr_bound(obj, "__name__").unwrap();
+            let module: String = externs::getattr(obj, "__module__").unwrap();
+            let name: String = externs::getattr(obj, "__name__").unwrap();
             // NB: this is a custom dunder method that Python code should populate before sending the
             // function (e.g. an `@rule`) through FFI.
-            let line_no: u64 = externs::getattr_bound(obj, "__line_number__").unwrap();
+            let line_no: u64 = externs::getattr(obj, "__line_number__").unwrap();
             (module, name, line_no)
         });
         format!("{module}:{line_no}:{name}")


### PR DESCRIPTION
While migrating from PyO3 v0.21.x to v0.23.x, we renamed many functions to include "_bound" in the name so that we could migrate to the `Bound` API in a piecemeal fashion. The upgrade to v0.23.x is done so all of these functions can be renamed back to their original names before the migration.

This PR only contains function renames.