### PR TITLE
fix issue with duplicated `BinaryPath` instances passed to `BinaryShimsRequest` (Cherry pick of #21745)

### DIFF
--- a/src/python/pants/core/util_rules/system_binaries.py
+++ b/src/python/pants/core/util_rules/system_binaries.py
@@ -11,6 +11,7 @@ import shlex
 import subprocess
 from dataclasses import dataclass
 from enum import Enum
+from itertools import groupby
 from textwrap import dedent  # noqa: PNT20
 from typing import Iterable, Mapping, Sequence
 
@@ -243,6 +244,21 @@ class BinaryShimsRequest:
         *paths: BinaryPath,
         rationale: str,
     ) -> BinaryShimsRequest:
+        # Remove any duplicates (which may result if the caller merges `BinaryPath` instances from multiple sources)
+        # and also sort to ensure a stable order for better caching.
+        paths = tuple(sorted(set(paths), key=lambda bp: bp.path))
+
+        # Then ensure that there are no duplicate paths with mismatched content.
+        duplicate_paths = set()
+        for path, group in groupby(paths, key=lambda x: x.path):
+            if len(list(group)) > 1:
+                duplicate_paths.add(path)
+        if duplicate_paths:
+            raise ValueError(
+                "Detected duplicate paths with mismatched content at paths: "
+                f"{', '.join(sorted(duplicate_paths))}"
+            )
+
         return cls(
             paths=paths,
             rationale=rationale,

--- a/src/python/pants/core/util_rules/system_binaries_test.py
+++ b/src/python/pants/core/util_rules/system_binaries_test.py
@@ -176,3 +176,76 @@ def test_binary_shims_paths(rule_runner: RuleRunner, tmp_path: Path) -> None:
         ),
         binary_shim.content.decode(),
     )
+
+
+def test_no_negative_caching_of_binary_paths_lookups(
+    rule_runner: RuleRunner, tmp_path: Path
+) -> None:
+    MyBin.create(tmp_path / "foo")
+    MyBin.create(tmp_path / "bar")
+
+    def find_binary_paths() -> BinaryPaths:
+        return rule_runner.request(
+            BinaryPaths,
+            [
+                BinaryPathRequest(
+                    binary_name=MyBin.binary_name,
+                    search_path=[
+                        str(tmp_path / "foo"),
+                        str(tmp_path / "bar"),
+                    ],
+                    check_file_entries=True,
+                )
+            ],
+        )
+
+    binary_paths = find_binary_paths()
+    assert len(binary_paths.paths) == 2
+    assert binary_paths.paths[0].path == str(tmp_path / "foo" / MyBin.binary_name)
+    assert binary_paths.paths[1].path == str(tmp_path / "bar" / MyBin.binary_name)
+
+    # Delete the one of the binaries. It should no longer be found by the binary paths lookup.
+    (tmp_path / "foo" / MyBin.binary_name).unlink()
+
+    # Force a new session since the path lookup even though uncached across sessions is still
+    # cached in the current session.
+    rule_runner.new_session("session2")
+    rule_runner.set_options([])
+
+    binary_paths = find_binary_paths()
+    assert len(binary_paths.paths) == 1
+    assert binary_paths.paths[0].path == str(tmp_path / "bar" / MyBin.binary_name)
+
+
+def test_merge_and_detection_of_duplicate_binary_paths() -> None:
+    # Test merge of duplicate paths where content hash is the same.
+    shims_request_1 = BinaryShimsRequest.for_paths(
+        BinaryPath("/foo/bar", "abc123"),
+        BinaryPath("/abc/def/123", "def456"),
+        BinaryPath("/foo/bar", "abc123"),
+        rationale="awesomeness",
+    )
+    assert shims_request_1.paths == (
+        BinaryPath("/abc/def/123", "def456"),
+        BinaryPath("/foo/bar", "abc123"),
+    )
+
+    # Test detection of duplicate pahs with differing content hashes. Exception should be thrown.
+    with pytest.raises(ValueError, match="Detected duplicate paths with mismatched content"):
+        _ = BinaryShimsRequest.for_paths(
+            BinaryPath("/foo/bar", "abc123"),
+            BinaryPath("/abc/def/123", "def456"),
+            BinaryPath("/foo/bar", "xyz789"),
+            rationale="awesomeness",
+        )
+
+    # Test paths with no duplication.
+    shims_request_2 = BinaryShimsRequest.for_paths(
+        BinaryPath("/foo/bar", "abc123"),
+        BinaryPath("/abc/def/123", "def456"),
+        rationale="awesomeness",
+    )
+    assert shims_request_2.paths == (
+        BinaryPath("/abc/def/123", "def456"),
+        BinaryPath("/foo/bar", "abc123"),
+    )


### PR DESCRIPTION
As reported in https://github.com/pantsbuild/pants/issues/21709, a Docker tool appearing in both the `--docker-tools` and `--docker-optional-tools` options was causing an error with the `create_digest` intrinsic: `Snapshots must be constructed from unique path stats; got duplicates in [Some("docker-credential-ecr-login"), Some("getent"), Some("sw_vers")]`

The root cause is that duplicate `BinaryPath` instances were being passed to `BinaryShimsRequest.for_paths` which was then translated eventually into a `create_digest` call with the duplicate paths (which is not permitted).

Solution: De-duplicate paths in `BinaryShimsRequest.for_paths` (and sort into stable order for good measure to ensure better cacheability).

Closes https://github.com/pantsbuild/pants/issues/21709.

---------