### PR TITLE
Fix issue where  pants run only working when package.json at root

### DIFF
--- a/docs/notes/2.25.x.md
+++ b/docs/notes/2.25.x.md
@@ -65,6 +65,10 @@ The `helm_infer.external_docker_images` glob syntax has been generalized.  In ad
 
 Fixed a bug where linting with the Helm backend enabled could induce serialization errors with the [workunit-logger](https://www.pantsbuild.org/2.25/reference/subsystems/workunit-logger).
 
+#### Javascript
+
+Fixed an issue where `pants run ...` commands only worked if the `package.json` file was in the root directory.
+
 #### Python
 
 The AWS Lambda backend now provides built-in complete platforms for the Python 3.13 runtime.

--- a/src/python/pants/backend/javascript/run/rules.py
+++ b/src/python/pants/backend/javascript/run/rules.py
@@ -45,6 +45,7 @@ async def run_node_build_script(
     target_env_vars = await Get(
         EnvironmentVars, EnvironmentVarsRequest(field_set.extra_env_vars.value or ())
     )
+    package_dir = "{chroot}" + "/" + installation.project_env.package_dir()
 
     process = await Get(
         Process,
@@ -52,7 +53,7 @@ async def run_node_build_script(
             installation.project_env,
             args=(
                 *installation.package_manager.current_directory_args,
-                "{chroot}",
+                package_dir,
                 "run",
                 str(field_set.entry_point.value),
             ),

--- a/src/python/pants/backend/javascript/run/rules_test.py
+++ b/src/python/pants/backend/javascript/run/rules_test.py
@@ -74,7 +74,7 @@ def test_creates_npm_run_requests_package_json_scripts(rule_runner: RuleRunner) 
         tgt = rule_runner.get_target(Address("src/js", generated_name=script))
         result = rule_runner.request(RunRequest, [RunNodeBuildScriptFieldSet.create(tgt)])
 
-        assert result.args == ("npm", "--prefix", "{chroot}", "run", script)
+        assert result.args == ("npm", "--prefix", "{chroot}/src/js", "run", script)
 
 
 def test_creates_yarn_run_requests_package_json_scripts(rule_runner: RuleRunner) -> None:
@@ -117,7 +117,7 @@ def test_creates_yarn_run_requests_package_json_scripts(rule_runner: RuleRunner)
         tgt = rule_runner.get_target(Address("src/js", generated_name=script))
         result = rule_runner.request(RunRequest, [RunNodeBuildScriptFieldSet.create(tgt)])
 
-        assert result.args == ("yarn", "--cwd", "{chroot}", "run", script)
+        assert result.args == ("yarn", "--cwd", "{chroot}/src/js", "run", script)
 
 
 def test_extra_envs(rule_runner: RuleRunner) -> None:


### PR DESCRIPTION
Fixes #21793

Note this now aligns with how the node build script is run as part of `pants package` goal [here](https://github.com/pantsbuild/pants/blob/main/src/python/pants/backend/javascript/package/rules.py#L182). Separately, I don't know if that logic can be consolidated. 