### PR TITLE
Install Python headers in the ARM64 wheel-building container.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,6 +57,8 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         version: 23.x
+    - name: Install Python headers
+      run: yum install -y python3.11-devel
     - env: {}
       name: Build wheels
       run: ./pants run src/python/pants_release/release.py -- build-wheels

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -376,6 +376,8 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         version: 23.x
+    - name: Install Python headers
+      run: yum install -y python3.11-devel
     - env: {}
       name: Build wheels
       run: ./pants run src/python/pants_release/release.py -- build-wheels

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -366,6 +366,13 @@ def install_go() -> Step:
     }
 
 
+def install_python_headers_in_manylinux_container() -> Step:
+    return {
+        "name": "Install Python headers",
+        "run": "yum install -y python3.11-devel",
+    }
+
+
 # NOTE: Any updates to the version of arduino/setup-protoc will require an audit of the updated  source code to verify
 # nothing "bad" has been added to the action. (We pass the user's GitHub secret to the action in order to avoid the
 # default GitHub rate limits when downloading protoc._
@@ -879,7 +886,11 @@ def build_wheels_job(
             "steps": [
                 *initial_steps,
                 install_protoc(),  # for prost crate
-                *([] if platform == Platform.LINUX_ARM64 else [install_go()]),
+                *(
+                    [install_python_headers_in_manylinux_container()]
+                    if platform == Platform.LINUX_ARM64
+                    else [install_go()]
+                ),
                 {
                     "name": "Build wheels",
                     "run": "./pants run src/python/pants_release/release.py -- build-wheels",


### PR DESCRIPTION
This fixes a CI error due to our switch to Python 3.11. 