### PR TITLE
Remove unnecessary logic from ArgSplitter

### DIFF
--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -102,17 +102,10 @@ class LocalPantsRunner:
         run_tracker = RunTracker(options_bootstrapper.args, options)
         native_engine.maybe_set_panic_handler()
 
-        # Option values are usually computed lazily on demand, but command line options are
-        # eagerly computed for validation.
         with options_initializer.handle_unknown_flags(options_bootstrapper, env, raise_=True):
             # Verify CLI flags.
             if not build_config.allow_unknown_options:
                 options.verify_args()
-
-            for scope, values in options.scope_to_flags.items():
-                if values:
-                    # Only compute values if there were any command line options presented.
-                    options.for_scope(scope)
 
         # Verify configs.
         if global_bootstrap_options.verify_config:

--- a/src/python/pants/option/arg_splitter_test.py
+++ b/src/python/pants/option/arg_splitter_test.py
@@ -49,7 +49,6 @@ def assert_valid_split(
     args = shlex.split(args_str)
     split_args = splitter.split_args(args)
     assert expected_goals == split_args.goals
-    assert expected_scope_to_flags == split_args.scope_to_flags
     assert expected_specs == split_args.specs
     assert expected_passthru == split_args.passthru
 

--- a/src/python/pants/option/arg_splitter_test.py
+++ b/src/python/pants/option/arg_splitter_test.py
@@ -38,7 +38,6 @@ def assert_valid_split(
     args_str: str,
     *,
     expected_goals: list[str],
-    expected_scope_to_flags: dict[str, list[str]],
     expected_specs: list[str],
     expected_passthru: list[str] | None = None,
     expected_is_help: bool = False,
@@ -114,7 +113,6 @@ def goal_split_test(command_line: str, **expected):
         command_line,
         {
             "expected_goals": ["test"],
-            "expected_scope_to_flags": {"": [], "test": []},
             **expected,
         },
     )
@@ -129,11 +127,6 @@ def goal_split_test(command_line: str, **expected):
             + " src/java/org/pantsbuild/foo src/java/org/pantsbuild/bar:baz",
             dict(
                 expected_goals=["check", "test"],
-                expected_scope_to_flags={
-                    "": ["--gg", "-ltrace"],
-                    "check": ["--long-flag", "--cc"],
-                    "test": ["--ii"],
-                },
                 expected_specs=["src/java/org/pantsbuild/foo", "src/java/org/pantsbuild/bar:baz"],
             ),
         ),
@@ -143,11 +136,6 @@ def goal_split_test(command_line: str, **expected):
             + " --another-global",
             dict(
                 expected_goals=["check", "test"],
-                expected_scope_to_flags={
-                    "": ["--fff=arg", "-ltrace", "--another-global"],
-                    "check": ["--gg-gg=arg-arg", "--long-flag"],
-                    "test": ["--iii"],
-                },
                 expected_specs=["src/java/org/pantsbuild/foo", "src/java/org/pantsbuild/bar:baz"],
             ),
         ),
@@ -156,7 +144,6 @@ def goal_split_test(command_line: str, **expected):
             "./pants check test foo::",
             dict(
                 expected_goals=["check", "test"],
-                expected_scope_to_flags={"": [], "check": [], "test": []},
                 expected_specs=["foo::"],
             ),
         ),
@@ -164,7 +151,6 @@ def goal_split_test(command_line: str, **expected):
             "./pants check test foo::",
             dict(
                 expected_goals=["check", "test"],
-                expected_scope_to_flags={"": [], "check": [], "test": []},
                 expected_specs=["foo::"],
             ),
         ),
@@ -172,7 +158,6 @@ def goal_split_test(command_line: str, **expected):
             "./pants check test:test",
             dict(
                 expected_goals=["check"],
-                expected_scope_to_flags={"": [], "check": []},
                 expected_specs=["test:test"],
             ),
         ),
@@ -193,7 +178,6 @@ def goal_split_test(command_line: str, **expected):
             "./pants test check.java",
             dict(
                 expected_goals=["test"],
-                expected_scope_to_flags={"": [], "test": []},
                 expected_specs=["check.java"],
             ),
         ),
@@ -214,7 +198,6 @@ def test_descoping_qualified_flags(splitter: ArgSplitter) -> None:
         splitter,
         "./pants check test --check-bar --no-test-baz foo/bar",
         expected_goals=["check", "test"],
-        expected_scope_to_flags={"": [], "check": ["--bar"], "test": ["--no-baz"]},
         expected_specs=["foo/bar"],
     )
     # Qualified flags don't count as explicit goals.
@@ -222,7 +205,6 @@ def test_descoping_qualified_flags(splitter: ArgSplitter) -> None:
         splitter,
         "./pants check --test-bar foo/bar",
         expected_goals=["check"],
-        expected_scope_to_flags={"": [], "check": [], "test": ["--bar"]},
         expected_specs=["foo/bar"],
     )
 
@@ -232,7 +214,6 @@ def test_passthru_args(splitter: ArgSplitter) -> None:
         splitter,
         "./pants test foo/bar -- -t 'this is the arg'",
         expected_goals=["test"],
-        expected_scope_to_flags={"": [], "test": []},
         expected_specs=["foo/bar"],
         expected_passthru=["-t", "this is the arg"],
     )
@@ -242,11 +223,6 @@ def test_passthru_args(splitter: ArgSplitter) -> None:
         + " --check-long-flag src/java/org/pantsbuild/foo src/java/org/pantsbuild/bar:baz --"
         + " passthru1 passthru2 -linfo",
         expected_goals=["check", "test"],
-        expected_scope_to_flags={
-            "": ["-lerror", "--fff=arg"],
-            "check": ["--gg-gg=arg-arg", "--long-flag"],
-            "test": ["--iii"],
-        },
         expected_specs=["src/java/org/pantsbuild/foo", "src/java/org/pantsbuild/bar:baz"],
         expected_passthru=["passthru1", "passthru2", "-linfo"],
     )
@@ -258,18 +234,12 @@ def test_subsystem_flags(splitter: ArgSplitter) -> None:
         splitter,
         "./pants --jvm-options=-Dbar=baz test foo:bar",
         expected_goals=["test"],
-        expected_scope_to_flags={"": [], "jvm": ["--options=-Dbar=baz"], "test": []},
         expected_specs=["foo:bar"],
     )
     assert_valid_split(
         splitter,
         "./pants test --reporting-template-dir=path foo:bar",
         expected_goals=["test"],
-        expected_scope_to_flags={
-            "": [],
-            "reporting": ["--template-dir=path"],
-            "test": [],
-        },
         expected_specs=["foo:bar"],
     )
 
@@ -285,11 +255,10 @@ def help_test(command_line: str, **expected):
     )
 
 
-def help_no_arguments_test(command_line: str, *scopes: str, **expected):
+def help_no_arguments_test(command_line: str, **expected):
     return help_test(
         command_line,
         expected_goals=[],
-        expected_scope_to_flags={scope: [] for scope in ("", *scopes)},
         expected_specs=[],
         **expected,
     )
@@ -299,119 +268,95 @@ def help_no_arguments_test(command_line: str, *scopes: str, **expected):
     "command_line, expected",
     [
         help_no_arguments_test("./pants"),
-        help_no_arguments_test("./pants help", "help"),
-        help_no_arguments_test("./pants -h", "help"),
-        help_no_arguments_test("./pants --help", "help"),
-        help_no_arguments_test(
-            "./pants help-advanced", "help-advanced", expected_help_advanced=True
-        ),
-        help_no_arguments_test(
-            "./pants --help-advanced", "help-advanced", expected_help_advanced=True
-        ),
-        help_no_arguments_test("./pants help-all", "help-all", expected_help_all=True),
+        help_no_arguments_test("./pants help"),
+        help_no_arguments_test("./pants -h"),
+        help_no_arguments_test("./pants --help"),
+        help_no_arguments_test("./pants help-advanced", expected_help_advanced=True),
+        help_no_arguments_test("./pants --help-advanced", expected_help_advanced=True),
+        help_no_arguments_test("./pants help-all", expected_help_all=True),
         help_test(
             "./pants --help-advanced --help",
             expected_goals=["help-advanced"],
-            expected_scope_to_flags={"": [], "help": [], "help-advanced": []},
             expected_specs=[],
             expected_help_advanced=False,
         ),
         help_test(
             "./pants --help --help-advanced --builtin-option --help-advanced-option",
             expected_goals=["help"],
-            expected_scope_to_flags={
-                "": [],
-                "help": [],
-                "help-advanced": ["--builtin-option", "--option"],
-            },
             expected_specs=[],
             expected_help_advanced=True,
         ),
         help_test(
             "./pants -f",
             expected_goals=[],
-            expected_scope_to_flags={"": []},
             expected_specs=["-f"],
         ),
         help_test(
             "./pants help check -x",
             expected_goals=["check"],
-            expected_scope_to_flags={"": [], "help": [], "check": []},
             expected_specs=["-x"],
         ),
         help_test(
             "./pants check -h",
             expected_goals=["check"],
-            expected_scope_to_flags={"": [], "check": [], "help": []},
             expected_specs=[],
         ),
         help_test(
             "./pants -linfo check -h",
             expected_goals=["check"],
-            expected_scope_to_flags={"": ["-linfo"], "check": [], "help": []},
             expected_specs=[],
         ),
         help_test(
             "./pants check -h -linfo",
             expected_goals=["check"],
-            expected_scope_to_flags={"": ["-linfo"], "check": [], "help": []},
             expected_specs=[],
         ),
         help_test(
             "./pants check --help test",
             expected_goals=["check", "test"],
-            expected_scope_to_flags={"": [], "check": [], "help": [], "test": []},
             expected_specs=[],
         ),
         help_test(
             "./pants test src/foo/bar:baz -h",
             expected_goals=["test"],
-            expected_scope_to_flags={"": [], "test": [], "help": []},
             expected_specs=["src/foo/bar:baz"],
         ),
         help_test(
             "./pants test src/foo/bar:baz --help",
             expected_goals=["test"],
-            expected_scope_to_flags={"": [], "test": [], "help": []},
             expected_specs=["src/foo/bar:baz"],
         ),
         help_test(
             "./pants --help test src/foo/bar:baz",
             expected_goals=["test"],
-            expected_scope_to_flags={"": [], "test": [], "help": []},
             expected_specs=["src/foo/bar:baz"],
         ),
         help_test(
             "./pants test --help src/foo/bar:baz",
             expected_goals=["test"],
-            expected_scope_to_flags={"": [], "test": [], "help": []},
             expected_specs=["src/foo/bar:baz"],
         ),
         help_test(
             "./pants check --help-advanced test",
             expected_goals=["check", "test"],
-            expected_scope_to_flags={"": [], "check": [], "help-advanced": [], "test": []},
             expected_specs=[],
             expected_help_advanced=True,
         ),
         help_test(
             "./pants help-advanced check",
             expected_goals=["check"],
-            expected_scope_to_flags={"": [], "check": [], "help-advanced": []},
             expected_specs=[],
             expected_help_advanced=True,
         ),
         help_test(
             "./pants check help-all test --help",
             expected_goals=["check", "test", "help-all"],
-            expected_scope_to_flags={"": [], "check": [], "help": [], "help-all": [], "test": []},
             expected_specs=[],
             expected_help_all=False,
         ),
         help_test(
             "./pants bsp --help",
             expected_goals=["bsp"],
-            expected_scope_to_flags={"": [], "help": [], "bsp": []},
             expected_specs=[],
         ),
     ],

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -181,7 +181,6 @@ class Options:
             builtin_or_auxiliary_goal=split_args.builtin_or_auxiliary_goal,
             goals=split_args.goals,
             unknown_goals=split_args.unknown_goals,
-            scope_to_flags=split_args.scope_to_flags,
             specs=split_args.specs,
             passthru=split_args.passthru,
             registrar_by_scope=registrar_by_scope,
@@ -195,7 +194,6 @@ class Options:
         builtin_or_auxiliary_goal: str | None,
         goals: list[str],
         unknown_goals: list[str],
-        scope_to_flags: dict[str, list[str]],
         specs: list[str],
         passthru: list[str],
         registrar_by_scope: dict[str, OptionRegistrar],
@@ -210,7 +208,6 @@ class Options:
         self._builtin_or_auxiliary_goal = builtin_or_auxiliary_goal
         self._goals = goals
         self._unknown_goals = unknown_goals
-        self._scope_to_flags = scope_to_flags
         self._specs = specs
         self._passthru = passthru
         self._registrar_by_scope = registrar_by_scope
@@ -264,10 +261,6 @@ class Options:
             scope: registrar.known_scoped_args
             for scope, registrar in self._registrar_by_scope.items()
         }
-
-    @property
-    def scope_to_flags(self) -> dict[str, list[str]]:
-        return self._scope_to_flags
 
     def verify_configs(self) -> None:
         """Verify all loaded configs have correct scopes and options."""


### PR DESCRIPTION
Now that options parsing is done in Rust, the ArgSplitter
no longer has to track CLI flags or assign them to scopes.

The ArgSplitter's remaining responsibilities are just
tracking goals and specs. A future change will port that
to Rust as well.