### PR TITLE
always use an explicit ubuntu image

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -6,7 +6,7 @@
 jobs:
   audit:
     if: github.repository_owner == 'pantsbuild'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Check out code
       uses: actions/checkout@v4

--- a/.github/workflows/cache_comparison.yaml
+++ b/.github/workflows/cache_comparison.yaml
@@ -5,7 +5,7 @@
 
 jobs:
   cache_comparison:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Check out code
       uses: actions/checkout@v4

--- a/.github/workflows/public_repos.yaml
+++ b/.github/workflows/public_repos.yaml
@@ -10,7 +10,7 @@ jobs:
       PANTS_REMOTE_CACHE_WRITE: 'false'
     name: AlexTereshenkov/cheeseshop-query
     permissions: {}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -95,7 +95,7 @@ jobs:
       PANTS_REMOTE_CACHE_WRITE: 'false'
     name: Ars-Linguistica/mlconjug3
     permissions: {}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -147,7 +147,7 @@ jobs:
       PANTS_REMOTE_CACHE_WRITE: 'false'
     name: OpenSaMD/OpenSaMD
     permissions: {}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -232,7 +232,7 @@ jobs:
       PANTS_REMOTE_CACHE_WRITE: 'false'
     name: StackStorm/st2
     permissions: {}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -330,7 +330,7 @@ jobs:
       PANTS_REMOTE_CACHE_WRITE: 'false'
     name: fucina/treb
     permissions: {}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -402,7 +402,7 @@ jobs:
       PANTS_REMOTE_CACHE_WRITE: 'false'
     name: ghandic/jsf
     permissions: {}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -464,7 +464,7 @@ jobs:
       PANTS_REMOTE_CACHE_WRITE: 'false'
     name: komprenilo/liga
     permissions: {}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -516,7 +516,7 @@ jobs:
       PANTS_REMOTE_CACHE_WRITE: 'false'
     name: lablup/backend.ai
     permissions: {}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -606,7 +606,7 @@ jobs:
       PANTS_REMOTE_CACHE_WRITE: 'false'
     name: mitodl/ol-django
     permissions: {}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -660,7 +660,7 @@ jobs:
       PANTS_REMOTE_CACHE_WRITE: 'false'
     name: mitodl/ol-infrastructure
     permissions: {}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -712,7 +712,7 @@ jobs:
       PANTS_REMOTE_CACHE_WRITE: 'false'
     name: naccdata/flywheel-gear-extensions
     permissions: {}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -775,7 +775,7 @@ jobs:
       PANTS_REMOTE_CACHE_WRITE: 'false'
     name: pantsbuild/example-adhoc
     permissions: {}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -841,7 +841,7 @@ jobs:
       PANTS_REMOTE_CACHE_WRITE: 'false'
     name: pantsbuild/example-codegen
     permissions: {}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -938,7 +938,7 @@ jobs:
       PANTS_REMOTE_CACHE_WRITE: 'false'
     name: pantsbuild/example-django
     permissions: {}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -1024,7 +1024,7 @@ jobs:
       PANTS_REMOTE_CACHE_WRITE: 'false'
     name: pantsbuild/example-docker
     permissions: {}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -1109,7 +1109,7 @@ jobs:
       PANTS_REMOTE_CACHE_WRITE: 'false'
     name: pantsbuild/example-golang
     permissions: {}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -1198,7 +1198,7 @@ jobs:
       PANTS_REMOTE_CACHE_WRITE: 'false'
     name: pantsbuild/example-jvm
     permissions: {}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -1283,7 +1283,7 @@ jobs:
       PANTS_REMOTE_CACHE_WRITE: 'false'
     name: pantsbuild/example-kotlin
     permissions: {}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -1368,7 +1368,7 @@ jobs:
       PANTS_REMOTE_CACHE_WRITE: 'false'
     name: pantsbuild/example-python
     permissions: {}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -1453,7 +1453,7 @@ jobs:
       PANTS_REMOTE_CACHE_WRITE: 'false'
     name: pantsbuild/example-visibility
     permissions: {}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -1528,7 +1528,7 @@ jobs:
       PANTS_REMOTE_CACHE_WRITE: 'false'
     name: pantsbuild/scie-pants
     permissions: {}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Check out code
       uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -394,7 +394,7 @@ jobs:
     - build_wheels_macos13_x86_64
     - build_wheels_macos14_arm64
     - release_info
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout Pants at Release Tag
       uses: actions/checkout@v4
@@ -520,7 +520,7 @@ jobs:
       is-release: ${{ steps.get_info.outputs.is-release }}
       release-asset-upload-url: ${{ steps.make_draft_release.outputs.release-asset-upload-url
         }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - env:
         REF: ${{ github.event.inputs.ref }}

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -1077,7 +1077,7 @@ def cache_comparison_jobs_and_inputs() -> tuple[Jobs, dict[str, Any]]:
 
     jobs = {
         "cache_comparison": {
-            "runs-on": "ubuntu-latest",
+            "runs-on": "ubuntu-22.04",
             "timeout-minutes": 90,
             "steps": [
                 *checkout(),
@@ -1125,7 +1125,7 @@ def release_jobs_and_inputs() -> tuple[Jobs, dict[str, Any]]:
     jobs = {
         "release_info": {
             "name": "Create draft release and output info",
-            "runs-on": "ubuntu-latest",
+            "runs-on": "ubuntu-22.04",
             "if": IS_PANTS_OWNER,
             "steps": [
                 {
@@ -1195,7 +1195,7 @@ def release_jobs_and_inputs() -> tuple[Jobs, dict[str, Any]]:
         },
         **wheels_jobs,
         "publish": {
-            "runs-on": "ubuntu-latest",
+            "runs-on": "ubuntu-22.04",
             "needs": [*wheels_job_names, "release_info"],
             "if": f"{IS_PANTS_OWNER} && needs.release_info.outputs.is-release == 'true'",
             "env": {
@@ -1544,7 +1544,7 @@ def public_repos() -> PublicReposOutput:
         }
         return {
             "name": repo.name,
-            "runs-on": "ubuntu-latest",
+            "runs-on": "ubuntu-22.04",
             "env": job_env,
             # we're running untrusted code, so this token shouldn't be able to do anything. We also
             # need to be sure we don't add any secrets to the job
@@ -1757,7 +1757,7 @@ def generate() -> dict[Path, str]:
             },
             "jobs": {
                 "audit": {
-                    "runs-on": "ubuntu-latest",
+                    "runs-on": "ubuntu-22.04",
                     "if": IS_PANTS_OWNER,
                     "steps": [
                         *checkout(),


### PR DESCRIPTION
The release of `2.24.0rc2` failed:
https://github.com/pantsbuild/pants/actions/runs/12909883768/job/36005845441#step:3:19
```
  Version 3.7 was not found in the local cache
  Error: The version '3.7' with architecture 'x64' was not found for Ubuntu 24.04.
  The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```

This is because the `publish` step was running on `ubuntu-latest` which GitHub recently switched from Ubuntu 24
to 22. https://github.com/actions/runner-images/issues/10636 Which has a different set of GitHub Python versions
<https://github.com/actions/python-versions> available.

Setting to an explicit image version lets us control the upgrade cadence instead of rugs being pulled out from under.