### PR TITLE
upgrade to Rust v1.84.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -230,7 +230,7 @@ jobs:
       with:
         key: macOS13-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain')
           }}-v2
-        path: '~/.rustup/toolchains/1.83.0-*
+        path: '~/.rustup/toolchains/1.84.0-*
 
           ~/.rustup/update-hashes
 
@@ -327,7 +327,7 @@ jobs:
       with:
         key: macOS14-ARM64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain')
           }}-v2
-        path: '~/.rustup/toolchains/1.83.0-*
+        path: '~/.rustup/toolchains/1.84.0-*
 
           ~/.rustup/update-hashes
 
@@ -429,7 +429,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.83.0-*
+        path: '~/.rustup/toolchains/1.84.0-*
 
           ~/.rustup/update-hashes
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,7 +40,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: Linux-ARM64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.83.0-*
+        path: '~/.rustup/toolchains/1.84.0-*
 
           ~/.rustup/update-hashes
 
@@ -145,7 +145,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.83.0-*
+        path: '~/.rustup/toolchains/1.84.0-*
 
           ~/.rustup/update-hashes
 
@@ -260,7 +260,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: macOS13-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.83.0-*
+        path: '~/.rustup/toolchains/1.84.0-*
 
           ~/.rustup/update-hashes
 
@@ -508,7 +508,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: macOS13-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.83.0-*
+        path: '~/.rustup/toolchains/1.84.0-*
 
           ~/.rustup/update-hashes
 
@@ -588,7 +588,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: macOS14-ARM64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.83.0-*
+        path: '~/.rustup/toolchains/1.84.0-*
 
           ~/.rustup/update-hashes
 

--- a/src/rust/engine/dep_inference/src/javascript/mod.rs
+++ b/src/rust/engine/dep_inference/src/javascript/mod.rs
@@ -198,7 +198,7 @@ impl ImportCollector<'_> {
         };
         comment_after_semicolon(node)
             .or_else(|| comment_after_no_semicolon(node))
-            .map_or(false, |comment| contains_pragma(node, comment))
+            .is_some_and(|comment| contains_pragma(node, comment))
     }
 
     fn insert_import(&mut self, import_string: Option<Node>) {

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -161,10 +161,10 @@ pub enum ChildOutput {
 ///
 /// Collect the outputs of a child process.
 ///
-pub async fn collect_child_outputs<'a, 'b>(
+pub async fn collect_child_outputs<'a>(
     stdout: &'a mut BytesMut,
     stderr: &'a mut BytesMut,
-    mut stream: BoxStream<'b, Result<ChildOutput, String>>,
+    mut stream: BoxStream<'_, Result<ChildOutput, String>>,
 ) -> Result<i32, String> {
     let mut exit_code = 1;
 

--- a/src/rust/engine/rust-toolchain
+++ b/src/rust/engine/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.83.0"
+channel = "1.84.0"
 # NB: We don't list the components (namely `clippy` and `rustfmt`) and instead rely on either the
 #  the profile being "default" (by-and-large the default profile) or the nice error message from
 #  `cargo fmt` and `cargo clippy` if the required component isn't installed


### PR DESCRIPTION
Upgrade to Rust v1.84.0.

[Release notes are here](https://blog.rust-lang.org/2025/01/09/Rust-1.84.0.html).