### PR TITLE
bump some test timeouts

### DIFF
--- a/src/python/pants/backend/build_files/fmt/black/BUILD
+++ b/src/python/pants/backend/build_files/fmt/black/BUILD
@@ -8,6 +8,7 @@ python_tests(
     overrides={
         "integration_test.py": {
             "tags": ["platform_specific_behavior"],
+            "timeout": 120,
         }
     },
 )

--- a/src/python/pants/backend/build_files/fmt/yapf/BUILD
+++ b/src/python/pants/backend/build_files/fmt/yapf/BUILD
@@ -8,6 +8,7 @@ python_tests(
     overrides={
         "integration_test.py": {
             "tags": ["platform_specific_behavior"],
+            "timeout": 120,
         }
     },
 )


### PR DESCRIPTION
Bump test timeouts for `src/python/pants/backend/build_files/fmt/black/integration_test.py` and `src/python/pants/backend/build_files/fmt/yapf/integration_test.py`.

See https://github.com/pantsbuild/pants/actions/runs/12839986315/job/35808114030#step:8:660 and 
https://github.com/pantsbuild/pants/actions/runs/12838202704/job/35803542545#step:8:576
