### PR TITLE
generalize glob syntax for known third party docker images

### DIFF
--- a/docs/notes/2.25.x.md
+++ b/docs/notes/2.25.x.md
@@ -57,6 +57,8 @@ Previously we did ad-hoc coercion of some field values, so that, e.g., you could
 Strict adherence to the [schema of Helm OCI registry configuration](https://www.pantsbuild.org/2.25/reference/subsystems/helm#registries) is now required.
 Previously we did ad-hoc coercion of some field values, so that, e.g., you could provide a "true"/"false" string as a boolean value. Now we require actual booleans.
 
+The `helm_infer.external_docker_images` glob syntax has been generalized.  In addition to `*`, you can now use Python [fnmatch](https://docs.python.org/3/library/fnmatch.html) to construct matterns like `quay.io/*`.
+
 #### Python
 
 The AWS Lambda backend now provides built-in complete platforms for the Python 3.13 runtime.

--- a/src/python/pants/backend/helm/dependency_inference/deployment.py
+++ b/src/python/pants/backend/helm/dependency_inference/deployment.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import fnmatch
 import logging
 import re
 from dataclasses import dataclass, field
@@ -256,17 +257,10 @@ class ImageReferenceResolver:
         else:
             image_name = parsed.group("repository")
 
-        # Putting this wildcard check after parsing
-        # will mean that we don't approve things that don't look like docker images.
-        if "*" in self.helm_infer.external_docker_images:
-            return True
-        if (
-            image_name in self.helm_infer.external_docker_images
-            or image_ref in self.helm_infer.external_docker_images
-        ):
-            return True
-
-        return False
+        return any(
+            (fnmatch.fnmatch(image_name, pattern) or fnmatch.fnmatch(image_ref, pattern))
+            for pattern in self.helm_infer.external_docker_images
+        )
 
     def _handle_missing_docker_image(self, message):
         self.errors.append(message)

--- a/src/python/pants/backend/helm/dependency_inference/subsystem.py
+++ b/src/python/pants/backend/helm/dependency_inference/subsystem.py
@@ -67,8 +67,9 @@ class HelmInferSubsystem(Subsystem):
             )
             ```
 
-            Use the value '*' to disable this check.
-            This will limit Pants's ability to warn on unknown docker images.
+            Use Python fnmatch glob syntax (ex: 'docker.io/*') to disable this
+            check for certain images or patterns.  This will limit Pants's
+            ability to warn on unknown docker images.
             """
         ),
     )


### PR DESCRIPTION
In #21076 a subsystem was introduced to provide better warnings for images that are "not found". It includes a method to either listing out known images, or using `*` as a wildcard to assume "everything else" that doesn't look like a target is an image.  This diff, generalized the `*` syntax to allow expressing something like `my.internal.registry.io/*` is the (only) source of non-target images.

ref #18346