### PR TITLE
Move the Rust Scope code to its own file.

### DIFF
--- a/src/rust/engine/options/src/args.rs
+++ b/src/rust/engine/options/src/args.rs
@@ -3,7 +3,8 @@
 
 use std::env;
 
-use super::id::{is_valid_scope_name, NameTransform, OptionId, Scope};
+use super::id::{NameTransform, OptionId};
+use super::scope::{is_valid_scope_name, Scope};
 use super::{DictEdit, OptionsSource};
 use crate::cli_alias::{expand_aliases, AliasMap};
 use crate::fromfile::FromfileExpander;

--- a/src/rust/engine/options/src/cli_alias.rs
+++ b/src/rust/engine/options/src/cli_alias.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-use crate::Scope;
+use crate::scope::Scope;
 use lazy_static::lazy_static;
 use regex::Regex;
 use std::collections::{HashMap, HashSet};

--- a/src/rust/engine/options/src/env.rs
+++ b/src/rust/engine/options/src/env.rs
@@ -6,10 +6,11 @@ use std::collections::HashMap;
 use std::env;
 use std::ffi::OsString;
 
-use super::id::{NameTransform, OptionId, Scope};
+use super::id::{NameTransform, OptionId};
 use super::{DictEdit, OptionsSource};
 use crate::fromfile::FromfileExpander;
 use crate::parse::Parseable;
+use crate::scope::Scope;
 use crate::ListEdit;
 
 #[derive(Debug)]

--- a/src/rust/engine/options/src/id.rs
+++ b/src/rust/engine/options/src/id.rs
@@ -1,44 +1,9 @@
 // Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-use lazy_static::lazy_static;
+use crate::scope::Scope;
 use std::fmt;
 use std::fmt::{Display, Formatter};
-
-use regex::Regex;
-
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub enum Scope {
-    Global,
-    Scope(String),
-}
-
-lazy_static! {
-    // Note: must be aligned with the regex in src/python/pants/option/subsystem.py.
-    static ref SCOPE_NAME_RE: Regex = Regex::new(r"^(?:[a-z0-9_])+(?:-(?:[a-z0-9_])+)*$").unwrap();
-}
-
-pub(crate) fn is_valid_scope_name(name: &str) -> bool {
-    // The exact string "pants" is not allowed as a scope name: if we encounter it on the
-    // command line, it is part of the invocation: /path/to/python -m pants <actual args>.
-    SCOPE_NAME_RE.is_match(name) && name != "pants"
-}
-
-impl Scope {
-    pub fn named(name: &str) -> Scope {
-        match name {
-            "" | "GLOBAL" => Scope::Global,
-            scope => Scope::Scope(scope.to_owned()),
-        }
-    }
-
-    pub fn name(&self) -> &str {
-        match self {
-            Scope::Global => "GLOBAL",
-            Scope::Scope(scope) => scope.as_str(),
-        }
-    }
-}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct OptionId {

--- a/src/rust/engine/options/src/id_tests.rs
+++ b/src/rust/engine/options/src/id_tests.rs
@@ -1,23 +1,9 @@
 // Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-use crate::id::{is_valid_scope_name, OptionId, Scope};
+use crate::id::OptionId;
 use crate::option_id;
-
-#[test]
-fn test_is_valid_scope_name() {
-    assert!(is_valid_scope_name("test"));
-    assert!(is_valid_scope_name("test1"));
-    assert!(is_valid_scope_name("generate-lockfiles"));
-    assert!(is_valid_scope_name("i_dont_like_underscores"));
-
-    assert!(!is_valid_scope_name("pants"));
-    assert!(!is_valid_scope_name("No-Caps"));
-    assert!(!is_valid_scope_name("looks/like/a/target"));
-    assert!(!is_valid_scope_name("//:target"));
-    assert!(!is_valid_scope_name("-b"));
-    assert!(!is_valid_scope_name("--flag=value"));
-}
+use crate::scope::Scope;
 
 #[test]
 fn test_option_id_global_switch() {

--- a/src/rust/engine/options/src/lib.rs
+++ b/src/rust/engine/options/src/lib.rs
@@ -37,6 +37,10 @@ mod parse;
 #[cfg(test)]
 mod parse_tests;
 
+mod scope;
+#[cfg(test)]
+mod scope_tests;
+
 #[cfg(test)]
 mod tests;
 
@@ -61,7 +65,8 @@ use self::env::EnvReader;
 use crate::fromfile::FromfileExpander;
 use crate::parse::Parseable;
 pub use build_root::BuildRoot;
-pub use id::{OptionId, Scope};
+pub use id::OptionId;
+pub use scope::Scope;
 pub use types::OptionType;
 
 // NB: The legacy Python options parser supported dicts with member_type "Any", which means

--- a/src/rust/engine/options/src/scope.rs
+++ b/src/rust/engine/options/src/scope.rs
@@ -1,0 +1,39 @@
+// Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+use lazy_static::lazy_static;
+
+use regex::Regex;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub enum Scope {
+    Global,
+    Scope(String),
+}
+
+lazy_static! {
+    // Note: must be aligned with the regex in src/python/pants/option/subsystem.py.
+    static ref SCOPE_NAME_RE: Regex = Regex::new(r"^(?:[a-z0-9_])+(?:-(?:[a-z0-9_])+)*$").unwrap();
+}
+
+pub(crate) fn is_valid_scope_name(name: &str) -> bool {
+    // The exact string "pants" is not allowed as a scope name: if we encounter it on the
+    // command line, it is part of the invocation: /path/to/python -m pants <actual args>.
+    SCOPE_NAME_RE.is_match(name) && name != "pants"
+}
+
+impl Scope {
+    pub fn named(name: &str) -> Scope {
+        match name {
+            "" | "GLOBAL" => Scope::Global,
+            scope => Scope::Scope(scope.to_owned()),
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        match self {
+            Scope::Global => "GLOBAL",
+            Scope::Scope(scope) => scope.as_str(),
+        }
+    }
+}

--- a/src/rust/engine/options/src/scope_tests.rs
+++ b/src/rust/engine/options/src/scope_tests.rs
@@ -1,0 +1,19 @@
+// Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+use crate::scope::is_valid_scope_name;
+
+#[test]
+fn test_is_valid_scope_name() {
+    assert!(is_valid_scope_name("test"));
+    assert!(is_valid_scope_name("test1"));
+    assert!(is_valid_scope_name("generate-lockfiles"));
+    assert!(is_valid_scope_name("i_dont_like_underscores"));
+
+    assert!(!is_valid_scope_name("pants"));
+    assert!(!is_valid_scope_name("No-Caps"));
+    assert!(!is_valid_scope_name("looks/like/a/target"));
+    assert!(!is_valid_scope_name("//:target"));
+    assert!(!is_valid_scope_name("-b"));
+    assert!(!is_valid_scope_name("--flag=value"));
+}


### PR DESCRIPTION
As I will shortly be adding a "ScopeInfo" type 
struct on the Rust side, and piling it on to id.rs
doesn't seem right.

This is just a move of top-level symbols and
their test. No logic changes.