### PR TITLE
substitute `{chroot}` marker in environment variables for remote execution

### DIFF
--- a/docs/notes/2.25.x.md
+++ b/docs/notes/2.25.x.md
@@ -29,7 +29,7 @@ Pants now sends a `user-agent` header with every request to a remote store or a 
 even when other headers are configured. If necessary, the user may override the user agent by specifying
 one in `remote_store_headers` or `remote_execution_headers`.
 
-Pants now supports the `{chroot}` replacement marker in program arguments for remote execution. (With local and Docker execution, the `{chroot}` marker is replaced with the absolute path of the sandbox directory if it appears in program arguments or environment variables. Pants will now replace `{chroot}` for program arguments with remote execution, but still does not yet support doing so in environment variables.  This requires `/bin/bash` to be available on the remote execution server.)
+Pants now supports the `{chroot}` replacement marker in remote execution contexts. (With local and Docker execution, the `{chroot}` marker is replaced with the absolute path of the sandbox directory if it appears in program arguments or environment variables. Pants will do the same as well in remote execution contexts. This requires `/bin/bash` to be available on the remote execution server.)
 
 ### New Options System
 

--- a/src/rust/engine/process_execution/remote/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/remote/src/remote_tests.rs
@@ -724,7 +724,7 @@ async fn make_execute_request_with_append_only_caches() {
         input_root_digest: Some(
             (Digest::new(
                 Fingerprint::from_hex_string(
-                    "d6f65a7f56380de341fac43fcb4e2006fd0e716579325c4640ec11b7c040bb9c",
+                    "40ff253312fe7bb50acad02e81e3a16b0109eb934c37bb61c3735792b8bead5f",
                 )
                 .unwrap(),
                 178,
@@ -739,7 +739,7 @@ async fn make_execute_request_with_append_only_caches() {
         action_digest: Some(
             (&Digest::new(
                 Fingerprint::from_hex_string(
-                    "d516c6b3b9781777486025ebc87cb4810bc7088dc45092a70a592d8ca74f48d8",
+                    "798ac2aaf68b36d571fcb90719e8dafdf5929081c491f178ac7f4663b591183e",
                 )
                 .unwrap(),
                 146,
@@ -752,7 +752,7 @@ async fn make_execute_request_with_append_only_caches() {
 
     let want_input_root_digest = DirectoryDigest::from_persisted_digest(Digest::new(
         Fingerprint::from_hex_string(
-            "d6f65a7f56380de341fac43fcb4e2006fd0e716579325c4640ec11b7c040bb9c",
+            "40ff253312fe7bb50acad02e81e3a16b0109eb934c37bb61c3735792b8bead5f",
         )
         .unwrap(),
         178,

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -1162,7 +1162,7 @@ pub async fn make_execute_request(
     let wrapper_script_content_opt = {
         let args_have_chroot_marker = req.argv.iter().any(|arg| arg.contains(CHROOT_MARKER));
 
-        let env_vars_with_chroot_marker = req
+        let mut env_vars_with_chroot_marker = req
             .env
             .iter()
             .filter_map(|(key, value)| {
@@ -1173,6 +1173,7 @@ pub async fn make_execute_request(
                 }
             })
             .collect::<Vec<_>>();
+        env_vars_with_chroot_marker.sort();
 
         let env_var_with_chroot_marker_refs = env_vars_with_chroot_marker
             .iter()

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -1238,7 +1238,7 @@ pub async fn make_execute_request(
             .environment_variables
             .push(remexec::command::EnvironmentVariable {
                 name: name.to_string(),
-                value: value.to_string(),
+                value: value.replace("{chroot}", SANDBOX_ROOT_TOKEN),
             });
     }
 

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -1115,15 +1115,15 @@ fn maybe_make_wrapper_script(
         writeln!(&mut script, "#!{shebang}").map_err(|err| format!("write! failed: {err:?}"))?;
 
         if let Some(sandbox_root_fragment) = sandbox_root_fragment {
-            writeln!(&mut script, "{sandbox_root_fragment}")
+            write!(&mut script, "{sandbox_root_fragment}")
                 .map_err(|err| format!("write! failed: {err:?}"))?;
         }
         if let Some(caches_fragment) = caches_fragment {
-            writeln!(&mut script, "{caches_fragment}")
+            write!(&mut script, "{caches_fragment}")
                 .map_err(|err| format!("write! failed: {err:?}"))?;
         }
         if let Some(chdir_fragment) = chdir_fragment {
-            writeln!(&mut script, "{chdir_fragment}")
+            write!(&mut script, "{chdir_fragment}")
                 .map_err(|err| format!("write! failed: {err:?}"))?;
         }
 

--- a/src/rust/engine/process_execution/src/tests.rs
+++ b/src/rust/engine/process_execution/src/tests.rs
@@ -182,7 +182,7 @@ async fn wrapper_script_supports_append_only_caches() {
         dummy_caches_base_path.path().to_str(),
         Some(SUBDIR_NAME),
         None,
-        &[],
+        vec![],
     )
     .unwrap()
     .unwrap();
@@ -243,7 +243,7 @@ async fn wrapper_script_supports_append_only_caches() {
 async fn wrapper_script_supports_sandbox_root_replacements_in_args() {
     let caches = BTreeMap::new();
 
-    let script_content = maybe_make_wrapper_script(&caches, None, None, Some("__ROOT__"), &[])
+    let script_content = maybe_make_wrapper_script(&caches, None, None, Some("__ROOT__"), vec![])
         .unwrap()
         .unwrap();
 
@@ -287,10 +287,15 @@ async fn wrapper_script_supports_sandbox_root_replacements_in_args() {
 async fn wrapper_script_supports_sandbox_root_replacements_in_environmenbt() {
     let caches = BTreeMap::new();
 
-    let script_content =
-        maybe_make_wrapper_script(&caches, None, None, Some("__ROOT__"), &["TEST_FILE_PATH"])
-            .unwrap()
-            .unwrap();
+    let script_content = maybe_make_wrapper_script(
+        &caches,
+        None,
+        None,
+        Some("__ROOT__"),
+        vec!["TEST_FILE_PATH"],
+    )
+    .unwrap()
+    .unwrap();
 
     let dummy_sandbox_path = TempDir::new().unwrap();
     let script_path = dummy_sandbox_path.path().join("wrapper");

--- a/src/rust/engine/process_execution/src/tests.rs
+++ b/src/rust/engine/process_execution/src/tests.rs
@@ -182,6 +182,7 @@ async fn wrapper_script_supports_append_only_caches() {
         dummy_caches_base_path.path().to_str(),
         Some(SUBDIR_NAME),
         None,
+        &[],
     )
     .unwrap()
     .unwrap();
@@ -242,7 +243,7 @@ async fn wrapper_script_supports_append_only_caches() {
 async fn wrapper_script_supports_sandbox_root_replacements_in_args() {
     let caches = BTreeMap::new();
 
-    let script_content = maybe_make_wrapper_script(&caches, None, None, Some("__ROOT__"))
+    let script_content = maybe_make_wrapper_script(&caches, None, None, Some("__ROOT__"), &[])
         .unwrap()
         .unwrap();
 


### PR DESCRIPTION
As described in #17519, remote execution environments did not substitute the `{chroot}` marker with the path to the execution sandbox as is done with local and Docker environments. #21803 added this support for program arguments. This PR completes the feature and implements that support for environment variables.

Closes #17519.