### PR TITLE
fix: Handle buildx output with BUILDX_NO_DEFAULT_ATTESTATIONS=1

### DIFF
--- a/docs/notes/2.22.x.md
+++ b/docs/notes/2.22.x.md
@@ -135,6 +135,10 @@ The default version of `semgrep` used by the `pants.backends.experimental.tool.s
 
 Setting [the `orphan_files_behaviour = "ignore"` option](https://www.pantsbuild.org/2.22/reference/subsystems/yamllint#orphan_files_behavior) the `pants.backend.experimental.tools.yamllint` backend is now properly silent. It previously showed spurious warnings.
 
+#### Docker
+
+Pants now correctly extracts the image ID when passing the equivalent of `--provenance=false` to `docker buildx`.
+
 ### Plugin API changes
 
 The `PythonToolRequirementsBase` and `PythonToolBase` classes now have a new `help_short` field. Subclasses should now use `help_short` instead of the `help` field. The `help` field will be automatically generated using `help_short`, and will include the tool's default package version and provide instructions on how to override this version using a custom lockfile.

--- a/src/python/pants/backend/docker/goals/package_image.py
+++ b/src/python/pants/backend/docker/goals/package_image.py
@@ -526,6 +526,8 @@ def parse_image_id_from_docker_build_output(docker: DockerBinary, *outputs: byte
                     r"(writing image (?P<digest>sha256:\S+))",
                     # BuildKit with containerd-snapshotter output.
                     r"(exporting manifest list (?P<manifest_list>sha256:\S+))",
+                    # BuildKit with containerd-snapshotter output and no attestation.
+                    r"(exporting manifest (?P<manifest>sha256:\S+))",
                     # Docker output.
                     r"(Successfully built (?P<short_id>\S+))",
                 ),
@@ -548,6 +550,7 @@ def parse_image_id_from_docker_build_output(docker: DockerBinary, *outputs: byte
                     image_id_match.group("digest")
                     or image_id_match.group("short_id")
                     or image_id_match.group("manifest_list")
+                    or image_id_match.group("manifest")
                 )
                 return image_id
 

--- a/src/python/pants/backend/docker/goals/package_image_test.py
+++ b/src/python/pants/backend/docker/goals/package_image_test.py
@@ -1733,6 +1733,26 @@ def test_get_context_root(
             ),
             "",
         ),
+        # Buildkit with containerd-snapshotter 0.17.1 and disabled attestations
+        (
+            DockerBinary("/bin/docker", "1234", is_podman=False),
+            "sha256:6c3aff6414781126578b3e7b4a217682e89c616c0eac864d5b3ea7c87f1094d0",
+            dedent(
+                """\
+                    #24 exporting to image
+                    #24 exporting layers done
+                    #24 preparing layers for inline cache
+                    #24 preparing layers for inline cache 0.4s done
+                    #24 exporting manifest sha256:6c3aff6414781126578b3e7b4a217682e89c616c0eac864d5b3ea7c87f1094d0 0.0s done
+                    #24 exporting config sha256:af716170542d95134cb41b56e2dfea2c000b05b6fc4f440158ed9834ff96d1b4 0.0s done
+                    #24 naming to REDACTED:latest done
+                    #24 unpacking to REDACTED:latest 0.0s done
+                    #24 DONE 0.5s
+
+                    """
+            ),
+            "",
+        ),
         # Podman
         (
             DockerBinary("/bin/podman", "abcd", is_podman=True),


### PR DESCRIPTION
Related reading as to why attestations can be disabled by users: https://github.com/aws/aws-cdk/issues/30258, https://stackoverflow.com/questions/77207485/why-are-there-extra-untagged-images-in-amazon-ecr-after-doing-docker-push

In short, upstream tooling is not really ready for buildx + docker desktop default outputs, and when disabling these we get a stdout which current pants parsing code was not ready for. 

Fixes https://github.com/pantsbuild/pants/issues/21729