### PR TITLE
truth in advertising for all major Python versions

### DIFF
--- a/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
@@ -71,7 +71,8 @@ def run_docformatter(
 @pytest.mark.platform_specific_behavior
 @pytest.mark.parametrize(
     "major_minor_interpreter",
-    all_major_minor_python_versions(Docformatter.default_interpreter_constraints),
+    # Excluded due to https://github.com/pantsbuild/pants/issues/21718
+    all_major_minor_python_versions(["CPython>=3.8,<3.13"]),
 )
 def test_passing(rule_runner: RuleRunner, major_minor_interpreter: str) -> None:
     rule_runner.write_files({"f.py": GOOD_FILE, "BUILD": "python_sources(name='t')"})

--- a/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
@@ -71,7 +71,9 @@ def run_docformatter(
 @pytest.mark.parametrize(
     "major_minor_interpreter",
     # Excluded due to https://github.com/pantsbuild/pants/issues/21718
-    all_major_minor_python_versions(["CPython>=3.8,<3.13"]),
+    # lib2to3 is Officially Removed in 3.13, but some distributions of Python
+    # remove it earlier See for example https://github.com/PyCQA/docformatter/issues/129
+    all_major_minor_python_versions(["CPython>=3.8,<3.12"]),
 )
 def test_passing(rule_runner: RuleRunner, major_minor_interpreter: str) -> None:
     rule_runner.write_files({"f.py": GOOD_FILE, "BUILD": "python_sources(name='t')"})

--- a/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
@@ -8,7 +8,6 @@ import pytest
 from pants.backend.python import target_types_rules
 from pants.backend.python.lint.docformatter.rules import DocformatterFieldSet, DocformatterRequest
 from pants.backend.python.lint.docformatter.rules import rules as docformatter_rules
-from pants.backend.python.lint.docformatter.subsystem import Docformatter
 from pants.backend.python.lint.docformatter.subsystem import rules as docformatter_subsystem_rules
 from pants.backend.python.target_types import PythonSourcesGeneratorTarget
 from pants.core.goals.fmt import FmtResult

--- a/src/python/pants/testutil/python_interpreter_selection.py
+++ b/src/python/pants/testutil/python_interpreter_selection.py
@@ -142,7 +142,7 @@ def all_major_minor_python_versions(
     """
     versions = InterpreterConstraints(constraints).partition_into_major_minor_versions(
         # Please update this when new stable Python versions are released to CI.
-        interpreter_universe=["2.7", "3.6", "3.7", "3.8", "3.9"]
+        interpreter_universe=["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     )
     return tuple(
         pytest.param(


### PR DESCRIPTION
This updates to in-code list to match what is currently available in CI.

See #21606 for further background, context, and why there are more snakes on the CI plane.