### PR TITLE
add `PexKeyringConfigurationRequest` API for configuring Pex/Pip keyring

### DIFF
--- a/docs/notes/2.25.x.md
+++ b/docs/notes/2.25.x.md
@@ -162,6 +162,8 @@ The version of Python used by Pants itself is now [3.11](https://docs.python.org
 
 The oldest [glibc version](https://www.sourceware.org/glibc/wiki/Glibc%20Timeline) supported by the published Pants wheels is now 2.28.  This should have no effect unless you are running on extremely old Linux distributions.  See <https://github.com/pypa/manylinux> for background context on Python wheels and C libraries.
 
+Added `PexKeyringConfigurationRequest`, a new API for plugins to supply credentials to Pex/Pip for when they access secured Python package indexes.
+
 
 ## Full Changelog
 

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -271,6 +271,10 @@ async def setup_keyring_state(
                 credentials_responses[site] = []
             credentials_responses[site].append((keyring_plugin_request_type.name, user_password))
 
+    # Short circuit if the providers did not supply any credentials.
+    if not credentials_responses:
+        return _KeyringState(keyring_data_path=None)
+
     # Check for multiple responses for a single site. Keyring and our simulation of it only supports
     # a single user/password per site.
     credentials: list[tuple[str, str, str]] = []

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -106,7 +106,6 @@ class PexCliProcess:
         level: LogLevel = LogLevel.INFO,
         concurrency_available: int = 0,
         cache_scope: ProcessCacheScope = ProcessCacheScope.SUCCESSFUL,
-        with_keyring_trampoline: bool = False,
     ) -> None:
         object.__setattr__(self, "subcommand", tuple(subcommand))
         object.__setattr__(self, "extra_args", tuple(extra_args))

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -414,7 +414,7 @@ async def setup_pex_cli_process(
         if "PATH" in env:
             env["PATH"] = f"{{chroot}}/{keyring_script_parent_path}:{env['PATH']}"
         else:
-            env["PATH"] = "{chroot}/{keyring_script_parent_path}"
+            env["PATH"] = f"{{chroot}}/{keyring_script_parent_path}"
 
     return Process(
         normalized_argv,

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -149,7 +149,7 @@ class PexKeyringConfigurationResponse:
 # credentials by invoking this "keyring" binary from the PATH.
 #
 # Credentials are stored in the file stored in the `__PANTS_KEYRING_DATA` environment variable.
-# The file is sourced to define a `pants_keyring_credentials` associate array.
+# The file is sourced to define a `pants_keyring_credentials` associative array.
 _KEYRING_SCRIPT = """\
 #!__BASH_PATH__
 if [ "$1" != "get" ]; then
@@ -291,7 +291,7 @@ async def setup_keyring_state(
         credentials.append((site, user_password_creds[0], user_password_creds[1]))
     credentials.sort()
 
-    # Write the credentials to a file based on the current session ID.
+    # Write the credentials to a file based on the current run ID.
     content = StringIO()
     content.write("declare -A pants_keyring_credentials\n")
     for site, user, password in credentials:

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -140,7 +140,7 @@ class PexKeyringConfigurationResponse:
     """Response containing credentials to expose to Pex/Pip via simulating the `keyring` package's
     binary."""
 
-    # Nested map from SITE -> USER -> PASSWORD.
+    # Nested map from SITE -> (USER, PASSWORD).
     credentials: FrozenDict[str, tuple[str, str]] | None
 
 

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -380,8 +380,7 @@ async def setup_pex_cli_process(
     # All old-style pex runs take the --pip-version flag, but only certain subcommands of the
     # `pex3` console script do. So if invoked with a subcommand, the caller must selectively
     # set --pip-version only on subcommands that take it.
-    # pip_version_args = [] if request.subcommand else ["--pip-version", python_setup.pip_version]
-    pip_version_args = ["--pip-version", python_setup.pip_version]
+    pip_version_args = [] if request.subcommand else ["--pip-version", python_setup.pip_version]
     args = [
         *request.subcommand,
         *keyring_args,

--- a/src/python/pants/backend/python/util_rules/pex_cli_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli_test.py
@@ -12,7 +12,6 @@ from pants.backend.python.util_rules.pex_cli import (
     PexKeyringConfigurationRequest,
     PexKeyringConfigurationResponse,
 )
-from pants.core.util_rules import distdir, system_binaries
 from pants.engine.fs import DigestContents
 from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import QueryRule, rule
@@ -26,8 +25,6 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
             *pex_cli.rules(),
-            *system_binaries.rules(),
-            *distdir.rules(),
             QueryRule(Process, (PexCliProcess,)),
         ]
     )

--- a/src/python/pants/backend/python/util_rules/pex_cli_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli_test.py
@@ -1,16 +1,24 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import textwrap
 from pathlib import Path
 
 import pytest
 
 from pants.backend.python.util_rules import pex_cli
-from pants.backend.python.util_rules.pex_cli import PexCliProcess
+from pants.backend.python.util_rules.pex_cli import (
+    PexCliProcess,
+    PexKeyringConfigurationRequest,
+    PexKeyringConfigurationResponse,
+)
+from pants.core.util_rules import distdir, system_binaries
 from pants.engine.fs import DigestContents
-from pants.engine.process import Process
-from pants.engine.rules import QueryRule
+from pants.engine.process import Process, ProcessResult
+from pants.engine.rules import QueryRule, rule
+from pants.engine.unions import UnionRule
 from pants.testutil.rule_runner import RuleRunner
+from pants.util.frozendict import FrozenDict
 
 
 @pytest.fixture
@@ -18,6 +26,8 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
             *pex_cli.rules(),
+            *system_binaries.rules(),
+            *distdir.rules(),
             QueryRule(Process, (PexCliProcess,)),
         ]
     )
@@ -52,3 +62,65 @@ def test_pass_global_args_to_pex_cli_subsystem(tmp_path: Path, rule_runner: Rule
         [PexCliProcess(subcommand=(), extra_args=(), description="")],
     )
     assert "--foo=bar --baz --spam=eggs" in proc.argv
+
+
+class DummyKeyringConfigRequest(PexKeyringConfigurationRequest):
+    name = "test-keyring-provider"
+
+
+@rule
+async def setup_dummy_keyring_provider(
+    _request: DummyKeyringConfigRequest,
+) -> PexKeyringConfigurationResponse:
+    return PexKeyringConfigurationResponse(
+        credentials=FrozenDict({"a-site": ("some-user", "xyzzy")})
+    )
+
+
+def test_keyring_support() -> None:
+    rule_runner = RuleRunner(
+        rules=[
+            *pex_cli.rules(),
+            setup_dummy_keyring_provider,
+            QueryRule(ProcessResult, (PexCliProcess,)),
+            QueryRule(Process, (PexCliProcess,)),
+            UnionRule(PexKeyringConfigurationRequest, DummyKeyringConfigRequest),
+        ]
+    )
+    proc = rule_runner.request(
+        Process,
+        [PexCliProcess(subcommand=(), extra_args=("some", "--args"), description="")],
+    )
+
+    assert "--keyring-provider=subprocess" in proc.argv
+
+    # Ensure that the expected username/password was written to the data file on disk.
+    keyring_data_path = proc.env.get("__PANTS_KEYRING_DATA")
+    assert keyring_data_path is not None
+    keyring_data = Path(keyring_data_path).read_text()
+    assert "pants_keyring_credentials['a-site']='some-user'\n" in keyring_data
+    assert "pants_keyring_credentials['a-site:some-user']='xyzzy'\n" in keyring_data
+
+    # Now invoke the `keyring` script to verify that it works.
+    proc2 = rule_runner.request(
+        ProcessResult,
+        [
+            PexCliProcess(
+                subcommand=(),
+                extra_args=(
+                    "--",
+                    "-c",
+                    textwrap.dedent(
+                        """\
+                import subprocess
+                import sys
+                result = subprocess.run(["keyring", "get", "a-site", "some-user"])
+                sys.exit(result.returncode)
+                """
+                    ),
+                ),
+                description="",
+            )
+        ],
+    )
+    assert proc2.stdout.decode().strip() == "xyzzy"


### PR DESCRIPTION
Add an API to allow plugins to provide credentials to be used by Pex/Pip when accessing secured Python package indexes.