### PR TITLE
Reimplement the pants_bin_name functionality in Rust.

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex_requirements_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements_test.py
@@ -209,7 +209,7 @@ def test_validate_lockfiles(
     contains("The `no_binary` arguments have changed", if_=invalid_no_binary)
     contains("The `manylinux` argument has changed", if_=invalid_manylinux)
 
-    contains("./pants generate-lockfiles --resolve=a`")
+    contains("pants generate-lockfiles --resolve=a`")
 
 
 def test_is_probably_pex_json_lockfile():

--- a/src/python/pants/engine/internals/native_engine.pyi
+++ b/src/python/pants/engine/internals/native_engine.pyi
@@ -686,6 +686,8 @@ OptionValueDerivation = list[Tuple[T, int, str]]
 # A tuple (value, rank of value, optional derivation of value).
 OptionValue = Tuple[Optional[T], int, Optional[OptionValueDerivation]]
 
+def py_bin_name() -> str: ...
+
 class PyOptionParser:
     def __init__(
         self,

--- a/src/python/pants/option/option_types_test.py
+++ b/src/python/pants/option/option_types_test.py
@@ -224,9 +224,9 @@ def test_specialized_options() -> None:
 
     assert list(collect_options_info(MySubsystem)) == [
         expected_skip_opt_info(
-            "If true, don't use Wrench when running `./pants fmt` and `./pants lint`."
+            "If true, don't use Wrench when running `pants fmt` and `pants lint`."
         ),
-        expected_skip_opt_info("If true, don't use Wrench when running `./pants fmt`."),
+        expected_skip_opt_info("If true, don't use Wrench when running `pants fmt`."),
         expected_args_opt_info(
             "Arguments to pass directly to Wrench, e.g. `--my-subsystem-args='--foo'`."
         ),
@@ -238,7 +238,7 @@ def test_specialized_options() -> None:
         ),
     ]
     assert list(collect_options_info(SubsystemWithName)) == [
-        expected_skip_opt_info("If true, don't use Hammer when running `./pants fmt`."),
+        expected_skip_opt_info("If true, don't use Hammer when running `pants fmt`."),
         expected_args_opt_info(
             "Arguments to pass directly to Hammer, e.g. `--other-subsystem-args='--nail'`."
         ),

--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -3,11 +3,10 @@
 
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Iterable, Mapping, Sequence
 
-from pants.base.build_environment import get_buildroot, pants_version
+from pants.base.build_environment import pants_version
 from pants.base.exceptions import BuildConfigurationError
 from pants.engine.unions import UnionMembership
 from pants.option.global_options import BootstrapOptions, GlobalOptions
@@ -58,16 +57,6 @@ class OptionsBootstrapper:
           decision of whether to respect pantsrc files.
         """
         args = tuple(args)
-        bootstrap_options = cls._create_bootstrap_options(args, env, allow_pantsrc)
-
-        # We need to set this env var to allow various static help strings to reference the
-        # right name (via `pants.util.docutil`), and we need to do it as early as possible to
-        # avoid needing to lazily import code to avoid chicken-and-egg-problems. This is the
-        # earliest place it makes sense to do so and is generically used by both the local and
-        # remote pants runners.
-        os.environ["__PANTS_BIN_NAME"] = munge_bin_name(
-            bootstrap_options.for_global_scope().pants_bin_name, get_buildroot()
-        )
 
         # TODO: We really only need the env vars starting with PANTS_, plus any env
         #  vars used in env.FOO-style interpolation in config files.
@@ -175,19 +164,3 @@ class OptionsBootstrapper:
             )
         GlobalOptions.validate_instance(options.for_global_scope())
         return options
-
-
-def munge_bin_name(pants_bin_name: str, build_root: str) -> str:
-    # Determine a useful bin name to embed in help strings.
-    # The bin name gets embedded in help comments in generated lockfiles,
-    # so we never want to use an abspath.
-    if os.path.isabs(pants_bin_name):
-        pants_bin_name = os.path.realpath(pants_bin_name)
-        build_root = os.path.realpath(os.path.abspath(build_root))
-        # If it's in the buildroot, use the relpath from there. Otherwise use the basename.
-        pants_bin_relpath = os.path.relpath(pants_bin_name, build_root)
-        if pants_bin_relpath.startswith(".."):
-            pants_bin_name = os.path.basename(pants_bin_name)
-        else:
-            pants_bin_name = os.path.join(".", pants_bin_relpath)
-    return pants_bin_name

--- a/src/python/pants/option/options_bootstrapper_test.py
+++ b/src/python/pants/option/options_bootstrapper_test.py
@@ -11,7 +11,7 @@ from textwrap import dedent
 from pants.base.build_environment import get_buildroot
 from pants.engine.unions import UnionMembership
 from pants.option.option_value_container import OptionValueContainer
-from pants.option.options_bootstrapper import OptionsBootstrapper, munge_bin_name
+from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.option.scope import ScopeInfo
 from pants.util.contextutil import temporary_file, temporary_file_path
 from pants.util.logging import LogLevel
@@ -352,22 +352,6 @@ class TestOptionsBootstrapper:
         )
         logdir = ob.bootstrap_options.for_global_scope().logdir
         assert "logdir1" == logdir
-
-
-def test_munge_bin_name():
-    build_root = "/my/repo"
-
-    def munge(bin_name: str) -> str:
-        return munge_bin_name(bin_name, build_root)
-
-    assert munge("pants") == "pants"
-    assert munge("pantsv2") == "pantsv2"
-    assert munge("bin/pantsv2") == "bin/pantsv2"
-    assert munge("./pants") == "./pants"
-    assert munge(os.path.join(build_root, "pants")) == "./pants"
-    assert munge(os.path.join(build_root, "bin", "pants")) == "./bin/pants"
-    assert munge("/foo/pants") == "pants"
-    assert munge("/foo/bar/pants") == "pants"
 
 
 def test_file_spec_args() -> None:

--- a/src/python/pants/pantsd/pants_daemon_client.py
+++ b/src/python/pants/pantsd/pants_daemon_client.py
@@ -4,8 +4,10 @@
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass
 
+from pants.engine.internals.native_engine import py_bin_name
 from pants.option.options import Options
 from pants.pantsd import pants_daemon
 from pants.pantsd.process_manager import PantsDaemonProcessManager
@@ -55,6 +57,8 @@ class PantsDaemonClient(PantsDaemonProcessManager):
 
         N.B. This should always be called under care of the `lifecycle_lock`.
         """
+        # Propagate the bin name to pantsd.
+        os.environ["__PANTS_BIN_NAME"] = py_bin_name()
         self.terminate()
         logger.debug("Launching pantsd")
         self.daemon_spawn()

--- a/src/python/pants/util/docutil.py
+++ b/src/python/pants/util/docutil.py
@@ -4,9 +4,9 @@
 
 from __future__ import annotations
 
-import os
 import shutil
 
+from pants.engine.internals.native_engine import py_bin_name
 from pants.version import MAJOR_MINOR, PANTS_SEMVER
 
 
@@ -41,18 +41,8 @@ def git_url(fp: str) -> str:
 
 
 def bin_name() -> str:
-    """Return the Pants binary name, e.g. './pants'."""
-    # NB: This will be called at import-time in several files to define static help strings
-    # (e.g. "help=f'run `{bin_name()} fmt`").
-    #
-    # Ideally, we'd assert this is set unconditionally before Pants imports any of the files which
-    # use it, to give us complete confidence we won't be returning "./pants" in our help strings.
-    #
-    # However, this assumption really breaks down when we go to test pants (or a plugin author goes
-    # to test their plugin). Therefore we give a fallback and have integration test(s) to assert
-    # we've set this at the right point in time.
-    #
-    # Note that __PANTS_BIN_NAME is set in options_bootstrapper.py based on the value of the
-    # pants_bin_name global option, so you cannot naively modify this by setting __PANTS_BIN_NAME
-    # externally. You must set that option value in one of the usual ways.
-    return os.environ.get("__PANTS_BIN_NAME", "./pants")  # noqa: PANTSBIN
+    """Return the Pants binary name, e.g. 'pants'.
+
+    Can be configured with the pants_bin_name option.
+    """
+    return py_bin_name()

--- a/src/rust/engine/src/externs/options.rs
+++ b/src/rust/engine/src/externs/options.rs
@@ -6,8 +6,8 @@ use pyo3::types::{PyBool, PyDict, PyFloat, PyInt, PyList, PyString, PyTuple};
 use pyo3::{prelude::*, BoundObject};
 
 use options::{
-    apply_dict_edits, apply_list_edits, Args, ConfigSource, DictEdit, DictEditAction, Env,
-    GoalInfo, ListEdit, ListEditAction, ListOptionValue, OptionId, OptionParser,
+    apply_dict_edits, apply_list_edits, bin_name, Args, ConfigSource, DictEdit, DictEditAction,
+    Env, GoalInfo, ListEdit, ListEditAction, ListOptionValue, OptionId, OptionParser,
     OptionalOptionValue, PantsCommand, Scope, Source, Val,
 };
 
@@ -16,7 +16,13 @@ use std::collections::{HashMap, HashSet};
 
 pyo3::import_exception!(pants.option.errors, ParseError);
 
+#[pyfunction]
+fn py_bin_name() -> String {
+    bin_name()
+}
+
 pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(py_bin_name, m)?)?;
     m.add_class::<PyGoalInfo>()?;
     m.add_class::<PyOptionId>()?;
     m.add_class::<PyPantsCommand>()?;


### PR DESCRIPTION
This feature allows users to set a custom binary name
for use in help messages and documentation. So that
if their org has a custom wrapper script or binary,
we can direct users to use that.

Reimplementing this in Rust allows us to further 
simplify OptionsBootstrapper.

Note that the old implementation relied on setting
an env var on the current process by manipulating
`os.environ`. This served two purposes:

1) Communicating the value within the process, and
2) Communicating the value from the client to pantsd,
since the latter inherits the environment of the former.

( 2) is important because pantsd uses bin_name() at
import time, and options (including the pants_bin_name
option) may not be available yet. )

But - setting an environment variable on the current
process is not thread-safe on POSIX, and there is no
way to make it so. Therefore we change the implementation
to use a static Mutex for 1), and an explicit pass-through
of that value when spawning pantsd for 2).