### PR TITLE
resolve Python 3.11 importlib deprecation WARNings

### DIFF
--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -225,7 +225,9 @@ class PythonToolRequirementsBase(Subsystem, ExportableTool):
                 lock_bytes = fp.read()
         elif parts.scheme == "resource":
             # The "netloc" in our made-up "resource://" scheme is the package.
-            lock_bytes = importlib.resources.read_binary(parts.netloc, lockfile_path)
+            lock_bytes = (
+                importlib.resources.files(parts.netloc).joinpath(lockfile_path).read_bytes()
+            )
         else:
             raise ValueError(
                 f"Unsupported scheme {parts.scheme} for lockfile URL: {lockfile.url} "

--- a/src/python/pants/backend/python/util_rules/pex_requirements.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements.py
@@ -210,7 +210,7 @@ async def load_lockfile(
         _fc = FileContent(
             lockfile_path,
             # The "netloc" in our made-up "resource://" scheme is the package.
-            importlib.resources.read_binary(parts.netloc, lockfile_path),
+            importlib.resources.files(parts.netloc).joinpath(lockfile_path).read_bytes(),
         )
         lockfile_path, lock_bytes = (_fc.path, _fc.content)
         lockfile_digest = await Get(Digest, CreateDigest([_fc]))

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -780,9 +780,7 @@ async def materialize_classpath_for_tool(request: ToolClasspathRequest) -> ToolC
         assert lockfile_req is not None
         regen_command = f"`{GenerateLockfilesSubsystem.name} --resolve={lockfile_req.resolve_name}`"
         if lockfile_req.lockfile == DEFAULT_TOOL_LOCKFILE:
-            lockfile_bytes = importlib.resources.read_binary(
-                *lockfile_req.default_lockfile_resource
-            )
+            lockfile_bytes = importlib.resources.files(lockfile_req.default_lockfile_resource[0]).joinpath(lockfile_req.default_lockfile_resource[1]).read_bytes()
             resolution = CoursierResolvedLockfile.from_serialized(lockfile_bytes)
         else:
             lockfile_snapshot = await Get(Snapshot, PathGlobs([lockfile_req.lockfile]))

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -780,7 +780,11 @@ async def materialize_classpath_for_tool(request: ToolClasspathRequest) -> ToolC
         assert lockfile_req is not None
         regen_command = f"`{GenerateLockfilesSubsystem.name} --resolve={lockfile_req.resolve_name}`"
         if lockfile_req.lockfile == DEFAULT_TOOL_LOCKFILE:
-            lockfile_bytes = importlib.resources.files(lockfile_req.default_lockfile_resource[0]).joinpath(lockfile_req.default_lockfile_resource[1]).read_bytes()
+            lockfile_bytes = (
+                importlib.resources.files(lockfile_req.default_lockfile_resource[0])
+                .joinpath(lockfile_req.default_lockfile_resource[1])
+                .read_bytes()
+            )
             resolution = CoursierResolvedLockfile.from_serialized(lockfile_bytes)
         else:
             lockfile_snapshot = await Get(Snapshot, PathGlobs([lockfile_req.lockfile]))


### PR DESCRIPTION
In a model of stability, these become "un-deprecated" in 3.13, but that doens't help us now.

ref #21673