### PR TITLE
ci: update python to use a matrix and have correct ordering

### DIFF
--- a/.github/workflows/cache_comparison.yaml
+++ b/.github/workflows/cache_comparison.yaml
@@ -6,27 +6,19 @@
 jobs:
   cache_comparison:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13]
     steps:
     - name: Check out code
       uses: actions/checkout@v4
       with:
         fetch-depth: 10
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
+    - name: Set up Python 3.7 through 3.13
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7
-
-          3.8
-
-          3.9
-
-          3.10
-
-          3.12
-
-          3.13
-
-          3.11'
+        python-version: ${{ matrix.python-version }}
     - env:
         BASE_REF: ${{ github.event.inputs.base_ref }}
         BUILD_COMMIT: ${{ github.event.inputs.build_commit }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -196,28 +196,20 @@ jobs:
     - release_info
     runs-on:
     - macos-13
+
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13]
     steps:
     - name: Check out code
       uses: actions/checkout@v4
       with:
         fetch-depth: 10
         ref: ${{ needs.release_info.outputs.build-ref }}
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
+    - name: Set up Python 3.7 through 3.13
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7
-
-          3.8
-
-          3.9
-
-          3.10
-
-          3.12
-
-          3.13
-
-          3.11'
+        python-version: ${{ matrix.python-version }}
     - name: Install Protoc
       uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
       with:
@@ -395,6 +387,9 @@ jobs:
     - build_wheels_macos14_arm64
     - release_info
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13]
     steps:
     - name: Checkout Pants at Release Tag
       uses: actions/checkout@v4
@@ -402,22 +397,10 @@ jobs:
         fetch-depth: '0'
         fetch-tags: true
         ref: ${{ needs.release_info.outputs.build-ref }}
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
+    - name: Set up Python 3.7 through 3.13
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7
-
-          3.8
-
-          3.9
-
-          3.10
-
-          3.12
-
-          3.13
-
-          3.11'
+        python-version: ${{ matrix.python-version }}
     - name: Install Protoc
       uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
       with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -113,27 +113,19 @@ jobs:
     - classify_changes
     runs-on:
     - ubuntu-22.04
+
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13]
     steps:
     - name: Check out code
       uses: actions/checkout@v4
       with:
         fetch-depth: 10
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
+    - name: Set up Python 3.7 through 3.13
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7
-
-          3.8
-
-          3.9
-
-          3.10
-
-          3.12
-
-          3.13
-
-          3.11'
+        python-version: ${{ matrix.python-version }}
     - name: Install Protoc
       uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
       with:
@@ -228,27 +220,18 @@ jobs:
     - classify_changes
     runs-on:
     - macos-13
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13]
     steps:
     - name: Check out code
       uses: actions/checkout@v4
       with:
         fetch-depth: 10
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
+    - name: Set up Python 3.7 through 3.13
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7
-
-          3.8
-
-          3.9
-
-          3.10
-
-          3.12
-
-          3.13
-
-          3.11'
+        python-version: ${{ matrix.python-version }}
     - name: Install Protoc
       uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
       with:
@@ -476,27 +459,19 @@ jobs:
     - classify_changes
     runs-on:
     - macos-13
+
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13]
     steps:
     - name: Check out code
       uses: actions/checkout@v4
       with:
         fetch-depth: 10
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
+    - name: Set up Python 3.7 through 3.13
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7
-
-          3.8
-
-          3.9
-
-          3.10
-
-          3.12
-
-          3.13
-
-          3.11'
+        python-version: ${{ matrix.python-version }}
     - name: Install Protoc
       uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
       with:
@@ -683,6 +658,9 @@ jobs:
     - classify_changes
     runs-on:
     - ubuntu-22.04
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13]
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -706,22 +684,10 @@ jobs:
         \                 --max_size 30\necho \"PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092\" >> \"$GITHUB_ENV\"\necho\
         \ \"PANTS_REMOTE_CACHE_READ=true\" >> \"$GITHUB_ENV\"\necho \"PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}\" >> \"$GITHUB_ENV\"\
         \n"
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
+    - name: Set up Python 3.7 through 3.13
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7
-
-          3.8
-
-          3.9
-
-          3.10
-
-          3.12
-
-          3.13
-
-          3.11'
+        python-version: ${{ matrix.python-version }}
     - name: Download native binaries
       uses: actions/download-artifact@v4
       with:
@@ -857,6 +823,9 @@ jobs:
     - classify_changes
     runs-on:
     - ubuntu-22.04
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13]
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -900,22 +869,10 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
+    - name: Set up Python 3.7 through 3.13
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7
-
-          3.8
-
-          3.9
-
-          3.10
-
-          3.12
-
-          3.13
-
-          3.11'
+        python-version: ${{ matrix.python-version }}
     - name: Download native binaries
       uses: actions/download-artifact@v4
       with:
@@ -959,6 +916,9 @@ jobs:
     - classify_changes
     runs-on:
     - ubuntu-22.04
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13]
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -1002,22 +962,10 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
+    - name: Set up Python 3.7 through 3.13
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7
-
-          3.8
-
-          3.9
-
-          3.10
-
-          3.12
-
-          3.13
-
-          3.11'
+        python-version: ${{ matrix.python-version }}
     - name: Download native binaries
       uses: actions/download-artifact@v4
       with:
@@ -1061,6 +1009,10 @@ jobs:
     - classify_changes
     runs-on:
     - ubuntu-22.04
+
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13]
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -1104,22 +1056,10 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
+    - name: Set up Python 3.7 through 3.13
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7
-
-          3.8
-
-          3.9
-
-          3.10
-
-          3.12
-
-          3.13
-
-          3.11'
+        python-version: ${{ matrix.python-version }}
     - name: Download native binaries
       uses: actions/download-artifact@v4
       with:
@@ -1163,6 +1103,9 @@ jobs:
     - classify_changes
     runs-on:
     - ubuntu-22.04
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13]
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -1206,22 +1149,10 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
+    - name: Set up Python 3.7 through 3.13
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7
-
-          3.8
-
-          3.9
-
-          3.10
-
-          3.12
-
-          3.13
-
-          3.11'
+        python-version: ${{ matrix.python-version }}
     - name: Download native binaries
       uses: actions/download-artifact@v4
       with:
@@ -1265,6 +1196,9 @@ jobs:
     - classify_changes
     runs-on:
     - ubuntu-22.04
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13]
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -1308,22 +1242,10 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
+    - name: Set up Python 3.7 through 3.13
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7
-
-          3.8
-
-          3.9
-
-          3.10
-
-          3.12
-
-          3.13
-
-          3.11'
+        python-version: ${{ matrix.python-version }}
     - name: Download native binaries
       uses: actions/download-artifact@v4
       with:
@@ -1367,6 +1289,9 @@ jobs:
     - classify_changes
     runs-on:
     - ubuntu-22.04
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13]
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -1410,22 +1335,10 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
+    - name: Set up Python 3.7 through 3.13
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7
-
-          3.8
-
-          3.9
-
-          3.10
-
-          3.12
-
-          3.13
-
-          3.11'
+        python-version: ${{ matrix.python-version }}
     - name: Download native binaries
       uses: actions/download-artifact@v4
       with:
@@ -1469,6 +1382,10 @@ jobs:
     - classify_changes
     runs-on:
     - ubuntu-22.04
+
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13]
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -1512,22 +1429,10 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
+    - name: Set up Python 3.7 through 3.13
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7
-
-          3.8
-
-          3.9
-
-          3.10
-
-          3.12
-
-          3.13
-
-          3.11'
+        python-version: ${{ matrix.python-version }}
     - name: Download native binaries
       uses: actions/download-artifact@v4
       with:
@@ -1571,6 +1476,9 @@ jobs:
     - classify_changes
     runs-on:
     - ubuntu-22.04
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13]
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -1614,22 +1522,10 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
+    - name: Set up Python 3.7 through 3.13
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7
-
-          3.8
-
-          3.9
-
-          3.10
-
-          3.12
-
-          3.13
-
-          3.11'
+        python-version: ${{ matrix.python-version }}
     - name: Download native binaries
       uses: actions/download-artifact@v4
       with:
@@ -1673,6 +1569,9 @@ jobs:
     - classify_changes
     runs-on:
     - ubuntu-22.04
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13]
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -1716,22 +1615,10 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
+    - name: Set up Python 3.7 through 3.13
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7
-
-          3.8
-
-          3.9
-
-          3.10
-
-          3.12
-
-          3.13
-
-          3.11'
+        python-version: ${{ matrix.python-version }}
     - name: Download native binaries
       uses: actions/download-artifact@v4
       with:
@@ -1775,6 +1662,9 @@ jobs:
     - classify_changes
     runs-on:
     - ubuntu-22.04
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13]
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -1818,22 +1708,10 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
+    - name: Set up Python 3.7 through 3.13
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7
-
-          3.8
-
-          3.9
-
-          3.10
-
-          3.12
-
-          3.13
-
-          3.11'
+        python-version: ${{ matrix.python-version }}
     - name: Download native binaries
       uses: actions/download-artifact@v4
       with:
@@ -1877,6 +1755,9 @@ jobs:
     - classify_changes
     runs-on:
     - macos-13
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13]
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -1891,22 +1772,10 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: 1.19.5
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
+    - name: Set up Python 3.7 through 3.13
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7
-
-          3.8
-
-          3.9
-
-          3.10
-
-          3.12
-
-          3.13
-
-          3.11'
+        python-version: ${{ matrix.python-version }}
     - name: Download native binaries
       uses: actions/download-artifact@v4
       with:

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -73,7 +73,7 @@ CARGO_AUDIT_IGNORED_ADVISORY_IDS = (
 # We don't specify a patch version so that we get the latest, which comes pre-installed:
 #  https://github.com/actions/setup-python#available-versions-of-python
 # NOTE: The last entry becomes the default
-_BASE_PYTHON_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.12", "3.13", "3.11"]
+_BASE_PYTHON_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
 PYTHON_VERSIONS_PER_PLATFORM = {
     Platform.LINUX_X86_64: _BASE_PYTHON_VERSIONS,


### PR DESCRIPTION
* Introduced in https://github.com/pantsbuild/pants/commit/e18484d94ae835ddd7407bfba67c04c472785fb4#diff-8f5723a712281f34ef9e6ab0a15737801bd4c72972b4d95d83fb8e95f4eb7b6aR18
* Previously only using a single python version here
* Also, kept 3.7 and 3.8 in to be less controversial but those are both EOL and could be dropped off if we decide to keep other versions in