### PR TITLE
golang: allow downloads during instalation of gRPC protobuf plugins (Cherry-pick of #21614)

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/go/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/go/rules.py
@@ -598,6 +598,8 @@ async def setup_go_protoc_plugin() -> _SetupGoProtocPlugin:
                 input_digest=download_sources_result.output_digest,
                 output_files=["gopath/bin/protoc-gen-go"],
                 description="Build Go protobuf plugin for `protoc`.",
+                # Allow `go` to contact the Go module proxy since it will run its own build.
+                allow_downloads=True,
             ),
         ),
         Get(
@@ -610,6 +612,8 @@ async def setup_go_protoc_plugin() -> _SetupGoProtocPlugin:
                 input_digest=download_sources_result.output_digest,
                 output_files=["gopath/bin/protoc-gen-go-grpc"],
                 description="Build Go gRPC protobuf plugin for `protoc`.",
+                # Allow `go` to contact the Go module proxy since it will run its own build.
+                allow_downloads=True,
             ),
         ),
     )


### PR DESCRIPTION
As described in https://github.com/pantsbuild/pants/issues/21529, the Go rules are setting `GOPROXY=off` during the invocations of `go install` to install the gRPC protobuf plugins because that is the default for `GoSdkProcess`. The plugin builds are failing because `GOPROXY=off` prevents `go` from contacting the Go module proxy to learn about module deprecations. (Unlike other uses of `GoSdkProcess`, the gRPC protobuf plugins are relying on `go install` to do a full build of the plugin sources, which is unlike the use of `GoSdkProcess` in the rest of the Go backend rules.)

Solution: Set `allow_downloads=True` (which is already done for a preceding `go mod download`) to allow `go` to contact the Go module proxy as needed by not setting `GOPROXY=off`.

Fixes #21529.
