### PR TITLE
fix bad `__hash__` overrides and make `TargetAdaptor` and `AddressMap` immutable

### DIFF
--- a/src/python/pants/engine/collection.py
+++ b/src/python/pants/engine/collection.py
@@ -52,7 +52,8 @@ class Collection(Tuple[T, ...]):
     # Unlike in Python 2 we must explicitly implement __hash__ since we explicitly implement __eq__
     # per the Python 3 data model.
     # See: https://docs.python.org/3/reference/datamodel.html#object.__hash__
-    __hash__ = Tuple.__hash__
+    def __hash__(self):
+        return super().__hash__()
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({list(self)})"

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -588,7 +588,9 @@ async def resolve_target_for_bootstrapping(
         ),
     )
     target_adaptor = adaptor_and_type.adaptor
+    assert isinstance(target_adaptor, TargetAdaptor)
     target_type = adaptor_and_type.target_type
+    assert issubclass(target_type, Target)
     target = target_type(
         target_adaptor.kwargs,
         request.address,

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -1586,8 +1586,8 @@ def test_parametrize_16190(generated_targets_rule_runner: RuleRunner) -> None:
 @pytest.mark.parametrize(
     "field_content",
     [
-        "tagz=['tag']",
-        "tagz=parametrize(['tag1'], ['tag2'])",
+        "tagz=('tag',)",
+        "tagz=parametrize('tag1', 'tag2')",
     ],
 )
 def test_parametrize_16910(generated_targets_rule_runner: RuleRunner, field_content: str) -> None:

--- a/src/python/pants/engine/internals/mapper.py
+++ b/src/python/pants/engine/internals/mapper.py
@@ -42,7 +42,9 @@ class AddressMap:
 
     def __init__(self, path: str, name_to_target_adaptor: Mapping[str, TargetAdaptor]) -> None:
         object.__setattr__(self, "path", path)
-        object.__setattr__(self, "name_to_target_adaptor", FrozenDict(name_to_target_adaptor))
+        object.__setattr__(
+            self, "name_to_target_adaptor", FrozenDict.deep_freeze(name_to_target_adaptor)
+        )
 
 
 @dataclass

--- a/src/python/pants/engine/internals/mapper_test.py
+++ b/src/python/pants/engine/internals/mapper_test.py
@@ -20,6 +20,7 @@ from pants.engine.internals.mapper import (
     AddressMap,
     DifferingFamiliesError,
     DuplicateNameError,
+    MutableAddressMap,
     SpecsFilter,
 )
 from pants.engine.internals.parser import BuildFilePreludeSymbols, Parser, _UnrecognizedSymbol
@@ -41,7 +42,7 @@ def parse_address_map(build_file: str, *, ignore_unrecognized_symbols: bool = Fa
         object_aliases=BuildFileAliases(),
         ignore_unrecognized_symbols=ignore_unrecognized_symbols,
     )
-    address_map = AddressMap.parse(
+    address_map = MutableAddressMap.parse(
         path,
         build_file,
         parser,
@@ -53,7 +54,7 @@ def parse_address_map(build_file: str, *, ignore_unrecognized_symbols: bool = Fa
         ),
         dependents_rules=None,
         dependencies_rules=None,
-    )
+    ).freeze()
     assert path == address_map.path
     return address_map
 

--- a/src/python/pants/engine/internals/parametrize.py
+++ b/src/python/pants/engine/internals/parametrize.py
@@ -56,7 +56,15 @@ class Parametrize:
     merge_behaviour: _MergeBehaviour = dataclasses.field(compare=False)
 
     def __init__(self, *args: str, **kwargs: Any) -> None:
-        object.__setattr__(self, "args", args)
+        for arg in args:
+            if not isinstance(arg, str):
+                raise TypeError(
+                    f"In {self}:\n  Positional arguments must be strings, but "
+                    f"`{arg!r}` was a `{type(arg).__name__}`.\n\n"
+                    + _named_args_explanation(f"{arg!r}")
+                )
+
+        object.__setattr__(self, "args", tuple(args))
         object.__setattr__(self, "kwargs", FrozenDict.deep_freeze(kwargs))
         object.__setattr__(self, "is_group", False)
         object.__setattr__(self, "merge_behaviour", Parametrize._MergeBehaviour.never)
@@ -71,10 +79,12 @@ class Parametrize:
             raise KeyError(key)
 
     def to_group(self) -> Self:
+        # TODO: This should use `dataclasses.replace` so class remains immutable!
         object.__setattr__(self, "is_group", True)
         return self
 
     def to_weak(self) -> Self:
+        # TODO: This should use `dataclasses.replace` so class remains immutable!
         object.__setattr__(self, "merge_behaviour", Parametrize._MergeBehaviour.replace)
         return self
 

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -936,7 +936,8 @@ class CoarsenedTargets(Collection[CoarsenedTarget]):
             l._eq_helper(r, equal_items) for l, r in zip(self, other)
         )
 
-    __hash__ = Tuple.__hash__
+    def __hash__(self):
+        return super().__hash__()
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
As described in https://github.com/pantsbuild/pants/issues/18250, `Collection` (among other use cases) was incorrectly setting `__hash__` to `Tuple.__hash__` instead of explicitly defining `__hash__` and calling to `super().__hash__`. This incorrect logic allowed the `AddressMap` and `TargetAdaptor` code to be mutable even though the rest of Pants expects immutability.

This seems to have been introduced by the synthetic targets code which modifies `AddressMap` and `TargetAdaptor` in place while resolving synthetic targets.

The fix:

1. Make `TargetAdaptor` and `AddressMap` (and the synthetic target variants) immutable. Introduce `Mutable*` companion classes which are mutable and can be frozen into the immutable version via a `.freeze()` method. The immutable versions can be unfrozen via `.unfreeze()` if there is a need to modify.
2. Fix `Collection`'s `__hash__` method to use the correct logic.
