### PR TITLE
support `{chroot}` for program arguments in remote execution 

### DIFF
--- a/docs/notes/2.25.x.md
+++ b/docs/notes/2.25.x.md
@@ -28,7 +28,7 @@ Pants now sends a `user-agent` header with every request to a remote store or a 
 even when other headers are configured. If necessary, the user may override the user agent by specifying
 one in `remote_store_headers` or `remote_execution_headers`.
 
-Pants now supports the `{chroot}` replacement marker in program arguments for remote execution. (With local and Docker execution, the `{chroot}` marker is replaced with the absolute path of the sandbox diretory if it appears in program arguments or environment variables. Pants will now replace `{chroot}` for program arguments with remote execution, but still does not yet support doing so in environment variables.)
+Pants now supports the `{chroot}` replacement marker in program arguments for remote execution. (With local and Docker execution, the `{chroot}` marker is replaced with the absolute path of the sandbox directory if it appears in program arguments or environment variables. Pants will now replace `{chroot}` for program arguments with remote execution, but still does not yet support doing so in environment variables.  This requires `/bin/bash` to be available on the remote execution server.)
 
 ### New Options System
 

--- a/docs/notes/2.25.x.md
+++ b/docs/notes/2.25.x.md
@@ -28,6 +28,8 @@ Pants now sends a `user-agent` header with every request to a remote store or a 
 even when other headers are configured. If necessary, the user may override the user agent by specifying
 one in `remote_store_headers` or `remote_execution_headers`.
 
+Pants now supports the `{chroot}` replacement marker in program arguments for remote execution. (With local and Docker execution, the `{chroot}` marker is replaced with the absolute path of the sandbox diretory if it appears in program arguments or environment variables. Pants will now replace `{chroot}` for program arguments with remote execution, but still does not yet support doing so in environment variables.)
+
 ### New Options System
 
 The "legacy" options system is removed in this release. All options parsing is now handled by the new, native parser.

--- a/src/rust/engine/process_execution/remote/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/remote/src/remote_tests.rs
@@ -724,7 +724,7 @@ async fn make_execute_request_with_append_only_caches() {
         input_root_digest: Some(
             (Digest::new(
                 Fingerprint::from_hex_string(
-                    "9f4ad1839decdee5e0b01d8ab2562302e42d590f331c3efb747c17f1936bedd4",
+                    "d6f65a7f56380de341fac43fcb4e2006fd0e716579325c4640ec11b7c040bb9c",
                 )
                 .unwrap(),
                 178,
@@ -739,7 +739,7 @@ async fn make_execute_request_with_append_only_caches() {
         action_digest: Some(
             (&Digest::new(
                 Fingerprint::from_hex_string(
-                    "18a5a53ad2909432f848f161af2b6886659b4047d608742b64a80f0879dc0a69",
+                    "d516c6b3b9781777486025ebc87cb4810bc7088dc45092a70a592d8ca74f48d8",
                 )
                 .unwrap(),
                 146,
@@ -752,7 +752,7 @@ async fn make_execute_request_with_append_only_caches() {
 
     let want_input_root_digest = DirectoryDigest::from_persisted_digest(Digest::new(
         Fingerprint::from_hex_string(
-            "9f4ad1839decdee5e0b01d8ab2562302e42d590f331c3efb747c17f1936bedd4",
+            "d6f65a7f56380de341fac43fcb4e2006fd0e716579325c4640ec11b7c040bb9c",
         )
         .unwrap(),
         178,

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -1178,13 +1178,11 @@ pub async fn make_execute_request(
         Some(_) => {
             let mut args = Vec::with_capacity(req.argv.len() + 1);
             args.push(WRAPPER_SCRIPT.to_string());
-            for orig_arg in &req.argv {
-                if orig_arg.contains("{chroot}") {
-                    args.push(orig_arg.replace("{chroot}", SANDBOX_ROOT_TOKEN));
-                } else {
-                    args.push(orig_arg.clone());
-                }
-            }
+            args.extend(
+                req.argv
+                    .iter()
+                    .map(|orig_arg| orig_arg.replace("{chroot}", SANDBOX_ROOT_TOKEN)),
+            );
             args
         }
         None => req.argv.clone(),

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -1107,7 +1107,13 @@ fn maybe_make_wrapper_script(
 
     let script = {
         let mut script = String::new();
-        writeln!(&mut script, "#!/bin/sh").map_err(|err| format!("write! failed: {err:?}"))?;
+
+        let shebang = match sandbox_root_fragment {
+            Some(_) => "/bin/bash", // the array features need bash and not just plain old /bin/sh
+            _ => "/bin/sh",
+        };
+        writeln!(&mut script, "#!{shebang}").map_err(|err| format!("write! failed: {err:?}"))?;
+
         if let Some(sandbox_root_fragment) = sandbox_root_fragment {
             writeln!(&mut script, "{sandbox_root_fragment}")
                 .map_err(|err| format!("write! failed: {err:?}"))?;
@@ -1120,7 +1126,9 @@ fn maybe_make_wrapper_script(
             writeln!(&mut script, "{chdir_fragment}")
                 .map_err(|err| format!("write! failed: {err:?}"))?;
         }
+
         writeln!(&mut script, "exec \"$@\"").map_err(|err| format!("write! failed: {err:?}"))?;
+
         script
     };
 

--- a/src/rust/engine/process_execution/src/tests.rs
+++ b/src/rust/engine/process_execution/src/tests.rs
@@ -6,6 +6,7 @@ use std::collections::BTreeMap;
 use std::fs::Permissions;
 use std::hash::{Hash, Hasher};
 use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
 use std::process::Stdio;
 use std::time::Duration;
 
@@ -17,7 +18,7 @@ use tempfile::TempDir;
 use workunit_store::RunId;
 
 use crate::{
-    make_wrapper_for_append_only_caches, CacheName, Platform, Process, ProcessExecutionEnvironment,
+    maybe_make_wrapper_script, CacheName, Platform, Process, ProcessExecutionEnvironment,
     ProcessExecutionStrategy, ProcessResultMetadata, ProcessResultSource,
 };
 
@@ -160,7 +161,7 @@ fn process_result_metadata_time_saved_from_cache() {
 }
 
 #[tokio::test]
-async fn test_make_wrapper_for_append_only_caches_success() {
+async fn wrapper_script_supports_append_only_caches() {
     const CACHE_NAME: &str = "test_cache";
     const SUBDIR_NAME: &str = "a subdir"; // Space intentionally included to test shell quoting.
 
@@ -176,11 +177,13 @@ async fn test_make_wrapper_for_append_only_caches_success() {
         .await
         .unwrap();
 
-    let script_content = make_wrapper_for_append_only_caches(
+    let script_content = maybe_make_wrapper_script(
         &caches,
-        dummy_caches_base_path.path().to_str().unwrap(),
+        dummy_caches_base_path.path().to_str(),
         Some(SUBDIR_NAME),
+        None,
     )
+    .unwrap()
     .unwrap();
 
     let script_path = dummy_sandbox_path.path().join("wrapper");
@@ -233,4 +236,53 @@ async fn test_make_wrapper_for_append_only_caches_success() {
         test_file_metadata.is_file(),
         "script wrote a file into a sudirectory (since script changed the working directory)"
     );
+}
+
+#[tokio::test]
+async fn wrapper_script_supports_sandbox_root_replacements_in_args() {
+    let caches = BTreeMap::new();
+
+    let script_content = maybe_make_wrapper_script(
+        &caches,
+        None,
+        None,
+        Some("__ROOT__"),
+    )
+    .unwrap()
+    .unwrap();
+
+    let dummy_sandbox_path = TempDir::new().unwrap();
+    let script_path = dummy_sandbox_path.path().join("wrapper");
+    tokio::fs::write(&script_path, script_content.as_bytes())
+        .await
+        .unwrap();
+    tokio::fs::set_permissions(&script_path, Permissions::from_mode(0o755))
+        .await
+        .unwrap();
+
+    let mut cmd = tokio::process::Command::new("./wrapper");
+    cmd.args(&[
+        "/bin/sh",
+        "-c",
+        "echo xyzzy > foo.txt && echo __ROOT__/foo.txt",
+    ]);
+    cmd.current_dir(dummy_sandbox_path.path());
+    cmd.stdin(Stdio::null());
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+
+    let child = cmd.spawn().unwrap();
+    let output = child.wait_with_output().await.unwrap();
+    if output.status.code() != Some(0) {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        println!("stdout:{}\n\nstderr: {}", &stdout, &stderr);
+        panic!("Wrapper script failed to run: {}", output.status);
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let content = tokio::fs::read_to_string(Path::new(stdout.trim()))
+        .await
+        .unwrap();
+    assert_eq!(content, "xyzzy\n");
 }

--- a/src/rust/engine/process_execution/src/tests.rs
+++ b/src/rust/engine/process_execution/src/tests.rs
@@ -242,14 +242,9 @@ async fn wrapper_script_supports_append_only_caches() {
 async fn wrapper_script_supports_sandbox_root_replacements_in_args() {
     let caches = BTreeMap::new();
 
-    let script_content = maybe_make_wrapper_script(
-        &caches,
-        None,
-        None,
-        Some("__ROOT__"),
-    )
-    .unwrap()
-    .unwrap();
+    let script_content = maybe_make_wrapper_script(&caches, None, None, Some("__ROOT__"))
+        .unwrap()
+        .unwrap();
 
     let dummy_sandbox_path = TempDir::new().unwrap();
     let script_path = dummy_sandbox_path.path().join("wrapper");


### PR DESCRIPTION
As reported in https://github.com/pantsbuild/pants/issues/17519, remote environments do not currently support the `{chroot}` replacement marker supported by the local and Docker environments. With local and Docker environments, Pants will replace any `{chroot}` marker with the absolute path of the sandbox directory if it appears in a program argument or environment variable.

This PR is a partial solution and implements `{chroot}` replacement for prorgram arguments used in remote execution. It by extends the existing wrapper script used for append-only caches to also support `{chroot}` replacements.

This PR does not try to implement `{chroot}` replacement for environment variables. That will need to come after I figure out a good way to do that.