### PR TITLE
PyO3: introduce `PyComparedBool` type to simplify __richcmp__ methods

### DIFF
--- a/src/rust/engine/src/externs/address.rs
+++ b/src/rust/engine/src/externs/address.rs
@@ -17,6 +17,8 @@ use pyo3::types::{PyDict, PyFrozenSet, PyType};
 use fnv::FnvHasher;
 use lazy_static::lazy_static;
 
+use crate::python::PyComparedBool;
+
 create_exception!(native_engine, AddressParseException, PyException);
 create_exception!(native_engine, InvalidAddressError, AddressParseException);
 create_exception!(native_engine, InvalidSpecPathError, InvalidAddressError);
@@ -406,20 +408,13 @@ impl AddressInput {
         format!("{self:?}")
     }
 
-    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python) -> PyResult<PyObject> {
-        Ok(match op {
-            CompareOp::Eq => (self == other)
-                .into_pyobject(py)?
-                .to_owned()
-                .into_any()
-                .unbind(),
-            CompareOp::Ne => (self != other)
-                .into_pyobject(py)?
-                .to_owned()
-                .into_any()
-                .unbind(),
-            _ => py.NotImplemented(),
-        })
+    fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyComparedBool {
+        match op {
+            CompareOp::Eq => Some(self == other),
+            CompareOp::Ne => Some(self != other),
+            _ => None,
+        }
+        .into()
     }
 }
 

--- a/src/rust/engine/src/externs/address.rs
+++ b/src/rust/engine/src/externs/address.rs
@@ -409,12 +409,11 @@ impl AddressInput {
     }
 
     fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyComparedBool {
-        match op {
+        PyComparedBool(match op {
             CompareOp::Eq => Some(self == other),
             CompareOp::Ne => Some(self != other),
             _ => None,
-        }
-        .into()
+        })
     }
 }
 

--- a/src/rust/engine/src/externs/dep_inference.rs
+++ b/src/rust/engine/src/externs/dep_inference.rs
@@ -60,12 +60,11 @@ impl PyInferenceMetadata {
     }
 
     fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyComparedBool {
-        match op {
+        PyComparedBool(match op {
             CompareOp::Eq => Some(self == other),
             CompareOp::Ne => Some(self != other),
             _ => None,
-        }
-        .into()
+        })
     }
 
     fn __repr__(&self) -> String {
@@ -113,11 +112,10 @@ impl PyNativeDependenciesRequest {
     }
 
     fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyComparedBool {
-        match op {
+        PyComparedBool(match op {
             CompareOp::Eq => Some(self == other),
             CompareOp::Ne => Some(self != other),
             _ => None,
-        }
-        .into()
+        })
     }
 }

--- a/src/rust/engine/src/externs/dep_inference.rs
+++ b/src/rust/engine/src/externs/dep_inference.rs
@@ -6,7 +6,6 @@ use std::hash::{Hash, Hasher};
 use pyo3::basic::CompareOp;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
-use pyo3::{PyObject, Python};
 
 use fs::DirectoryDigest;
 use protos::gen::pants::cache::{
@@ -14,6 +13,7 @@ use protos::gen::pants::cache::{
 };
 
 use crate::externs::fs::PyDigest;
+use crate::python::PyComparedBool;
 
 pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyNativeDependenciesRequest>()?;
@@ -59,20 +59,13 @@ impl PyInferenceMetadata {
         )))
     }
 
-    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python) -> PyResult<PyObject> {
-        Ok(match op {
-            CompareOp::Eq => (self == other)
-                .into_pyobject(py)?
-                .to_owned()
-                .into_any()
-                .unbind(),
-            CompareOp::Ne => (self != other)
-                .into_pyobject(py)?
-                .to_owned()
-                .into_any()
-                .unbind(),
-            _ => py.NotImplemented(),
-        })
+    fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyComparedBool {
+        match op {
+            CompareOp::Eq => Some(self == other),
+            CompareOp::Ne => Some(self != other),
+            _ => None,
+        }
+        .into()
     }
 
     fn __repr__(&self) -> String {
@@ -119,19 +112,12 @@ impl PyNativeDependenciesRequest {
         )
     }
 
-    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python) -> PyResult<PyObject> {
-        Ok(match op {
-            CompareOp::Eq => (self == other)
-                .into_pyobject(py)?
-                .to_owned()
-                .into_any()
-                .unbind(),
-            CompareOp::Ne => (self != other)
-                .into_pyobject(py)?
-                .to_owned()
-                .into_any()
-                .unbind(),
-            _ => py.NotImplemented(),
-        })
+    fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyComparedBool {
+        match op {
+            CompareOp::Eq => Some(self == other),
+            CompareOp::Ne => Some(self != other),
+            _ => None,
+        }
+        .into()
     }
 }

--- a/src/rust/engine/src/externs/fs.rs
+++ b/src/rust/engine/src/externs/fs.rs
@@ -96,12 +96,11 @@ impl PyDigest {
 
     fn __richcmp__(&self, other: &Bound<'_, PyDigest>, op: CompareOp) -> PyComparedBool {
         let other_digest = other.borrow();
-        match op {
+        PyComparedBool(match op {
             CompareOp::Eq => Some(*self == *other_digest),
             CompareOp::Ne => Some(*self != *other_digest),
             _ => None,
-        }
-        .into()
+        })
     }
 
     #[getter]
@@ -142,12 +141,11 @@ impl PyFileDigest {
 
     fn __richcmp__(&self, other: &Bound<'_, PyFileDigest>, op: CompareOp) -> PyComparedBool {
         let other_file_digest = other.borrow();
-        match op {
+        PyComparedBool(match op {
             CompareOp::Eq => Some(*self == *other_file_digest),
             CompareOp::Ne => Some(*self != *other_file_digest),
             _ => None,
-        }
-        .into()
+        })
     }
 
     #[getter]
@@ -203,12 +201,11 @@ impl PySnapshot {
 
     fn __richcmp__(&self, other: &Bound<'_, PySnapshot>, op: CompareOp) -> PyComparedBool {
         let other_digest = other.borrow().0.digest;
-        match op {
+        PyComparedBool(match op {
             CompareOp::Eq => Some(self.0.digest == other_digest),
             CompareOp::Ne => Some(self.0.digest != other_digest),
             _ => None,
-        }
-        .into()
+        })
     }
 
     #[getter]
@@ -304,12 +301,11 @@ impl PyMergeDigests {
 
     fn __richcmp__(&self, other: &Bound<'_, PyMergeDigests>, op: CompareOp) -> PyComparedBool {
         let other = other.borrow();
-        match op {
+        PyComparedBool(match op {
             CompareOp::Eq => Some(*self == *other),
             CompareOp::Ne => Some(*self != *other),
             _ => None,
-        }
-        .into()
+        })
     }
 }
 
@@ -347,12 +343,11 @@ impl PyAddPrefix {
 
     fn __richcmp__(&self, other: &Bound<'_, PyAddPrefix>, op: CompareOp) -> PyComparedBool {
         let other = other.borrow();
-        match op {
+        PyComparedBool(match op {
             CompareOp::Eq => Some(*self == *other),
             CompareOp::Ne => Some(*self != *other),
             _ => None,
-        }
-        .into()
+        })
     }
 }
 
@@ -390,12 +385,11 @@ impl PyRemovePrefix {
 
     fn __richcmp__(&self, other: &Bound<'_, PyRemovePrefix>, op: CompareOp) -> PyComparedBool {
         let other = other.borrow();
-        match op {
+        PyComparedBool(match op {
             CompareOp::Eq => Some(*self == *other),
             CompareOp::Ne => Some(*self != *other),
             _ => None,
-        }
-        .into()
+        })
     }
 }
 
@@ -477,7 +471,7 @@ impl PyFilespecMatcher {
 
     fn __richcmp__(&self, other: &Bound<'_, PyFilespecMatcher>, op: CompareOp) -> PyComparedBool {
         let other = other.borrow();
-        match op {
+        PyComparedBool(match op {
             CompareOp::Eq => Some(
                 self.0.include_globs() == other.0.include_globs()
                     && self.0.exclude_globs() == other.0.exclude_globs(),
@@ -487,8 +481,7 @@ impl PyFilespecMatcher {
                     || self.0.exclude_globs() != other.0.exclude_globs(),
             ),
             _ => None,
-        }
-        .into()
+        })
     }
 
     fn matches(&self, paths: Vec<String>, py: Python) -> PyResult<Vec<String>> {

--- a/src/rust/engine/src/externs/fs.rs
+++ b/src/rust/engine/src/externs/fs.rs
@@ -21,6 +21,7 @@ use fs::{
 use hashing::{Digest, Fingerprint, EMPTY_DIGEST};
 use store::Snapshot;
 
+use crate::python::PyComparedBool;
 use crate::Failure;
 
 pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
@@ -93,26 +94,14 @@ impl PyDigest {
         format!("{self}")
     }
 
-    fn __richcmp__(
-        &self,
-        other: &Bound<'_, PyDigest>,
-        op: CompareOp,
-        py: Python,
-    ) -> PyResult<PyObject> {
+    fn __richcmp__(&self, other: &Bound<'_, PyDigest>, op: CompareOp) -> PyComparedBool {
         let other_digest = other.borrow();
-        Ok(match op {
-            CompareOp::Eq => (*self == *other_digest)
-                .into_pyobject(py)?
-                .to_owned()
-                .into_any()
-                .unbind(),
-            CompareOp::Ne => (*self != *other_digest)
-                .into_pyobject(py)?
-                .to_owned()
-                .into_any()
-                .unbind(),
-            _ => py.NotImplemented(),
-        })
+        match op {
+            CompareOp::Eq => Some(*self == *other_digest),
+            CompareOp::Ne => Some(*self != *other_digest),
+            _ => None,
+        }
+        .into()
     }
 
     #[getter]
@@ -151,26 +140,14 @@ impl PyFileDigest {
         )
     }
 
-    fn __richcmp__(
-        &self,
-        other: &Bound<'_, PyFileDigest>,
-        op: CompareOp,
-        py: Python,
-    ) -> PyResult<PyObject> {
+    fn __richcmp__(&self, other: &Bound<'_, PyFileDigest>, op: CompareOp) -> PyComparedBool {
         let other_file_digest = other.borrow();
-        Ok(match op {
-            CompareOp::Eq => (*self == *other_file_digest)
-                .into_pyobject(py)?
-                .to_owned()
-                .into_any()
-                .unbind(),
-            CompareOp::Ne => (*self != *other_file_digest)
-                .into_pyobject(py)?
-                .to_owned()
-                .into_any()
-                .unbind(),
-            _ => py.NotImplemented(),
-        })
+        match op {
+            CompareOp::Eq => Some(*self == *other_file_digest),
+            CompareOp::Ne => Some(*self != *other_file_digest),
+            _ => None,
+        }
+        .into()
     }
 
     #[getter]
@@ -224,26 +201,14 @@ impl PySnapshot {
         ))
     }
 
-    fn __richcmp__(
-        &self,
-        other: &Bound<'_, PySnapshot>,
-        op: CompareOp,
-        py: Python,
-    ) -> PyResult<PyObject> {
+    fn __richcmp__(&self, other: &Bound<'_, PySnapshot>, op: CompareOp) -> PyComparedBool {
         let other_digest = other.borrow().0.digest;
-        Ok(match op {
-            CompareOp::Eq => (self.0.digest == other_digest)
-                .into_pyobject(py)?
-                .to_owned()
-                .into_any()
-                .unbind(),
-            CompareOp::Ne => (self.0.digest != other_digest)
-                .into_pyobject(py)?
-                .to_owned()
-                .into_any()
-                .unbind(),
-            _ => py.NotImplemented(),
-        })
+        match op {
+            CompareOp::Eq => Some(self.0.digest == other_digest),
+            CompareOp::Ne => Some(self.0.digest != other_digest),
+            _ => None,
+        }
+        .into()
     }
 
     #[getter]
@@ -337,26 +302,14 @@ impl PyMergeDigests {
         format!("MergeDigests([{digests}])")
     }
 
-    fn __richcmp__(
-        &self,
-        other: &Bound<'_, PyMergeDigests>,
-        op: CompareOp,
-        py: Python,
-    ) -> PyResult<PyObject> {
+    fn __richcmp__(&self, other: &Bound<'_, PyMergeDigests>, op: CompareOp) -> PyComparedBool {
         let other = other.borrow();
-        Ok(match op {
-            CompareOp::Eq => (*self == *other)
-                .into_pyobject(py)?
-                .to_owned()
-                .into_any()
-                .unbind(),
-            CompareOp::Ne => (*self != *other)
-                .into_pyobject(py)?
-                .to_owned()
-                .into_any()
-                .unbind(),
-            _ => py.NotImplemented(),
-        })
+        match op {
+            CompareOp::Eq => Some(*self == *other),
+            CompareOp::Ne => Some(*self != *other),
+            _ => None,
+        }
+        .into()
     }
 }
 
@@ -392,26 +345,14 @@ impl PyAddPrefix {
         )
     }
 
-    fn __richcmp__(
-        &self,
-        other: &Bound<'_, PyAddPrefix>,
-        op: CompareOp,
-        py: Python,
-    ) -> PyResult<PyObject> {
+    fn __richcmp__(&self, other: &Bound<'_, PyAddPrefix>, op: CompareOp) -> PyComparedBool {
         let other = other.borrow();
-        Ok(match op {
-            CompareOp::Eq => (*self == *other)
-                .into_pyobject(py)?
-                .to_owned()
-                .into_any()
-                .unbind(),
-            CompareOp::Ne => (*self != *other)
-                .into_pyobject(py)?
-                .to_owned()
-                .into_any()
-                .unbind(),
-            _ => py.NotImplemented(),
-        })
+        match op {
+            CompareOp::Eq => Some(*self == *other),
+            CompareOp::Ne => Some(*self != *other),
+            _ => None,
+        }
+        .into()
     }
 }
 
@@ -447,26 +388,14 @@ impl PyRemovePrefix {
         )
     }
 
-    fn __richcmp__(
-        &self,
-        other: &Bound<'_, PyRemovePrefix>,
-        op: CompareOp,
-        py: Python,
-    ) -> PyResult<PyObject> {
+    fn __richcmp__(&self, other: &Bound<'_, PyRemovePrefix>, op: CompareOp) -> PyComparedBool {
         let other = other.borrow();
-        Ok(match op {
-            CompareOp::Eq => (*self == *other)
-                .into_pyobject(py)?
-                .to_owned()
-                .into_any()
-                .unbind(),
-            CompareOp::Ne => (*self != *other)
-                .into_pyobject(py)?
-                .to_owned()
-                .into_any()
-                .unbind(),
-            _ => py.NotImplemented(),
-        })
+        match op {
+            CompareOp::Eq => Some(*self == *other),
+            CompareOp::Ne => Some(*self != *other),
+            _ => None,
+        }
+        .into()
     }
 }
 
@@ -546,25 +475,20 @@ impl PyFilespecMatcher {
         format!("FilespecMatcher(includes=['{includes}'], excludes=[{excludes}])",)
     }
 
-    fn __richcmp__(
-        &self,
-        other: &Bound<'_, PyFilespecMatcher>,
-        op: CompareOp,
-        py: Python,
-    ) -> PyResult<PyObject> {
+    fn __richcmp__(&self, other: &Bound<'_, PyFilespecMatcher>, op: CompareOp) -> PyComparedBool {
         let other = other.borrow();
-        let res = match op {
-            CompareOp::Eq => {
+        match op {
+            CompareOp::Eq => Some(
                 self.0.include_globs() == other.0.include_globs()
-                    && self.0.exclude_globs() == other.0.exclude_globs()
-            }
-            CompareOp::Ne => {
+                    && self.0.exclude_globs() == other.0.exclude_globs(),
+            ),
+            CompareOp::Ne => Some(
                 self.0.include_globs() != other.0.include_globs()
-                    || self.0.exclude_globs() != other.0.exclude_globs()
-            }
-            _ => return Ok(py.NotImplemented().into_any()),
-        };
-        Ok(res.into_pyobject(py)?.to_owned().into_any().unbind())
+                    || self.0.exclude_globs() != other.0.exclude_globs(),
+            ),
+            _ => None,
+        }
+        .into()
     }
 
     fn matches(&self, paths: Vec<String>, py: Python) -> PyResult<Vec<String>> {

--- a/src/rust/engine/src/externs/process.rs
+++ b/src/rust/engine/src/externs/process.rs
@@ -4,12 +4,12 @@
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
+use process_execution::{Platform, ProcessExecutionEnvironment, ProcessExecutionStrategy};
 use pyo3::basic::CompareOp;
 use pyo3::exceptions::{PyAssertionError, PyValueError};
-use pyo3::{prelude::*, BoundObject};
+use pyo3::prelude::*;
 
-use process_execution::{Platform, ProcessExecutionEnvironment, ProcessExecutionStrategy};
-use pyo3::types::PyBool;
+use crate::python::PyComparedBool;
 
 pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyProcessExecutionEnvironment>()?;
@@ -84,22 +84,14 @@ impl PyProcessExecutionEnvironment {
         &self,
         other: &Bound<'_, PyProcessExecutionEnvironment>,
         op: CompareOp,
-        py: Python,
-    ) -> PyObject {
+    ) -> PyComparedBool {
         let other = other.borrow();
         match op {
-            CompareOp::Eq => PyBool::new(py, *self == *other)
-                .into_bound()
-                .as_any()
-                .clone()
-                .unbind(),
-            CompareOp::Ne => PyBool::new(py, *self != *other)
-                .into_bound()
-                .as_any()
-                .clone()
-                .unbind(),
-            _ => py.NotImplemented(),
+            CompareOp::Eq => Some(*self == *other),
+            CompareOp::Ne => Some(*self != *other),
+            _ => None,
         }
+        .into()
     }
 
     #[getter]

--- a/src/rust/engine/src/externs/process.rs
+++ b/src/rust/engine/src/externs/process.rs
@@ -86,12 +86,11 @@ impl PyProcessExecutionEnvironment {
         op: CompareOp,
     ) -> PyComparedBool {
         let other = other.borrow();
-        match op {
+        PyComparedBool(match op {
             CompareOp::Eq => Some(*self == *other),
             CompareOp::Ne => Some(*self != *other),
             _ => None,
-        }
-        .into()
+        })
     }
 
     #[getter]

--- a/src/rust/engine/src/externs/target.rs
+++ b/src/rust/engine/src/externs/target.rs
@@ -183,12 +183,11 @@ impl Field {
                 .value
                 .bind(py)
                 .eq(&other.extract::<PyRef<Field>>()?.value)?;
-        Ok(match op {
+        Ok(PyComparedBool(match op {
             CompareOp::Eq => Some(is_eq),
             CompareOp::Ne => Some(!is_eq),
             _ => None,
-        }
-        .into())
+        }))
     }
 }
 

--- a/src/rust/engine/src/python.rs
+++ b/src/rust/engine/src/python.rs
@@ -605,6 +605,7 @@ pub fn throw(msg: String) -> Failure {
 /// (via `None``) which `__richcmp__` methods may return when a particular comparison operator is
 /// not supported.
 #[derive(Clone, Copy, Eq, PartialEq, Hash, Debug)]
+#[repr(transparent)]
 pub struct PyComparedBool(pub Option<bool>);
 
 impl From<Option<bool>> for PyComparedBool {

--- a/src/rust/engine/src/python.rs
+++ b/src/rust/engine/src/python.rs
@@ -620,8 +620,8 @@ impl<'py> IntoPyObject<'py> for PyComparedBool {
     type Error = Infallible;
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-        Ok(match &self.0 {
-            Some(value) => PyBool::new(py, *value).to_owned().into_any(),
+        Ok(match self.0 {
+            Some(value) => PyBool::new(py, value).to_owned().into_any(),
             None => py.NotImplemented().into_bound(py),
         })
     }

--- a/src/rust/engine/src/python.rs
+++ b/src/rust/engine/src/python.rs
@@ -601,11 +601,9 @@ pub fn throw(msg: String) -> Failure {
 }
 
 /// A tri-state boolean value for use with `__richcmp__` dunder method implementations. The type
-/// represents not only `true` and `false`, but also the `NotImplemented` type which `__richcmp__`
-/// methods may return when a particular comparison operator is not supported.
-///
-/// Even better is the type supports a conversion from `Option<bool>` so implementing `__richcmp__`
-/// implementations should avoid a lot of boilerplate.
+/// represents not only `true` and `false` (via `Some(value`), but also the `NotImplemented` value
+/// (via `None``) which `__richcmp__` methods may return when a particular comparison operator is
+/// not supported.
 #[derive(Clone, Copy, Eq, PartialEq, Hash, Debug)]
 pub struct PyComparedBool(pub Option<bool>);
 


### PR DESCRIPTION
Introduce a `PyComparedBool` type as a newtype of `Option<bool>` to simplify the boilerplate currently present in most of the `__richcmp__` dunder methods. This allows `__richcmp__` methods to easily return Python `True`/`False` when a comparison is supported or `NotImplemented` just by building an appropriate `Option<bool>`.