### PR TITLE
A new RunsOn AMI (cherry-pick of #21827)

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -3,4 +3,4 @@ images:
     platform: "linux"
     arch: "arm64"
     owner: "408085265505"
-    ami: "ami-0718bef309678bb83"
+    ami: "ami-0ed317d88ec559763"


### PR DESCRIPTION
The existing one now gets these errors:

`Runner version v2.320.0 is deprecated and cannot receive messages`