### PR TITLE
bump minimum scie-pants version for Python 3.11 support

### DIFF
--- a/docs/notes/2.25.x.md
+++ b/docs/notes/2.25.x.md
@@ -33,7 +33,7 @@ The "legacy" options system is removed in this release. All options parsing is n
 
 ### Internal Python Upgrade
 
-The version of Python used by Pants itself has been updated to [3.11](https://docs.python.org/3/whatsnew/3.11.html). To support this the [Pants Launcher Binary](https://www.pantsbuild.org/blog/2023/02/23/the-pants-launcher-binary-a-much-simpler-way-to-install-and-run-pants) known as  [`scie-pants`](https://github.com/pantsbuild/scie-pants/) now has a minimum version of `0.12.0`.  To update to the latest launcher binary run:
+The version of Python used by Pants itself has been updated to [3.11](https://docs.python.org/3/whatsnew/3.11.html). To support this the [Pants Launcher Binary](https://www.pantsbuild.org/blog/2023/02/23/the-pants-launcher-binary-a-much-simpler-way-to-install-and-run-pants) known as  [`scie-pants`](https://github.com/pantsbuild/scie-pants/) now has a minimum version of `0.12.2`.  To update to the latest launcher binary run:
 
 ```
 SCIE_BOOT=update pants

--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -25,9 +25,9 @@ from pants.util.strutil import softwrap
 
 logger = logging.getLogger(__name__)
 
-# First version with Python 3.11 support:
-# https://github.com/pantsbuild/scie-pants/releases/tag/v0.12.0
-MINIMUM_SCIE_PANTS_VERSION = Version("0.12.0")
+# First version with (fully working) Python 3.11 support:
+# https://github.com/pantsbuild/scie-pants/releases/tag/v0.12.2
+MINIMUM_SCIE_PANTS_VERSION = Version("0.12.2")
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
See the saga of changes leading up to
https://github.com/pantsbuild/scie-pants/releases/tag/v0.12.2 for further context.