### PR TITLE
Turn nailgun initialization message down to debug

### DIFF
--- a/src/rust/engine/process_execution/pe_nailgun/src/nailgun_pool.rs
+++ b/src/rust/engine/process_execution/pe_nailgun/src/nailgun_pool.rs
@@ -67,7 +67,7 @@ pub struct NailgunPool {
 
 impl NailgunPool {
     pub fn new(workdir_base: PathBuf, size: usize, store: Store, executor: Executor) -> Self {
-        info!("Initializing Nailgun pool for {} processes...", size);
+        debug!("Initializing Nailgun pool for {} processes...", size);
         NailgunPool {
             workdir_base,
             size,

--- a/src/rust/engine/process_execution/pe_nailgun/src/nailgun_pool.rs
+++ b/src/rust/engine/process_execution/pe_nailgun/src/nailgun_pool.rs
@@ -14,7 +14,7 @@ use std::time::{Duration, Instant};
 use async_lock::{Mutex, MutexGuardArc};
 use futures::future;
 use lazy_static::lazy_static;
-use log::{debug, info};
+use log::debug;
 use regex::Regex;
 use tempfile::TempDir;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};


### PR DESCRIPTION
I think the intention with these log lines is logging expensive operations. However, the `NailgunPool::new` operation itself isn't expensive, and so doesn't need to be logged (sometimes twice) on every start-up.

As a fairly-expert Pants user, I'm not sure what information one should get from knowing that there's potentially 16 processes managed by nailgun, and other less-expert users likely have even less use for it!

Fixes #21863 , revisits https://github.com/pantsbuild/pants/pull/20946#issuecomment-2124545876 (particularly the last paragraph).