### PR TITLE
enable C420: Unnecessary dict comprehension

### DIFF
--- a/build-support/flake8/.flake8
+++ b/build-support/flake8/.flake8
@@ -19,7 +19,7 @@ extend-ignore:
   # Unnecessary dict call - rewrite as a literal
   C408,
   # Temporarily exclude during Python upgrade
-  C420,E721
+  E721
 
 [flake8:local-plugins]
 extension =

--- a/src/python/pants/backend/debian/target_types_test.py
+++ b/src/python/pants/backend/debian/target_types_test.py
@@ -28,17 +28,17 @@ def sources_rule_runner() -> RuleRunner:
 
 def test_sources_expected_num_files(sources_rule_runner: RuleRunner) -> None:
     sources_rule_runner.write_files(
-        {
-            f: ""
-            for f in [
+        dict.fromkeys(
+            [
                 "f1.txt",
                 "f2.txt",
                 "dirA/f3.txt",
                 "dirB/f4.txt",
                 "dirC/f5.txt",
                 "dirC/f6.txt",
-            ]
-        }
+            ],
+            "",
+        )
     )
 
     def hydrate(sources_cls: Type[DebianSources], sources: Iterable[str]) -> HydratedSources:

--- a/src/python/pants/backend/nfpm/dependency_inference_test.py
+++ b/src/python/pants/backend/nfpm/dependency_inference_test.py
@@ -94,7 +94,7 @@ def test_infer_nfpm_package_scripts_dependencies(
                 )
                 """
             ),
-            **{path: "" for path in scripts_paths},
+            **dict.fromkeys(scripts_paths, ""),
         }
     )
 

--- a/src/python/pants/backend/nfpm/rules_integration_test.py
+++ b/src/python/pants/backend/nfpm/rules_integration_test.py
@@ -269,7 +269,7 @@ def test_generate_package_with_contents(
                     )
                 """
             ),
-            **{path: "" for path in scripts.values()},
+            **dict.fromkeys(scripts.values(), ""),
             "contents/BUILD": dedent(
                 f"""
                 file(

--- a/src/python/pants/backend/nfpm/util_rules/generate_config_test.py
+++ b/src/python/pants/backend/nfpm/util_rules/generate_config_test.py
@@ -396,7 +396,7 @@ def test_generate_nfpm_yaml(
     extra_metadata: dict[str, Any],
     expect_raise: ContextManager | None,
 ):
-    content_sandbox_digest = get_digest(rule_runner, {path: "" for path in content_sandbox_files})
+    content_sandbox_digest = get_digest(rule_runner, dict.fromkeys(content_sandbox_files, ""))
 
     description = f"A {packager} package"
     rule_runner.write_files(
@@ -494,16 +494,16 @@ def test_generate_nfpm_yaml(
                 )
                 """
             ),
-            **{
-                path: ""
-                for path in [
+            **dict.fromkeys(
+                [
                     "scripts/postinstall.sh",
                     "scripts/apk-postupgrade.sh",
                     "scripts/arch-postupgrade.sh",
                     "scripts/deb-config.sh",
                     "scripts/rpm-verify.sh",
-                ]
-            },
+                ],
+                "",
+            ),
         }
     )
     target = rule_runner.get_target(Address("", target_name=_PKG_NAME))

--- a/src/python/pants/backend/nfpm/util_rules/sandbox_test.py
+++ b/src/python/pants/backend/nfpm/util_rules/sandbox_test.py
@@ -497,16 +497,16 @@ def test_populate_nfpm_content_sandbox(
                 )
                 """
             ),
-            **{
-                path: ""
-                for path in [
+            **dict.fromkeys(
+                [
                     "scripts/postinstall.sh",
                     "scripts/apk-postupgrade.sh",
                     "scripts/arch-postupgrade.sh",
                     "scripts/deb-config.sh",
                     "scripts/rpm-verify.sh",
-                ]
-            },
+                ],
+                "",
+            ),
         }
     )
 

--- a/src/python/pants/backend/python/util_rules/ancestor_files_test.py
+++ b/src/python/pants/backend/python/util_rules/ancestor_files_test.py
@@ -33,7 +33,9 @@ def assert_injected(
     expected_discovered: list[str],
     ignore_empty_files: bool,
 ) -> None:
-    rule_runner.write_files({**{f: "" for f in empty_files}, **{f: "foo" for f in nonempty_files}})
+    rule_runner.write_files(
+        {**dict.fromkeys(empty_files, ""), **dict.fromkeys(nonempty_files, "foo")}
+    )
     request = AncestorFilesRequest(
         requested=("__init__.py",),
         input_files=tuple(input_files),

--- a/src/python/pants/backend/shell/lint/shfmt/subsystem.py
+++ b/src/python/pants/backend/shell/lint/shfmt/subsystem.py
@@ -61,5 +61,5 @@ class Shfmt(TemplatedExternalTool):
         candidates = (os.path.join(d, ".editorconfig") for d in ("", *dirs))
         return ConfigFilesRequest(
             discovery=self.config_discovery,
-            check_content={fp: b"[*.sh]" for fp in candidates},
+            check_content=dict.fromkeys(candidates, b"[*.sh]"),
         )

--- a/src/python/pants/backend/visibility/rule_types_test.py
+++ b/src/python/pants/backend/visibility/rule_types_test.py
@@ -867,7 +867,7 @@ def test_file_specific_rules(rule_runner: RuleRunner) -> None:
                 files(sources=["**/*.txt"])
                 """
             ),
-            **{path: "" for path in files},
+            **dict.fromkeys(files, ""),
         },
     )
 

--- a/src/python/pants/core/util_rules/source_files_test.py
+++ b/src/python/pants/core/util_rules/source_files_test.py
@@ -58,7 +58,7 @@ def mock_sources_field(
         sources.source_files if include_sources else [],
         Address(sources.source_root, target_name="lib"),
     )
-    rule_runner.write_files({fp: "" for fp in sources.full_paths})
+    rule_runner.write_files(dict.fromkeys(sources.full_paths, ""))
     return sources_field
 
 

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -1772,7 +1772,7 @@ def test_sources_output_type(sources_rule_runner: RuleRunner) -> None:
         pass
 
     addr = Address("", target_name="lib")
-    sources_rule_runner.write_files({f: "" for f in ["f1.f95"]})
+    sources_rule_runner.write_files({"f1.f95": ""})
 
     valid_sources = SourcesSubclass(["*"], addr)
     hydrated_valid_sources = sources_rule_runner.request(
@@ -1809,7 +1809,7 @@ def test_sources_output_type(sources_rule_runner: RuleRunner) -> None:
 
 def test_sources_unmatched_globs(sources_rule_runner: RuleRunner) -> None:
     sources_rule_runner.set_options(["--unmatched-build-file-globs=error"])
-    sources_rule_runner.write_files({f: "" for f in ["f1.f95"]})
+    sources_rule_runner.write_files({"f1.f95": ""})
     sources = MultipleSourcesField(["non_existent.f95"], Address("", target_name="lib"))
     with engine_error(contains="non_existent.f95"):
         sources_rule_runner.request(HydratedSources, [HydrateSourcesRequest(sources)])
@@ -1878,7 +1878,7 @@ def test_sources_expected_num_files(sources_rule_runner: RuleRunner) -> None:
         # We allow for 1 or 3 files
         expected_num_files = range(1, 4, 2)
 
-    sources_rule_runner.write_files({f: "" for f in ["f1.txt", "f2.txt", "f3.txt", "f4.txt"]})
+    sources_rule_runner.write_files(dict.fromkeys(["f1.txt", "f2.txt", "f3.txt", "f4.txt"], ""))
 
     def hydrate(sources_cls: Type[MultipleSourcesField], sources: Iterable[str]) -> HydratedSources:
         return sources_rule_runner.request(

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -596,7 +596,7 @@ class RuleRunner:
 
         :API: public
         """
-        return self.make_snapshot({fp: "" for fp in files})
+        return self.make_snapshot(dict.fromkeys(files, ""))
 
     def get_target(self, address: Address) -> Target:
         """Find the target for a given address.

--- a/src/python/pants/util/ordered_set.py
+++ b/src/python/pants/util/ordered_set.py
@@ -30,7 +30,7 @@ class _AbstractOrderedSet(AbstractSet[T]):
         # in a ~20% performance increase for the constructor.
         #
         # NB: Dictionaries are ordered in Python 3.7+.
-        self._items: dict[T, None] = {v: None for v in iterable or ()}
+        self._items: dict[T, None] = dict.fromkeys(iterable) if iterable else {}
 
     def __len__(self) -> int:
         """Returns the number of unique elements in the set."""


### PR DESCRIPTION
This was disabled to minimize changes during the Python 3.11 upgrade.

See https://github.com/adamchainz/flake8-comprehensions?tab=readme-ov-file#c420-unnecessary-dict-comprehension---rewrite-using-dictfromkeys

ref #21647