### PR TITLE
Fix bad `__hash__` implementations.

### DIFF
--- a/docs/notes/2.24.x.md
+++ b/docs/notes/2.24.x.md
@@ -17,17 +17,13 @@ Thank you to [Klayvio](https://www.klaviyo.com/) and [Normal Computing](https://
 - A new experimental Python Provider backend using [Python Build Standalone](https://gregoryszorc.com/docs/python-build-standalone/main/).
 - A new options system unlocks future changes.
 
-
 ### Deprecations
 
 - **Python 2.7**: As announced in the v2.23.x release series, Pants v2.24 and later are not proactively tested in CI with Python 2.7 since [Python 2.7 is no longer supported by its maintainers as of 1 January 2020](https://www.python.org/doc/sunset-python-2/). While Pants may continue to work with Python 2.7 in the near term, Pants no longer officially supports use of Python 2.7, and, consequently, any remaining support for Python 2.7 may "bit rot" and diverge over time. Contributions to fix issues with Python 2.7 support will continue to be accepted, but will depend on any community contributions and will not constitute continued official support for Python 2.7.
 - **macOS versions**: Pants v2.24 is the last version that will support macOS 12, as macOS 12 is reaching the end of Apple's support. Future versions of Pants will require macOS 14 or newer (on arm64), and macOS 13 or newer (on x86-64). In addition, as announced in the v2.23.x release series, Pants v2.24 is built on macOS 12 and so may not work on versions of macOS 10.15 and 11 (which Apple no longer supports).
 - **Pants runner**: Pants v2.24 is the last version that supports versions of the `pants` launcher binary older than 0.12.2. Pants v2.25 and newer will require 0.12.2. [Follow the upgrade instructions](https://www.pantsbuild.org/2.24/docs/getting-started/installing-pants#upgrading-pants).
 
-
 ### General
-
-Fixed a longstanding bug in the processing of [synthetic targets](https://www.pantsbuild.org/2.24/docs/writing-plugins/the-target-api/concepts#synthetic-targets-api). This fix has the side-effect of requiring immutability and hashability of scalar values in BUILD files, which was always assumed but not enforced. This may cause BUILD file parsing errors, if you have custom field types involving custom mutable data structures. See ([#21725](https://github.com/pantsbuild/pants/pull/21725)) for more.
 
 Fixed bug where `pants peek --include-additional-info` was not actually displaying the additional info ([#21399](https://github.com/pantsbuild/pants/pull/21399)).
 

--- a/docs/notes/2.24.x.md
+++ b/docs/notes/2.24.x.md
@@ -24,6 +24,8 @@ We offer [formal sponsorship tiers for companies](https://www.pantsbuild.org/spo
 
 ### General
 
+Fixed a longstanding bug in the processing of [synthetic targets](https://www.pantsbuild.org/2.24/docs/writing-plugins/the-target-api/concepts#synthetic-targets-api). This fix has the side-effect of requiring immutability and hashability of scalar values in BUILD files, which was always assumed but not enforced. This may cause BUILD file parsing errors, if you have custom field types involving custom mutable data structures. See ([#21725](https://github.com/pantsbuild/pants/pull/21725)) for more.
+
 Fixed bug where `pants peek --include-additional-info` was not actually displaying the additional info ([#21399](https://github.com/pantsbuild/pants/pull/21399)).
 
 Fixed a BSP server bug where multiple concurrent writes of the same workspace files would contend and cause filesystem errors ([#21698](https://github.com/pantsbuild/pants/pull/21698)).

--- a/docs/notes/2.25.x.md
+++ b/docs/notes/2.25.x.md
@@ -18,6 +18,7 @@ Thank you to [Klayvio](https://www.klaviyo.com/) and [Normal Computing](https://
 
 ### General
 
+- Fixed a longstanding bug in the processing of [synthetic targets](https://www.pantsbuild.org/2.24/docs/writing-plugins/the-target-api/concepts#synthetic-targets-api). This fix has the side-effect of requiring immutability and hashability of scalar values in BUILD files, which was always assumed but not enforced. This may cause BUILD file parsing errors, if you have custom field types involving custom mutable data structures. See ([#21725](https://github.com/pantsbuild/pants/pull/21725)) for more.
 - [Fixed](https://github.com/pantsbuild/pants/pull/21665) bug where `pants --export-resolve=<resolve> --export-py-generated-sources-in-resolve=<resolve>` fails (see [#21659](https://github.com/pantsbuild/pants/issues/21659) for more info).
 - [Fixed](https://github.com/pantsbuild/pants/pull/21694) bug where an `archive` target is unable to produce a ZIP file with no extension (see [#21693](https://github.com/pantsbuild/pants/issues/21693) for more info).
 
@@ -31,17 +32,13 @@ one in `remote_store_headers` or `remote_execution_headers`.
 
 The "legacy" options system is removed in this release. All options parsing is now handled by the new, native parser.
 
-
 ### Internal Python Upgrade
 
-The version of Python used by Pants itself has been updated to [3.11](https://docs.python.org/3/whatsnew/3.11.html). To support this the [Pants Launcher Binary](https://www.pantsbuild.org/blog/2023/02/23/the-pants-launcher-binary-a-much-simpler-way-to-install-and-run-pants) known as  [`scie-pants`](https://github.com/pantsbuild/scie-pants/) now has a minimum version of `0.12.2`.  To update to the latest launcher binary, either :
-
+The version of Python used by Pants itself has been updated to [3.11](https://docs.python.org/3/whatsnew/3.11.html). To support this the [Pants Launcher Binary](https://www.pantsbuild.org/blog/2023/02/23/the-pants-launcher-binary-a-much-simpler-way-to-install-and-run-pants) known as  [`scie-pants`](https://github.com/pantsbuild/scie-pants/) now has a minimum version of `0.12.2`.  To update to the latest launcher binary, either:
 - Use the package manager you used to install Pants. For example, with Homebrew: `brew update && brew upgrade pantsbuild/tap/pants`.
 - Use its built-in self-update functionality: `SCIE_BOOT=update pants`.
 
 That Pants itself happens to be partially writtin in Python has no bearing on the versions of Python that Pants can use to test and build your code.
-
-
 
 ### Goals
 

--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -343,7 +343,7 @@ async def python_lockfile_synthetic_targets(
                     TargetAdaptor(
                         "_lockfiles",
                         name=synthetic_lockfile_target_name(name),
-                        sources=[lockfile],
+                        sources=(lockfile,),
                         __description_of_origin__=f"the [python].resolves option {name!r}",
                     )
                     for _, lockfile, name in lockfiles

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -206,7 +206,7 @@ class MockTestRequest(TestRequest):
 
     @classmethod
     def test_result(cls, field_sets: Iterable[MockTestFieldSet]) -> TestResult:
-        addresses = [field_set.address for field_set in field_sets]
+        addresses = tuple(field_set.address for field_set in field_sets)
         return make_test_result(
             addresses,
             exit_code=cls.exit_code(addresses),

--- a/src/python/pants/engine/collection.py
+++ b/src/python/pants/engine/collection.py
@@ -52,7 +52,8 @@ class Collection(Tuple[T, ...]):
     # Unlike in Python 2 we must explicitly implement __hash__ since we explicitly implement __eq__
     # per the Python 3 data model.
     # See: https://docs.python.org/3/reference/datamodel.html#object.__hash__
-    __hash__ = Tuple.__hash__
+    def __hash__(self):
+        return super().__hash__()
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({list(self)})"

--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -469,7 +469,6 @@ async def parse_address_family(
         directory.path,
         AddressFamily.create(
             spec_path=directory.path,
-            # TODO: Does the order matter here? If not we could have a single tuple.
             address_maps=address_maps,
             defaults=frozen_defaults,
             dependents_rules=frozen_dependents_rules,

--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -10,6 +10,7 @@ import logging
 import os.path
 import sys
 import typing
+from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import PurePath
 from typing import Any, Sequence, cast
@@ -50,6 +51,7 @@ from pants.engine.rules import Get, MultiGet, QueryRule, collect_rules, rule
 from pants.engine.target import (
     DependenciesRuleApplication,
     DependenciesRuleApplicationRequest,
+    InvalidTargetException,
     RegisteredTargetTypes,
 )
 from pants.engine.unions import UnionMembership
@@ -358,7 +360,7 @@ async def parse_address_family(
         for fc in digest_contents
     )
 
-    address_maps = [
+    declared_address_maps = [
         AddressMap.parse(
             fc.path,
             fc.content.decode(),
@@ -387,16 +389,88 @@ async def parse_address_family(
     )
 
     # Process synthetic targets.
-    for address_map in address_maps:
-        for synthetic in synthetic_address_maps:
-            synthetic.process_declared_targets(address_map)
-            synthetic.apply_defaults(frozen_defaults)
+
+    def apply_defaults(tgt: TargetAdaptor) -> TargetAdaptor:
+        default_values = frozen_defaults.get(tgt.type_alias)
+        if default_values is None:
+            return tgt
+        return tgt.with_new_kwargs(**default_values, **tgt.kwargs)
+
+    name_to_path_and_synthetic_target: dict[str, tuple[str, TargetAdaptor]] = {}
+    for synthetic_address_map in synthetic_address_maps:
+        for name, target in synthetic_address_map.name_to_target_adaptor.items():
+            name_to_path_and_synthetic_target[name] = (
+                synthetic_address_map.path,
+                apply_defaults(target),
+            )
+
+    name_to_path_and_declared_target: dict[str, tuple[str, TargetAdaptor]] = {}
+    for declared_address_map in declared_address_maps:
+        for name, target in declared_address_map.name_to_target_adaptor.items():
+            name_to_path_and_declared_target[name] = (declared_address_map.path, target)
+
+    # We listify the items() so we can modify name_to_path_and_declared_target in the loop.
+    for name, (declared_target_path, declared_target) in list(
+        name_to_path_and_declared_target.items()
+    ):
+        extend_synthetic = declared_target.kwargs.get("_extend_synthetic", False)
+        if extend_synthetic:
+            # Pop synthetic target to let the declared target take precedence.
+            synthetic_target_path, synthetic_target = name_to_path_and_synthetic_target.pop(
+                name, (None, None)
+            )
+            if synthetic_target is None:
+                raise InvalidTargetException(
+                    softwrap(
+                        f"""
+                            The `{declared_target.type_alias}` target {name!r} in {declared_target_path} has
+                            `_extend_synthetic=True` but there is no synthetic target to extend.
+                            """
+                    )
+                )
+
+            if synthetic_target.type_alias != declared_target.type_alias:
+                raise InvalidTargetException(
+                    softwrap(
+                        f"""
+                        The `{declared_target.type_alias}` target {name!r} in {declared_target_path} is
+                        of a different type than the synthetic target
+                        `{synthetic_target.type_alias}` from {synthetic_target_path}.
+
+                        When `_extend_synthetic` is true the target types must match, set this to
+                        false if you want to replace the synthetic target with the target from your
+                        BUILD file.
+                        """
+                    )
+                )
+
+            # Preserve synthetic field values not overriden by the declared target from the BUILD.
+            kwargs = dict(synthetic_target.kwargs)
+            kwargs.update(declared_target.kwargs)
+            name_to_path_and_declared_target[name] = (
+                declared_target_path,
+                declared_target.with_new_kwargs(**kwargs),
+            )
+
+    # Now reconstitute into AddressMaps, to pass into AddressFamily.create().
+    # We no longer need to distinguish between synthetic and declared AddressMaps.
+    # TODO: We might want to move the validation done by AddressFamily.create() to here, since
+    #  we're already iterating over the AddressMap data, and simplify AddressFamily.
+    path_to_targets = defaultdict(list)
+    for name_to_path_and_target in [
+        name_to_path_and_declared_target,
+        name_to_path_and_synthetic_target,
+    ]:
+        for path_and_target in name_to_path_and_target.values():
+            path_to_targets[path_and_target[0]].append(path_and_target[1])
+    address_maps = [AddressMap.create(path, targets) for path, targets in path_to_targets.items()]
 
     return OptionalAddressFamily(
         directory.path,
         AddressFamily.create(
             spec_path=directory.path,
-            address_maps=(*address_maps, *synthetic_address_maps),
+            # TODO: Does the order matter here? If not we could have a single tuple.
+            address_maps=address_maps,
             defaults=frozen_defaults,
             dependents_rules=frozen_dependents_rules,
             dependencies_rules=frozen_dependencies_rules,

--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -409,10 +409,11 @@ async def parse_address_family(
         for name, target in declared_address_map.name_to_target_adaptor.items():
             name_to_path_and_declared_target[name] = (declared_address_map.path, target)
 
-    # We listify the items() so we can modify name_to_path_and_declared_target in the loop.
-    for name, (declared_target_path, declared_target) in list(
-        name_to_path_and_declared_target.items()
-    ):
+    # We copy the dict so we can modify the original in the loop.
+    for name, (
+        declared_target_path,
+        declared_target,
+    ) in name_to_path_and_declared_target.copy().items():
         extend_synthetic = declared_target.kwargs.get("_extend_synthetic", False)
         if extend_synthetic:
             # Pop synthetic target to let the declared target take precedence.

--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -418,14 +418,13 @@ async def parse_address_family(
         synthetic_target_path, synthetic_target = name_to_path_and_synthetic_target.pop(
             name, (None, None)
         )
-        extend_synthetic = declared_target.kwargs.get("_extend_synthetic")
-        if extend_synthetic is None:
+        if "_extend_synthetic" not in declared_target.kwargs:
             # The explicitly declared target should replace the synthetic one.
             continue
 
         # The _extend_synthetic kwarg was explicitly provided, so we must strip it.
         declared_target_kwargs = dict(declared_target.kwargs)
-        declared_target_kwargs.pop("_extend_synthetic")
+        extend_synthetic = declared_target_kwargs.pop("_extend_synthetic")
         if extend_synthetic:
             if synthetic_target is None:
                 raise InvalidTargetException(
@@ -453,10 +452,9 @@ async def parse_address_family(
                 )
 
             # Preserve synthetic field values not overriden by the declared target from the BUILD.
-            kwargs = dict(synthetic_target.kwargs)
+            kwargs = {**synthetic_target.kwargs, **declared_target_kwargs}
         else:
-            kwargs = {}
-        kwargs.update(declared_target_kwargs)
+            kwargs = declared_target_kwargs
         name_to_path_and_declared_target[name] = (
             declared_target_path,
             declared_target.with_new_kwargs(**kwargs),

--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -414,7 +414,8 @@ async def parse_address_family(
         declared_target_path,
         declared_target,
     ) in name_to_path_and_declared_target.copy().items():
-        extend_synthetic = declared_target.kwargs.get("_extend_synthetic", False)
+        declared_target_kwargs = dict(declared_target.kwargs)
+        extend_synthetic = declared_target_kwargs.pop("_extend_synthetic", False)
         if extend_synthetic:
             # Pop synthetic target to let the declared target take precedence.
             synthetic_target_path, synthetic_target = name_to_path_and_synthetic_target.pop(
@@ -447,11 +448,13 @@ async def parse_address_family(
 
             # Preserve synthetic field values not overriden by the declared target from the BUILD.
             kwargs = dict(synthetic_target.kwargs)
-            kwargs.update(declared_target.kwargs)
-            name_to_path_and_declared_target[name] = (
-                declared_target_path,
-                declared_target.with_new_kwargs(**kwargs),
-            )
+        else:
+            kwargs = {}
+        kwargs.update(declared_target_kwargs)
+        name_to_path_and_declared_target[name] = (
+            declared_target_path,
+            declared_target.with_new_kwargs(**kwargs),
+        )
 
     # Now reconstitute into AddressMaps, to pass into AddressFamily.create().
     # We no longer need to distinguish between synthetic and declared AddressMaps.

--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -140,8 +140,9 @@ def test_extend_synthetic_target() -> None:
                 input_types=(PathGlobs,),
                 mock=lambda _: DigestContents(
                     [
-                        FileContent(path="/foo/BUILD.1",
-                                    content=b"resource(name='aaa', some_arg='a')"),
+                        FileContent(
+                            path="/foo/BUILD.1", content=b"resource(name='aaa', some_arg='a')"
+                        ),
                         FileContent(
                             path="/foo/BUILD.2",
                             content=b"resource(name='bar', some_arg='b', _extend_synthetic=True)",

--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -12,7 +12,7 @@ import pytest
 
 from pants.build_graph.address import BuildFileAddressRequest, MaybeAddress, ResolveError
 from pants.build_graph.build_file_aliases import BuildFileAliases
-from pants.core.target_types import GenericTarget
+from pants.core.target_types import GenericTarget, ResourceTarget
 from pants.engine.addresses import Address, AddressInput, BuildFileAddress
 from pants.engine.env_vars import CompleteEnvironmentVars, EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import DigestContents, FileContent, PathGlobs
@@ -33,6 +33,7 @@ from pants.engine.internals.parser import BuildFilePreludeSymbols, BuildFileSymb
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.internals.session import SessionValues
 from pants.engine.internals.synthetic_targets import (
+    SyntheticAddressMap,
     SyntheticAddressMaps,
     SyntheticAddressMapsRequest,
 )
@@ -111,6 +112,96 @@ def test_parse_address_family_empty() -> None:
     af = optional_af.address_family
     assert af.namespace == "/dev/null"
     assert len(af.name_to_target_adaptors) == 0
+
+
+def test_extend_synthetic_target() -> None:
+    optional_af = run_rule_with_mocks(
+        parse_address_family,
+        rule_args=[
+            Parser(
+                build_root="",
+                registered_target_types=RegisteredTargetTypes({"resource": ResourceTarget}),
+                union_membership=UnionMembership({}),
+                object_aliases=BuildFileAliases(),
+                ignore_unrecognized_symbols=False,
+            ),
+            BootstrapStatus(in_progress=False),
+            BuildFileOptions(("BUILD",)),
+            BuildFilePreludeSymbols(FrozenDict(), ()),
+            AddressFamilyDir("/foo"),
+            RegisteredTargetTypes({}),
+            UnionMembership({}),
+            MaybeBuildFileDependencyRulesImplementation(None),
+            SessionValues({CompleteEnvironmentVars: CompleteEnvironmentVars({})}),
+        ],
+        mock_gets=[
+            MockGet(
+                output_type=DigestContents,
+                input_types=(PathGlobs,),
+                mock=lambda _: DigestContents(
+                    [
+                        FileContent(path="/foo/BUILD.1",
+                                    content=b"resource(name='aaa', some_arg='a')"),
+                        FileContent(
+                            path="/foo/BUILD.2",
+                            content=b"resource(name='bar', some_arg='b', _extend_synthetic=True)",
+                        ),
+                    ]
+                ),
+            ),
+            MockGet(
+                output_type=OptionalAddressFamily,
+                input_types=(AddressFamilyDir,),
+                mock=lambda _: OptionalAddressFamily("/foo"),
+            ),
+            MockGet(
+                output_type=SyntheticAddressMaps,
+                input_types=(SyntheticAddressMapsRequest,),
+                mock=lambda _: SyntheticAddressMaps(
+                    [
+                        SyntheticAddressMap.create(
+                            "/foo/synthetic1",
+                            [
+                                TargetAdaptor("resource", "xxx", "", some_arg="x"),
+                            ],
+                        ),
+                        SyntheticAddressMap.create(
+                            "/foo/synthetic2",
+                            [
+                                TargetAdaptor("resource", "yyy", ""),
+                                TargetAdaptor("resource", "bar", "", extend=42),
+                            ],
+                        ),
+                    ]
+                ),
+            ),
+            MockGet(
+                output_type=EnvironmentVars,
+                input_types=(EnvironmentVarsRequest, CompleteEnvironmentVars),
+                mock=lambda _1, _2: EnvironmentVars({}),
+            ),
+        ],
+    )
+    assert optional_af.path == "/foo"
+    assert optional_af.address_family is not None
+    af = optional_af.address_family
+    assert af.namespace == "/foo"
+
+    path, tgt = af.name_to_target_adaptors["aaa"]
+    assert path == "/foo/BUILD.1"
+    assert tgt.kwargs == FrozenDict({"some_arg": "a"})
+
+    path, tgt = af.name_to_target_adaptors["xxx"]
+    assert path == "/foo/synthetic1"
+    assert tgt.kwargs == FrozenDict({"some_arg": "x"})
+
+    path, tgt = af.name_to_target_adaptors["yyy"]
+    assert path == "/foo/synthetic2"
+    assert tgt.kwargs == FrozenDict({})
+
+    path, tgt = af.name_to_target_adaptors["bar"]
+    assert path == "/foo/BUILD.2"
+    assert tgt.kwargs == FrozenDict({"some_arg": "b", "extend": 42})
 
 
 def run_prelude_parsing_rule(prelude_content: str) -> BuildFilePreludeSymbols:

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -1586,8 +1586,12 @@ def test_parametrize_16190(generated_targets_rule_runner: RuleRunner) -> None:
 @pytest.mark.parametrize(
     "field_content",
     [
-        "tagz=['tag']",
-        "tagz=parametrize(['tag1'], ['tag2'])",
+        "tagz=('tag',)",
+        # TODO: The documentation of `parametrize()`, and the type annotations in its
+        #  implementation in parametrize.py, imply that a positional arg must be
+        #  a string, and other arg types should be applied as kwargs, so it's unclear
+        #  why we expect this to work, and should revisit.
+        "tagz=parametrize(('tag1',), ('tag2',))",
     ],
 )
 def test_parametrize_16910(generated_targets_rule_runner: RuleRunner, field_content: str) -> None:

--- a/src/python/pants/engine/internals/mapper.py
+++ b/src/python/pants/engine/internals/mapper.py
@@ -22,6 +22,7 @@ from pants.engine.internals.parser import BuildFilePreludeSymbols, Parser
 from pants.engine.internals.target_adaptor import TargetAdaptor
 from pants.engine.target import RegisteredTargetTypes, Tags, Target
 from pants.util.filtering import TargetFilter, and_filters, create_filters
+from pants.util.frozendict import FrozenDict
 from pants.util.memo import memoized_property
 
 
@@ -37,7 +38,7 @@ class AddressMap:
     """Maps target adaptors from a byte source."""
 
     path: str
-    name_to_target_adaptor: dict[str, TargetAdaptor]
+    name_to_target_adaptor: FrozenDict[str, TargetAdaptor]
 
     @classmethod
     def parse(
@@ -87,7 +88,7 @@ class AddressMap:
                     "cannot use the same name."
                 )
             name_to_target_adaptors[name] = target_adaptor
-        return cls(filepath, dict(sorted(name_to_target_adaptors.items())))
+        return cls(filepath, FrozenDict(sorted(name_to_target_adaptors.items())))
 
 
 class DifferingFamiliesError(MappingError):

--- a/src/python/pants/engine/internals/mapper_test.py
+++ b/src/python/pants/engine/internals/mapper_test.py
@@ -115,12 +115,12 @@ def test_address_family_create_single() -> None:
     address_family = AddressFamily.create(
         "",
         [
-            AddressMap(
+            AddressMap.create(
                 "0",
-                {
-                    "one": TargetAdaptor(type_alias="thing", name="one", age=42),
-                    "two": TargetAdaptor(type_alias="thing", name="two", age=37),
-                },
+                [
+                    TargetAdaptor(type_alias="thing", name="one", age=42),
+                    TargetAdaptor(type_alias="thing", name="two", age=37),
+                ],
             )
         ],
     )
@@ -135,11 +135,11 @@ def test_address_family_create_multiple() -> None:
     address_family = AddressFamily.create(
         "name/space",
         [
-            AddressMap(
-                "name/space/0", {"one": TargetAdaptor(type_alias="thing", name="one", age=42)}
+            AddressMap.create(
+                "name/space/0", [TargetAdaptor(type_alias="thing", name="one", age=42)]
             ),
-            AddressMap(
-                "name/space/1", {"two": TargetAdaptor(type_alias="thing", name="two", age=37)}
+            AddressMap.create(
+                "name/space/1", [TargetAdaptor(type_alias="thing", name="two", age=37)]
             ),
         ],
     )
@@ -165,7 +165,8 @@ def test_address_family_create_empty() -> None:
 def test_address_family_mismatching_paths() -> None:
     with pytest.raises(DifferingFamiliesError):
         AddressFamily.create(
-            "one", [AddressMap("/dev/null/one/0", {}), AddressMap("/dev/null/two/0", {})]
+            "one",
+            [AddressMap.create("/dev/null/one/0", []), AddressMap.create("/dev/null/two/0", [])],
         )
 
 
@@ -174,11 +175,11 @@ def test_address_family_duplicate_names() -> None:
         AddressFamily.create(
             "name/space",
             [
-                AddressMap(
-                    "name/space/0", {"one": TargetAdaptor(type_alias="thing", name="one", age=42)}
+                AddressMap.create(
+                    "name/space/0", [TargetAdaptor(type_alias="thing", name="one", age=42)]
                 ),
-                AddressMap(
-                    "name/space/1", {"one": TargetAdaptor(type_alias="thing", name="one", age=37)}
+                AddressMap.create(
+                    "name/space/1", [TargetAdaptor(type_alias="thing", name="one", age=37)]
                 ),
             ],
         )

--- a/src/python/pants/engine/internals/parametrize.py
+++ b/src/python/pants/engine/internals/parametrize.py
@@ -56,7 +56,7 @@ class Parametrize:
     merge_behaviour: _MergeBehaviour = dataclasses.field(compare=False)
 
     def __init__(self, *args: str, **kwargs: Any) -> None:
-        object.__setattr__(self, "args", args)
+        object.__setattr__(self, "args", tuple(args))
         object.__setattr__(self, "kwargs", FrozenDict.deep_freeze(kwargs))
         object.__setattr__(self, "is_group", False)
         object.__setattr__(self, "merge_behaviour", Parametrize._MergeBehaviour.never)

--- a/src/python/pants/engine/internals/synthetic_targets.py
+++ b/src/python/pants/engine/internals/synthetic_targets.py
@@ -80,14 +80,11 @@ from typing import ClassVar, Iterable, Iterator, Sequence
 
 from pants.base.specs import GlobSpecsProtocol
 from pants.engine.collection import Collection
-from pants.engine.internals.defaults import BuildFileDefaults
 from pants.engine.internals.mapper import AddressMap
 from pants.engine.internals.target_adaptor import TargetAdaptor
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import InvalidTargetException
 from pants.engine.unions import UnionMembership, UnionRule, union
 from pants.util.frozendict import FrozenDict
-from pants.util.strutil import softwrap
 
 
 @dataclass(frozen=True)
@@ -152,54 +149,7 @@ class SyntheticTargetsRequest:
 
 
 class SyntheticAddressMap(AddressMap):
-    def process_declared_targets(self, address_map: AddressMap) -> None:
-        for name, target_adaptor in address_map.name_to_target_adaptor.items():
-            extend_synthetic = target_adaptor.kwargs.pop("_extend_synthetic", False)
-            if name not in self.name_to_target_adaptor:
-                if extend_synthetic:
-                    raise InvalidTargetException(
-                        softwrap(
-                            f"""
-                            The `{target_adaptor.type_alias}` target {name!r} in {address_map.path}
-                            has `_extend_synthetic=True` but there is no synthetic target to extend.
-                            """
-                        )
-                    )
-                continue
-
-            # Pop synthetic target to let the explicit target declared in BUILD file take
-            # precedence.
-            synthetic_target_adaptor = self.name_to_target_adaptor.pop(name)
-
-            if not extend_synthetic:
-                # The explicitly declared target should replace the synthetic one.
-                continue
-
-            # Check target type matches, when marked as extending the synthetic target.
-            if synthetic_target_adaptor.type_alias != target_adaptor.type_alias:
-                raise InvalidTargetException(
-                    softwrap(
-                        f"""
-                        The `{target_adaptor.type_alias}` target {name!r} in {address_map.path} is
-                        of a different type than the synthetic target
-                        `{synthetic_target_adaptor.type_alias}` from {self.path}.
-
-                        When `_extend_synthetic` is true the target types must match, set this to
-                        false if you want to replace the synthetic target with the target from your
-                        BUILD file.
-                        """
-                    )
-                )
-
-            # Preserve synthetic field values not overriden by the declared target from the BUILD.
-            synthetic_target_adaptor.kwargs.update(target_adaptor.kwargs)
-            target_adaptor.kwargs = synthetic_target_adaptor.kwargs
-
-    def apply_defaults(self, defaults: BuildFileDefaults) -> None:
-        for target_adaptor in self.name_to_target_adaptor.values():
-            default_values = defaults.get(target_adaptor.type_alias)
-            if default_values is not None:
-                target_adaptor.kwargs = {**default_values, **target_adaptor.kwargs}
+    ...
 
 
 @dataclass(frozen=True)
@@ -219,10 +169,8 @@ class SyntheticAddressMaps(Collection[SyntheticAddressMap]):
         synthetic_target_adaptors: Iterable[tuple[str, Iterable[TargetAdaptor]]],
     ) -> SyntheticAddressMaps:
         return cls(
-            [
-                SyntheticAddressMap.create(os.path.join(request.path, filename), target_adaptors)
-                for filename, target_adaptors in synthetic_target_adaptors
-            ]
+            SyntheticAddressMap.create(os.path.join(request.path, filename), target_adaptors)
+            for filename, target_adaptors in synthetic_target_adaptors
         )
 
 

--- a/src/python/pants/engine/internals/synthetic_targets.py
+++ b/src/python/pants/engine/internals/synthetic_targets.py
@@ -149,7 +149,7 @@ class SyntheticTargetsRequest:
 
 
 class SyntheticAddressMap(AddressMap):
-    ...
+    pass
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/engine/internals/target_adaptor.py
+++ b/src/python/pants/engine/internals/target_adaptor.py
@@ -104,9 +104,18 @@ class TargetAdaptor:
     ) -> None:
         self.type_alias = type_alias
         self.name = name
-        self.kwargs = kwargs
+        self.kwargs = FrozenDict.deep_freeze(kwargs)
         self.description_of_origin = __description_of_origin__
         self.origin_sources_blocks = __origin_sources_blocks__
+
+    def with_new_kwargs(self, **kwargs) -> TargetAdaptor:
+        return TargetAdaptor(
+            type_alias=self.type_alias,
+            name=self.name,
+            kwargs=kwargs,
+            __description_of_origin__=self.description_of_origin,
+            __origin_sources_blocks__=self.origin_sources_blocks,
+        )
 
     def __repr__(self) -> str:
         maybe_blocks = f", {self.origin_sources_blocks}" if self.origin_sources_blocks else ""
@@ -120,6 +129,9 @@ class TargetAdaptor:
             and self.name == other.name
             and self.kwargs == other.kwargs
         )
+
+    def __hash__(self) -> int:
+        return hash((self.type_alias, self.name, self.kwargs))
 
     @property
     def name_explicitly_set(self) -> bool:

--- a/src/python/pants/engine/internals/target_adaptor.py
+++ b/src/python/pants/engine/internals/target_adaptor.py
@@ -112,9 +112,9 @@ class TargetAdaptor:
         return TargetAdaptor(
             type_alias=self.type_alias,
             name=self.name,
-            kwargs=kwargs,
             __description_of_origin__=self.description_of_origin,
             __origin_sources_blocks__=self.origin_sources_blocks,
+            **kwargs,
         )
 
     def __repr__(self) -> str:

--- a/src/python/pants/engine/internals/target_adaptor.py
+++ b/src/python/pants/engine/internals/target_adaptor.py
@@ -104,7 +104,12 @@ class TargetAdaptor:
     ) -> None:
         self.type_alias = type_alias
         self.name = name
-        self.kwargs = FrozenDict.deep_freeze(kwargs)
+        try:
+            self.kwargs = FrozenDict.deep_freeze(kwargs)
+        except TypeError as e:
+            # FrozenDict's ctor eagerly computes its hash. If some kwarg is unhashable it will
+            # raise a TypeError, which we enhance with the description of origin.
+            raise TypeError(f"In {__description_of_origin__}: {e}")
         self.description_of_origin = __description_of_origin__
         self.origin_sources_blocks = __origin_sources_blocks__
 

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -2062,8 +2062,8 @@ class ListOfDictStringToStringField(Field):
         )
 
         # Also support passing in a single dictionary by wrapping it
-        if not isinstance(value_or_default, list):
-            value_or_default = [value_or_default]
+        if not isinstance(value_or_default, tuple):
+            value_or_default = tuple(value_or_default)
 
         result_lst: list[FrozenDict[str, str]] = []
         for item in value_or_default:

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -2062,8 +2062,8 @@ class ListOfDictStringToStringField(Field):
         )
 
         # Also support passing in a single dictionary by wrapping it
-        if not isinstance(value_or_default, tuple):
-            value_or_default = tuple(value_or_default)
+        if not isinstance(value_or_default, (list, tuple)):
+            value_or_default = [value_or_default]
 
         result_lst: list[FrozenDict[str, str]] = []
         for item in value_or_default:

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -936,7 +936,8 @@ class CoarsenedTargets(Collection[CoarsenedTarget]):
             l._eq_helper(r, equal_items) for l, r in zip(self, other)
         )
 
-    __hash__ = Tuple.__hash__
+    def __hash__(self):
+        return super().__hash__()
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
This required making AddressMap and TargetAdaptor immutable.
This in turn required inlining the logic of the `process_declared_targets()` 
and`apply_defaults()` methods on SyntheticAddressMap to their
only callsite in build_files.py, where we have all necessary data
to perform the mutations in a straightforward way.

Note that while `SyntheticAddressMaps` is part of the Plugin API,
those mutating methods are not documented or intended to be
used by any caller except build_files.py (and indeed using them
in a plugin would likely break things, which is why they are now 
removed). 

Fixes https://github.com/pantsbuild/pants/issues/18250
