### PR TITLE
make Platform class serializable for workunit-logger

### DIFF
--- a/docs/notes/2.25.x.md
+++ b/docs/notes/2.25.x.md
@@ -58,6 +58,8 @@ Previously we did ad-hoc coercion of some field values, so that, e.g., you could
 
 The `helm_infer.external_docker_images` glob syntax has been generalized.  In addition to `*`, you can now use Python [fnmatch](https://docs.python.org/3/library/fnmatch.html) to construct matterns like `quay.io/*`.
 
+Fixed a bug where linting with the Helm backend enabled could induce serialization errors with the [workunit-logger](https://www.pantsbuild.org/2.25/reference/subsystems/workunit-logger).
+
 #### Python
 
 The AWS Lambda backend now provides built-in complete platforms for the Python 3.13 runtime.

--- a/src/python/pants/engine/internals/platform_rules.py
+++ b/src/python/pants/engine/internals/platform_rules.py
@@ -39,7 +39,9 @@ def current_platform(
         if env_tgt.val.has_field(DockerPlatformField):
             return Platform(env_tgt.val[DockerPlatformField].normalized_value)
         if env_tgt.val.has_field(RemotePlatformField):
-            return Platform(env_tgt.val[RemotePlatformField].value)
+            remote_platform = env_tgt.val[RemotePlatformField].value
+            if remote_platform:
+                return Platform(remote_platform)
     return Platform.create_for_localhost()
 
 

--- a/src/python/pants/engine/platform.py
+++ b/src/python/pants/engine/platform.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from enum import StrEnum
 
 from pants.util.osutil import get_normalized_arch_name, get_normalized_os_name
 
@@ -15,7 +15,7 @@ class PlatformError(Exception):
     """
 
 
-class Platform(Enum):
+class Platform(StrEnum):
     linux_arm64 = "linux_arm64"
     linux_x86_64 = "linux_x86_64"
     macos_arm64 = "macos_arm64"


### PR DESCRIPTION
As described in #21773, having the Helm backend lint with the workunit-logger results in json serialization errors.  Giving `Platform` a string representation resolves this (and anywhere else we may want to "print" it.

Example workunit:
```
{"name": "pants.backend.helm.util_rules.tool.download_external_helm_plugin", "span_id": "bdaa19a5cd1ef797", "level": "DEBUG", "parent_id": "c8c137a5b78f02ea", "start_secs": 1734722271, "start_nanos": 296631921, "duration_secs": 0, "duration_nanos": 51846519, "description": "Download external Helm plugin", "metadata": {"name": "unittest", "version": "0.3.3", "platform": "linux_x86_64"}}
```

NOTE: I think this is a totally safe ~one line change, but admit it is to a rather core class.

fixes #21773