### PR TITLE
A global lock on side effects into the workspace. (Cherry-pick of #21698)

### DIFF
--- a/docs/notes/2.24.x.md
+++ b/docs/notes/2.24.x.md
@@ -24,8 +24,11 @@ We offer [formal sponsorship tiers for companies](https://www.pantsbuild.org/spo
 
 ### General
 
-* Fixed bug where `pants peek --include-additional-info` was not actually displaying the additional info ([#21399](https://github.com/pantsbuild/pants/pull/21399)).
-* [Fixed](https://github.com/pantsbuild/pants/pull/21665) bug where `pants --export-resolve=<resolve> --export-py-generated-sources-in-resolve=<resolve>` fails (see [#21659](https://github.com/pantsbuild/pants/issues/21659) for more info).
+Fixed bug where `pants peek --include-additional-info` was not actually displaying the additional info ([#21399](https://github.com/pantsbuild/pants/pull/21399)).
+
+[Fixed](https://github.com/pantsbuild/pants/pull/21665) bug where `pants --export-resolve=<resolve> --export-py-generated-sources-in-resolve=<resolve>` fails (see [#21659](https://github.com/pantsbuild/pants/issues/21659) for more info).
+
+Fixed a BSP server bug where multiple concurrent writes of the same workspace files would contend and cause filesystem errors ([#21698](https://github.com/pantsbuild/pants/pull/21698)).
 
 ### New Options System
 

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -18,6 +18,9 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::sync::Mutex;
+
+use lazy_static::lazy_static;
 
 use async_latch::AsyncLatch;
 use fnv::FnvHasher;
@@ -1819,6 +1822,10 @@ fn ensure_path_doesnt_exist(path: &Path) -> io::Result<()> {
     }
 }
 
+lazy_static! {
+    static ref GLOBAL_WORKSPACE_WRITE_LOCK: Mutex<()> = Mutex::new(());
+}
+
 #[pyfunction]
 fn write_digest(
     py: Python<'_>,
@@ -1856,16 +1863,33 @@ fn write_digest(
         }
 
         block_in_place_and_wait(py, || async move {
-            store
-                .materialize_directory(
-                    destination.clone(),
-                    &scheduler.core.build_root,
-                    lifted_digest.clone(),
-                    true, // Force everything we write to be mutable
-                    &BTreeSet::new(),
-                    fs::Permissions::Writable,
-                )
-                .await?;
+            {
+                // Although Workspace.write_digest() is typically used in @goal_rules, and so is not
+                // invoked concurrently, there are a handful of cases where we might need to write
+                // deeper inside the rule graph, and therefore may run into concurrency issues.
+                // One example is the bsp server, which may attempt to write build byproducts into
+                // the workspace for the IDE to consume, and in some cases may try and write the
+                // same files concurrently. Therefore we force all workspace writes to run in
+                // a critical section.
+                //
+                // Side note: When using Workspace.write_digest() outside a @goal_rule, you must
+                // take care to ensure that it always runs, and is not short-circuited by rule
+                // memoization, so that you can rely on the side effect always taking effect.
+                // This is typically done via an @_uncacheable_rule.
+                // This lock makes Workspace safe to use outside a @goal_rule, but does nothing to
+                // guarantee that it will run when you expect it to.
+                let _locked = GLOBAL_WORKSPACE_WRITE_LOCK.lock().await;
+                store
+                    .materialize_directory(
+                        destination.clone(),
+                        &scheduler.core.build_root,
+                        lifted_digest.clone(),
+                        true, // Force everything we write to be mutable
+                        &BTreeSet::new(),
+                        fs::Permissions::Writable,
+                    )
+                    .await?;
+            } // _locked released here.
 
             // Invalidate all the paths we've changed within `path_prefix`: both the paths we cleared and
             // the files we've just written to.


### PR DESCRIPTION
Although Workspace.write_digest() is typically used in @goal_rules, 
and so is not invoked concurrently, there are a handful of cases where
we might need to write deeper inside the rule graph, and therefore
may run into concurrency issues.

One example is the bsp server, which may attempt to write build
byproducts into the workspace for the IDE to consume, and in some
cases may try and write the same files concurrently. Therefore we
force all workspace writes to run in a critical section.

In the common case of @goal_rule, the calls are sequential anyway,
and so there will be no lock contention. In the bsp case, locking is
required, and any contention is necessary.

