### PR TITLE
Enable proto3 optional to enable engine builds for Ubuntu 22.04

### DIFF
--- a/src/rust/engine/protos/build.rs
+++ b/src/rust/engine/protos/build.rs
@@ -14,6 +14,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     ]);
 
     tonic_build::configure()
+    .protoc_arg("--experimental_allow_proto3_optional")
     .build_client(true)
     .build_server(true)
     .compile_protos_with_config(


### PR DESCRIPTION
Enabled as a default for protoc 3.15, but current apt package dist for ubuntu 22.04 LTS (my system) is 3.12.