### PR TITLE
store all known releases for Python Build Standalone known versions

### DIFF
--- a/docs/notes/2.25.x.md
+++ b/docs/notes/2.25.x.md
@@ -62,7 +62,7 @@ The `helm_infer.external_docker_images` glob syntax has been generalized.  In ad
 
 The AWS Lambda backend now provides built-in complete platforms for the Python 3.13 runtime.
 
-The Python Build Standalone backend (`pants.backend.python.providers.experimental.python_build_standalone`) now supports filtering PBS releases via their "release tag" via [the new `--python-build-standalone-release-constraints` option](https://www.pantsbuild.org/2.25/reference/subsystems/python-build-standalone-python-provider#release_constraints).
+The Python Build Standalone backend (`pants.backend.python.providers.experimental.python_build_standalone`) now supports filtering PBS releases via their "release tag" via [the new `--python-build-standalone-release-constraints` option](https://www.pantsbuild.org/2.25/reference/subsystems/python-build-standalone-python-provider#release_constraints). THe PBS "known versions" database now contains metadata on all known PBS versions, and not just the latest PBS release tag per Python patchlevel.
 
 Also, the PBS "release tag" will be inferred for PBS releases supplied via the `--python-build-standalone-known-python-versions` option from the given URLs if those URLs conform to the naming convention used by the PBS project. The new advanced option `--python-build-standalone-require-inferrable-release-tag` controls whether Pants requires the tag to be inferrable. This option currently defaults to `False`, but will be migrated to `True` in a future Pants release. (The release tag cannot currently be specified via `--python-build-standalone-known-python-versions` since changing that option would not be a backward compatible change.)
 

--- a/src/python/pants/backend/python/providers/python_build_standalone/rules_integration_test.py
+++ b/src/python/pants/backend/python/providers/python_build_standalone/rules_integration_test.py
@@ -161,11 +161,10 @@ def test_tag_inference_from_url() -> None:
     )
 
     user_supplied_pbs_versions = subsystem.get_user_supplied_pbs_pythons(require_tag=False)
-    assert user_supplied_pbs_versions["3.10.13"]["linux_arm"] == pbs.PBSPythonInfo(
+    assert user_supplied_pbs_versions["3.10.13"]["20240224"]["linux_arm"] == pbs.PBSPythonInfo(
         url="https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-aarch64-unknown-linux-gnu-install_only.tar.gz",
         sha256="abc123",
         size=123,
-        tag="20240224",
     )
 
     # Confirm whether requiring tag inference results in an error.
@@ -218,28 +217,24 @@ def test_release_constraint_evaluation(rule_runner: RuleRunner) -> None:
     ics = InterpreterConstraints(["cpython==3.9.*"])
     universe = ["3.9"]
 
-    def make_version(tag: str):
+    def make_platform_metadata():
         return {
             "linux_arm64": {
-                "tag": tag,
                 "sha256": "abc123",
                 "size": 1,
                 "url": "foobar",
             },
             "linux_x86_64": {
-                "tag": tag,
                 "sha256": "abc123",
                 "size": 1,
                 "url": "https://example.com/foo.zip",
             },
             "macos_arm64": {
-                "tag": tag,
                 "sha256": "abc123",
                 "size": 1,
                 "url": "https://example.com/foo.zip",
             },
             "macos_x86_64": {
-                "tag": tag,
                 "sha256": "abc123",
                 "size": 1,
                 "url": "https://example.com/foo.zip",
@@ -247,9 +242,9 @@ def test_release_constraint_evaluation(rule_runner: RuleRunner) -> None:
         }
 
     pbs_versions = {
-        "3.9.18": make_version("20241001"),
-        "3.9.19": make_version("20241101"),
-        "3.9.20": make_version("20241201"),
+        "3.9.18": {"20241001": make_platform_metadata()},
+        "3.9.19": {"20241101": make_platform_metadata()},
+        "3.9.20": {"20241201": make_platform_metadata()},
     }
 
     platform = rule_runner.request(Platform, [])

--- a/src/python/pants/backend/python/providers/python_build_standalone/versions_info.json
+++ b/src/python/pants/backend/python/providers/python_build_standalone/versions_info.json
@@ -18,6 +18,28 @@
       }
     },
     "3.10.11": {
+      "20230507": {
+        "linux_arm64": {
+          "sha256": "c7573fdb00239f86b22ea0e8e926ca881d24fde5e5890851339911d76110bc35",
+          "size": 24243246,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "c5bcaac91bc80bfc29cf510669ecad12d506035ecb3ad85ef213416d54aecd79",
+          "size": 26689876,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "8348bc3c2311f94ec63751fb71bd0108174be1c4def002773cf519ee1506f96f",
+          "size": 17074991,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "bd3fc6e4da6f4033ebf19d66704e73b0804c22641ddae10bbe347c48f82374ad",
+          "size": 17354339,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "c7573fdb00239f86b22ea0e8e926ca881d24fde5e5890851339911d76110bc35",
         "size": 24243246,
@@ -44,6 +66,28 @@
       }
     },
     "3.10.12": {
+      "20230726": {
+        "linux_arm64": {
+          "sha256": "fee80e221663eca5174bd794cb5047e40d3910dbeadcdf1f09d405a4c1c15fe4",
+          "size": 23973769,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "a476dbca9184df9fc69fe6309cda5ebaf031d27ca9e529852437c94ec1bc43d3",
+          "size": 26421382,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "bc66c706ea8c5fc891635fda8f9da971a1a901d41342f6798c20ad0b2a25d1d6",
+          "size": 16817271,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "8a6e3ed973a671de468d9c691ed9cb2c3a4858c5defffcf0b08969fba9c1dd04",
+          "size": 17095895,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "fee80e221663eca5174bd794cb5047e40d3910dbeadcdf1f09d405a4c1c15fe4",
         "size": 23973769,
@@ -70,6 +114,94 @@
       }
     },
     "3.10.13": {
+      "20230826": {
+        "linux_arm64": {
+          "sha256": "0479cf10254adbf7a554453874e91bb526ba62cbac8a758f6865cdcdbef20f2d",
+          "size": 23980115,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.10.13%2B20230826-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "ba512bcca3ac6cb6d834f496cd0a66416f0a53ff20b05c4794fa82ece185b85a",
+          "size": 26421821,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.10.13%2B20230826-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "142332021441ee1ab04eb126baa6c6690dc41699d4af608b72b399a786f6ee71",
+          "size": 16830300,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.10.13%2B20230826-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "3a5d50b98e4981af4fc23cf3fc53a38ef3f9a8f32453849e295e747aa9936b2b",
+          "size": 17103383,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.10.13%2B20230826-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
+      "20231002": {
+        "linux_arm64": {
+          "sha256": "8675915ff454ed2f1597e27794bc7df44f5933c26b94aa06af510fe91b58bb97",
+          "size": 24445269,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.10.13%2B20231002-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "5d0429c67c992da19ba3eb58b3acd0b35ec5e915b8cae9a4aa8ca565c423847a",
+          "size": 26952466,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.10.13%2B20231002-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "fd027b1dedf1ea034cdaa272e91771bdf75ddef4c8653b05d224a0645aa2ca3c",
+          "size": 16913053,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.10.13%2B20231002-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "be0b19b6af1f7d8c667e5abef5505ad06cf72e5a11bb5844970c395a7e5b1275",
+          "size": 17489531,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.10.13%2B20231002-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
+      "20240107": {
+        "linux_arm64": {
+          "sha256": "4793cab2b657d8656463ca423aae7cf9cdacf49059d9e4c01888f5650883e85e",
+          "size": 24482356,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.10.13%2B20240107-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "c40d749904089c2d4b77a23df132a113c02114e67d2eaa953d52b8555385b7fa",
+          "size": 26991304,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.10.13%2B20240107-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "4d19a0509c274f360a5c250d71a2af7263ebaf898ecdb71427f3532cbc6b2cf7",
+          "size": 16944702,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.10.13%2B20240107-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "47da6831e269ad6af603f59bbd4767636c5749bd70a24363c9cf003c32c8ecfc",
+          "size": 17525124,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.10.13%2B20240107-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
+      "20240224": {
+        "linux_arm64": {
+          "sha256": "a898a88705611b372297bb8fe4d23cc16b8603ce5f24494c3a8cfa65d83787f9",
+          "size": 24901728,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "d995d032ca702afd2fc3a689c1f84a6c64972ecd82bba76a61d525f08eb0e195",
+          "size": 27409290,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "5fdc0f6a5b5a90fd3c528e8b1da8e3aac931ea8690126c2fdb4254c84a3ff04a",
+          "size": 17298908,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "6378dfd22f58bb553ddb02be28304d739cd730c1f95c15c74955c923a1bc3d6a",
+          "size": 17641238,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "a898a88705611b372297bb8fe4d23cc16b8603ce5f24494c3a8cfa65d83787f9",
         "size": 24901728,
@@ -96,6 +228,116 @@
       }
     },
     "3.10.14": {
+      "20240415": {
+        "linux_arm64": {
+          "sha256": "2f9f26c430df19d6d2a25ac3f2a8e74106d32b9951b85f95218ceeb13d52e952",
+          "size": 24907073,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.10.14%2B20240415-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "c83c5485659250ef4e4fedb8e7f7b97bc99cc8cf5a1b11d0d1a98d347a43411d",
+          "size": 27417490,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.10.14%2B20240415-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "389da793b7666e9310908b4fe3ddcf0a20b55727fcb384c7c49b01bb21716f89",
+          "size": 17296078,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.10.14%2B20240415-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "8e27ec6f27b3a27be892c7a9db1e278c858acd9d90c1114013fe5587cd6fc5e6",
+          "size": 17642458,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.10.14%2B20240415-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
+      "20240713": {
+        "linux_arm64": {
+          "sha256": "f58ab2cadc7dc955c8ac2dbb7920207591e56ea22aab60b9a527d5473522f0bc",
+          "size": 24906983,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240713/cpython-3.10.14%2B20240713-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "6e90e30d1b2af67ddb65739df0e86f8b096f0d8e1e17feee8c70483760b0dc38",
+          "size": 27404483,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240713/cpython-3.10.14%2B20240713-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "cb3e18229e4d2cb0d5c5903dd9d52dd47da8a22328e3cab5401cb8f7a184b73b",
+          "size": 17299450,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240713/cpython-3.10.14%2B20240713-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "a8a7f6d6efb18ff3c068ef311abad48a778aadbb958aaacb2193bfb374cbebf5",
+          "size": 17645695,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240713/cpython-3.10.14%2B20240713-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
+      "20240725": {
+        "linux_arm64": {
+          "sha256": "def6e1104e332921c6b624c100ecf2549aa597507a45f649d07314fa0e24d7cf",
+          "size": 24774688,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240725/cpython-3.10.14%2B20240725-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "4878e0e1d791c87a888e211ec725e9a6d3e4fd386aeae4d892547093245d1dd4",
+          "size": 27447861,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240725/cpython-3.10.14%2B20240725-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "4651ccef9d2418ce9d971e91aa8cb7f14381d85eb00dc2d86c3061c9de2a07fe",
+          "size": 17196463,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240725/cpython-3.10.14%2B20240725-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "0f6331419c1c93eac657dad33541df882497af33474dad960021db91315c551e",
+          "size": 17528620,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240725/cpython-3.10.14%2B20240725-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      },
+      "20240726": {
+        "linux_arm64": {
+          "sha256": "827af2ada1f4e2ec8289ddc7b495ba9e85d4a57f9a8b2ad7e019c4693b2945c3",
+          "size": 19394245,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.10.14%2B20240726-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "6ff16d445e3ca486b555e26e8cb9db52c3bba7fb5245dc100614d9e178c16418",
+          "size": 20510415,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.10.14%2B20240726-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "cdba5811d148375e0308cf034683ec418ef7bd2f9eaf83aeb5316fb1663390c0",
+          "size": 17065979,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.10.14%2B20240726-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "0ef54e12063de80726c1a6ae021e65bd0915595c24f1ccd774cac1d3f14c6b89",
+          "size": 17418096,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.10.14%2B20240726-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      },
+      "20240814": {
+        "linux_arm64": {
+          "sha256": "0ffe64c77cacda7e3afcb0d8ba271c59ca0a30dfda218da39a573b412bb4afd7",
+          "size": 19394162,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "159c456bb4a3802bafbce065ff54b99ddb16422500d75c1315573ee3b673af17",
+          "size": 20510166,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "f7ca9bffbce433c8d445edd33a5424c405553d735efee65a2fc5d8bbb1c8e137",
+          "size": 17070246,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "4404f44ec69c0708d4d88e98f39c2c1fe3bd462dc6a958b60aaf63028550c485",
+          "size": 17409127,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "0ffe64c77cacda7e3afcb0d8ba271c59ca0a30dfda218da39a573b412bb4afd7",
         "size": 19394162,
@@ -122,6 +364,94 @@
       }
     },
     "3.10.15": {
+      "20240909": {
+        "linux_arm64": {
+          "sha256": "e3af89047c713b812779aaa576a364b77f9ebbbbe182fd6bda03a52d3166ee14",
+          "size": 19397559,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.10.15%2B20240909-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "816a958735bb9927b2884d55938683770eda823d4c74c38f2b49ef3cc8ce4585",
+          "size": 20513201,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.10.15%2B20240909-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "cdf154e4ca6e78d613611ddb6bc67a73f682442c31ca498df4383775e87bd5c8",
+          "size": 17068265,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.10.15%2B20240909-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "89dc3fd2e8d1a1b6c9eb000cbad85830c06ab776eed891bda369847671f0fb4f",
+          "size": 17414798,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.10.15%2B20240909-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      },
+      "20241002": {
+        "linux_arm64": {
+          "sha256": "2773766d4dbe106a61031e38fd844f64886de93b7ae4389e0af52f7dc77092c3",
+          "size": 19393431,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.10.15%2B20241002-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "db58da5c9888a0dd7036d76ae4babd62f26ba74530a528b684af6f4688b86583",
+          "size": 20516421,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.10.15%2B20241002-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "1f753073b2333b2977922387fe016255ebde0f8558c567ffb960b7f50477fd34",
+          "size": 17067396,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.10.15%2B20241002-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "18dd6c0c219da1ec7daede9da923205594dbdc7f37a283873363b4634a5e3f8f",
+          "size": 17413317,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.10.15%2B20241002-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      },
+      "20241008": {
+        "linux_arm64": {
+          "sha256": "4a354407285995b12dc67bd5e99c588699cc0c434fddc38c84a61909381a2e2f",
+          "size": 19393429,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "bf234c7fa23dfcc70c7248c4a46ea58775b39005f107084e51afd439e67f2baf",
+          "size": 20516114,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "bcd994f136c4568763e2d642f4236c81e19ffc2a3536224598dc1ad0c3e16bf7",
+          "size": 17068393,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "c8cc9d58f4c71106472e9b9b2801b702e7939db1922dceabe5b33b5602b490e4",
+          "size": 17413236,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      },
+      "20241016": {
+        "linux_arm64": {
+          "sha256": "6008b42df79a0c8a4efe3aa88c2aea1471116aa66881a8ed15f04d66438cb7f5",
+          "size": 19395962,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "25fb8e23cd3b82b748075a04fd18f3183cc7316c11d6f59eb4b0326843892600",
+          "size": 20518101,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "fa79bd909bfeb627ffe66a8b023153495ece659e5e3b2ff56268535024db851c",
+          "size": 17068674,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "0d952fa2342794523ea7beee6a58e79e62045d0f018314ce282e9f2f1427ee2c",
+          "size": 17416153,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "6008b42df79a0c8a4efe3aa88c2aea1471116aa66881a8ed15f04d66438cb7f5",
         "size": 19395962,
@@ -147,7 +477,75 @@
         "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-x86_64-apple-darwin-install_only_stripped.tar.gz"
       }
     },
+    "3.10.16": {
+      "20241205": {
+        "linux_arm64": {
+          "sha256": "1921bfe4087a5236f317377af293780ea6d0ec6228dc74fc9ac66c5dafc65472",
+          "size": 19642729,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241205/cpython-3.10.16%2B20241205-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "07f0880109dcb6d3c2f362744ebcdc9aee349befeb6bc9edd69189ea6784c4b8",
+          "size": 20774245,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241205/cpython-3.10.16%2B20241205-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "0286938f7c3e42221c76ec59177c02fe8a96cebd3e321a8a9021574e816a6ba7",
+          "size": 17322864,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241205/cpython-3.10.16%2B20241205-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "348ac5edd1a5afe257e05bcafae515f7d2517984fab491f7e216b526423acfce",
+          "size": 17672984,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241205/cpython-3.10.16%2B20241205-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      },
+      "20241206": {
+        "linux_arm64": {
+          "sha256": "2daf6007da8fc31d387eaddcbfe696e56fb144ec52c9d481a013140ad2a99577",
+          "size": 19642727,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.10.16%2B20241206-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "6d73aa4829ba89e1ede7cde94ad064730fb3635b4853143e855a67bd62f828b0",
+          "size": 20772599,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.10.16%2B20241206-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "e5e63f308525fd99f638f8ab7dd425a96b430d8ede91f940558ee36987985898",
+          "size": 17322071,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.10.16%2B20241206-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "28e161d8896fcd7df9f68acf230e2c1224fedeb9d547e52a48ff7b39ed07708e",
+          "size": 17674785,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.10.16%2B20241206-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      }
+    },
     "3.10.2": {
+      "20220227": {
+        "linux_arm64": {
+          "sha256": "8f351a8cc348bb45c0f95b8634c8345ec6e749e483384188ad865b7428342703",
+          "size": 88747017,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "9b64eca2a94f7aff9409ad70bdaa7fbbf8148692662e764401883957943620dd",
+          "size": 53642545,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "1409acd9a506e2d1d3b65c1488db4e40d8f19d09a7df099667c87a506f71c0ef",
+          "size": 42503895,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "8146ad4390710ec69b316a5649912df0247d35f4a42e2aa9615bffd87b3e235a",
+          "size": 42785626,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "8f351a8cc348bb45c0f95b8634c8345ec6e749e483384188ad865b7428342703",
         "size": 88747017,
@@ -174,6 +572,28 @@
       }
     },
     "3.10.3": {
+      "20220318": {
+        "linux_arm64": {
+          "sha256": "f52ee68c13c4f9356eb78a5305d3178af2cb90c38a8ce8ce9990a7cf6ff06144",
+          "size": 89386559,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "b9989411bed71ba4867538c991f20b55f549dd9131905733f0df9f3fde81ad1d",
+          "size": 54110057,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "db46dadfccc407aa1f66ed607eefbf12f781e343adcb1edee0a3883d081292ce",
+          "size": 43030480,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "ec2e90b6a589db7ef9f74358b1436558167629f9e4d725c8150496f9cb08a9d4",
+          "size": 43289051,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "f52ee68c13c4f9356eb78a5305d3178af2cb90c38a8ce8ce9990a7cf6ff06144",
         "size": 89386559,
@@ -200,6 +620,50 @@
       }
     },
     "3.10.4": {
+      "20220502": {
+        "linux_arm64": {
+          "sha256": "d8098c0c54546637e7516f93b13403b11f9db285def8d7abd825c31407a13d7e",
+          "size": 89194558,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.10.4%2B20220502-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "f6f871e53a7b1469c13f9bd7920ad98c4589e549acad8e5a1e14760fff3dd5c9",
+          "size": 54091940,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.10.4%2B20220502-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "2c99983d1e83e4b6e7411ed9334019f193fba626344a50c36fba6c25d4de78a2",
+          "size": 42900401,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.10.4%2B20220502-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "f2711eaffff3477826a401d09a013c6802f11c04c63ab3686aa72664f1216a05",
+          "size": 43153224,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.10.4%2B20220502-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
+      "20220528": {
+        "linux_arm64": {
+          "sha256": "7a8989392dc9b41d85959a752448c60852cf0061de565e98445c27f6bbdf63be",
+          "size": 89292900,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "1f8423808ad84c0e56c8e14c32685cbfbc1159e0d9f943ac946f29e84cf1b5ee",
+          "size": 54186539,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "6d2e4e6b1c403bce84cfb846400754017f525fe8017f186e8e7072fcaaf3aa71",
+          "size": 42984466,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "c4a57a13b084d49ce8c2eb5b2662ee45b0c55b08ddd696f473233b0787f03988",
+          "size": 43233147,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "7a8989392dc9b41d85959a752448c60852cf0061de565e98445c27f6bbdf63be",
         "size": 89292900,
@@ -226,6 +690,28 @@
       }
     },
     "3.10.5": {
+      "20220630": {
+        "linux_arm64": {
+          "sha256": "012fa37c12d2647d76d004dc003302563864d2f1cd0731b71eeafad63d28b3f0",
+          "size": 89356775,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "460f87a389be28c953c24c6f942f172f9ce7f331367b4daf89cb450baedd51d7",
+          "size": 54207014,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "19d1aa4a6d9ddb0094fc36961b129de9abe1673bce66c86cd97b582795c496a8",
+          "size": 43000441,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "eca0584397d9a3ef6f7bb32b0476318b01c89b7b0a031ef97a0dcaa5ba5127a8",
+          "size": 43257698,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "012fa37c12d2647d76d004dc003302563864d2f1cd0731b71eeafad63d28b3f0",
         "size": 89356775,
@@ -252,6 +738,28 @@
       }
     },
     "3.10.6": {
+      "20220802": {
+        "linux_arm64": {
+          "sha256": "81625f5c97f61e2e3d7e9f62c484b1aa5311f21bd6545451714b949a29da5435",
+          "size": 24921808,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "55aa2190d28dcfdf414d96dc5dcea9fe048fadcd583dc3981fec020869826111",
+          "size": 27536682,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "efaf66acdb9a4eb33d57702607d2e667b1a319d58c167a43c96896b97419b8b7",
+          "size": 17138410,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "7718411adf3ea1480f3f018a643eb0550282aefe39e5ecb3f363a4a566a9398c",
+          "size": 17544359,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "81625f5c97f61e2e3d7e9f62c484b1aa5311f21bd6545451714b949a29da5435",
         "size": 24921808,
@@ -278,6 +786,28 @@
       }
     },
     "3.10.7": {
+      "20221002": {
+        "linux_arm64": {
+          "sha256": "dfeec186a62a6068259d90e8d77e7d30eaf9c2b4ae7b205ff8caab7cb21f277c",
+          "size": 24938179,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "c12c9ad2b2c75464541d897c0528013adecd8be5b30acf4411f7759729841711",
+          "size": 27546579,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "70f6ca1da8e6fce832ad0b7f9fdaba0b84ba0ac0a4c626127acb6d49df4b8f91",
+          "size": 17142891,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "6101f580434544d28d5590543029a7c6bdf07efa4bcdb5e4cbedb3cd83241922",
+          "size": 17554388,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "dfeec186a62a6068259d90e8d77e7d30eaf9c2b4ae7b205ff8caab7cb21f277c",
         "size": 24938179,
@@ -304,6 +834,28 @@
       }
     },
     "3.10.8": {
+      "20221106": {
+        "linux_arm64": {
+          "sha256": "33170bef18c811906b738be530f934640491b065bf16c4d276c6515321918132",
+          "size": 24947106,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "6c8db44ae0e18e320320bbaaafd2d69cde8bfea171ae2d651b7993d1396260b7",
+          "size": 27555856,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "d52b03817bd245d28e0a8b2f715716cd0fcd112820ccff745636932c76afa20a",
+          "size": 17150191,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "525b79c7ce5de90ab66bd07b0ac1008bafa147ddc8a41bef15ffb7c9c1e9e7c5",
+          "size": 17560650,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "33170bef18c811906b738be530f934640491b065bf16c4d276c6515321918132",
         "size": 24947106,
@@ -330,6 +882,50 @@
       }
     },
     "3.10.9": {
+      "20221220": {
+        "linux_arm64": {
+          "sha256": "4dfed493a8e6f5a797cd171b270c7c7152d8e8492ca60c1c582b68403e5ecd78",
+          "size": 24961415,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221220/cpython-3.10.9%2B20221220-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "5eabd117850cf92280569db874f3548d90048abc8ce55c315aeefd69d2ad6e44",
+          "size": 27579433,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221220/cpython-3.10.9%2B20221220-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "e9a7a69a153621b5e9f930c81478f06819dd5bc0edec20212c3392851b8803e1",
+          "size": 17182797,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221220/cpython-3.10.9%2B20221220-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "861aa2cc40d0e01ff570b75dec180bfe4709b98bd0cfa3f5135799c2cb2a2228",
+          "size": 17580272,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221220/cpython-3.10.9%2B20221220-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
+      "20230116": {
+        "linux_arm64": {
+          "sha256": "2003750f40cd09d4bf7a850342613992f8d9454f03b3c067989911fb37e7a4d1",
+          "size": 24505626,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "d196347aeb701a53fe2bb2b095abec38d27d0fa0443f8a1c2023a1bed6e18cdf",
+          "size": 27081922,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "018d05a779b2de7a476f3b3ff2d10f503d69d14efcedd0774e6dab8c22ef84ff",
+          "size": 17509509,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "0e685f98dce0e5bc8da93c7081f4e6c10219792e223e4b5886730fd73a7ba4c6",
+          "size": 17474702,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "2003750f40cd09d4bf7a850342613992f8d9454f03b3c067989911fb37e7a4d1",
         "size": 24505626,
@@ -356,6 +952,28 @@
       }
     },
     "3.11.1": {
+      "20230116": {
+        "linux_arm64": {
+          "sha256": "debf15783bdcb5530504f533d33fda75a7b905cec5361ae8f33da5ba6599f8b4",
+          "size": 25579178,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "02a551fefab3750effd0e156c25446547c238688a32fabde2995c941c03a6423",
+          "size": 29321007,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "4918cdf1cab742a90f85318f88b8122aeaa2d04705803c7b6e78e81a3dd40f80",
+          "size": 18024309,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "20a4203d069dc9b710f70b09e7da2ce6f473d6b1110f9535fb6f4c469ed54733",
+          "size": 18042424,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "debf15783bdcb5530504f533d33fda75a7b905cec5361ae8f33da5ba6599f8b4",
         "size": 25579178,
@@ -382,6 +1000,94 @@
       }
     },
     "3.11.10": {
+      "20240909": {
+        "linux_arm64": {
+          "sha256": "7ac6ef4209153a1de211ab112ed318b4d702d6ca2655829ad6695d9523eaf47d",
+          "size": 19962035,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.11.10%2B20240909-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "2f8fdc87e8aab1f9f166575e3379d36abd0f7a87ea6c66c5e97e3aaadedd291d",
+          "size": 21202781,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.11.10%2B20240909-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "74a9e2921aefecf22f79d633fd436dd2e756a075fff45d52c55f55e62b90a4e0",
+          "size": 17623422,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.11.10%2B20240909-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "46c5dd0fc5f2963541ac6748671d04e01217f6b4f55dcdf7022e74ccb4452683",
+          "size": 18013415,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.11.10%2B20240909-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      },
+      "20241002": {
+        "linux_arm64": {
+          "sha256": "723ec57b64349d748bbd55579be8a08c0d3633267f0c5820eb75df598792c975",
+          "size": 19962031,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.11.10%2B20241002-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "34c58f0dfd84ce2b16cea07ca39c47ed8d7b7b3656dda63062e9e9db55d43ec4",
+          "size": 21203182,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.11.10%2B20241002-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "263b1b50ff705ab064c50c3165de9df2ed712a77cd81c55dd340c3172e103687",
+          "size": 17622888,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.11.10%2B20241002-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "a8174aef8a662201d1bb4680571cf383e89f5b44dc06614df5928595ddf82876",
+          "size": 18012721,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.11.10%2B20241002-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      },
+      "20241008": {
+        "linux_arm64": {
+          "sha256": "4cc6a85666586732a08f456616e234e3a49f0c85e28df4703064118a465b32be",
+          "size": 19962035,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "d025f46c2ff20dd5ad8ff4628f65e691be73ca314b53b4145a691d9237601534",
+          "size": 21202915,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "fd187c5c12813e27261768d37ad46f08bc182f346d6ca9f3f87b57442ef9ed56",
+          "size": 17626378,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "ecd44a6309939d6d06db2b9b3a9b40361dc1e248b4956bd635671a1475ee3f17",
+          "size": 18013033,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      },
+      "20241016": {
+        "linux_arm64": {
+          "sha256": "9d124604ffdea4fbaabb10b343c5a36b636a3e7b94dfc1cccd4531f33fceae5e",
+          "size": 19963074,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "03f15e19e2452641b6375b59ba094ff6cf2fc118315d24a6ca63ce60e4d4a6e0",
+          "size": 21205300,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "a5a224138a526acecfd17210953d76a28487968a767204902e2bde809bb0e759",
+          "size": 17629090,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "575b49a7aa64e97b06de605b7e947033bf2310b5bc5f9aedb9859d4745033d91",
+          "size": 18011078,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "9d124604ffdea4fbaabb10b343c5a36b636a3e7b94dfc1cccd4531f33fceae5e",
         "size": 19963074,
@@ -407,7 +1113,75 @@
         "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-x86_64-apple-darwin-install_only_stripped.tar.gz"
       }
     },
+    "3.11.11": {
+      "20241205": {
+        "linux_arm64": {
+          "sha256": "eb73b51cf10cb796554de424aa0ffbb9c34153b98fbf089d56ff65a197e3c5b8",
+          "size": 20214207,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241205/cpython-3.11.11%2B20241205-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "41d3dee25432da62f9e87e3eb651ac94b88ccd50bab3e934831286281c8d5bca",
+          "size": 21466394,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241205/cpython-3.11.11%2B20241205-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "8786259f346673719efd15c8a8cc7bdb859941a8759d309b797de7e2e3f7a7d6",
+          "size": 17884553,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241205/cpython-3.11.11%2B20241205-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "c7dec1cb612b44b4d6f003cc731b6fed761bd6b92243a83b9b14c58c9f3ec968",
+          "size": 18262007,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241205/cpython-3.11.11%2B20241205-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      },
+      "20241206": {
+        "linux_arm64": {
+          "sha256": "d1602bc7d9b99e4189c21c00bfce2b3690d90f47d13ae5d14968f2b9ca6321c2",
+          "size": 20214319,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.11.11%2B20241206-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "bdef41c5bf7fcdec13dc9eddf557cffd21b740f4fe575cb31dc877219af58a39",
+          "size": 21462058,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.11.11%2B20241206-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "ddd8fc255df97dd8b902927d284205346f929afa74d58f0ffe1ffd35b3543514",
+          "size": 17883204,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.11.11%2B20241206-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "9fce00c70f5230e0d822a71420e19599f8e1f1940e17bcc13be72fa251871d90",
+          "size": 18263933,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.11.11%2B20241206-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      }
+    },
     "3.11.3": {
+      "20230507": {
+        "linux_arm64": {
+          "sha256": "8190accbbbbcf7620f1ff6d668e4dd090c639665d11188ce864b62554d40e5ab",
+          "size": 25301609,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "da50b87d1ec42b3cb577dfd22a3655e43a53150f4f98a4bfb40757c9d7839ab5",
+          "size": 28906807,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "09e412506a8d63edbb6901742b54da9aa7faf120b8dbdce56c57b303fc892c86",
+          "size": 17585902,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "f710b8d60621308149c100d5175fec39274ed0b9c99645484fd93d1716ef4310",
+          "size": 17912223,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "8190accbbbbcf7620f1ff6d668e4dd090c639665d11188ce864b62554d40e5ab",
         "size": 25301609,
@@ -434,6 +1208,28 @@
       }
     },
     "3.11.4": {
+      "20230726": {
+        "linux_arm64": {
+          "sha256": "2e84fc53f4e90e11963281c5c871f593abcb24fc796a50337fa516be99af02fb",
+          "size": 25061612,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "e26247302bc8e9083a43ce9e8dd94905b40d464745b1603041f7bc9a93c65d05",
+          "size": 28658858,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "cb6d2948384a857321f2aa40fa67744cd9676a330f08b6dad7070bda0b6120a4",
+          "size": 17343022,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "47e1557d93a42585972772e82661047ca5f608293158acb2778dccf120eabb00",
+          "size": 17677396,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "2e84fc53f4e90e11963281c5c871f593abcb24fc796a50337fa516be99af02fb",
         "size": 25061612,
@@ -460,6 +1256,28 @@
       }
     },
     "3.11.5": {
+      "20230826": {
+        "linux_arm64": {
+          "sha256": "bb5c5d1ea0f199fe2d3f0996fff4b48ca6ddc415a3dbd98f50bff7fce48aac80",
+          "size": 25085307,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "fbed6f7694b2faae5d7c401a856219c945397f772eea5ca50c6eb825cbc9d1e1",
+          "size": 28705307,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "dab64b3580118ad2073babd7c29fd2053b616479df5c107d31fe2af1f45e948b",
+          "size": 17379941,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "4a4efa7378c72f1dd8ebcce1afb99b24c01b07023aa6b8fea50eaedb50bf2bfc",
+          "size": 17702502,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "bb5c5d1ea0f199fe2d3f0996fff4b48ca6ddc415a3dbd98f50bff7fce48aac80",
         "size": 25085307,
@@ -486,6 +1304,28 @@
       }
     },
     "3.11.6": {
+      "20231002": {
+        "linux_arm64": {
+          "sha256": "3e26a672df17708c4dc928475a5974c3fb3a34a9b45c65fb4bd1e50504cc84ec",
+          "size": 25547472,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "ee37a7eae6e80148c7e3abc56e48a397c1664f044920463ad0df0fc706eacea8",
+          "size": 29257565,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "916c35125b5d8323a21526d7a9154ca626453f63d0878e95b9f613a95006c990",
+          "size": 17456917,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "178cb1716c2abc25cb56ae915096c1a083e60abeba57af001996e8bc6ce1a371",
+          "size": 18090352,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "3e26a672df17708c4dc928475a5974c3fb3a34a9b45c65fb4bd1e50504cc84ec",
         "size": 25547472,
@@ -512,6 +1352,28 @@
       }
     },
     "3.11.7": {
+      "20240107": {
+        "linux_arm64": {
+          "sha256": "b102eaf865eb715aa98a8a2ef19037b6cc3ae7dfd4a632802650f29de635aa13",
+          "size": 25593238,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "4a51ce60007a6facf64e5495f4cf322e311ba9f39a8cd3f3e4c026eae488e140",
+          "size": 29335084,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "b042c966920cf8465385ca3522986b12d745151a72c060991088977ca36d3883",
+          "size": 17492365,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "a0e615eef1fafdc742da0008425a9030b7ea68a4ae4e73ac557ef27b112836d4",
+          "size": 18136686,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "b102eaf865eb715aa98a8a2ef19037b6cc3ae7dfd4a632802650f29de635aa13",
         "size": 25593238,
@@ -538,6 +1400,28 @@
       }
     },
     "3.11.8": {
+      "20240224": {
+        "linux_arm64": {
+          "sha256": "389b9005fb78dd5a6f68df5ea45ab7b30d9a4b3222af96999e94fd20d4ad0c6a",
+          "size": 26053684,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "94e13d0e5ad417035b80580f3e893a72e094b0900d5d64e7e34ab08e95439987",
+          "size": 29798726,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "389a51139f5abe071a0d70091ca5df3e7a3dfcfcbe3e0ba6ad85fb4c5638421e",
+          "size": 17908564,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "097f467b0c36706bfec13f199a2eaf924e668f70c6e2bd1f1366806962f7e86e",
+          "size": 18294281,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "389b9005fb78dd5a6f68df5ea45ab7b30d9a4b3222af96999e94fd20d4ad0c6a",
         "size": 26053684,
@@ -564,6 +1448,116 @@
       }
     },
     "3.11.9": {
+      "20240415": {
+        "linux_arm64": {
+          "sha256": "b3a7199ac2615d75fb906e5ba556432efcf24baf8651fc70370d9f052d4069ee",
+          "size": 26061145,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.11.9%2B20240415-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "78b1c16a9fd032997ba92a60f46a64f795cd18ff335659dfdf6096df277b24d5",
+          "size": 29812587,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.11.9%2B20240415-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "7af7058f7c268b4d87ed7e08c2c7844ef8460863b3e679db3afdce8bb1eedfae",
+          "size": 17915401,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.11.9%2B20240415-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "9afd734f63a23783cf0257bef25c9231ffc80e7747486dc54cf72f325213fd15",
+          "size": 18295939,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.11.9%2B20240415-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
+      "20240713": {
+        "linux_arm64": {
+          "sha256": "32f70725d45dc5affd8d3eb132671eaea02695e6d072dc5591f2d7418dee6fc1",
+          "size": 26061137,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240713/cpython-3.11.9%2B20240713-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "1f91c44febc850376a35ae77e1d45f7c823994b0c80293bbbc17e647eb893853",
+          "size": 29814546,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240713/cpython-3.11.9%2B20240713-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "a25a23802821699fae913dacd123033998ed745dfed692c8c7079590d2153d8d",
+          "size": 17909691,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240713/cpython-3.11.9%2B20240713-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "9b56b0d2e301de0f5f94be9d5b7bd3f318c88d7897f9b183269ccada6356ac45",
+          "size": 18295672,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240713/cpython-3.11.9%2B20240713-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
+      "20240725": {
+        "linux_arm64": {
+          "sha256": "01d2bbe3edb46188656db4a4c7e2292072e34bb8aa4849576c34dbe58718c078",
+          "size": 25922357,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240725/cpython-3.11.9%2B20240725-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "34ea39bca968c63c1a8e45dd2114a52b3dc9b5473300278c0bceeb793dba90db",
+          "size": 29717161,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240725/cpython-3.11.9%2B20240725-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "672b17e5c41e2c7dbce4cf7f2fbd0a972895bc781f4e7adca927629e9be993ad",
+          "size": 17794122,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240725/cpython-3.11.9%2B20240725-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "013941df52f7957058e3459c9d85c0587374f0541ac881733f63d00e6cee1b6a",
+          "size": 18162238,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240725/cpython-3.11.9%2B20240725-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      },
+      "20240726": {
+        "linux_arm64": {
+          "sha256": "1b631d5d76a0f4ab70f2bc9dcad06284a7ffcba53fe0b38fbd3135fbe00c2efc",
+          "size": 19962479,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.11.9%2B20240726-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "59427f06d187a51963ca025b3b37d58acfa55cb9d9e2dc6944e191158715cede",
+          "size": 21198922,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.11.9%2B20240726-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "4e60044786e069ef827792f9357734c222f7ec57731bf7a31f1882eca91cce52",
+          "size": 17626034,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.11.9%2B20240726-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "0d83ce532ae48559147be3ab2bf59242f9197c89fe215f6bba327429cdd6730a",
+          "size": 18009281,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.11.9%2B20240726-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      },
+      "20240814": {
+        "linux_arm64": {
+          "sha256": "364cf099524fff92c31b8ff5ae3f7b32b0fa6cf1d380c6e37cf56140d08dfc87",
+          "size": 19962482,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "daa487c7e73005c4426ac393273117cf0e2dc4ab9b2eeda366e04cd00eea00c9",
+          "size": 21200862,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "c4e2f7774421bcb381245945e132419b529399dfa4a56059acda1493751fa377",
+          "size": 17618881,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "c8680f90137e36b54b3631271ccdfe5de363e7d563d8df87c53e11b956a00e04",
+          "size": 18009651,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "364cf099524fff92c31b8ff5ae3f7b32b0fa6cf1d380c6e37cf56140d08dfc87",
         "size": 19962482,
@@ -590,6 +1584,28 @@
       }
     },
     "3.12.0": {
+      "20231002": {
+        "linux_arm64": {
+          "sha256": "bccfe67cf5465a3dfb0336f053966e2613a9bc85a6588c2fcf1366ef930c4f88",
+          "size": 25109984,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "e51a5293f214053ddb4645b2c9f84542e2ef86870b8655704367bd4b29d39fe9",
+          "size": 67780633,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "4734a2be2becb813830112c780c9879ac3aff111a0b0cd590e65ec7465774d02",
+          "size": 16380983,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "5a9e88c8aa52b609d556777b52ebde464ae4b4f77e4aac4eb693af57395c9abf",
+          "size": 16985354,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "bccfe67cf5465a3dfb0336f053966e2613a9bc85a6588c2fcf1366ef930c4f88",
         "size": 25109984,
@@ -616,6 +1632,28 @@
       }
     },
     "3.12.1": {
+      "20240107": {
+        "linux_arm64": {
+          "sha256": "236533ef20e665007a111c2f36efb59c87ae195ad7dca223b6dc03fb07064f0b",
+          "size": 25167638,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "74e330b8212ca22fd4d9a2003b9eec14892155566738febc8e5e572f267b9472",
+          "size": 67786580,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "f93f8375ca6ac0a35d58ff007043cbd3a88d9609113f1cb59cf7c8d215f064af",
+          "size": 16428491,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "eca96158c1568dedd9a0b3425375637a83764d1fa74446438293089a8bfac1f8",
+          "size": 17020244,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "236533ef20e665007a111c2f36efb59c87ae195ad7dca223b6dc03fb07064f0b",
         "size": 25167638,
@@ -642,6 +1680,28 @@
       }
     },
     "3.12.2": {
+      "20240224": {
+        "linux_arm64": {
+          "sha256": "e52550379e7c4ac27a87de832d172658bc04150e4e27d4e858e6d8cbb96fd709",
+          "size": 25620958,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "57a37b57f8243caa4cdac016176189573ad7620f0b6da5941c5e40660f9468ab",
+          "size": 68023315,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "01c064c00013b0175c7858b159989819ead53f4746d40580b5b0b35b6e80fba6",
+          "size": 16840399,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "a53a6670a202c96fec0b8c55ccc780ea3af5307eb89268d5b41a9775b109c094",
+          "size": 17177894,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "e52550379e7c4ac27a87de832d172658bc04150e4e27d4e858e6d8cbb96fd709",
         "size": 25620958,
@@ -668,6 +1728,28 @@
       }
     },
     "3.12.3": {
+      "20240415": {
+        "linux_arm64": {
+          "sha256": "ec8126de97945e629cca9aedc80a29c4ae2992c9d69f2655e27ae73906ba187d",
+          "size": 25626233,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "a73ba777b5d55ca89edef709e6b8521e3f3d4289581f174c8699adfb608d09d6",
+          "size": 67368051,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "ccc40e5af329ef2af81350db2a88bbd6c17b56676e82d62048c15d548401519e",
+          "size": 16814925,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "c37a22fca8f57d4471e3708de6d13097668c5f160067f264bb2b18f524c890c8",
+          "size": 17151699,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "ec8126de97945e629cca9aedc80a29c4ae2992c9d69f2655e27ae73906ba187d",
         "size": 25626233,
@@ -694,6 +1776,72 @@
       }
     },
     "3.12.4": {
+      "20240713": {
+        "linux_arm64": {
+          "sha256": "c152d5c82272cc66f183dd00c5e9883148a25bb8a91a66d5b3e9c8a11289b2eb",
+          "size": 25622381,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240713/cpython-3.12.4%2B20240713-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "eb5f83bfcd16391a5c010356e82708a0f1e6b7d4d8106f21e545a858f7d5f409",
+          "size": 63306192,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240713/cpython-3.12.4%2B20240713-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "1c0e0fe57200fc7787e3a11a56e641a08a853d31860aa2c21483ffbe1261c115",
+          "size": 16793087,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240713/cpython-3.12.4%2B20240713-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "6713765cf6b16e55d8b36dc304a34c9dfcd9365d02ad78e2801c49d0e91266ef",
+          "size": 17125560,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240713/cpython-3.12.4%2B20240713-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
+      "20240725": {
+        "linux_arm64": {
+          "sha256": "723ef3059201e0018144e3ffb712b69a536911dd85b8ff85280ce3ca20e7ade6",
+          "size": 25483974,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240725/cpython-3.12.4%2B20240725-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "d491e01f71e9bf97877a8009353fdf0f749e9038c7e67a7be866717a6bcdfd1c",
+          "size": 63437008,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240725/cpython-3.12.4%2B20240725-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "72dd8279ef671033fa766590168091ae82b2b65e031da855e5a4f6725dc4b8c4",
+          "size": 16680539,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240725/cpython-3.12.4%2B20240725-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "cd7601f4137c3c16c90f7de64223ee5adb425b73d27f3256ce68f02ddfe3bdb8",
+          "size": 17013922,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240725/cpython-3.12.4%2B20240725-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      },
+      "20240726": {
+        "linux_arm64": {
+          "sha256": "6c9cf13644edc7250525ab1b2529ba1c0fff56c0c5a5c2242d84b6d4889d2bea",
+          "size": 18953227,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "ca076aee4329f53f988346eb0521ad2a2cf7f723b6296088d03b98d8f22f5420",
+          "size": 22253274,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "ef6948e836f531bd7a58ffbe602803ff1c83c65f99d1da19be369ea61f136c93",
+          "size": 16490253,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "9d68cbdd12d1d6f98d35cc76add232c12db75c6b7f49733bffc88e7b1c025a79",
+          "size": 16838842,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "6c9cf13644edc7250525ab1b2529ba1c0fff56c0c5a5c2242d84b6d4889d2bea",
         "size": 18953227,
@@ -720,6 +1868,28 @@
       }
     },
     "3.12.5": {
+      "20240814": {
+        "linux_arm64": {
+          "sha256": "06e512178cb513658a01c054b3eafc649ca362ccbeb02a6ae8a55b02c1ba75ca",
+          "size": 18670032,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "10680b593b5e31833218fd83104dee74af970a3463403a22bae613b952a34e8d",
+          "size": 21984711,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "90715cdab075e5a2680acf2695572d165b6269bdb5d1942ab577491478aea55f",
+          "size": 16223961,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "49a9f7ad41d62e0ece9e664ca5ae95f022e7b68eef48e8a6f11620ec9247c686",
+          "size": 16564547,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "06e512178cb513658a01c054b3eafc649ca362ccbeb02a6ae8a55b02c1ba75ca",
         "size": 18670032,
@@ -746,6 +1916,28 @@
       }
     },
     "3.12.6": {
+      "20240909": {
+        "linux_arm64": {
+          "sha256": "22d119ac7df7f0bddfd4dfd075bcc4eb2532ed3df0bdba0579106835d49ef9cd",
+          "size": 17862875,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "b080463e4f0c452e592cdac1ca97936a6a19bb3d9a64da669a50ca843fce0108",
+          "size": 21243376,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "0419bafa4444a5aa0c554197bce0679e7cc0f28edc7ee8cfbe0ccea860bdb904",
+          "size": 15421366,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "b10d19eb5548a3b3b0a5e6f9109834d7ecfc139bc15754f81a94d39eaa5bdd26",
+          "size": 15780284,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "22d119ac7df7f0bddfd4dfd075bcc4eb2532ed3df0bdba0579106835d49ef9cd",
         "size": 17862875,
@@ -772,6 +1964,72 @@
       }
     },
     "3.12.7": {
+      "20241002": {
+        "linux_arm64": {
+          "sha256": "5d2cf6bfd11351ba6d07a112ff563a62176a3f9f90a169f350f8c4d7489c08d5",
+          "size": 17867195,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.12.7%2B20241002-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "5ca4e88da44d5e07462a4a8b5ad27956dad9eedcfae4b1db37a784daf1827396",
+          "size": 21277646,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.12.7%2B20241002-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "473c8745464e2b20477bb4faa2e0de51b6fadae68ecd79ca7951df2d15c1b214",
+          "size": 15461292,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.12.7%2B20241002-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "acc9294db71a23be6ca947b039b1fc5be40638d2ab212034dba37abe4df9f53b",
+          "size": 15817001,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.12.7%2B20241002-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      },
+      "20241008": {
+        "linux_arm64": {
+          "sha256": "e254373827bde6b389ed17b8bb8aa8ac7b3659cf56d36e084a53ed1d04a02210",
+          "size": 17867198,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "11091cd2eb8b7f4551665ba8f9f5b83aa3d09fc0e17f1649d76d5f4f75254bf8",
+          "size": 21283830,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "dc1f4d80c9b4ae40ba2c725e310e61446f8f778a7bea4efa56e4b1b4446e0a1a",
+          "size": 15455089,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "7091bd9ce844bcbceb8f3466a9c9583a139f79edd3b0cbed82f7423d333b2d4b",
+          "size": 15809998,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      },
+      "20241016": {
+        "linux_arm64": {
+          "sha256": "c8f5ed70ee3c19da72d117f7b306adc6ca1eaf26afcbe1cc1be57d1e18df184c",
+          "size": 17865102,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "3a4d53a7ba3916c0c1f35cbbe57068e2571b138389f29cf5c35367fec8f4c617",
+          "size": 21276148,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "95dd397e3aef4cc1846867cf20be704bdd74edd16ea8032caf01e48f0c53d65d",
+          "size": 15457017,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "848405b92bda20fad1f9bba99234c7d3f11e0b31e46f89835d1cb3d735e932aa",
+          "size": 15817311,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "c8f5ed70ee3c19da72d117f7b306adc6ca1eaf26afcbe1cc1be57d1e18df184c",
         "size": 17865102,
@@ -797,7 +2055,97 @@
         "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-x86_64-apple-darwin-install_only_stripped.tar.gz"
       }
     },
+    "3.12.8": {
+      "20241205": {
+        "linux_arm64": {
+          "sha256": "906ae76a74fc727dc316ca13e49dbc4d9b5efc09fdcf055eaddbf04165fdb208",
+          "size": 17891856,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241205/cpython-3.12.8%2B20241205-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "b95ec400706da032f4644fc931dfc3d8d916aad9b09b2d9b8f9b4934f32e045e",
+          "size": 21295616,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241205/cpython-3.12.8%2B20241205-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "820df160dbfc13e4b4661a85217335d7d22f5c68b016f6725f2f747afba6360b",
+          "size": 15492971,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241205/cpython-3.12.8%2B20241205-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "79ea2ce1c9fd5841beb883ce33b7d0974b464b1f8f85b1b172158b3ca645fa58",
+          "size": 15848643,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241205/cpython-3.12.8%2B20241205-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      },
+      "20241206": {
+        "linux_arm64": {
+          "sha256": "de4dacd5b182523e3567d547f0e072af0502a52ac2e8244ae14f58049daf7a66",
+          "size": 17891847,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.12.8%2B20241206-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "a19f6765df233ec3943c5e975c104a2ffd60ba1258cb038d7d6b8208308921c0",
+          "size": 21294852,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.12.8%2B20241206-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "d6e607f109db29f2e4a00137fde91f29f359709e1815887334305e4f560b19ac",
+          "size": 15485682,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.12.8%2B20241206-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "2dbebc822dea55d60db64f93f532aa72aea4b5ccb400a1cee4f8b4a489a10ce5",
+          "size": 15846800,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.12.8%2B20241206-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      }
+    },
     "3.13.0": {
+      "20241008": {
+        "linux_arm64": {
+          "sha256": "1bfc058821199c4313ae67bb6c105df2c9dd3515bca955ff96724976acf64462",
+          "size": 17577491,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "aa876c2660a802d0df8ef46f9c4b1c952e63c65d16e103663c22b9468dad40b7",
+          "size": 19021119,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "7bc4b23590a1e4b41b21b6aae6f92046c1d16d09bc0c1ab81272aa81b55221d1",
+          "size": 15436943,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "d6bc769002842147150a561502a23b57d5a8aa1ba643a6a0abf589bfe834e642",
+          "size": 15879991,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      },
+      "20241016": {
+        "linux_arm64": {
+          "sha256": "06e633164cb0133685a2ce14af88df0dbcaea4b0b2c5d3348d6b81393307481a",
+          "size": 17577968,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "b5e74d1e16402b633c6f04519618231fc0dbae7d2f9e4b1ac17c294cc3d3d076",
+          "size": 19024698,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "e94fafbac07da52c965cb6a7ffc51ce779bd253cd98af801347aac791b96499f",
+          "size": 15440316,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "406664681bd44af35756ad08f5304f1ec57070bb76fae8ff357ff177f229b224",
+          "size": 15874759,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "06e633164cb0133685a2ce14af88df0dbcaea4b0b2c5d3348d6b81393307481a",
         "size": 17577968,
@@ -867,7 +2215,70 @@
         "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64-apple-darwin-install_only_stripped.tar.gz"
       }
     },
+    "3.13.1": {
+      "20241205": {
+        "linux_arm64": {
+          "sha256": "39dff35b89d3ccc8ea5297b8de304f3bcb4e77d308ba8c7edca6bcb86237498b",
+          "size": 17601974,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241205/cpython-3.13.1%2B20241205-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "b38ad43d08fbdf8ae87d21384aed5484d4454ad96c4965f58a59ee291d9d3006",
+          "size": 19086534,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241205/cpython-3.13.1%2B20241205-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "8e9d7c71a24d3562db1d1d14f423e48cfaa9bcb7bdc5a13dc14abda85e8c763b",
+          "size": 15494104,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241205/cpython-3.13.1%2B20241205-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "8c40f0b2584f97ea23735501c55c6c080f75ac294451ef6719aa0a7686a92d5f",
+          "size": 15930220,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241205/cpython-3.13.1%2B20241205-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      },
+      "20241206": {
+        "linux_arm64": {
+          "sha256": "aa587f93f04f09c666e574f42f1dbe2cda59c99029fda837226426311018c7fe",
+          "size": 17601970,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.13.1%2B20241206-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "5f4ed2b4444b62844dc88cca756435041c2fc2b7a5a64ac5281d83b3d19dcb72",
+          "size": 19083294,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.13.1%2B20241206-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "64638847581cd5f4e4a364b014b5dfb4da6589a10e52f64553b832d2f2113fa3",
+          "size": 15498222,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.13.1%2B20241206-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "e8d98cf814341ac173d2d19b013f76a0c2e707397a86a4a384f7e186f555cbfb",
+          "size": 15928195,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.13.1%2B20241206-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      }
+    },
     "3.8.12": {
+      "20220227": {
+        "linux_x86_64": {
+          "sha256": "5be9c6d61e238b90dfd94755051c0d3a2d8023ebffdb4b0fa4e8fedd09a6cab6",
+          "size": 49945411,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "f9a3cbb81e0463d6615125964762d133387d561b226a30199f5b039b20f1d944",
+          "size": 40042198,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "f323fbc558035c13a85ce2267d0fad9e89282268ecb810e364fff1d0a079d525",
+          "size": 40287093,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
       "linux_x86_64": {
         "sha256": "5be9c6d61e238b90dfd94755051c0d3a2d8023ebffdb4b0fa4e8fedd09a6cab6",
         "size": 49945411,
@@ -888,6 +2299,96 @@
       }
     },
     "3.8.13": {
+      "20220318": {
+        "linux_x86_64": {
+          "sha256": "e566beec8d2ed9efd44f0170662efea0ddb302be2e5bb83bd8c39a361985c32f",
+          "size": 50552822,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.8.13%2B20220318-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "baa8ea669d2ecb521a98bb5a53891fc367b810ab4845bcf6ba07dabe202c2481",
+          "size": 40629957,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.8.13%2B20220318-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "26bd9c838d2d65ef7ffda8f9f265f8a75af60ff80ad782e29c3779542ba7ceef",
+          "size": 40895520,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.8.13%2B20220318-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
+      "20220502": {
+        "linux_x86_64": {
+          "sha256": "884c6c4605c11685164237bad5f8f2773edcf3abb0637a83efa7912a54f658b3",
+          "size": 50609885,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.8.13%2B20220502-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "ba604867d8c6e0a1a85b1be789cad4c69af8a1699043f51e8a85998b55979127",
+          "size": 40536342,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.8.13%2B20220502-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "52e3541f41d165002e19a60e11dcc145e90ffe1fe8a6f94b17d5b72a674674ea",
+          "size": 40743012,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.8.13%2B20220502-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
+      "20220528": {
+        "linux_x86_64": {
+          "sha256": "8c97b4d2305be6b76362265ea8449fc071c387b26bfd2a09ca8a7879543fa7dc",
+          "size": 50691625,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.8.13%2B20220528-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "bc1914f76eb6465ae8abaae0958d4276d1514f936ec5767005dbcda76c2d968f",
+          "size": 40645889,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.8.13%2B20220528-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "d8e816bea432ae2859de6aeb6914831705914ac8fabaed9fd08ebff8c4975e54",
+          "size": 40823000,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.8.13%2B20220528-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
+      "20220630": {
+        "linux_x86_64": {
+          "sha256": "fb191a5a1e1e3cb60dbd26ebd6cb197fc6f1557b0c06e9b31484d5b4576f07b4",
+          "size": 50654106,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.8.13%2B20220630-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "470ac1120de88f2f73bbcbfc2b629e2e32764531e35f80fb5ac75614b247ced5",
+          "size": 40639707,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.8.13%2B20220630-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "cdfa3c7188507329833ace2d459532ec06a4a140953fe7139eafd5f104b42a0b",
+          "size": 40830755,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.8.13%2B20220630-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
+      "20220802": {
+        "linux_arm64": {
+          "sha256": "8dc7814bf3425bbf78c6e6e5a6529ded6ae463fa6a4b79c025b343bae4fd955a",
+          "size": 25074929,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "fb566629ccb5f76ef56d275a3f8017d683f1c20c5beb5d5f38b155ed11e16187",
+          "size": 26896334,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "ae4131253d890b013171cb5f7b03cadc585ae263719506f7b7e063a7cf6fde76",
+          "size": 17586341,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "cd6e7c0a27daf7df00f6882eaba01490dd963f698e99aeee9706877333e0df69",
+          "size": 17973220,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "8dc7814bf3425bbf78c6e6e5a6529ded6ae463fa6a4b79c025b343bae4fd955a",
         "size": 25074929,
@@ -914,6 +2415,28 @@
       }
     },
     "3.8.14": {
+      "20221002": {
+        "linux_arm64": {
+          "sha256": "c45e42deee43e3ebc4ca5b019c37d8ae25fb5b5f1ba5f602098a81b99d2bc804",
+          "size": 25070295,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "4eb53bce831bf52682067579c09ccaccb6524dd44bd4b8047454c69b4817f4f0",
+          "size": 26912560,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "6c17f6dcda59de5d8eee922ef7eede403a540dae05423ef2c2a042d8d4f22467",
+          "size": 17594484,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "3ed4db8d0308c584196d97c629058ea69bbd8b7f9a034cf8c2c701ebb286c091",
+          "size": 17976638,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "c45e42deee43e3ebc4ca5b019c37d8ae25fb5b5f1ba5f602098a81b99d2bc804",
         "size": 25070295,
@@ -940,6 +2463,28 @@
       }
     },
     "3.8.15": {
+      "20221106": {
+        "linux_arm64": {
+          "sha256": "886ab33ced13c84bf59ce8ff79eba6448365bfcafea1bf415bd1d75e21b690aa",
+          "size": 25080793,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "e47edfb2ceaf43fc699e20c179ec428b6f3e497cf8e2dcd8e9c936d4b96b1e56",
+          "size": 26922922,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "1e0a92d1a4f5e6d4a99f86b1cbf9773d703fe7fd032590f3e9c285c7a5eeb00a",
+          "size": 17603392,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "70b57f28c2b5e1e3dd89f0d30edd5bc414e8b20195766cf328e1b26bed7890e1",
+          "size": 17985182,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "886ab33ced13c84bf59ce8ff79eba6448365bfcafea1bf415bd1d75e21b690aa",
         "size": 25080793,
@@ -966,6 +2511,94 @@
       }
     },
     "3.8.16": {
+      "20221220": {
+        "linux_arm64": {
+          "sha256": "f5f30a21b915d21d99e0b0847ba323a58930f619b43d525923e674b7dc1d4816",
+          "size": 25106134,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221220/cpython-3.8.16%2B20221220-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "04115eb3a7d134511dc65a95c9afde8f6683ee031c8e8634ea048b0539461432",
+          "size": 26933018,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221220/cpython-3.8.16%2B20221220-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "a71280128ef05311affb8196a8d80571e48952a50093907ffcad33d886d04736",
+          "size": 17620428,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221220/cpython-3.8.16%2B20221220-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "2916eea6b522d5b755ba2e328527019015597751e0f32c27d73c7d618b61f6b1",
+          "size": 17984565,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221220/cpython-3.8.16%2B20221220-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
+      "20230116": {
+        "linux_arm64": {
+          "sha256": "15d00bc8400ed6d94c665a797dc8ed7a491ae25c5022e738dcd665cd29beec42",
+          "size": 24423021,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.8.16%2B20230116-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "c890de112f1ae31283a31fefd2061d5c97bdd4d1bdd795552c7abddef2697ea1",
+          "size": 26257571,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.8.16%2B20230116-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "d1f408569d8807c1053939d7822b082a17545e363697e1ce3cfb1ee75834c7be",
+          "size": 17929365,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.8.16%2B20230116-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "484ba901f64fc7888bec5994eb49343dc3f9d00ed43df17ee9c40935aad4aa18",
+          "size": 17889962,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.8.16%2B20230116-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
+      "20230507": {
+        "linux_arm64": {
+          "sha256": "cd6c229eb21c42ae1b4dc15d85270c0172e083d12599264bbdfd3c617bd92e8a",
+          "size": 24120593,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.8.16%2B20230507-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "8522b181c018e798ecb7dc54b5eedf7686cb258e6e33b3f7f0488ceb912a341e",
+          "size": 25953194,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.8.16%2B20230507-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "99620c121aaa96c4102f325bfb18d3b5140580894b0fae2a8d387c21de9ff573",
+          "size": 17491180,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.8.16%2B20230507-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "4ca383c4ef57d163c30d2f583bd89367383d9aaf9e503798861297cef919fa1e",
+          "size": 17754654,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.8.16%2B20230507-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
+      "20230726": {
+        "linux_arm64": {
+          "sha256": "9c6615931fd1045bf9f2148aa7dd9ce1ece8575ed68a5483a0b615322a43d54c",
+          "size": 23873980,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "b1f1502c3a13b899724dbd32bd77a973fa9733b932c5700d747fe33d5de9ac4f",
+          "size": 25685510,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "7e484eb6de40d6f6bdfd5099eaa9647f65e45fb6d846ccfc56b1cb1e38b5ab02",
+          "size": 17227282,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "28506e509646c11cb2f57a7203bd1b08b6e8e5b159ae308bd5bb93b0d334bdaf",
+          "size": 17491676,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "9c6615931fd1045bf9f2148aa7dd9ce1ece8575ed68a5483a0b615322a43d54c",
         "size": 23873980,
@@ -992,6 +2625,28 @@
       }
     },
     "3.8.17": {
+      "20230826": {
+        "linux_arm64": {
+          "sha256": "9f6d585091fe26906ff1dbb80437a3fe37a1e3db34d6ecc0098f3d6a78356682",
+          "size": 25883841,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "8d3e1826c0bb7821ec63288038644808a2d45553245af106c685ef5892fabcd8",
+          "size": 27685259,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "c6f7a130d0044a78e39648f4dae56dcff5a41eba91888a99f6e560507162e6a1",
+          "size": 19247729,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "155b06821607bae1a58ecc60a7d036b358c766f19e493b8876190765c883a5c2",
+          "size": 19505723,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "9f6d585091fe26906ff1dbb80437a3fe37a1e3db34d6ecc0098f3d6a78356682",
         "size": 25883841,
@@ -1018,6 +2673,72 @@
       }
     },
     "3.8.18": {
+      "20231002": {
+        "linux_arm64": {
+          "sha256": "236a300f386ead02ca98dbddbc026ff4ef4de6701a394106e291ff8b75445ee1",
+          "size": 26346661,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.8.18%2B20231002-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "1e8a3babd1500111359b0f5675d770984bcbcb2cc8890b117394f0ed342fb9ec",
+          "size": 28222319,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.8.18%2B20231002-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "1825b1f7220bc93ff143f2e70b5c6a79c6469e0eeb40824e07a7277f59aabfda",
+          "size": 19347519,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.8.18%2B20231002-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "fcf04532e644644213977242cd724fe5e84c0a5ac92ae038e07f1b01b474fca3",
+          "size": 19888884,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.8.18%2B20231002-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
+      "20240107": {
+        "linux_arm64": {
+          "sha256": "75e1b1ff3852eb43c1dd15acb0e2333d398fea5b00fd2f888b13404d02b9acd1",
+          "size": 26392661,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.8.18%2B20240107-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "cc900726935ef5970a846e710384a79a7f4d725e44536dae75791ccda4ed96f8",
+          "size": 28268485,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.8.18%2B20240107-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "5272e2a2350e58e342a15e607c8b519d0d85e530cafdd55f0900df66e7771746",
+          "size": 19374989,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.8.18%2B20240107-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "2bd0ae21d3aadc028063a825072b28cd4a41b86e342f13d657c3582e2f8dde49",
+          "size": 19921793,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.8.18%2B20240107-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
+      "20240224": {
+        "linux_arm64": {
+          "sha256": "6588c9eed93833d9483d01fe40ac8935f691a1af8e583d404ec7666631b52487",
+          "size": 26807467,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "5ae36825492372554c02708bdd26b8dcd57e3dbf34b3d6d599ad91d93540b2b7",
+          "size": 28681831,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "4d493a1792bf211f37f98404cc1468f09bd781adc2602dea0df82ad264c11abc",
+          "size": 19717855,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "7d2cd8d289d5e3cdd0a8c06c028c7c621d3d00ce44b7e2f08c1724ae0471c626",
+          "size": 20040915,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "6588c9eed93833d9483d01fe40ac8935f691a1af8e583d404ec7666631b52487",
         "size": 26807467,
@@ -1044,6 +2765,116 @@
       }
     },
     "3.8.19": {
+      "20240415": {
+        "linux_arm64": {
+          "sha256": "5bde36c53a9a511a1618f159abed77264392eb054edeb57bb5740f6335db34a3",
+          "size": 24743030,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.8.19%2B20240415-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "b33feb5ce0d7f9c4aca8621a9d231dfd9d2f6e26eccb56b63f07041ff573d5a5",
+          "size": 26604389,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.8.19%2B20240415-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "eae09ed83ee66353c0cee435ea2d3e4868bd0537214803fb256a1a2928710bc0",
+          "size": 17651989,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.8.19%2B20240415-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "05f0c488d84f7590afb6f5d192f071df80584339dda581b6186effc6cd690f6b",
+          "size": 17969684,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.8.19%2B20240415-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
+      "20240713": {
+        "linux_arm64": {
+          "sha256": "915fda01a8530c7f68eec70f00b60b61ea23e9210db44435bc5702d2b2ce3a5b",
+          "size": 24743115,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240713/cpython-3.8.19%2B20240713-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "974075f112347cd3c2ef680de0d54dd865b63471c4e0f5dbf7951c8f7c4317c2",
+          "size": 26606908,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240713/cpython-3.8.19%2B20240713-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "0be10f265da68c9be2bb4d66228eabc72a8e60bd62e3950012771a1227a33775",
+          "size": 17652273,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240713/cpython-3.8.19%2B20240713-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "6750756db0b1d3e9f874465d98467b66fc720e693437baf8a7e29fdef1e0674d",
+          "size": 17970036,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240713/cpython-3.8.19%2B20240713-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
+      "20240725": {
+        "linux_arm64": {
+          "sha256": "292c416f244152bfca4ce1de7b706aa6e64cb6f2188c07fc1be7dbe47504d21e",
+          "size": 24598280,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240725/cpython-3.8.19%2B20240725-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "15db6196d8a0ac26f0fbf8e05b1d1ebe64424722eb0dd8f5c63670f99adb2aa2",
+          "size": 26552720,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240725/cpython-3.8.19%2B20240725-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "4e481beb11d9faa7938aed201508d28506f9b73fe740e55048aa5113e02c9a7a",
+          "size": 17538917,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240725/cpython-3.8.19%2B20240725-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "f6be36c5a5c984c00c205ada6c2373dbffe1c694dba8c5a5abaecb9234bdda72",
+          "size": 17842135,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240725/cpython-3.8.19%2B20240725-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      },
+      "20240726": {
+        "linux_arm64": {
+          "sha256": "63d7e556cffc4ad86683546251bdb9aaf3b0cfa3ac3c47fe7a0ac842cc26f554",
+          "size": 19759107,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.8.19%2B20240726-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "a1ac3502e1aeb67362bed216c2dcdc18ab73ccd1384f1af2958a4e567bdc8a89",
+          "size": 20849727,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.8.19%2B20240726-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "7aebd1cb21e1531f74310032b1b4eaea987ecd8c5eaf8deb25aaf1d1ffeab2a0",
+          "size": 17422733,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.8.19%2B20240726-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "ea54ed5f2439507c90127283e5b47ec12a2ed601aeea6f6c328681609df11519",
+          "size": 17737009,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.8.19%2B20240726-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      },
+      "20240814": {
+        "linux_arm64": {
+          "sha256": "202211923850303f521146ee1831642aaf357ffeeadbe13a0a91884317227528",
+          "size": 19759196,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "0f1579dbb01c98af7a12fef4c9aa8a99d45b91393f64431f5de712f892bc5c0b",
+          "size": 20850693,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "6a15ee2b507aed4d5b15fd1b66fc570aa49183f15aa6c412eccd065446f17d8e",
+          "size": 17417243,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "1a24263b039c1172bd42d74a5694492f3e3dbe4d3e52a1e7cc2856fee7dbee4a",
+          "size": 17735922,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "202211923850303f521146ee1831642aaf357ffeeadbe13a0a91884317227528",
         "size": 19759196,
@@ -1070,6 +2901,50 @@
       }
     },
     "3.8.20": {
+      "20240909": {
+        "linux_arm64": {
+          "sha256": "a0cf896059fa8f323c88342154868cea4cca32314175e246f0ac601b978f0e7a",
+          "size": 19762574,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.8.20%2B20240909-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "07efe55ae8f494356877effdf98e661d21b1de077964e95940ca1a35119d5b28",
+          "size": 20852885,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.8.20%2B20240909-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "ba5e82a768111e58c1c10f452a8c2a352343ade11a726649305b5be9c50e2c4e",
+          "size": 17424432,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.8.20%2B20240909-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "d1df0f170f65b572e34f2f308578e7803a65ba67adda24faf4c3b91c4c35ca12",
+          "size": 17738690,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.8.20%2B20240909-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      },
+      "20241002": {
+        "linux_arm64": {
+          "sha256": "75a187ebfab81096e3f3d91d70c1349e64defbdfb0e8a067cb5233d017655e31",
+          "size": 19762577,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "a3a75094545912d4e9413673441b3f0d2e58ce9b264477f910800148801ccf11",
+          "size": 20852474,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "30ba44af64e599bde7307908393374bdcd99e185bf9b3c9de3f697f3fbe6bf8f",
+          "size": 17424339,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "375b6eead6c852cabbf3ccfd43dc4f6dd4c36381bf74c9a7910acb839fd5c57f",
+          "size": 17738861,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "75a187ebfab81096e3f3d91d70c1349e64defbdfb0e8a067cb5233d017655e31",
         "size": 19762577,
@@ -1096,6 +2971,28 @@
       }
     },
     "3.9.10": {
+      "20220227": {
+        "linux_arm64": {
+          "sha256": "12dd1f125762f47975990ec744532a1cf3db74ad60f4dfb476ca42deb7f78ca4",
+          "size": 85992370,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "455089cc576bd9a58db45e919d1fc867ecdbb0208067dffc845cc9bbf0701b70",
+          "size": 51624807,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "ad66c2a3e7263147e046a32694de7b897a46fb0124409d29d3a93ede631c8aee",
+          "size": 40999185,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "fdaf594142446029e314a9beb91f1ac75af866320b50b8b968181e592550cd68",
+          "size": 41228694,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "12dd1f125762f47975990ec744532a1cf3db74ad60f4dfb476ca42deb7f78ca4",
         "size": 85992370,
@@ -1122,6 +3019,28 @@
       }
     },
     "3.9.11": {
+      "20220318": {
+        "linux_arm64": {
+          "sha256": "0e50f099409c5e651b5fddd16124af1d830d11653e786a93c28e5b8f8aa470c4",
+          "size": 86614999,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "0429d5ceb095d5e24c292bf1a39208b88ae236a680ef8fa3e1830e3a1a7e8882",
+          "size": 52181358,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "cf92a28f98c8d884df0937bf19d5f1a40caa25a6a211a237b7e9b592b2b71c2b",
+          "size": 41570037,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "43889d1a424c84fb155e1619f062adb6984fbde80b6043611790f22bcbeec300",
+          "size": 41767821,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "0e50f099409c5e651b5fddd16124af1d830d11653e786a93c28e5b8f8aa470c4",
         "size": 86614999,
@@ -1148,6 +3067,28 @@
       }
     },
     "3.9.12": {
+      "20220502": {
+        "linux_arm64": {
+          "sha256": "2ee1426c181e65133e57dc55c6a685cb1fb5e63ef02d684b8a667d5c031c4203",
+          "size": 86402456,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "ccca12f698b3b810d79c52f007078f520d588232a36bc12ede944ec3ea417816",
+          "size": 52175226,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "8dee06c07cc6429df34b6abe091a4684a86f7cec76f5d1ccc1c3ce2bd11168df",
+          "size": 41443679,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "2453ba7f76b3df3310353b48c881d6cff622ba06e30d2b6ae91588b2bc9e481a",
+          "size": 41592297,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "2ee1426c181e65133e57dc55c6a685cb1fb5e63ef02d684b8a667d5c031c4203",
         "size": 86402456,
@@ -1174,6 +3115,72 @@
       }
     },
     "3.9.13": {
+      "20220528": {
+        "linux_arm64": {
+          "sha256": "ed67f24078e12d961bc6cbf72cfab5d3f5d79ff392d3fee8958d2c97d45fd7b3",
+          "size": 86521667,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.9.13%2B20220528-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "b9fcb0c114518cc0f1fb1347c997de5aff5b18465110e26e106ab9cda74f959e",
+          "size": 52272943,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.9.13%2B20220528-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "8f27a9dbd2fa7a26b46dc43b25dcdf41108ad4dd74eab917b803109f7bd0f2a5",
+          "size": 41547868,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.9.13%2B20220528-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "28cb1a22cd5af9034f97095b4b4d04866d106e179b321aace55fb55413e214f3",
+          "size": 41687411,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.9.13%2B20220528-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
+      "20220630": {
+        "linux_arm64": {
+          "sha256": "1888380e7823bdcde11c5d84bf17b311a4087b7a62388367675c59ec5fe926df",
+          "size": 86523746,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.9.13%2B20220630-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "0a6fa65cf00e916e38aa2fdd42355d83b93fbf87eeffe511145b9471c5699d01",
+          "size": 52303084,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.9.13%2B20220630-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "62fd3c9df323aaa9986f069ec5f618d65de0e736828cee1eba493f03cbb372f9",
+          "size": 41561501,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.9.13%2B20220630-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "15900c5613cea98ee093737743b5dde41b9def6ad28032334a1c5e49b5e3e4c5",
+          "size": 41688811,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.9.13%2B20220630-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
+      "20220802": {
+        "linux_arm64": {
+          "sha256": "80415aac1b96255b9211f6a4c300f31e9940c7e07a23d0dec12b53aa52c0d25e",
+          "size": 24521230,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "ce1cfca2715e7e646dd618a8cb9baff93000e345ccc979b801fc6ccde7ce97df",
+          "size": 26747628,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "d9603edc296a2dcbc59d7ada780fd12527f05c3e0b99f7545112daf11636d6e5",
+          "size": 16730332,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "9540a7efb7c8a54a48aff1cb9480e49588d9c0a3f934ad53f5b167338174afa3",
+          "size": 17132546,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "80415aac1b96255b9211f6a4c300f31e9940c7e07a23d0dec12b53aa52c0d25e",
         "size": 24521230,
@@ -1200,6 +3207,28 @@
       }
     },
     "3.9.14": {
+      "20221002": {
+        "linux_arm64": {
+          "sha256": "fe538201559ca37f44cd5f66c42a65fe7272cb4f1f63edd698b6f306771db1e9",
+          "size": 24525886,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "e63d0c00a499e0202ba7a0f53ce69fca6d30237af39af9bc3c76bce6c7bf14d7",
+          "size": 26761725,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "e38df7f230979ce6c53a5bafb3a81287838e5f3892c40cd1b98a0c961c444713",
+          "size": 16734921,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "b7d3a1f4b57e9350571ccee49c82f503133de0d113a2dbaebc8ccf108fb3fe1b",
+          "size": 17138819,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "fe538201559ca37f44cd5f66c42a65fe7272cb4f1f63edd698b6f306771db1e9",
         "size": 24525886,
@@ -1226,6 +3255,28 @@
       }
     },
     "3.9.15": {
+      "20221106": {
+        "linux_arm64": {
+          "sha256": "52a8c0a67fb919f80962d992da1bddb511cdf92faf382701ce7673e10a8ff98f",
+          "size": 24524876,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "cdc3a4cfddcd63b6cebdd75b14970e02d8ef0ac5be4d350e57ab5df56c19e85e",
+          "size": 26765574,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "64dc7e1013481c9864152c3dd806c41144c79d5e9cd3140e185c6a5060bdc9ab",
+          "size": 16748283,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "f2bcade6fc976c472f18f2b3204d67202d43ae55cf6f9e670f95e488f780da08",
+          "size": 17148635,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "52a8c0a67fb919f80962d992da1bddb511cdf92faf382701ce7673e10a8ff98f",
         "size": 24524876,
@@ -1252,6 +3303,72 @@
       }
     },
     "3.9.16": {
+      "20221220": {
+        "linux_arm64": {
+          "sha256": "75f3d10ae8933e17bf27e8572466ff8a1e7792f521d33acba578cc8a25d82e0b",
+          "size": 24540128,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221220/cpython-3.9.16%2B20221220-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "f885f3d011ab08e4d9521a7ae2662e9e0073acc0305a1178984b5a1cf057309a",
+          "size": 26767987,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221220/cpython-3.9.16%2B20221220-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "73bad3a610a0ff14166fbd5045cd186084bd2ce99edd2c6327054509e790b9ab",
+          "size": 16765350,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221220/cpython-3.9.16%2B20221220-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "69331e93656b179fcbfec0d506dfca11d899fe5dced990b28915e41755ce215c",
+          "size": 17151321,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221220/cpython-3.9.16%2B20221220-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
+      "20230116": {
+        "linux_arm64": {
+          "sha256": "1ba520c0db431c84305677f56eb9a4254f5097430ed443e92fc8617f8fba973d",
+          "size": 23873387,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.9.16%2B20230116-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "7ba397787932393e65fc2fb9fcfabf54f2bb6751d5da2b45913cb25b2d493758",
+          "size": 26129729,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.9.16%2B20230116-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "d732d212d42315ac27c6da3e0b69636737a8d72086c980daf844344c010cab80",
+          "size": 17084463,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.9.16%2B20230116-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "3948384af5e8d4ee7e5ccc648322b99c1c5cf4979954ed5e6b3382c69d6db71e",
+          "size": 17059474,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.9.16%2B20230116-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
+      "20230507": {
+        "linux_arm64": {
+          "sha256": "f629b75ebfcafe9ceee2e796b7e4df5cf8dbd14f3c021afca078d159ab797acf",
+          "size": 23583066,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "2b6e146234a4ef2a8946081fc3fbfffe0765b80b690425a49ebe40b47c33445b",
+          "size": 25738357,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "c1de1d854717a6245f45262ef1bb17b09e2c587590e7e3f406593c143ff875bd",
+          "size": 16634170,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "3abc4d5fbbc80f5f848f280927ac5d13de8dc03aabb6ae65d8247cbb68e6f6bf",
+          "size": 16908516,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "f629b75ebfcafe9ceee2e796b7e4df5cf8dbd14f3c021afca078d159ab797acf",
         "size": 23583066,
@@ -1278,6 +3395,28 @@
       }
     },
     "3.9.17": {
+      "20230726": {
+        "linux_arm64": {
+          "sha256": "b77012ddaf7e0673e4aa4b1c5085275a06eee2d66f33442b5c54a12b62b96cbe",
+          "size": 23259487,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "26c4a712b4b8e11ed5c027db5654eb12927c02da4857b777afb98f7a930ce637",
+          "size": 25409877,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "73dbe2d702210b566221da9265acc274ba15275c5d0d1fa327f44ad86cde9aa1",
+          "size": 16312686,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "dfe1bea92c94b9cb779288b0b06e39157c5ff7e465cdd24032ac147c2af485c0",
+          "size": 16579635,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "b77012ddaf7e0673e4aa4b1c5085275a06eee2d66f33442b5c54a12b62b96cbe",
         "size": 23259487,
@@ -1304,6 +3443,94 @@
       }
     },
     "3.9.18": {
+      "20230826": {
+        "linux_arm64": {
+          "sha256": "2161e834aa4334cc8bb55335767a073aafff3338cf37392d2a9123b4972276f9",
+          "size": 23258597,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.9.18%2B20230826-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "377da2aebc3b58c5af901899e8efeb2c91b35b0ea92c8b447036767e529fc5b2",
+          "size": 25387991,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.9.18%2B20230826-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "44000d3bd79a6c689f3b6cae846d302d9a4e974c46d078b1bc79cc0c706a0718",
+          "size": 16320623,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.9.18%2B20230826-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "ce03b97a41be6d548698baaf5804fff2ce96bf49237fb73f8692aca3f5798454",
+          "size": 16596001,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.9.18%2B20230826-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
+      "20231002": {
+        "linux_arm64": {
+          "sha256": "1e0a3e8ce8e58901a259748c0ab640d2b8294713782d14229e882c6898b2fb36",
+          "size": 23724182,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.9.18%2B20231002-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "f3ff38b1ccae7dcebd8bbf2e533c9a984fac881de0ffd1636fbb61842bd924de",
+          "size": 25907495,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.9.18%2B20231002-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "fdc4054837e37b69798c2ef796222a480bc1f80e8ad3a01a95d0168d8282a007",
+          "size": 16424167,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.9.18%2B20231002-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "82231cb77d4a5c8081a1a1d5b8ae440abe6993514eb77a926c826e9a69a94fb1",
+          "size": 16989455,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.9.18%2B20231002-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
+      "20240107": {
+        "linux_arm64": {
+          "sha256": "7d19e1ecd6e582423f7c74a0c67491eaa982ce9d5c5f35f0e4289f83127abcb8",
+          "size": 23762513,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.9.18%2B20240107-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "67912efc04f9156d8f5b48a0348983defb964de043b8c13ddc6cc8a002f8e691",
+          "size": 25920461,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.9.18%2B20240107-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "bf0cd90204a2cc6da48cae1e4b32f48c9f7031fbe1238c5972104ccb0155d368",
+          "size": 16454545,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.9.18%2B20240107-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "5a0bf895a5cb08d6d008140abb41bb2c8cd638a665273f7d8eb258bc89de439b",
+          "size": 17018468,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.9.18%2B20240107-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
+      "20240224": {
+        "linux_arm64": {
+          "sha256": "e5bc5196baa603d635ee6b0cd141e359752ad3e8ea76127eb9141a3155c51200",
+          "size": 24171241,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "0e5663025121186bd17d331538a44f48b41baff247891d014f3f962cbe2716b4",
+          "size": 26338278,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "2548f911a6e316575c303ba42bb51540dc9b47a9f76a06a2a37460d93b177aa2",
+          "size": 16799720,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "171d8b472fce0295be0e28bb702c43d5a2a39feccb3e72efe620ac3843c3e402",
+          "size": 17132069,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "e5bc5196baa603d635ee6b0cd141e359752ad3e8ea76127eb9141a3155c51200",
         "size": 24171241,
@@ -1330,6 +3557,116 @@
       }
     },
     "3.9.19": {
+      "20240415": {
+        "linux_arm64": {
+          "sha256": "b18ad819f04c5b2cff6ffa95dd59263d00dcd6f5633d11e43685b4017469cb1c",
+          "size": 24184609,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.9.19%2B20240415-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "00f698873804863dedc0e2b2c2cc4303b49ab0703af2e5883e11340cb8079d0f",
+          "size": 26341892,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.9.19%2B20240415-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "2671bb4ffd036f03076c8aa41e3828c4c16a602e93e2249a8e7b28fd83fdde51",
+          "size": 16797917,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.9.19%2B20240415-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "627d903588c0e69ed8b941ba9f91e070e38105a627c5b8c730267744760dca84",
+          "size": 17131003,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.9.19%2B20240415-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
+      "20240713": {
+        "linux_arm64": {
+          "sha256": "f70b404a297a607405d6f2eb6ac4cb6160a7be0ae594983637da4e48b5c7cc26",
+          "size": 24184610,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240713/cpython-3.9.19%2B20240713-aarch64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "046db998b28373f69c55611e58a6611e5bb4e17997d0265beddad7c61e19f602",
+          "size": 26339346,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240713/cpython-3.9.19%2B20240713-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "780a36bb0c0b0600561d225537d55b26a6a84fc4e7e593b3ec50126c5c79019f",
+          "size": 16802018,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240713/cpython-3.9.19%2B20240713-aarch64-apple-darwin-install_only.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "2d812e5d1c6608430391ef603f37cc2b8e78bde54e49f29f575f6558e8cde2e7",
+          "size": 17131429,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240713/cpython-3.9.19%2B20240713-x86_64-apple-darwin-install_only.tar.gz"
+        }
+      },
+      "20240725": {
+        "linux_arm64": {
+          "sha256": "a5efe24931ab137ec0cafcbebc25f1a77281f864e08e9dbc745edcf90f562300",
+          "size": 24043784,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240725/cpython-3.9.19%2B20240725-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "cce7ae7270caf42ec45ece981f43186cd20f3236c079259682855624ac833eb7",
+          "size": 26318862,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240725/cpython-3.9.19%2B20240725-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "8840ac5d2c98926ea7397d6f10ef3d23ea83a7e942480eb30d6c9dc4f998d70d",
+          "size": 16688929,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240725/cpython-3.9.19%2B20240725-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "df4346fbb2c91e79310460608c6e9cb9569a8973c7ee0e51c1f4f4574aa28726",
+          "size": 17013257,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240725/cpython-3.9.19%2B20240725-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      },
+      "20240726": {
+        "linux_arm64": {
+          "sha256": "874bef7efb4090e02070f6399ff47a890c7e1c35c5ed0b36fe457369da4673a8",
+          "size": 18910555,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.9.19%2B20240726-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "26d8b588feb2c69d49b83f751c2a26c301d73022fac7ae74b3a1d0473ebc3674",
+          "size": 19992652,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.9.19%2B20240726-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "9a555e124516da59da73357f22d427cd34254ca8c18ff9c458d8e44f58566337",
+          "size": 16568758,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.9.19%2B20240726-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "1e8b3e67650e1b549fdcbc39b08af260ee9b5525a8a2252b8ee47c4258dae9e2",
+          "size": 16898147,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.9.19%2B20240726-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      },
+      "20240814": {
+        "linux_arm64": {
+          "sha256": "23d08f7f0bf151c2ea54b2c9c143bc710faf166ff74225b0f967fab1e2d7a151",
+          "size": 18910563,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "3b7d574b6bbf8303789a1d26b96a81dcca907381441ce15818c784e18d1db299",
+          "size": 19992626,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "451582f8a6a8c15ef35a327afcdbf8d03b1ebba7192e90d850d092dac91f91c6",
+          "size": 16567269,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "ebaf4336d0cbff4466c994d5bcaa92a38c91d06694d0cd675ec663259d5f37c7",
+          "size": 16899149,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "23d08f7f0bf151c2ea54b2c9c143bc710faf166ff74225b0f967fab1e2d7a151",
         "size": 18910563,
@@ -1356,6 +3693,94 @@
       }
     },
     "3.9.20": {
+      "20240909": {
+        "linux_arm64": {
+          "sha256": "2a78b16be1be07cb514183d09b9e421fea9256e366cca0642639c3161611b6ab",
+          "size": 18914403,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.9.20%2B20240909-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "8106a101967d52c78f56603a2fcfa2926c140ca45abfbf5a984cc63b726a0ee9",
+          "size": 19997771,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.9.20%2B20240909-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "80a7fa0a25cf0dbbb4cab9d7dc37b3172efed05cefd0667192690a30cadd85dd",
+          "size": 16570012,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.9.20%2B20240909-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "8af628a1786ebc6012689d3f06cd955672bcb75ff37e9518b4028e38d185d2d7",
+          "size": 16903168,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.9.20%2B20240909-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      },
+      "20241002": {
+        "linux_arm64": {
+          "sha256": "4105f5324b6920af5ebc541f4f29dedd60753ef655c343b77d6835cdb5749d99",
+          "size": 18914404,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.9.20%2B20241002-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "390f555ff4d5f9df83b923f6da4cd71eb88f4400d87f513aaef78b00dd29eade",
+          "size": 19996250,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.9.20%2B20241002-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "02c376d7a931c7a4575158e8908978ec7686cd11ba93a0df1770858974f53822",
+          "size": 16569267,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.9.20%2B20241002-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "dddb504549d27beb7ee39e88a9a9db72ac890df987d890edc5fa7310179ebe9f",
+          "size": 16901565,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.9.20%2B20241002-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      },
+      "20241008": {
+        "linux_arm64": {
+          "sha256": "7b3fe4868b127b75c82c7e56815e9ea90d7d5f76676d5d79c4e5901423a0e271",
+          "size": 18914403,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "f78ac2daa816647d8de170a1b7296d08d3a1227d1a5b46bde4d0e20834dc9212",
+          "size": 19993496,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "e7551a119bded40bfc268c850110b6a5af1d5fdd63842a56569477490d20e0a6",
+          "size": 16569829,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "02a912676153c0b87a2b6127f5bc9ddccf831b5c390e44073b1f45e829e712ca",
+          "size": 16901389,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      },
+      "20241016": {
+        "linux_arm64": {
+          "sha256": "3742c9d6563527a003b12ac689c07e6965911ff89fd9cbbd3c17ac7bfb037d4a",
+          "size": 18915696,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "44d9d016f9820f39e5bb542782557d46876b69d23d0a204eb2f367739da623e0",
+          "size": 19996785,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "41e9bb2d45e1a0467e534dafc6691b3d3c2b79fd9a564562f4c0c41eb343d30a",
+          "size": 16572425,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "440f4ebc651e707ed24d5dc68d3b0b2197e7fb369bb77685b1b539dbf30ab1e5",
+          "size": 16906013,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      },
       "linux_arm64": {
         "sha256": "3742c9d6563527a003b12ac689c07e6965911ff89fd9cbbd3c17ac7bfb037d4a",
         "size": 18915696,
@@ -1379,6 +3804,52 @@
         "size": 16906013,
         "tag": "20241016",
         "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-x86_64-apple-darwin-install_only_stripped.tar.gz"
+      }
+    },
+    "3.9.21": {
+      "20241205": {
+        "linux_arm64": {
+          "sha256": "9f4f9903117b096b275f851ec6f2f1a31e1c44cf66a7aba61e0be7bb4d8e252d",
+          "size": 19162140,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241205/cpython-3.9.21%2B20241205-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "827fc9530f92749cd2454f087252fafb7c02217113d6f5a9f47adb8528c47952",
+          "size": 20254811,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241205/cpython-3.9.21%2B20241205-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "a0553c6f982cb81db5dc4b437c94e02c034a41f60d038973733e8b125e5d5c40",
+          "size": 16822778,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241205/cpython-3.9.21%2B20241205-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "914261e6581c681381d3a2a1d0e5f71189cab77377d629c02cde076d12a103b9",
+          "size": 17160176,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241205/cpython-3.9.21%2B20241205-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      },
+      "20241206": {
+        "linux_arm64": {
+          "sha256": "027cf9f8b8bc3d214a938b06ad2fd9a04a9f86aee8b72594b32ea1e0b87cf5d9",
+          "size": 19162049,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.9.21%2B20241206-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "d8f14d3b78fb724aa6e65f745a2507913a85f8506aae3132aa3894abbef9ad6e",
+          "size": 20255369,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.9.21%2B20241206-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "8f162d89f58baa82efd2430d541b08391c8ed7f41770348b1ec5d7d2bdd71657",
+          "size": 16822309,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.9.21%2B20241206-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "1533c728fd732483924443cb4dd4ac86324de082ce9611f21280facbcc4ba300",
+          "size": 17163660,
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.9.21%2B20241206-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
       }
     },
     "3.9.6": {
@@ -1473,6 +3944,8 @@
     "20240909",
     "20241002",
     "20241008",
-    "20241016"
+    "20241016",
+    "20241205",
+    "20241206"
   ]
 }

--- a/src/python/pants/backend/python/providers/python_build_standalone/versions_info.json
+++ b/src/python/pants/backend/python/providers/python_build_standalone/versions_info.json
@@ -1,22 +1,5 @@
 {
   "pythons": {
-    "3.10.0": {
-      "linux_x86_64": {
-        "sha256": "eada875c9b39cc4bf4a055dd8f5188e99c0c90dd5deb05b6c213f49482fe20a6",
-        "size": 52105389,
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-x86_64-unknown-linux-gnu-install_only-20211017T1616.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "d26edcf5a696c559c49e2844d65cfdbef5bcb999b005babc9263433b678d0cec",
-        "size": 41476935,
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-aarch64-apple-darwin-install_only-20211017T1616.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "fc0d184feb6db61f410871d0660d2d560e0397c36d08b086dfe115264d1963f4",
-        "size": 41755961,
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-x86_64-apple-darwin-install_only-20211017T1616.tar.gz"
-      }
-    },
     "3.10.11": {
       "20230507": {
         "linux_arm64": {
@@ -39,30 +22,6 @@
           "size": 17354339,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64-apple-darwin-install_only.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "c7573fdb00239f86b22ea0e8e926ca881d24fde5e5890851339911d76110bc35",
-        "size": 24243246,
-        "tag": "20230507",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-aarch64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "c5bcaac91bc80bfc29cf510669ecad12d506035ecb3ad85ef213416d54aecd79",
-        "size": 26689876,
-        "tag": "20230507",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "8348bc3c2311f94ec63751fb71bd0108174be1c4def002773cf519ee1506f96f",
-        "size": 17074991,
-        "tag": "20230507",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-aarch64-apple-darwin-install_only.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "bd3fc6e4da6f4033ebf19d66704e73b0804c22641ddae10bbe347c48f82374ad",
-        "size": 17354339,
-        "tag": "20230507",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64-apple-darwin-install_only.tar.gz"
       }
     },
     "3.10.12": {
@@ -87,30 +46,6 @@
           "size": 17095895,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64-apple-darwin-install_only.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "fee80e221663eca5174bd794cb5047e40d3910dbeadcdf1f09d405a4c1c15fe4",
-        "size": 23973769,
-        "tag": "20230726",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-aarch64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "a476dbca9184df9fc69fe6309cda5ebaf031d27ca9e529852437c94ec1bc43d3",
-        "size": 26421382,
-        "tag": "20230726",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "bc66c706ea8c5fc891635fda8f9da971a1a901d41342f6798c20ad0b2a25d1d6",
-        "size": 16817271,
-        "tag": "20230726",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-aarch64-apple-darwin-install_only.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "8a6e3ed973a671de468d9c691ed9cb2c3a4858c5defffcf0b08969fba9c1dd04",
-        "size": 17095895,
-        "tag": "20230726",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64-apple-darwin-install_only.tar.gz"
       }
     },
     "3.10.13": {
@@ -201,30 +136,6 @@
           "size": 17641238,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64-apple-darwin-install_only.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "a898a88705611b372297bb8fe4d23cc16b8603ce5f24494c3a8cfa65d83787f9",
-        "size": 24901728,
-        "tag": "20240224",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-aarch64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "d995d032ca702afd2fc3a689c1f84a6c64972ecd82bba76a61d525f08eb0e195",
-        "size": 27409290,
-        "tag": "20240224",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "5fdc0f6a5b5a90fd3c528e8b1da8e3aac931ea8690126c2fdb4254c84a3ff04a",
-        "size": 17298908,
-        "tag": "20240224",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-aarch64-apple-darwin-install_only.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "6378dfd22f58bb553ddb02be28304d739cd730c1f95c15c74955c923a1bc3d6a",
-        "size": 17641238,
-        "tag": "20240224",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64-apple-darwin-install_only.tar.gz"
       }
     },
     "3.10.14": {
@@ -337,30 +248,6 @@
           "size": 17409127,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "0ffe64c77cacda7e3afcb0d8ba271c59ca0a30dfda218da39a573b412bb4afd7",
-        "size": 19394162,
-        "tag": "20240814",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "159c456bb4a3802bafbce065ff54b99ddb16422500d75c1315573ee3b673af17",
-        "size": 20510166,
-        "tag": "20240814",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "f7ca9bffbce433c8d445edd33a5424c405553d735efee65a2fc5d8bbb1c8e137",
-        "size": 17070246,
-        "tag": "20240814",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-aarch64-apple-darwin-install_only_stripped.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "4404f44ec69c0708d4d88e98f39c2c1fe3bd462dc6a958b60aaf63028550c485",
-        "size": 17409127,
-        "tag": "20240814",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz"
       }
     },
     "3.10.15": {
@@ -451,30 +338,6 @@
           "size": 17416153,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-x86_64-apple-darwin-install_only_stripped.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "6008b42df79a0c8a4efe3aa88c2aea1471116aa66881a8ed15f04d66438cb7f5",
-        "size": 19395962,
-        "tag": "20241016",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "25fb8e23cd3b82b748075a04fd18f3183cc7316c11d6f59eb4b0326843892600",
-        "size": 20518101,
-        "tag": "20241016",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "fa79bd909bfeb627ffe66a8b023153495ece659e5e3b2ff56268535024db851c",
-        "size": 17068674,
-        "tag": "20241016",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-aarch64-apple-darwin-install_only_stripped.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "0d952fa2342794523ea7beee6a58e79e62045d0f018314ce282e9f2f1427ee2c",
-        "size": 17416153,
-        "tag": "20241016",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-x86_64-apple-darwin-install_only_stripped.tar.gz"
       }
     },
     "3.10.16": {
@@ -545,30 +408,6 @@
           "size": 42785626,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64-apple-darwin-install_only.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "8f351a8cc348bb45c0f95b8634c8345ec6e749e483384188ad865b7428342703",
-        "size": 88747017,
-        "tag": "20220227",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-aarch64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "9b64eca2a94f7aff9409ad70bdaa7fbbf8148692662e764401883957943620dd",
-        "size": 53642545,
-        "tag": "20220227",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "1409acd9a506e2d1d3b65c1488db4e40d8f19d09a7df099667c87a506f71c0ef",
-        "size": 42503895,
-        "tag": "20220227",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-aarch64-apple-darwin-install_only.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "8146ad4390710ec69b316a5649912df0247d35f4a42e2aa9615bffd87b3e235a",
-        "size": 42785626,
-        "tag": "20220227",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64-apple-darwin-install_only.tar.gz"
       }
     },
     "3.10.3": {
@@ -593,30 +432,6 @@
           "size": 43289051,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64-apple-darwin-install_only.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "f52ee68c13c4f9356eb78a5305d3178af2cb90c38a8ce8ce9990a7cf6ff06144",
-        "size": 89386559,
-        "tag": "20220318",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-aarch64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "b9989411bed71ba4867538c991f20b55f549dd9131905733f0df9f3fde81ad1d",
-        "size": 54110057,
-        "tag": "20220318",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "db46dadfccc407aa1f66ed607eefbf12f781e343adcb1edee0a3883d081292ce",
-        "size": 43030480,
-        "tag": "20220318",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-aarch64-apple-darwin-install_only.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "ec2e90b6a589db7ef9f74358b1436558167629f9e4d725c8150496f9cb08a9d4",
-        "size": 43289051,
-        "tag": "20220318",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64-apple-darwin-install_only.tar.gz"
       }
     },
     "3.10.4": {
@@ -663,30 +478,6 @@
           "size": 43233147,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64-apple-darwin-install_only.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "7a8989392dc9b41d85959a752448c60852cf0061de565e98445c27f6bbdf63be",
-        "size": 89292900,
-        "tag": "20220528",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-aarch64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "1f8423808ad84c0e56c8e14c32685cbfbc1159e0d9f943ac946f29e84cf1b5ee",
-        "size": 54186539,
-        "tag": "20220528",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "6d2e4e6b1c403bce84cfb846400754017f525fe8017f186e8e7072fcaaf3aa71",
-        "size": 42984466,
-        "tag": "20220528",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-aarch64-apple-darwin-install_only.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "c4a57a13b084d49ce8c2eb5b2662ee45b0c55b08ddd696f473233b0787f03988",
-        "size": 43233147,
-        "tag": "20220528",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64-apple-darwin-install_only.tar.gz"
       }
     },
     "3.10.5": {
@@ -711,30 +502,6 @@
           "size": 43257698,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64-apple-darwin-install_only.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "012fa37c12d2647d76d004dc003302563864d2f1cd0731b71eeafad63d28b3f0",
-        "size": 89356775,
-        "tag": "20220630",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-aarch64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "460f87a389be28c953c24c6f942f172f9ce7f331367b4daf89cb450baedd51d7",
-        "size": 54207014,
-        "tag": "20220630",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "19d1aa4a6d9ddb0094fc36961b129de9abe1673bce66c86cd97b582795c496a8",
-        "size": 43000441,
-        "tag": "20220630",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-aarch64-apple-darwin-install_only.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "eca0584397d9a3ef6f7bb32b0476318b01c89b7b0a031ef97a0dcaa5ba5127a8",
-        "size": 43257698,
-        "tag": "20220630",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64-apple-darwin-install_only.tar.gz"
       }
     },
     "3.10.6": {
@@ -759,30 +526,6 @@
           "size": 17544359,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64-apple-darwin-install_only.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "81625f5c97f61e2e3d7e9f62c484b1aa5311f21bd6545451714b949a29da5435",
-        "size": 24921808,
-        "tag": "20220802",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-aarch64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "55aa2190d28dcfdf414d96dc5dcea9fe048fadcd583dc3981fec020869826111",
-        "size": 27536682,
-        "tag": "20220802",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "efaf66acdb9a4eb33d57702607d2e667b1a319d58c167a43c96896b97419b8b7",
-        "size": 17138410,
-        "tag": "20220802",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-aarch64-apple-darwin-install_only.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "7718411adf3ea1480f3f018a643eb0550282aefe39e5ecb3f363a4a566a9398c",
-        "size": 17544359,
-        "tag": "20220802",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64-apple-darwin-install_only.tar.gz"
       }
     },
     "3.10.7": {
@@ -807,30 +550,6 @@
           "size": 17554388,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64-apple-darwin-install_only.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "dfeec186a62a6068259d90e8d77e7d30eaf9c2b4ae7b205ff8caab7cb21f277c",
-        "size": 24938179,
-        "tag": "20221002",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-aarch64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "c12c9ad2b2c75464541d897c0528013adecd8be5b30acf4411f7759729841711",
-        "size": 27546579,
-        "tag": "20221002",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "70f6ca1da8e6fce832ad0b7f9fdaba0b84ba0ac0a4c626127acb6d49df4b8f91",
-        "size": 17142891,
-        "tag": "20221002",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-aarch64-apple-darwin-install_only.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "6101f580434544d28d5590543029a7c6bdf07efa4bcdb5e4cbedb3cd83241922",
-        "size": 17554388,
-        "tag": "20221002",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64-apple-darwin-install_only.tar.gz"
       }
     },
     "3.10.8": {
@@ -855,30 +574,6 @@
           "size": 17560650,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64-apple-darwin-install_only.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "33170bef18c811906b738be530f934640491b065bf16c4d276c6515321918132",
-        "size": 24947106,
-        "tag": "20221106",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-aarch64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "6c8db44ae0e18e320320bbaaafd2d69cde8bfea171ae2d651b7993d1396260b7",
-        "size": 27555856,
-        "tag": "20221106",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "d52b03817bd245d28e0a8b2f715716cd0fcd112820ccff745636932c76afa20a",
-        "size": 17150191,
-        "tag": "20221106",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-aarch64-apple-darwin-install_only.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "525b79c7ce5de90ab66bd07b0ac1008bafa147ddc8a41bef15ffb7c9c1e9e7c5",
-        "size": 17560650,
-        "tag": "20221106",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64-apple-darwin-install_only.tar.gz"
       }
     },
     "3.10.9": {
@@ -925,30 +620,6 @@
           "size": 17474702,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64-apple-darwin-install_only.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "2003750f40cd09d4bf7a850342613992f8d9454f03b3c067989911fb37e7a4d1",
-        "size": 24505626,
-        "tag": "20230116",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-aarch64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "d196347aeb701a53fe2bb2b095abec38d27d0fa0443f8a1c2023a1bed6e18cdf",
-        "size": 27081922,
-        "tag": "20230116",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "018d05a779b2de7a476f3b3ff2d10f503d69d14efcedd0774e6dab8c22ef84ff",
-        "size": 17509509,
-        "tag": "20230116",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-aarch64-apple-darwin-install_only.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "0e685f98dce0e5bc8da93c7081f4e6c10219792e223e4b5886730fd73a7ba4c6",
-        "size": 17474702,
-        "tag": "20230116",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64-apple-darwin-install_only.tar.gz"
       }
     },
     "3.11.1": {
@@ -973,30 +644,6 @@
           "size": 18042424,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64-apple-darwin-install_only.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "debf15783bdcb5530504f533d33fda75a7b905cec5361ae8f33da5ba6599f8b4",
-        "size": 25579178,
-        "tag": "20230116",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-aarch64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "02a551fefab3750effd0e156c25446547c238688a32fabde2995c941c03a6423",
-        "size": 29321007,
-        "tag": "20230116",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "4918cdf1cab742a90f85318f88b8122aeaa2d04705803c7b6e78e81a3dd40f80",
-        "size": 18024309,
-        "tag": "20230116",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-aarch64-apple-darwin-install_only.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "20a4203d069dc9b710f70b09e7da2ce6f473d6b1110f9535fb6f4c469ed54733",
-        "size": 18042424,
-        "tag": "20230116",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64-apple-darwin-install_only.tar.gz"
       }
     },
     "3.11.10": {
@@ -1087,30 +734,6 @@
           "size": 18011078,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-x86_64-apple-darwin-install_only_stripped.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "9d124604ffdea4fbaabb10b343c5a36b636a3e7b94dfc1cccd4531f33fceae5e",
-        "size": 19963074,
-        "tag": "20241016",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "03f15e19e2452641b6375b59ba094ff6cf2fc118315d24a6ca63ce60e4d4a6e0",
-        "size": 21205300,
-        "tag": "20241016",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "a5a224138a526acecfd17210953d76a28487968a767204902e2bde809bb0e759",
-        "size": 17629090,
-        "tag": "20241016",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-aarch64-apple-darwin-install_only_stripped.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "575b49a7aa64e97b06de605b7e947033bf2310b5bc5f9aedb9859d4745033d91",
-        "size": 18011078,
-        "tag": "20241016",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-x86_64-apple-darwin-install_only_stripped.tar.gz"
       }
     },
     "3.11.11": {
@@ -1181,30 +804,6 @@
           "size": 17912223,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64-apple-darwin-install_only.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "8190accbbbbcf7620f1ff6d668e4dd090c639665d11188ce864b62554d40e5ab",
-        "size": 25301609,
-        "tag": "20230507",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-aarch64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "da50b87d1ec42b3cb577dfd22a3655e43a53150f4f98a4bfb40757c9d7839ab5",
-        "size": 28906807,
-        "tag": "20230507",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "09e412506a8d63edbb6901742b54da9aa7faf120b8dbdce56c57b303fc892c86",
-        "size": 17585902,
-        "tag": "20230507",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-aarch64-apple-darwin-install_only.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "f710b8d60621308149c100d5175fec39274ed0b9c99645484fd93d1716ef4310",
-        "size": 17912223,
-        "tag": "20230507",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64-apple-darwin-install_only.tar.gz"
       }
     },
     "3.11.4": {
@@ -1229,30 +828,6 @@
           "size": 17677396,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64-apple-darwin-install_only.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "2e84fc53f4e90e11963281c5c871f593abcb24fc796a50337fa516be99af02fb",
-        "size": 25061612,
-        "tag": "20230726",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-aarch64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "e26247302bc8e9083a43ce9e8dd94905b40d464745b1603041f7bc9a93c65d05",
-        "size": 28658858,
-        "tag": "20230726",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "cb6d2948384a857321f2aa40fa67744cd9676a330f08b6dad7070bda0b6120a4",
-        "size": 17343022,
-        "tag": "20230726",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-aarch64-apple-darwin-install_only.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "47e1557d93a42585972772e82661047ca5f608293158acb2778dccf120eabb00",
-        "size": 17677396,
-        "tag": "20230726",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64-apple-darwin-install_only.tar.gz"
       }
     },
     "3.11.5": {
@@ -1277,30 +852,6 @@
           "size": 17702502,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64-apple-darwin-install_only.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "bb5c5d1ea0f199fe2d3f0996fff4b48ca6ddc415a3dbd98f50bff7fce48aac80",
-        "size": 25085307,
-        "tag": "20230826",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-aarch64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "fbed6f7694b2faae5d7c401a856219c945397f772eea5ca50c6eb825cbc9d1e1",
-        "size": 28705307,
-        "tag": "20230826",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "dab64b3580118ad2073babd7c29fd2053b616479df5c107d31fe2af1f45e948b",
-        "size": 17379941,
-        "tag": "20230826",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-aarch64-apple-darwin-install_only.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "4a4efa7378c72f1dd8ebcce1afb99b24c01b07023aa6b8fea50eaedb50bf2bfc",
-        "size": 17702502,
-        "tag": "20230826",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64-apple-darwin-install_only.tar.gz"
       }
     },
     "3.11.6": {
@@ -1325,30 +876,6 @@
           "size": 18090352,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64-apple-darwin-install_only.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "3e26a672df17708c4dc928475a5974c3fb3a34a9b45c65fb4bd1e50504cc84ec",
-        "size": 25547472,
-        "tag": "20231002",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-aarch64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "ee37a7eae6e80148c7e3abc56e48a397c1664f044920463ad0df0fc706eacea8",
-        "size": 29257565,
-        "tag": "20231002",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "916c35125b5d8323a21526d7a9154ca626453f63d0878e95b9f613a95006c990",
-        "size": 17456917,
-        "tag": "20231002",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-aarch64-apple-darwin-install_only.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "178cb1716c2abc25cb56ae915096c1a083e60abeba57af001996e8bc6ce1a371",
-        "size": 18090352,
-        "tag": "20231002",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64-apple-darwin-install_only.tar.gz"
       }
     },
     "3.11.7": {
@@ -1373,30 +900,6 @@
           "size": 18136686,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64-apple-darwin-install_only.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "b102eaf865eb715aa98a8a2ef19037b6cc3ae7dfd4a632802650f29de635aa13",
-        "size": 25593238,
-        "tag": "20240107",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-aarch64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "4a51ce60007a6facf64e5495f4cf322e311ba9f39a8cd3f3e4c026eae488e140",
-        "size": 29335084,
-        "tag": "20240107",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "b042c966920cf8465385ca3522986b12d745151a72c060991088977ca36d3883",
-        "size": 17492365,
-        "tag": "20240107",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-aarch64-apple-darwin-install_only.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "a0e615eef1fafdc742da0008425a9030b7ea68a4ae4e73ac557ef27b112836d4",
-        "size": 18136686,
-        "tag": "20240107",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64-apple-darwin-install_only.tar.gz"
       }
     },
     "3.11.8": {
@@ -1421,30 +924,6 @@
           "size": 18294281,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64-apple-darwin-install_only.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "389b9005fb78dd5a6f68df5ea45ab7b30d9a4b3222af96999e94fd20d4ad0c6a",
-        "size": 26053684,
-        "tag": "20240224",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-aarch64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "94e13d0e5ad417035b80580f3e893a72e094b0900d5d64e7e34ab08e95439987",
-        "size": 29798726,
-        "tag": "20240224",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "389a51139f5abe071a0d70091ca5df3e7a3dfcfcbe3e0ba6ad85fb4c5638421e",
-        "size": 17908564,
-        "tag": "20240224",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-aarch64-apple-darwin-install_only.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "097f467b0c36706bfec13f199a2eaf924e668f70c6e2bd1f1366806962f7e86e",
-        "size": 18294281,
-        "tag": "20240224",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64-apple-darwin-install_only.tar.gz"
       }
     },
     "3.11.9": {
@@ -1557,30 +1036,6 @@
           "size": 18009651,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "364cf099524fff92c31b8ff5ae3f7b32b0fa6cf1d380c6e37cf56140d08dfc87",
-        "size": 19962482,
-        "tag": "20240814",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "daa487c7e73005c4426ac393273117cf0e2dc4ab9b2eeda366e04cd00eea00c9",
-        "size": 21200862,
-        "tag": "20240814",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "c4e2f7774421bcb381245945e132419b529399dfa4a56059acda1493751fa377",
-        "size": 17618881,
-        "tag": "20240814",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-aarch64-apple-darwin-install_only_stripped.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "c8680f90137e36b54b3631271ccdfe5de363e7d563d8df87c53e11b956a00e04",
-        "size": 18009651,
-        "tag": "20240814",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz"
       }
     },
     "3.12.0": {
@@ -1605,30 +1060,6 @@
           "size": 16985354,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64-apple-darwin-install_only.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "bccfe67cf5465a3dfb0336f053966e2613a9bc85a6588c2fcf1366ef930c4f88",
-        "size": 25109984,
-        "tag": "20231002",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-aarch64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "e51a5293f214053ddb4645b2c9f84542e2ef86870b8655704367bd4b29d39fe9",
-        "size": 67780633,
-        "tag": "20231002",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "4734a2be2becb813830112c780c9879ac3aff111a0b0cd590e65ec7465774d02",
-        "size": 16380983,
-        "tag": "20231002",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-aarch64-apple-darwin-install_only.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "5a9e88c8aa52b609d556777b52ebde464ae4b4f77e4aac4eb693af57395c9abf",
-        "size": 16985354,
-        "tag": "20231002",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64-apple-darwin-install_only.tar.gz"
       }
     },
     "3.12.1": {
@@ -1653,30 +1084,6 @@
           "size": 17020244,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64-apple-darwin-install_only.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "236533ef20e665007a111c2f36efb59c87ae195ad7dca223b6dc03fb07064f0b",
-        "size": 25167638,
-        "tag": "20240107",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-aarch64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "74e330b8212ca22fd4d9a2003b9eec14892155566738febc8e5e572f267b9472",
-        "size": 67786580,
-        "tag": "20240107",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "f93f8375ca6ac0a35d58ff007043cbd3a88d9609113f1cb59cf7c8d215f064af",
-        "size": 16428491,
-        "tag": "20240107",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-aarch64-apple-darwin-install_only.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "eca96158c1568dedd9a0b3425375637a83764d1fa74446438293089a8bfac1f8",
-        "size": 17020244,
-        "tag": "20240107",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64-apple-darwin-install_only.tar.gz"
       }
     },
     "3.12.2": {
@@ -1701,30 +1108,6 @@
           "size": 17177894,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64-apple-darwin-install_only.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "e52550379e7c4ac27a87de832d172658bc04150e4e27d4e858e6d8cbb96fd709",
-        "size": 25620958,
-        "tag": "20240224",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-aarch64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "57a37b57f8243caa4cdac016176189573ad7620f0b6da5941c5e40660f9468ab",
-        "size": 68023315,
-        "tag": "20240224",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "01c064c00013b0175c7858b159989819ead53f4746d40580b5b0b35b6e80fba6",
-        "size": 16840399,
-        "tag": "20240224",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-aarch64-apple-darwin-install_only.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "a53a6670a202c96fec0b8c55ccc780ea3af5307eb89268d5b41a9775b109c094",
-        "size": 17177894,
-        "tag": "20240224",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64-apple-darwin-install_only.tar.gz"
       }
     },
     "3.12.3": {
@@ -1749,30 +1132,6 @@
           "size": 17151699,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64-apple-darwin-install_only.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "ec8126de97945e629cca9aedc80a29c4ae2992c9d69f2655e27ae73906ba187d",
-        "size": 25626233,
-        "tag": "20240415",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-aarch64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "a73ba777b5d55ca89edef709e6b8521e3f3d4289581f174c8699adfb608d09d6",
-        "size": 67368051,
-        "tag": "20240415",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "ccc40e5af329ef2af81350db2a88bbd6c17b56676e82d62048c15d548401519e",
-        "size": 16814925,
-        "tag": "20240415",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-aarch64-apple-darwin-install_only.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "c37a22fca8f57d4471e3708de6d13097668c5f160067f264bb2b18f524c890c8",
-        "size": 17151699,
-        "tag": "20240415",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64-apple-darwin-install_only.tar.gz"
       }
     },
     "3.12.4": {
@@ -1841,30 +1200,6 @@
           "size": 16838842,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64-apple-darwin-install_only_stripped.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "6c9cf13644edc7250525ab1b2529ba1c0fff56c0c5a5c2242d84b6d4889d2bea",
-        "size": 18953227,
-        "tag": "20240726",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "ca076aee4329f53f988346eb0521ad2a2cf7f723b6296088d03b98d8f22f5420",
-        "size": 22253274,
-        "tag": "20240726",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "ef6948e836f531bd7a58ffbe602803ff1c83c65f99d1da19be369ea61f136c93",
-        "size": 16490253,
-        "tag": "20240726",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-aarch64-apple-darwin-install_only_stripped.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "9d68cbdd12d1d6f98d35cc76add232c12db75c6b7f49733bffc88e7b1c025a79",
-        "size": 16838842,
-        "tag": "20240726",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64-apple-darwin-install_only_stripped.tar.gz"
       }
     },
     "3.12.5": {
@@ -1889,30 +1224,6 @@
           "size": 16564547,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "06e512178cb513658a01c054b3eafc649ca362ccbeb02a6ae8a55b02c1ba75ca",
-        "size": 18670032,
-        "tag": "20240814",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "10680b593b5e31833218fd83104dee74af970a3463403a22bae613b952a34e8d",
-        "size": 21984711,
-        "tag": "20240814",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "90715cdab075e5a2680acf2695572d165b6269bdb5d1942ab577491478aea55f",
-        "size": 16223961,
-        "tag": "20240814",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-aarch64-apple-darwin-install_only_stripped.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "49a9f7ad41d62e0ece9e664ca5ae95f022e7b68eef48e8a6f11620ec9247c686",
-        "size": 16564547,
-        "tag": "20240814",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz"
       }
     },
     "3.12.6": {
@@ -1937,30 +1248,6 @@
           "size": 15780284,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64-apple-darwin-install_only_stripped.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "22d119ac7df7f0bddfd4dfd075bcc4eb2532ed3df0bdba0579106835d49ef9cd",
-        "size": 17862875,
-        "tag": "20240909",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "b080463e4f0c452e592cdac1ca97936a6a19bb3d9a64da669a50ca843fce0108",
-        "size": 21243376,
-        "tag": "20240909",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "0419bafa4444a5aa0c554197bce0679e7cc0f28edc7ee8cfbe0ccea860bdb904",
-        "size": 15421366,
-        "tag": "20240909",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-aarch64-apple-darwin-install_only_stripped.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "b10d19eb5548a3b3b0a5e6f9109834d7ecfc139bc15754f81a94d39eaa5bdd26",
-        "size": 15780284,
-        "tag": "20240909",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64-apple-darwin-install_only_stripped.tar.gz"
       }
     },
     "3.12.7": {
@@ -2029,30 +1316,6 @@
           "size": 15817311,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-x86_64-apple-darwin-install_only_stripped.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "c8f5ed70ee3c19da72d117f7b306adc6ca1eaf26afcbe1cc1be57d1e18df184c",
-        "size": 17865102,
-        "tag": "20241016",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "3a4d53a7ba3916c0c1f35cbbe57068e2571b138389f29cf5c35367fec8f4c617",
-        "size": 21276148,
-        "tag": "20241016",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "95dd397e3aef4cc1846867cf20be704bdd74edd16ea8032caf01e48f0c53d65d",
-        "size": 15457017,
-        "tag": "20241016",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-aarch64-apple-darwin-install_only_stripped.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "848405b92bda20fad1f9bba99234c7d3f11e0b31e46f89835d1cb3d735e932aa",
-        "size": 15817311,
-        "tag": "20241016",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-x86_64-apple-darwin-install_only_stripped.tar.gz"
       }
     },
     "3.12.8": {
@@ -2145,74 +1408,6 @@
           "size": 15874759,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64-apple-darwin-install_only_stripped.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "06e633164cb0133685a2ce14af88df0dbcaea4b0b2c5d3348d6b81393307481a",
-        "size": 17577968,
-        "tag": "20241016",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "b5e74d1e16402b633c6f04519618231fc0dbae7d2f9e4b1ac17c294cc3d3d076",
-        "size": 19024698,
-        "tag": "20241016",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "e94fafbac07da52c965cb6a7ffc51ce779bd253cd98af801347aac791b96499f",
-        "size": 15440316,
-        "tag": "20241016",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-aarch64-apple-darwin-install_only_stripped.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "406664681bd44af35756ad08f5304f1ec57070bb76fae8ff357ff177f229b224",
-        "size": 15874759,
-        "tag": "20241016",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64-apple-darwin-install_only_stripped.tar.gz"
-      }
-    },
-    "3.13.0rc2": {
-      "linux_arm64": {
-        "sha256": "d99a663d3b9f8792a659e366372e685550045cad12aef11645c06a9b6edcd071",
-        "size": 17577277,
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "1893a218709d3664b7a2b80f5598b5f25c0c3fe2bcc8d0a1c75eec6bbb93d602",
-        "size": 19026674,
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "9e17f9fcc314a5dd489089a7502a525c4dd08af862f9cf33b52161a752f2a5b7",
-        "size": 15445592,
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-aarch64-apple-darwin-install_only_stripped.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "971668ac7f3168efc4d2b589e9d36247ab8ca9f9525c56c8aa7bfd374060105b",
-        "size": 15873381,
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64-apple-darwin-install_only_stripped.tar.gz"
-      }
-    },
-    "3.13.0rc3": {
-      "linux_arm64": {
-        "sha256": "1414c6b37f37e8fd9d14e48d81e313eb9c965cb0330747d5d2d689dd7e0c7043",
-        "size": 17578602,
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "445156c61e1cc167f7b8777ad08cc36e5598e12cd27e07453f6e6dc0f62e421e",
-        "size": 19024187,
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "685ef71882f16eabab0bc838094727978370f0ad95c29f7f5c244ffa31316aeb",
-        "size": 15439870,
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-aarch64-apple-darwin-install_only_stripped.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "0f5f9fcf82093c428b80c552165544439f4adcdbe5129ecf721d619e532e9b5e",
-        "size": 15879142,
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64-apple-darwin-install_only_stripped.tar.gz"
       }
     },
     "3.13.1": {
@@ -2278,24 +1473,6 @@
           "size": 40287093,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-x86_64-apple-darwin-install_only.tar.gz"
         }
-      },
-      "linux_x86_64": {
-        "sha256": "5be9c6d61e238b90dfd94755051c0d3a2d8023ebffdb4b0fa4e8fedd09a6cab6",
-        "size": 49945411,
-        "tag": "20220227",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-x86_64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "f9a3cbb81e0463d6615125964762d133387d561b226a30199f5b039b20f1d944",
-        "size": 40042198,
-        "tag": "20220227",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-aarch64-apple-darwin-install_only.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "f323fbc558035c13a85ce2267d0fad9e89282268ecb810e364fff1d0a079d525",
-        "size": 40287093,
-        "tag": "20220227",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-x86_64-apple-darwin-install_only.tar.gz"
       }
     },
     "3.8.13": {
@@ -2388,30 +1565,6 @@
           "size": 17973220,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-x86_64-apple-darwin-install_only.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "8dc7814bf3425bbf78c6e6e5a6529ded6ae463fa6a4b79c025b343bae4fd955a",
-        "size": 25074929,
-        "tag": "20220802",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-aarch64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "fb566629ccb5f76ef56d275a3f8017d683f1c20c5beb5d5f38b155ed11e16187",
-        "size": 26896334,
-        "tag": "20220802",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-x86_64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "ae4131253d890b013171cb5f7b03cadc585ae263719506f7b7e063a7cf6fde76",
-        "size": 17586341,
-        "tag": "20220802",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-aarch64-apple-darwin-install_only.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "cd6e7c0a27daf7df00f6882eaba01490dd963f698e99aeee9706877333e0df69",
-        "size": 17973220,
-        "tag": "20220802",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-x86_64-apple-darwin-install_only.tar.gz"
       }
     },
     "3.8.14": {
@@ -2436,30 +1589,6 @@
           "size": 17976638,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-x86_64-apple-darwin-install_only.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "c45e42deee43e3ebc4ca5b019c37d8ae25fb5b5f1ba5f602098a81b99d2bc804",
-        "size": 25070295,
-        "tag": "20221002",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-aarch64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "4eb53bce831bf52682067579c09ccaccb6524dd44bd4b8047454c69b4817f4f0",
-        "size": 26912560,
-        "tag": "20221002",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-x86_64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "6c17f6dcda59de5d8eee922ef7eede403a540dae05423ef2c2a042d8d4f22467",
-        "size": 17594484,
-        "tag": "20221002",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-aarch64-apple-darwin-install_only.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "3ed4db8d0308c584196d97c629058ea69bbd8b7f9a034cf8c2c701ebb286c091",
-        "size": 17976638,
-        "tag": "20221002",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-x86_64-apple-darwin-install_only.tar.gz"
       }
     },
     "3.8.15": {
@@ -2484,30 +1613,6 @@
           "size": 17985182,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-x86_64-apple-darwin-install_only.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "886ab33ced13c84bf59ce8ff79eba6448365bfcafea1bf415bd1d75e21b690aa",
-        "size": 25080793,
-        "tag": "20221106",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-aarch64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "e47edfb2ceaf43fc699e20c179ec428b6f3e497cf8e2dcd8e9c936d4b96b1e56",
-        "size": 26922922,
-        "tag": "20221106",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-x86_64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "1e0a92d1a4f5e6d4a99f86b1cbf9773d703fe7fd032590f3e9c285c7a5eeb00a",
-        "size": 17603392,
-        "tag": "20221106",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-aarch64-apple-darwin-install_only.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "70b57f28c2b5e1e3dd89f0d30edd5bc414e8b20195766cf328e1b26bed7890e1",
-        "size": 17985182,
-        "tag": "20221106",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-x86_64-apple-darwin-install_only.tar.gz"
       }
     },
     "3.8.16": {
@@ -2598,30 +1703,6 @@
           "size": 17491676,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-x86_64-apple-darwin-install_only.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "9c6615931fd1045bf9f2148aa7dd9ce1ece8575ed68a5483a0b615322a43d54c",
-        "size": 23873980,
-        "tag": "20230726",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-aarch64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "b1f1502c3a13b899724dbd32bd77a973fa9733b932c5700d747fe33d5de9ac4f",
-        "size": 25685510,
-        "tag": "20230726",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-x86_64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "7e484eb6de40d6f6bdfd5099eaa9647f65e45fb6d846ccfc56b1cb1e38b5ab02",
-        "size": 17227282,
-        "tag": "20230726",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-aarch64-apple-darwin-install_only.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "28506e509646c11cb2f57a7203bd1b08b6e8e5b159ae308bd5bb93b0d334bdaf",
-        "size": 17491676,
-        "tag": "20230726",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-x86_64-apple-darwin-install_only.tar.gz"
       }
     },
     "3.8.17": {
@@ -2646,30 +1727,6 @@
           "size": 19505723,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-x86_64-apple-darwin-install_only.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "9f6d585091fe26906ff1dbb80437a3fe37a1e3db34d6ecc0098f3d6a78356682",
-        "size": 25883841,
-        "tag": "20230826",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-aarch64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "8d3e1826c0bb7821ec63288038644808a2d45553245af106c685ef5892fabcd8",
-        "size": 27685259,
-        "tag": "20230826",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-x86_64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "c6f7a130d0044a78e39648f4dae56dcff5a41eba91888a99f6e560507162e6a1",
-        "size": 19247729,
-        "tag": "20230826",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-aarch64-apple-darwin-install_only.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "155b06821607bae1a58ecc60a7d036b358c766f19e493b8876190765c883a5c2",
-        "size": 19505723,
-        "tag": "20230826",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-x86_64-apple-darwin-install_only.tar.gz"
       }
     },
     "3.8.18": {
@@ -2738,30 +1795,6 @@
           "size": 20040915,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-x86_64-apple-darwin-install_only.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "6588c9eed93833d9483d01fe40ac8935f691a1af8e583d404ec7666631b52487",
-        "size": 26807467,
-        "tag": "20240224",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-aarch64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "5ae36825492372554c02708bdd26b8dcd57e3dbf34b3d6d599ad91d93540b2b7",
-        "size": 28681831,
-        "tag": "20240224",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-x86_64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "4d493a1792bf211f37f98404cc1468f09bd781adc2602dea0df82ad264c11abc",
-        "size": 19717855,
-        "tag": "20240224",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-aarch64-apple-darwin-install_only.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "7d2cd8d289d5e3cdd0a8c06c028c7c621d3d00ce44b7e2f08c1724ae0471c626",
-        "size": 20040915,
-        "tag": "20240224",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-x86_64-apple-darwin-install_only.tar.gz"
       }
     },
     "3.8.19": {
@@ -2874,30 +1907,6 @@
           "size": 17735922,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "202211923850303f521146ee1831642aaf357ffeeadbe13a0a91884317227528",
-        "size": 19759196,
-        "tag": "20240814",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "0f1579dbb01c98af7a12fef4c9aa8a99d45b91393f64431f5de712f892bc5c0b",
-        "size": 20850693,
-        "tag": "20240814",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "6a15ee2b507aed4d5b15fd1b66fc570aa49183f15aa6c412eccd065446f17d8e",
-        "size": 17417243,
-        "tag": "20240814",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-aarch64-apple-darwin-install_only_stripped.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "1a24263b039c1172bd42d74a5694492f3e3dbe4d3e52a1e7cc2856fee7dbee4a",
-        "size": 17735922,
-        "tag": "20240814",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz"
       }
     },
     "3.8.20": {
@@ -2944,30 +1953,6 @@
           "size": 17738861,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-x86_64-apple-darwin-install_only_stripped.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "75a187ebfab81096e3f3d91d70c1349e64defbdfb0e8a067cb5233d017655e31",
-        "size": 19762577,
-        "tag": "20241002",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "a3a75094545912d4e9413673441b3f0d2e58ce9b264477f910800148801ccf11",
-        "size": 20852474,
-        "tag": "20241002",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "30ba44af64e599bde7307908393374bdcd99e185bf9b3c9de3f697f3fbe6bf8f",
-        "size": 17424339,
-        "tag": "20241002",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-aarch64-apple-darwin-install_only_stripped.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "375b6eead6c852cabbf3ccfd43dc4f6dd4c36381bf74c9a7910acb839fd5c57f",
-        "size": 17738861,
-        "tag": "20241002",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-x86_64-apple-darwin-install_only_stripped.tar.gz"
       }
     },
     "3.9.10": {
@@ -2992,30 +1977,6 @@
           "size": 41228694,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64-apple-darwin-install_only.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "12dd1f125762f47975990ec744532a1cf3db74ad60f4dfb476ca42deb7f78ca4",
-        "size": 85992370,
-        "tag": "20220227",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-aarch64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "455089cc576bd9a58db45e919d1fc867ecdbb0208067dffc845cc9bbf0701b70",
-        "size": 51624807,
-        "tag": "20220227",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "ad66c2a3e7263147e046a32694de7b897a46fb0124409d29d3a93ede631c8aee",
-        "size": 40999185,
-        "tag": "20220227",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-aarch64-apple-darwin-install_only.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "fdaf594142446029e314a9beb91f1ac75af866320b50b8b968181e592550cd68",
-        "size": 41228694,
-        "tag": "20220227",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64-apple-darwin-install_only.tar.gz"
       }
     },
     "3.9.11": {
@@ -3040,30 +2001,6 @@
           "size": 41767821,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64-apple-darwin-install_only.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "0e50f099409c5e651b5fddd16124af1d830d11653e786a93c28e5b8f8aa470c4",
-        "size": 86614999,
-        "tag": "20220318",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-aarch64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "0429d5ceb095d5e24c292bf1a39208b88ae236a680ef8fa3e1830e3a1a7e8882",
-        "size": 52181358,
-        "tag": "20220318",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "cf92a28f98c8d884df0937bf19d5f1a40caa25a6a211a237b7e9b592b2b71c2b",
-        "size": 41570037,
-        "tag": "20220318",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-aarch64-apple-darwin-install_only.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "43889d1a424c84fb155e1619f062adb6984fbde80b6043611790f22bcbeec300",
-        "size": 41767821,
-        "tag": "20220318",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64-apple-darwin-install_only.tar.gz"
       }
     },
     "3.9.12": {
@@ -3088,30 +2025,6 @@
           "size": 41592297,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64-apple-darwin-install_only.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "2ee1426c181e65133e57dc55c6a685cb1fb5e63ef02d684b8a667d5c031c4203",
-        "size": 86402456,
-        "tag": "20220502",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-aarch64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "ccca12f698b3b810d79c52f007078f520d588232a36bc12ede944ec3ea417816",
-        "size": 52175226,
-        "tag": "20220502",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "8dee06c07cc6429df34b6abe091a4684a86f7cec76f5d1ccc1c3ce2bd11168df",
-        "size": 41443679,
-        "tag": "20220502",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-aarch64-apple-darwin-install_only.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "2453ba7f76b3df3310353b48c881d6cff622ba06e30d2b6ae91588b2bc9e481a",
-        "size": 41592297,
-        "tag": "20220502",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64-apple-darwin-install_only.tar.gz"
       }
     },
     "3.9.13": {
@@ -3180,30 +2093,6 @@
           "size": 17132546,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64-apple-darwin-install_only.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "80415aac1b96255b9211f6a4c300f31e9940c7e07a23d0dec12b53aa52c0d25e",
-        "size": 24521230,
-        "tag": "20220802",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-aarch64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "ce1cfca2715e7e646dd618a8cb9baff93000e345ccc979b801fc6ccde7ce97df",
-        "size": 26747628,
-        "tag": "20220802",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "d9603edc296a2dcbc59d7ada780fd12527f05c3e0b99f7545112daf11636d6e5",
-        "size": 16730332,
-        "tag": "20220802",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-aarch64-apple-darwin-install_only.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "9540a7efb7c8a54a48aff1cb9480e49588d9c0a3f934ad53f5b167338174afa3",
-        "size": 17132546,
-        "tag": "20220802",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64-apple-darwin-install_only.tar.gz"
       }
     },
     "3.9.14": {
@@ -3228,30 +2117,6 @@
           "size": 17138819,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64-apple-darwin-install_only.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "fe538201559ca37f44cd5f66c42a65fe7272cb4f1f63edd698b6f306771db1e9",
-        "size": 24525886,
-        "tag": "20221002",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-aarch64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "e63d0c00a499e0202ba7a0f53ce69fca6d30237af39af9bc3c76bce6c7bf14d7",
-        "size": 26761725,
-        "tag": "20221002",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "e38df7f230979ce6c53a5bafb3a81287838e5f3892c40cd1b98a0c961c444713",
-        "size": 16734921,
-        "tag": "20221002",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-aarch64-apple-darwin-install_only.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "b7d3a1f4b57e9350571ccee49c82f503133de0d113a2dbaebc8ccf108fb3fe1b",
-        "size": 17138819,
-        "tag": "20221002",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64-apple-darwin-install_only.tar.gz"
       }
     },
     "3.9.15": {
@@ -3276,30 +2141,6 @@
           "size": 17148635,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64-apple-darwin-install_only.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "52a8c0a67fb919f80962d992da1bddb511cdf92faf382701ce7673e10a8ff98f",
-        "size": 24524876,
-        "tag": "20221106",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-aarch64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "cdc3a4cfddcd63b6cebdd75b14970e02d8ef0ac5be4d350e57ab5df56c19e85e",
-        "size": 26765574,
-        "tag": "20221106",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "64dc7e1013481c9864152c3dd806c41144c79d5e9cd3140e185c6a5060bdc9ab",
-        "size": 16748283,
-        "tag": "20221106",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-aarch64-apple-darwin-install_only.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "f2bcade6fc976c472f18f2b3204d67202d43ae55cf6f9e670f95e488f780da08",
-        "size": 17148635,
-        "tag": "20221106",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64-apple-darwin-install_only.tar.gz"
       }
     },
     "3.9.16": {
@@ -3368,30 +2209,6 @@
           "size": 16908516,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64-apple-darwin-install_only.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "f629b75ebfcafe9ceee2e796b7e4df5cf8dbd14f3c021afca078d159ab797acf",
-        "size": 23583066,
-        "tag": "20230507",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-aarch64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "2b6e146234a4ef2a8946081fc3fbfffe0765b80b690425a49ebe40b47c33445b",
-        "size": 25738357,
-        "tag": "20230507",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "c1de1d854717a6245f45262ef1bb17b09e2c587590e7e3f406593c143ff875bd",
-        "size": 16634170,
-        "tag": "20230507",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-aarch64-apple-darwin-install_only.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "3abc4d5fbbc80f5f848f280927ac5d13de8dc03aabb6ae65d8247cbb68e6f6bf",
-        "size": 16908516,
-        "tag": "20230507",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64-apple-darwin-install_only.tar.gz"
       }
     },
     "3.9.17": {
@@ -3416,30 +2233,6 @@
           "size": 16579635,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64-apple-darwin-install_only.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "b77012ddaf7e0673e4aa4b1c5085275a06eee2d66f33442b5c54a12b62b96cbe",
-        "size": 23259487,
-        "tag": "20230726",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-aarch64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "26c4a712b4b8e11ed5c027db5654eb12927c02da4857b777afb98f7a930ce637",
-        "size": 25409877,
-        "tag": "20230726",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "73dbe2d702210b566221da9265acc274ba15275c5d0d1fa327f44ad86cde9aa1",
-        "size": 16312686,
-        "tag": "20230726",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-aarch64-apple-darwin-install_only.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "dfe1bea92c94b9cb779288b0b06e39157c5ff7e465cdd24032ac147c2af485c0",
-        "size": 16579635,
-        "tag": "20230726",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64-apple-darwin-install_only.tar.gz"
       }
     },
     "3.9.18": {
@@ -3530,30 +2323,6 @@
           "size": 17132069,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64-apple-darwin-install_only.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "e5bc5196baa603d635ee6b0cd141e359752ad3e8ea76127eb9141a3155c51200",
-        "size": 24171241,
-        "tag": "20240224",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-aarch64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "0e5663025121186bd17d331538a44f48b41baff247891d014f3f962cbe2716b4",
-        "size": 26338278,
-        "tag": "20240224",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64-unknown-linux-gnu-install_only.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "2548f911a6e316575c303ba42bb51540dc9b47a9f76a06a2a37460d93b177aa2",
-        "size": 16799720,
-        "tag": "20240224",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-aarch64-apple-darwin-install_only.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "171d8b472fce0295be0e28bb702c43d5a2a39feccb3e72efe620ac3843c3e402",
-        "size": 17132069,
-        "tag": "20240224",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64-apple-darwin-install_only.tar.gz"
       }
     },
     "3.9.19": {
@@ -3666,30 +2435,6 @@
           "size": 16899149,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "23d08f7f0bf151c2ea54b2c9c143bc710faf166ff74225b0f967fab1e2d7a151",
-        "size": 18910563,
-        "tag": "20240814",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "3b7d574b6bbf8303789a1d26b96a81dcca907381441ce15818c784e18d1db299",
-        "size": 19992626,
-        "tag": "20240814",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "451582f8a6a8c15ef35a327afcdbf8d03b1ebba7192e90d850d092dac91f91c6",
-        "size": 16567269,
-        "tag": "20240814",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-aarch64-apple-darwin-install_only_stripped.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "ebaf4336d0cbff4466c994d5bcaa92a38c91d06694d0cd675ec663259d5f37c7",
-        "size": 16899149,
-        "tag": "20240814",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz"
       }
     },
     "3.9.20": {
@@ -3780,30 +2525,6 @@
           "size": 16906013,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-x86_64-apple-darwin-install_only_stripped.tar.gz"
         }
-      },
-      "linux_arm64": {
-        "sha256": "3742c9d6563527a003b12ac689c07e6965911ff89fd9cbbd3c17ac7bfb037d4a",
-        "size": 18915696,
-        "tag": "20241016",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
-      },
-      "linux_x86_64": {
-        "sha256": "44d9d016f9820f39e5bb542782557d46876b69d23d0a204eb2f367739da623e0",
-        "size": 19996785,
-        "tag": "20241016",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "41e9bb2d45e1a0467e534dafc6691b3d3c2b79fd9a564562f4c0c41eb343d30a",
-        "size": 16572425,
-        "tag": "20241016",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-aarch64-apple-darwin-install_only_stripped.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "440f4ebc651e707ed24d5dc68d3b0b2197e7fb369bb77685b1b539dbf30ab1e5",
-        "size": 16906013,
-        "tag": "20241016",
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-x86_64-apple-darwin-install_only_stripped.tar.gz"
       }
     },
     "3.9.21": {
@@ -3850,40 +2571,6 @@
           "size": 17163660,
           "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.9.21%2B20241206-x86_64-apple-darwin-install_only_stripped.tar.gz"
         }
-      }
-    },
-    "3.9.6": {
-      "linux_x86_64": {
-        "sha256": "a5e1f952a50a3a660922a7b558911d56c4d046078c67a83ec048f81ee4d3b8bd",
-        "size": 51505407,
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-x86_64-unknown-linux-gnu-install_only-20210724T1424.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "d11109ba3fe4943e21e195fe4d5fbeff8a5452efcee7035542815bc0e54434d5",
-        "size": 40156472,
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-aarch64-apple-darwin-install_only-20210724T1424.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "f503b62231833ae3b64a3cf77f45b471e5ffcc0af1381ed1010f9a57e874619a",
-        "size": 40391040,
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-x86_64-apple-darwin-install_only-20210724T1424.tar.gz"
-      }
-    },
-    "3.9.7": {
-      "linux_x86_64": {
-        "sha256": "a92dfd11be92c8b5f7b50953bdb5864456d68d316f73d9cfb4bde33a68ac8239",
-        "size": 50239692,
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-x86_64-unknown-linux-gnu-install_only-20211017T1616.tar.gz"
-      },
-      "macos_arm64": {
-        "sha256": "b8014771b2adbd98a9edee176364d77af5cc5dd0596a1938213827204d88d10d",
-        "size": 40043665,
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-aarch64-apple-darwin-install_only-20211017T1616.tar.gz"
-      },
-      "macos_x86_64": {
-        "sha256": "67d3a0a2f35e43054c450e380118a5913dbbad2bda83959891653362f9d979e5",
-        "size": 40250527,
-        "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-x86_64-apple-darwin-install_only-20211017T1616.tar.gz"
       }
     }
   },


### PR DESCRIPTION
As first mentioned by @huonw in https://github.com/pantsbuild/pants/pull/21710#pullrequestreview-2493831818 and more fully discussed in https://github.com/pantsbuild/pants/issues/21748, the addition of filtering PBS releases by the PBS release tag means that users may now see a breaking change if Pants scrapes newer versions of PBS releases, replaces some of the existing "known versions" data with the newly-scraped release metadata, and the user selects an older release via a PBS release constraint.

In that case, the user would see an error because Pants would be unable to select that specific PBS version anymore due to no longer having any metadata regarding that PBS release tag.

The solution is for Pants to store metadata for _all_ PBS release tags. Newer versions will only add to the PBS "known versions" data and not replace nor delete any metadata. With all metadata available, a user who selects a particular PBS release via the release constraints will still continue to see that release be selected. And users who want the latest matching PBS release will continue to get the latest PBS release (known to Pants).

Closes https://github.com/pantsbuild/pants/issues/21748.