### PR TITLE
fix flaky failure in `export_integration_test.py` (Cherry-pick of #21756)

### DIFF
--- a/src/python/pants/backend/python/goals/export_integration_test.py
+++ b/src/python/pants/backend/python/goals/export_integration_test.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import os
 import platform
+import re
 import shutil
 from textwrap import dedent
 from typing import Mapping, MutableMapping
@@ -113,8 +114,12 @@ def test_export(py_resolve_format: PythonResolveExportFormat, py_hermetic_script
             activate_path = os.path.join(export_dir, "bin", "activate")
             assert os.path.isfile(activate_path), "virtualenv's bin/activate is missing"
             with open(activate_path) as activate_file:
-                prompt = f'PS1="({resolve}/{platform.python_version()}) '
-                assert prompt in activate_file.read()
+                activate_content = activate_file.read()
+
+            prompt_re = re.compile(rf"""PS1=('|")\({resolve}/{platform.python_version()}\) """)
+            assert (
+                prompt_re.search(activate_content) is not None
+            ), "Expected PS1 prompt not defined in bin/activate."
 
             script_path = os.path.join(export_dir, "bin", "wheel")
             assert os.path.isfile(


### PR DESCRIPTION
`src/python/pants/backend/python/goals/export_integration_test.py` was failing for me consistently in a PR of mine and on `main` locally. Not sure why it passes elsewhere.

See this failure for example: https://github.com/pantsbuild/pants/actions/runs/12306576175/job/34349676205?pr=21745#step:10:478

The test is checking whether a venv activation script has a certain prompt with both a resolve name and the Python version. The test also checks whether the quote character starting that string begins with a double-quote character.

On my system for `main` and in the PR on CI, that quote character became a single quote instead so the test fails.

Use a regex and allow either quote character.
