### PR TITLE
Add plugin hook to nfpm backend so plugins can inject nfpm package field values

### DIFF
--- a/docs/notes/2.25.x.md
+++ b/docs/notes/2.25.x.md
@@ -126,6 +126,34 @@ python_requirement(name="black", resolve="your-resolve-name", requirements=["bla
 
 The previously deprecated `[shell-setup].tailor` option has now been removed. See [`[shell-setup].tailor_sources`](https://www.pantsbuild.org/2.25/reference/subsystems/shell-setup#tailor_sources) and [`[shell-setup].tailor_shunit2_tests`](https://www.pantsbuild.org/2.25/reference/subsystems/shell#tailor_shunit2_tests) to update.
 
+#### nFPM
+
+The nFPM backend has a new plugin hook that allows plugins to inject field values that are used to generate nfpm config. To use this, a plugin needs to implement `InjectNfpmPackageFieldsRequest`:
+
+```python
+from pants.backend.nfpm.fields.version import NfpmVersionField, NfpmVersionReleaseField
+from pants.backend.nfpm.util_rules.inject_config import InjectedNfpmPackageFields, InjectNfpmPackageFieldsRequest
+from pants.engine.internals.native_engine import Address, Field
+from pants.engine.rules import rule
+
+class MyCustomInjectFieldsRequest(InjectNfpmPackageFieldsRequest):
+    @classmethod
+    def is_applicable(cls, target) -> bool:
+        # this could check the target's address, packager, package_name field, etc.
+        return True
+
+@rule
+def inject_my_custom_fields(request: MyCustomInjectFieldsRequest) -> InjectedNfpmPackageFields:
+    # this could get the version from a file
+    version = "9.8.7-dev+git"
+    release = 6
+    fields: list[Field] = [
+        NfpmVersionField(version, request.target.address),
+        NfpmVersionReleaseField(release, request.target.address),
+    ]
+    return InjectedNfpmPackageFields(fields, address=request.target.address)
+```
+
 ### Plugin API changes
 
 The version of Python used by Pants itself is now [3.11](https://docs.python.org/3/whatsnew/3.11.html) (up from 3.9).

--- a/src/python/pants/backend/nfpm/field_sets_test.py
+++ b/src/python/pants/backend/nfpm/field_sets_test.py
@@ -43,6 +43,7 @@ from pants.backend.nfpm.target_types import (
 )
 from pants.engine.addresses import Address
 from pants.engine.target import DescriptionField
+from pants.util.frozendict import FrozenDict
 
 MTIME = NfpmPackageMtimeField.default
 
@@ -90,7 +91,7 @@ def test_generate_nfpm_config_for_apk():
     }
 
     field_set = NfpmApkPackageFieldSet.create(tgt)
-    nfpm_config = field_set.nfpm_config(tgt, default_mtime=MTIME)
+    nfpm_config = field_set.nfpm_config(tgt, FrozenDict({}), default_mtime=MTIME)
     assert nfpm_config == expected_nfpm_config
 
 
@@ -137,7 +138,7 @@ def test_generate_nfpm_config_for_archlinux():
     }
 
     field_set = NfpmArchlinuxPackageFieldSet.create(tgt)
-    nfpm_config = field_set.nfpm_config(tgt, default_mtime=MTIME)
+    nfpm_config = field_set.nfpm_config(tgt, FrozenDict({}), default_mtime=MTIME)
     assert nfpm_config == expected_nfpm_config
 
 
@@ -193,7 +194,7 @@ def test_generate_nfpm_config_for_deb():
     }
 
     field_set = NfpmDebPackageFieldSet.create(tgt)
-    nfpm_config = field_set.nfpm_config(tgt, default_mtime=MTIME)
+    nfpm_config = field_set.nfpm_config(tgt, FrozenDict({}), default_mtime=MTIME)
     assert nfpm_config == expected_nfpm_config
 
 
@@ -247,5 +248,5 @@ def test_generate_nfpm_config_for_rpm():
     }
 
     field_set = NfpmRpmPackageFieldSet.create(tgt)
-    nfpm_config = field_set.nfpm_config(tgt, default_mtime=MTIME)
+    nfpm_config = field_set.nfpm_config(tgt, FrozenDict({}), default_mtime=MTIME)
     assert nfpm_config == expected_nfpm_config

--- a/src/python/pants/backend/nfpm/field_sets_test.py
+++ b/src/python/pants/backend/nfpm/field_sets_test.py
@@ -47,6 +47,9 @@ from pants.util.frozendict import FrozenDict
 
 MTIME = NfpmPackageMtimeField.default
 
+ADDRESS = Address("", target_name="t")
+INJECTED = FrozenDict({NfpmVersionField: NfpmVersionField("9.8.7", ADDRESS)})
+
 
 def test_generate_nfpm_config_for_apk():
     depends = [
@@ -68,7 +71,7 @@ def test_generate_nfpm_config_for_apk():
             NfpmLicenseField.alias: "MIT",
             NfpmApkDependsField.alias: depends,
         },
-        Address("", target_name="t"),
+        ADDRESS,
     )
     expected_nfpm_config = {
         "disable_globbing": True,
@@ -94,6 +97,10 @@ def test_generate_nfpm_config_for_apk():
     nfpm_config = field_set.nfpm_config(tgt, FrozenDict({}), default_mtime=MTIME)
     assert nfpm_config == expected_nfpm_config
 
+    nfpm_config_2 = field_set.nfpm_config(tgt, INJECTED, default_mtime=MTIME)
+    assert nfpm_config["version"] != nfpm_config_2["version"]
+    assert nfpm_config_2["version"] == "9.8.7"
+
 
 def test_generate_nfpm_config_for_archlinux():
     depends = [
@@ -115,7 +122,7 @@ def test_generate_nfpm_config_for_archlinux():
             NfpmLicenseField.alias: "MIT",
             NfpmArchlinuxDependsField.alias: depends,
         },
-        Address("", target_name="t"),
+        ADDRESS,
     )
     expected_nfpm_config = {
         "disable_globbing": True,
@@ -141,6 +148,10 @@ def test_generate_nfpm_config_for_archlinux():
     nfpm_config = field_set.nfpm_config(tgt, FrozenDict({}), default_mtime=MTIME)
     assert nfpm_config == expected_nfpm_config
 
+    nfpm_config_2 = field_set.nfpm_config(tgt, INJECTED, default_mtime=MTIME)
+    assert nfpm_config["version"] != nfpm_config_2["version"]
+    assert nfpm_config_2["version"] == "9.8.7"
+
 
 def test_generate_nfpm_config_for_deb():
     depends = [
@@ -165,7 +176,7 @@ def test_generate_nfpm_config_for_deb():
             NfpmDebFieldsField.alias: {"Urgency": "high (critical for landlubbers)"},
             NfpmDebTriggersField.alias: {"interest_noawait": ["some-trigger", "other-trigger"]},
         },
-        Address("", target_name="t"),
+        ADDRESS,
     )
     expected_nfpm_config = {
         "disable_globbing": True,
@@ -197,6 +208,10 @@ def test_generate_nfpm_config_for_deb():
     nfpm_config = field_set.nfpm_config(tgt, FrozenDict({}), default_mtime=MTIME)
     assert nfpm_config == expected_nfpm_config
 
+    nfpm_config_2 = field_set.nfpm_config(tgt, INJECTED, default_mtime=MTIME)
+    assert nfpm_config["version"] != nfpm_config_2["version"]
+    assert nfpm_config_2["version"] == "9.8.7"
+
 
 def test_generate_nfpm_config_for_rpm():
     depends = [
@@ -220,7 +235,7 @@ def test_generate_nfpm_config_for_rpm():
             NfpmRpmPrefixesField.alias: ["/", "/usr", "/opt/treasure"],
             NfpmRpmGhostContents.alias: ["/var/log/captains.log"],
         },
-        Address("", target_name="t"),
+        ADDRESS,
     )
     expected_nfpm_config = {
         "disable_globbing": True,
@@ -250,3 +265,7 @@ def test_generate_nfpm_config_for_rpm():
     field_set = NfpmRpmPackageFieldSet.create(tgt)
     nfpm_config = field_set.nfpm_config(tgt, FrozenDict({}), default_mtime=MTIME)
     assert nfpm_config == expected_nfpm_config
+
+    nfpm_config_2 = field_set.nfpm_config(tgt, INJECTED, default_mtime=MTIME)
+    assert nfpm_config["version"] != nfpm_config_2["version"]
+    assert nfpm_config_2["version"] == "9.8.7"

--- a/src/python/pants/backend/nfpm/util_rules/generate_config.py
+++ b/src/python/pants/backend/nfpm/util_rules/generate_config.py
@@ -17,6 +17,7 @@ from pants.backend.nfpm.fields.all import NfpmDependencies
 from pants.backend.nfpm.fields.contents import NfpmContentFileSourceField, NfpmContentSrcField
 from pants.backend.nfpm.subsystem import NfpmSubsystem
 from pants.backend.nfpm.target_types import NfpmContentFile
+from pants.backend.nfpm.util_rules.inject_config import determine_injected_nfpm_package_fields
 from pants.core.goals.package import TraverseIfNotPackageTarget
 from pants.engine.fs import CreateDigest, FileContent, FileEntry
 from pants.engine.internals.graph import find_valid_field_sets
@@ -74,7 +75,12 @@ async def generate_nfpm_yaml(
 
     # Fist get the config that can be constructed from the target itself.
     nfpm_package_target = transitive_targets.roots[0]
-    config = request.field_set.nfpm_config(nfpm_package_target, default_mtime=default_mtime)
+    injected_fields = await determine_injected_nfpm_package_fields(
+        nfpm_package_target, union_membership
+    )
+    config = request.field_set.nfpm_config(
+        nfpm_package_target, injected_fields.field_values, default_mtime=default_mtime
+    )
 
     # Second, gather package contents from hydrated deps.
     contents: list[NfpmContent] = config["contents"]

--- a/src/python/pants/backend/nfpm/util_rules/generate_config.py
+++ b/src/python/pants/backend/nfpm/util_rules/generate_config.py
@@ -17,7 +17,10 @@ from pants.backend.nfpm.fields.all import NfpmDependencies
 from pants.backend.nfpm.fields.contents import NfpmContentFileSourceField, NfpmContentSrcField
 from pants.backend.nfpm.subsystem import NfpmSubsystem
 from pants.backend.nfpm.target_types import NfpmContentFile
-from pants.backend.nfpm.util_rules.inject_config import determine_injected_nfpm_package_fields
+from pants.backend.nfpm.util_rules.inject_config import (
+    NfpmPackageTargetWrapper,
+    determine_injected_nfpm_package_fields,
+)
 from pants.core.goals.package import TraverseIfNotPackageTarget
 from pants.engine.fs import CreateDigest, FileContent, FileEntry
 from pants.engine.internals.graph import find_valid_field_sets
@@ -76,7 +79,7 @@ async def generate_nfpm_yaml(
     # Fist get the config that can be constructed from the target itself.
     nfpm_package_target = transitive_targets.roots[0]
     injected_fields = await determine_injected_nfpm_package_fields(
-        nfpm_package_target, union_membership
+        NfpmPackageTargetWrapper(nfpm_package_target), union_membership
     )
     config = request.field_set.nfpm_config(
         nfpm_package_target, injected_fields.field_values, default_mtime=default_mtime

--- a/src/python/pants/backend/nfpm/util_rules/inject_config.py
+++ b/src/python/pants/backend/nfpm/util_rules/inject_config.py
@@ -40,7 +40,7 @@ class InjectedNfpmPackageFields:
         self,
         fields: Iterable[Field],
         *,
-        address: Address,  # might be needed for error messages
+        address: Address,
         _allow_banned_fields: bool = False,
     ) -> None:
         super().__init__()
@@ -53,7 +53,7 @@ class InjectedNfpmPackageFields:
                     raise ValueError(
                         softwrap(
                             f"""
-                            {alias} cannot be an injected nfpm package field to avoid
+                            {alias} cannot be an injected nfpm package field for {address} to avoid
                             breaking dependency inference.
                             """
                         )
@@ -94,10 +94,21 @@ class InjectNfpmPackageFieldsRequest(ABC):
         """Whether to use this InjectNfpmPackageFieldsRequest implementation for this target."""
 
 
+@dataclass(frozen=True)
+class NfpmPackageTargetWrapper:
+    """Nfpm Package target Wrapper.
+
+    This is not meant to be used by plugin authors.
+    """
+
+    target: Target
+
+
 @rule
 async def determine_injected_nfpm_package_fields(
-    target: Target, union_membership: UnionMembership
+    wrapper: NfpmPackageTargetWrapper, union_membership: UnionMembership
 ) -> InjectedNfpmPackageFields:
+    target = wrapper.target
     inject_nfpm_config_requests = union_membership.get(InjectNfpmPackageFieldsRequest)
     applicable_inject_nfpm_config_requests = tuple(
         request for request in inject_nfpm_config_requests if request.is_applicable(target)

--- a/src/python/pants/backend/nfpm/util_rules/inject_config.py
+++ b/src/python/pants/backend/nfpm/util_rules/inject_config.py
@@ -1,0 +1,136 @@
+# Copyright 2025 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Iterable
+
+from pants.backend.nfpm.fields.scripts import NfpmPackageScriptsField
+from pants.engine.environment import EnvironmentName
+from pants.engine.internals.native_engine import Address, Field
+from pants.engine.internals.selectors import Get
+from pants.engine.rules import collect_rules, rule
+from pants.engine.target import Target
+from pants.engine.unions import UnionMembership, union
+from pants.util.frozendict import FrozenDict
+from pants.util.strutil import softwrap
+
+
+@dataclass(frozen=True)
+class InjectedNfpmPackageFields:
+    """The injected fields that should be used instead of the target's fields.
+
+    Though any field can technically be provided (except "scripts" which is banned),
+    only nfpm package metadata fields will have an impact. Passing other fields are
+    silently ignored. For example, "dependencies", and "output_path" are not used
+    when generating nfpm config, so they will be ignored; "sources" is not a valid
+    field for nfpm package targets, so it will also be ignored.
+
+    The "scripts" field is special in that it has dependency inference tied to it.
+    If you write your own dependency inference rule (possibly based on a custom
+    field you've added to the nfpm package target), then you can pass
+    _allow_banned_fields=True to allow injection of the "scripts" field.
+    """
+
+    field_values: FrozenDict[type[Field], Field]
+
+    def __init__(
+        self,
+        fields: Iterable[Field],
+        *,
+        address: Address,  # might be needed for error messages
+        _allow_banned_fields: bool = False,
+    ) -> None:
+        super().__init__()
+        if not _allow_banned_fields:
+            aliases = [field.alias for field in fields]
+            for alias in {
+                NfpmPackageScriptsField.alias,  # if _allow_banned_fields, the plugin author must handle scripts deps.
+            }:
+                if alias in aliases:
+                    raise ValueError(
+                        softwrap(
+                            f"""
+                            {alias} cannot be an injected nfpm package field to avoid
+                            breaking dependency inference.
+                            """
+                        )
+                    )
+        # Ignore any fields that do not have a value (assuming nfpm fields have 'none_is_valid_value=False').
+        field_values = {type(field): field for field in fields if field.value is not None}
+        object.__setattr__(
+            self,
+            "field_values",
+            FrozenDict(
+                sorted(
+                    field_values.items(),
+                    key=lambda field_type_to_val_pair: field_type_to_val_pair[0].alias,
+                )
+            ),
+        )
+
+
+# Note: This only exists as a hook for additional logic for nFPM config generation, e.g. for plugin
+# authors. To resolve `InjectedNfpmPackageFields`, call `determine_injected_nfpm_package_fields`,
+# which handles running any custom implementations vs. using the default implementation.
+@union(in_scope_types=[EnvironmentName])
+@dataclass(frozen=True)
+class InjectNfpmPackageFieldsRequest(ABC):
+    """A request to inject nFPM config for nfpm_package_* targets.
+
+    By default, Pants will use the nfpm_package_* fields in the BUILD file unchanged to generate the
+    nfpm.yaml config file for nFPM. To customize this, subclass `InjectNfpmPackageFieldsRequest`,
+    register `UnionRule(InjectNfpmPackageFieldsRequest, MyCustomInjectNfpmPackageFieldsRequest)`,
+    and add a rule that takes your subclass as a parameter and returns `InjectedNfpmPackageFields`.
+    """
+
+    target: Target
+
+    @classmethod
+    @abstractmethod
+    def is_applicable(cls, target: Target) -> bool:
+        """Whether to use this InjectNfpmPackageFieldsRequest implementation for this target."""
+
+
+@rule
+async def determine_injected_nfpm_package_fields(
+    target: Target, union_membership: UnionMembership
+) -> InjectedNfpmPackageFields:
+    inject_nfpm_config_requests = union_membership.get(InjectNfpmPackageFieldsRequest)
+    applicable_inject_nfpm_config_requests = tuple(
+        request for request in inject_nfpm_config_requests if request.is_applicable(target)
+    )
+
+    # If no provided implementations, fall back to our default implementation that simply returns
+    # what the user explicitly specified in the BUILD file.
+    if not applicable_inject_nfpm_config_requests:
+        return InjectedNfpmPackageFields((), address=target.address)
+
+    if len(applicable_inject_nfpm_config_requests) > 1:
+        possible_requests = sorted(
+            plugin.__name__ for plugin in applicable_inject_nfpm_config_requests
+        )
+        raise ValueError(
+            softwrap(
+                f"""
+                Multiple registered `InjectNfpmPackageFieldsRequest`s can work on the target
+                {target.address}, and it's ambiguous which to use: {possible_requests}
+
+                Please activate fewer implementations, or make the classmethod `is_applicable()`
+                more precise so that only one implementation is applicable for this target.
+                """
+            )
+        )
+    inject_nfpm_config_request_type = applicable_inject_nfpm_config_requests[0]
+    inject_nfpm_config_request: InjectNfpmPackageFieldsRequest = inject_nfpm_config_request_type(target)  # type: ignore[abstract]
+    return await Get(
+        InjectedNfpmPackageFields, InjectNfpmPackageFieldsRequest, inject_nfpm_config_request
+    )
+
+
+def rules():
+    return [
+        *collect_rules(),
+    ]

--- a/src/python/pants/backend/nfpm/util_rules/inject_config_test.py
+++ b/src/python/pants/backend/nfpm/util_rules/inject_config_test.py
@@ -1,0 +1,95 @@
+# Copyright 2025 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from textwrap import dedent
+
+import pytest
+
+from pants.backend.nfpm.fields.version import NfpmVersionField, NfpmVersionReleaseField
+from pants.backend.nfpm.target_types import target_types as nfpm_target_types
+from pants.backend.nfpm.target_types_rules import rules as nfpm_target_types_rules
+from pants.backend.nfpm.util_rules.inject_config import (
+    InjectedNfpmPackageFields,
+    InjectNfpmPackageFieldsRequest,
+    NfpmPackageTargetWrapper,
+)
+from pants.backend.nfpm.util_rules.inject_config import rules as nfpm_inject_config_rules
+from pants.engine.internals.native_engine import Address, Field
+from pants.engine.rules import QueryRule, rule
+from pants.engine.unions import UnionRule
+from pants.testutil.rule_runner import RuleRunner
+
+_PKG_NAME = "pkg"
+
+
+class PluginInjectNfpmPackageFieldsRequest(InjectNfpmPackageFieldsRequest):
+    @classmethod
+    def is_applicable(cls, _) -> bool:
+        return True
+
+
+@rule
+def inject_nfpm_package_fields_plugin(
+    request: PluginInjectNfpmPackageFieldsRequest,
+) -> InjectedNfpmPackageFields:
+    address = request.target.address
+    fields: list[Field] = [
+        NfpmVersionField("9.8.7-dev+git", address),
+        NfpmVersionReleaseField(6, address),
+    ]
+    return InjectedNfpmPackageFields(fields, address=address)
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    rule_runner = RuleRunner(
+        target_types=[
+            *nfpm_target_types(),
+        ],
+        rules=[
+            *nfpm_target_types_rules(),
+            *nfpm_inject_config_rules(),
+            inject_nfpm_package_fields_plugin,
+            UnionRule(InjectNfpmPackageFieldsRequest, PluginInjectNfpmPackageFieldsRequest),
+            QueryRule(InjectedNfpmPackageFields, (NfpmPackageTargetWrapper,)),
+        ],
+    )
+    rule_runner.set_options([], env_inherit={"PATH", "PYENV_ROOT", "HOME"})
+    return rule_runner
+
+
+@pytest.mark.parametrize(
+    "packager",
+    (
+        "apk",
+        "archlinux",
+        "deb",
+        "rpm",
+    ),
+)
+def test_determine_injected_nfpm_package_fields(rule_runner: RuleRunner, packager: str) -> None:
+    packager = "deb"
+    rule_runner.write_files(
+        {
+            "BUILD": dedent(
+                f"""
+                nfpm_{packager}_package(
+                    name="{_PKG_NAME}",
+                    description="A {packager} package",
+                    package_name="{_PKG_NAME}",
+                    version="",  # the plugin should provide this
+                    {'' if packager != 'deb' else 'maintainer="Foo Bar <deb@example.com>",'}
+                    dependencies=[],
+                )
+                """
+            ),
+        }
+    )
+    target = rule_runner.get_target(Address("", target_name=_PKG_NAME))
+    result = rule_runner.request(InjectedNfpmPackageFields, [NfpmPackageTargetWrapper(target)])
+    field_values = result.field_values
+    assert len(field_values) == 2
+    assert field_values[NfpmVersionField].value == "9.8.7-dev+git"
+    assert field_values[NfpmVersionReleaseField].value == 6


### PR DESCRIPTION
With the nfpm backend, I need to inject some field values, like `version` and `version_release` from an in-repo plugin. In particular, I need to retrieve the `version` from a file in the repo, and the `version_release` needs to be calculated using some API calls to the remote package repository.

I could inject `version` using .pants.bootstrap as described here: https://www.pantsbuild.org/blog/2024/04/27/simple-versioning-with-git-tags However, looking up the value for `version_release` requires some of the parametrized values of the package target's fields (like `platform`, `arch`, and a custom field for distribution major version). So, I need a way to dynamically inject some of these metadata values.