### PR TITLE
Get rid of bootstrap_option_values in Options instance.

### DIFF
--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -125,7 +125,7 @@ class LocalPantsRunner:
             dynamic_remote_options, _ = DynamicRemoteOptions.from_options(
                 options, env, remote_auth_plugin_func=build_config.remote_auth_plugin_func
             )
-            bootstrap_options = options.bootstrap_option_values()
+            bootstrap_options = options_bootstrapper.bootstrap_options.for_global_scope()
             assert bootstrap_options is not None
             scheduler = EngineInitializer.setup_graph(
                 bootstrap_options, build_config, dynamic_remote_options, executor

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -438,17 +438,16 @@ class DynamicRemoteOptions:
         prior_result: AuthPluginResult | None = None,
         remote_auth_plugin_func: Callable | None = None,
     ) -> tuple[DynamicRemoteOptions, AuthPluginResult | None]:
-        bootstrap_options = full_options.bootstrap_option_values()
-        assert bootstrap_options is not None
-        execution = cast(bool, bootstrap_options.remote_execution)
-        cache_read = cast(bool, bootstrap_options.remote_cache_read)
-        cache_write = cast(bool, bootstrap_options.remote_cache_write)
+        global_options = full_options.for_global_scope()
+        execution = cast(bool, global_options.remote_execution)
+        cache_read = cast(bool, global_options.remote_cache_read)
+        cache_write = cast(bool, global_options.remote_cache_write)
         if not (execution or cache_read or cache_write):
             return cls.disabled(), None
 
         sources = {
             str(remote_auth_plugin_func): bool(remote_auth_plugin_func),
-            "[GLOBAL].remote_oauth_bearer_token": bool(bootstrap_options.remote_oauth_bearer_token),
+            "[GLOBAL].remote_oauth_bearer_token": bool(global_options.remote_oauth_bearer_token),
         }
         enabled_sources = [name for name, enabled in sources.items() if enabled]
         if len(enabled_sources) > 1:
@@ -461,17 +460,17 @@ class DynamicRemoteOptions:
                     """
                 )
             )
-        if bootstrap_options.remote_oauth_bearer_token:
-            return cls._use_oauth_token(bootstrap_options), None
+        if global_options.remote_oauth_bearer_token:
+            return cls._use_oauth_token(global_options), None
         if remote_auth_plugin_func is not None:
             return cls._use_auth_plugin(
-                bootstrap_options,
+                global_options,
                 full_options=full_options,
                 env=env,
                 prior_result=prior_result,
                 remote_auth_plugin_func=remote_auth_plugin_func,
             )
-        return cls._use_no_auth(bootstrap_options), None
+        return cls._use_no_auth(global_options), None
 
     @classmethod
     def _use_no_auth(cls, bootstrap_options: OptionValueContainer) -> DynamicRemoteOptions:

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -195,7 +195,6 @@ class Options:
             passthru=split_args.passthru,
             registrar_by_scope=registrar_by_scope,
             native_parser=native_parser,
-            bootstrap_option_values=bootstrap_option_values,
             known_scope_to_info=known_scope_to_info,
             allow_unknown_options=allow_unknown_options,
         )
@@ -210,7 +209,6 @@ class Options:
         passthru: list[str],
         registrar_by_scope: dict[str, OptionRegistrar],
         native_parser: NativeOptionParser,
-        bootstrap_option_values: OptionValueContainer | None,
         known_scope_to_info: dict[str, ScopeInfo],
         allow_unknown_options: bool = False,
     ) -> None:
@@ -226,7 +224,6 @@ class Options:
         self._passthru = passthru
         self._registrar_by_scope = registrar_by_scope
         self._native_parser = native_parser
-        self._bootstrap_option_values = bootstrap_option_values
         self._known_scope_to_info = known_scope_to_info
         self._allow_unknown_options = allow_unknown_options
 
@@ -510,14 +507,6 @@ class Options:
         # TODO(John Sirois): Mainly supports use of dict<str, dict<str, str>> for mock options in tests,
         # Consider killing if tests consolidate on using TestOptions instead of the raw dicts.
         return self.for_scope(scope)
-
-    def bootstrap_option_values(self) -> OptionValueContainer | None:
-        """Return the option values for bootstrap options.
-
-        General code can also access these values in the global scope.  But option registration code
-        cannot, hence this special-casing of this small set of options.
-        """
-        return self._bootstrap_option_values
 
     def for_global_scope(self) -> OptionValueContainer:
         """Return the option values for the global scope.

--- a/src/python/pants/pantsd/pants_daemon_core.py
+++ b/src/python/pants/pantsd/pants_daemon_core.py
@@ -168,7 +168,7 @@ class PantsDaemonCore:
                 # The fingerprint mismatches, either because this is the first run (and there is no
                 # fingerprint) or because relevant options have changed. Create a new scheduler
                 # and services.
-                bootstrap_options = options.bootstrap_option_values()
+                bootstrap_options = options_bootstrapper.bootstrap_options.for_global_scope()
                 assert bootstrap_options is not None
                 with self._handle_exceptions():
                     self._initialize(


### PR DESCRIPTION
If you have an Options instance you can get the individual
values from the global scope, since every bootstrap
option is a regular global scope option 
(the "bootstrap" designation just means "needed for
creating a Scheduler").

Or, if you need all the bootstrap options in a single
OptionValueContainer (say, to pass them en masse
to Scheduler initialization) then you can get that
directly from the OptionsBootstrapper.