### PR TITLE
Remove long-obsolete cruft from options registration.

### DIFF
--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -345,20 +345,6 @@ class Options:
         if deprecated_scope:
             self.get_registrar(deprecated_scope).register(*args, **kwargs)
 
-    def registration_function_for_subsystem(self, subsystem_cls):
-        """Returns a function for registering options on the given scope."""
-
-        # TODO(benjy): Make this an instance of a class that implements __call__, so we can
-        # docstring it, and so it's less weird than attaching properties to a function.
-        def register(*args, **kwargs):
-            self.register(subsystem_cls.options_scope, *args, **kwargs)
-
-        # Clients can access the bootstrap option values as register.bootstrap.
-        register.bootstrap = self.bootstrap_option_values()
-        # Clients can access the scope as register.scope.
-        register.scope = subsystem_cls.options_scope
-        return register
-
     def get_registrar(self, scope: str) -> OptionRegistrar:
         """Returns the registrar for the given scope, so code can register on it directly.
 

--- a/src/python/pants/option/subsystem.py
+++ b/src/python/pants/option/subsystem.py
@@ -288,7 +288,10 @@ class Subsystem(metaclass=_SubsystemMeta):
 
         Subclasses should not generally need to override this method.
         """
-        register = options.registration_function_for_subsystem(cls)
+
+        def register(*args, **kwargs):
+            options.register(cls.options_scope, *args, **kwargs)
+
         plugin_option_containers = union_membership.get(cls.PluginOption)
         for options_info in collect_options_info(cls):
             register(*options_info.flag_names, **options_info.flag_options)
@@ -300,10 +303,6 @@ class Subsystem(metaclass=_SubsystemMeta):
             for option in collect_options_info(container)
         ):
             register(*options_info.flag_names, **options_info.flag_options)
-
-        # NB: If the class defined `register_options` we should call it
-        if "register_options" in cls.__dict__:
-            cls.register_options(register)  # type: ignore[attr-defined]
 
     def __init__(self, options: OptionValueContainer) -> None:
         self.validate_scope()


### PR DESCRIPTION
#15090 removed (after deprecation) the ability to implement
custom `register_options()` hooks, and required plugin authors
to use the `*Option` class members to register options.

This change removes some cruft left over from support for that
functionality.