### PR TITLE
[WIP] MyPy: upgrade to v1.14.0

### DIFF
--- a/3rdparty/python/mypy-requirements.txt
+++ b/3rdparty/python/mypy-requirements.txt
@@ -1,3 +1,3 @@
-mypy==1.13.0
+mypy==1.14.0
 mypy-typing-asserts
 strawberry-graphql==0.240.4

--- a/3rdparty/python/mypy.lock
+++ b/3rdparty/python/mypy.lock
@@ -10,7 +10,7 @@
 //   ],
 //   "generated_with_requirements": [
 //     "mypy-typing-asserts",
-//     "mypy==1.13.0",
+//     "mypy==1.14.0",
 //     "strawberry-graphql==0.240.4"
 //   ],
 //   "manylinux": "manylinux2014",
@@ -26,6 +26,7 @@
   "allow_wheels": true,
   "build_isolation": true,
   "constraints": [],
+  "elide_unused_requires_dist": false,
   "excluded": [],
   "locked_resolves": [
     {
@@ -54,48 +55,48 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "9c250883f9fd81d212e0952c92dbfcc96fc237f4b7c92f56ac81fd48460b3e5a",
-              "url": "https://files.pythonhosted.org/packages/3b/86/72ce7f57431d87a7ff17d442f521146a6585019eb8f4f31b7c02801f78ad/mypy-1.13.0-py3-none-any.whl"
+              "hash": "2238d7f93fc4027ed1efc944507683df3ba406445a2b6c96e79666a045aadfab",
+              "url": "https://files.pythonhosted.org/packages/39/32/0214608af400cdf8f5102144bb8af10d880675c65ed0b58f7e0e77175d50/mypy-1.14.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "20c7ee0bc0d5a9595c46f38beb04201f2620065a93755704e141fcac9f59db2b",
-              "url": "https://files.pythonhosted.org/packages/26/50/29d3e7dd166e74dc13d46050b23f7d6d7533acf48f5217663a3719db024e/mypy-1.13.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl"
+              "hash": "6e73c8a154eed31db3445fe28f63ad2d97b674b911c00191416cf7f6459fd49a",
+              "url": "https://files.pythonhosted.org/packages/34/c1/b9dd3e955953aec1c728992545b7877c9f6fa742a623ce4c200da0f62540/mypy-1.14.0-cp311-cp311-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3790ded76f0b34bc9c8ba4def8f919dd6a46db0f5a6610fb994fe8efdd447f73",
-              "url": "https://files.pythonhosted.org/packages/3f/1d/676e76f07f7d5ddcd4227af3938a9c9640f293b7d8a44dd4ff41d4db25c1/mypy-1.13.0-cp311-cp311-musllinux_1_1_x86_64.whl"
+              "hash": "1daca283d732943731a6a9f20fdbcaa927f160bc51602b1d4ef880a6fb252015",
+              "url": "https://files.pythonhosted.org/packages/69/2c/3dbe51877a24daa467f8d8631f9ffd1aabbf0f6d9367a01c44a59df81fe0/mypy-1.14.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3ddb5b9bf82e05cc9a627e84707b528e5c7caaa1c55c69e175abb15a761cec2d",
-              "url": "https://files.pythonhosted.org/packages/c8/71/6950fcc6ca84179137e4cbf7cf41e6b68b4a339a1f5d3e954f8c34e02d66/mypy-1.13.0-cp311-cp311-macosx_11_0_arm64.whl"
+              "hash": "822dbd184d4a9804df5a7d5335a68cf7662930e70b8c1bc976645d1509f9a9d6",
+              "url": "https://files.pythonhosted.org/packages/8c/7b/08046ef9330735f536a09a2e31b00f42bccdb2795dcd979636ba43bb2d63/mypy-1.14.0.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "581665e6f3a8a9078f28d5502f4c334c0c8d802ef55ea0e7276a6e409bc0d82d",
-              "url": "https://files.pythonhosted.org/packages/d0/19/de0822609e5b93d02579075248c7aa6ceaddcea92f00bf4ea8e4c22e3598/mypy-1.13.0-cp311-cp311-macosx_10_9_x86_64.whl"
+              "hash": "7e68047bedb04c1c25bba9901ea46ff60d5eaac2d71b1f2161f33107e2b368eb",
+              "url": "https://files.pythonhosted.org/packages/a1/a8/eb20cde4ba9c4c3e20d958918a7c5d92210f4d1a0200c27de9a641f70996/mypy-1.14.0-cp311-cp311-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0291a61b6fbf3e6673e3405cfcc0e7650bebc7939659fdca2702958038bd835e",
-              "url": "https://files.pythonhosted.org/packages/e8/21/7e9e523537991d145ab8a0a2fd98548d67646dc2aaaf6091c31ad883e7c1/mypy-1.13.0.tar.gz"
+              "hash": "273e70fcb2e38c5405a188425aa60b984ffdcef65d6c746ea5813024b68c73dc",
+              "url": "https://files.pythonhosted.org/packages/ee/96/c52d5d516819ab95bf41f4a1ada828a3decc302f8c152ff4fc5feb0e4529/mypy-1.14.0-cp311-cp311-macosx_11_0_arm64.whl"
             }
           ],
           "project_name": "mypy",
           "requires_dists": [
             "lxml; extra == \"reports\"",
-            "mypy-extensions>=1.0.0",
+            "mypy_extensions>=1.0.0",
             "orjson; extra == \"faster-cache\"",
             "pip; extra == \"install-types\"",
             "psutil>=4.0; extra == \"dmypy\"",
             "setuptools>=50; extra == \"mypyc\"",
             "tomli>=1.1.0; python_version < \"3.11\"",
-            "typing-extensions>=4.6.0"
+            "typing_extensions>=4.6.0"
           ],
           "requires_python": ">=3.8",
-          "version": "1.13.0"
+          "version": "1.14.0"
         },
         {
           "artifacts": [
@@ -157,19 +158,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254",
-              "url": "https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl"
+              "hash": "4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274",
+              "url": "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
-              "url": "https://files.pythonhosted.org/packages/71/39/171f1c67cd00715f190ba0b100d606d440a28c93c7714febeca8b79af85e/six-1.16.0.tar.gz"
+              "hash": "ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81",
+              "url": "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz"
             }
           ],
           "project_name": "six",
           "requires_dists": [],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7",
-          "version": "1.16.0"
+          "version": "1.17.0"
         },
         {
           "artifacts": [
@@ -242,12 +243,12 @@
   "only_wheels": [],
   "overridden": [],
   "path_mappings": {},
-  "pex_version": "2.20.3",
-  "pip_version": "24.2",
+  "pex_version": "2.29.0",
+  "pip_version": "24.3.1",
   "prefer_older_binary": false,
   "requirements": [
     "mypy-typing-asserts",
-    "mypy==1.13.0",
+    "mypy==1.14.0",
     "strawberry-graphql==0.240.4"
   ],
   "requires_python": [

--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -10,7 +10,7 @@ fasteners==0.16.3
 freezegun==1.2.1
 ijson==3.2.3
 libcst==1.4.0
-packaging==21.3
+packaging==24.2
 pex==2.29.0
 psutil==5.9.8
 # This should be compatible with pytest.py, although it can be looser so that we don't

--- a/3rdparty/python/user_reqs.lock
+++ b/3rdparty/python/user_reqs.lock
@@ -22,7 +22,7 @@
 //     "libcst==1.4.0",
 //     "mypy-typing-asserts==0.1.1",
 //     "node-semver==0.9.0",
-//     "packaging==21.3",
+//     "packaging==24.2",
 //     "pex==2.29.0",
 //     "psutil==5.9.8",
 //     "pydevd-pycharm==203.5419.8",
@@ -987,21 +987,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522",
-              "url": "https://files.pythonhosted.org/packages/05/8e/8de486cbd03baba4deef4142bd643a3e7bbe954a784dc1bb17142572d127/packaging-21.3-py3-none-any.whl"
+              "hash": "09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759",
+              "url": "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
-              "url": "https://files.pythonhosted.org/packages/df/9e/d1a7217f69310c1db8fdf8ab396229f55a699ce34a203691794c5d1cad0c/packaging-21.3.tar.gz"
+              "hash": "c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f",
+              "url": "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz"
             }
           ],
           "project_name": "packaging",
-          "requires_dists": [
-            "pyparsing!=3.0.5,>=2.0.2"
-          ],
-          "requires_python": ">=3.6",
-          "version": "21.3"
+          "requires_dists": [],
+          "requires_python": ">=3.8",
+          "version": "24.2"
         },
         {
           "artifacts": [
@@ -1317,27 +1315,6 @@
           ],
           "requires_python": ">=3.6",
           "version": "1.5.0"
-        },
-        {
-          "artifacts": [
-            {
-              "algorithm": "sha256",
-              "hash": "506ff4f4386c4cec0590ec19e6302d3aedb992fdc02c761e90416f158dacf8e1",
-              "url": "https://files.pythonhosted.org/packages/1c/a7/c8a2d361bf89c0d9577c934ebb7421b25dc84bf3a8e3ac0a40aed9acc547/pyparsing-3.2.1-py3-none-any.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "61980854fd66de3a90028d679a954d5f2623e83144b5afe5ee86f43d762e5f0a",
-              "url": "https://files.pythonhosted.org/packages/8b/1a/3544f4f299a47911c2ab3710f534e52fea62a633c96806995da5d25be4b2/pyparsing-3.2.1.tar.gz"
-            }
-          ],
-          "project_name": "pyparsing",
-          "requires_dists": [
-            "jinja2; extra == \"diagrams\"",
-            "railroad-diagrams; extra == \"diagrams\""
-          ],
-          "requires_python": ">=3.9",
-          "version": "3.2.1"
         },
         {
           "artifacts": [
@@ -2189,64 +2166,64 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "4d4fc827a20abe6d544a119896f6b78ee13fe81cbfef416f3f2ddf09a03f0e2e",
-              "url": "https://files.pythonhosted.org/packages/b0/0b/c7e5d11020242984d9d37990310520ed663b942333b83a033c2f20191113/websockets-14.1-py3-none-any.whl"
+              "hash": "7a6ceec4ea84469f15cf15807a747e9efe57e369c384fa86e022b3bea679b79b",
+              "url": "https://files.pythonhosted.org/packages/7b/c8/d529f8a32ce40d98309f4470780631e971a5a842b60aec864833b3615786/websockets-14.2-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a35f704be14768cea9790d921c2c1cc4fc52700410b1c10948511039be824aac",
-              "url": "https://files.pythonhosted.org/packages/06/91/bf0a44e238660d37a2dda1b4896235d20c29a2d0450f3a46cd688f43b239/websockets-14.1-cp311-cp311-macosx_10_9_x86_64.whl"
+              "hash": "9f05702e93203a6ff5226e21d9b40c037761b2cfb637187c9802c10f58e40473",
+              "url": "https://files.pythonhosted.org/packages/00/8b/bec2bdba92af0762d42d4410593c1d7d28e9bfd952c97a3729df603dc6ea/websockets-14.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f6cf0ad281c979306a6a34242b371e90e891bce504509fb6bb5246bbbf31e7b6",
-              "url": "https://files.pythonhosted.org/packages/11/43/e2dbd4401a63e409cebddedc1b63b9834de42f51b3c84db885469e9bdcef/websockets-14.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "3bdc8c692c866ce5fefcaf07d2b55c91d6922ac397e031ef9b774e5b9ea42166",
+              "url": "https://files.pythonhosted.org/packages/15/b6/504695fb9a33df0ca56d157f5985660b5fc5b4bf8c78f121578d2d653392/websockets-14.2-cp311-cp311-macosx_10_9_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f95ba34d71e2fa0c5d225bde3b3bdb152e957150100e75c86bc7f3964c450d89",
-              "url": "https://files.pythonhosted.org/packages/49/69/e6f3d953f2fa0f8a723cf18cd011d52733bd7f6e045122b24e0e7f49f9b0/websockets-14.1-cp311-cp311-musllinux_1_2_i686.whl"
+              "hash": "efd9b868d78b194790e6236d9cbc46d68aba4b75b22497eb4ab64fa640c3af56",
+              "url": "https://files.pythonhosted.org/packages/60/d5/a6eadba2ed9f7e65d677fec539ab14a9b83de2b484ab5fe15d3d6d208c28/websockets-14.2-cp311-cp311-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3c3deac3748ec73ef24fc7be0b68220d14d47d6647d2f85b2771cb35ea847aa1",
-              "url": "https://files.pythonhosted.org/packages/5a/8a/0849968d83474be89c183d8ae8dcb7f7ada1a3c24f4d2a0d7333c231a2c3/websockets-14.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "34277a29f5303d54ec6468fb525d99c99938607bc96b8d72d675dee2b9f5bf1d",
+              "url": "https://files.pythonhosted.org/packages/64/22/e5f7c33db0cb2c1d03b79fd60d189a1da044e2661f5fd01d629451e1db89/websockets-14.2-cp311-cp311-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "cc1fc87428c1d18b643479caa7b15db7d544652e5bf610513d4a3478dbe823d0",
-              "url": "https://files.pythonhosted.org/packages/6d/d6/7063e3f5c1b612e9f70faae20ebaeb2e684ffa36cb959eb0862ee2809b32/websockets-14.1-cp311-cp311-musllinux_1_2_aarch64.whl"
+              "hash": "22441c81a6748a53bfcb98951d58d1af0661ab47a536af08920d129b4d1c3473",
+              "url": "https://files.pythonhosted.org/packages/6b/a9/37531cb5b994f12a57dec3da2200ef7aadffef82d888a4c29a0d781568e4/websockets-14.2-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9481a6de29105d73cf4515f2bef8eb71e17ac184c19d0b9918a3701c6c9c4f23",
-              "url": "https://files.pythonhosted.org/packages/70/ff/f31fa14561fc1d7b8663b0ed719996cf1f581abee32c8fb2f295a472f268/websockets-14.1-cp311-cp311-musllinux_1_2_x86_64.whl"
+              "hash": "1a5a20d5843886d34ff8c57424cc65a1deda4375729cbca4cb6b3353f3ce4142",
+              "url": "https://files.pythonhosted.org/packages/76/57/a338ccb00d1df881c1d1ee1f2a20c9c1b5b29b51e9e0191ee515d254fea6/websockets-14.2-cp311-cp311-musllinux_1_2_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "449d77d636f8d9c17952628cc7e3b8faf6e92a17ec581ec0c0256300717e1512",
-              "url": "https://files.pythonhosted.org/packages/97/ed/c0d03cb607b7fe1f7ff45e2cd4bb5cd0f9e3299ced79c2c303a6fff44524/websockets-14.1-cp311-cp311-macosx_10_9_universal2.whl"
+              "hash": "c93215fac5dadc63e51bcc6dceca72e72267c11def401d6668622b47675b097f",
+              "url": "https://files.pythonhosted.org/packages/81/26/ebfb8f6abe963c795122439c6433c4ae1e061aaedfc7eff32d09394afbae/websockets-14.2-cp311-cp311-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7048eb4415d46368ef29d32133134c513f507fff7d953c18c91104738a68c3b3",
-              "url": "https://files.pythonhosted.org/packages/bd/4f/ef886e37245ff6b4a736a09b8468dae05d5d5c99de1357f840d54c6f297d/websockets-14.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "5059ed9c54945efb321f097084b4c7e52c246f2c869815876a69d1efc4ad6eb5",
+              "url": "https://files.pythonhosted.org/packages/94/54/8359678c726243d19fae38ca14a334e740782336c9f19700858c4eb64a1e/websockets-14.2.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "398b10c77d471c0aab20a845e7a60076b6390bfdaac7a6d2edb0d2c59d75e8d8",
-              "url": "https://files.pythonhosted.org/packages/f4/1b/380b883ce05bb5f45a905b61790319a28958a9ab1e4b6b95ff5464b60ca1/websockets-14.1.tar.gz"
+              "hash": "0a52a6d7cf6938e04e9dceb949d35fbdf58ac14deea26e685ab6368e73744e4c",
+              "url": "https://files.pythonhosted.org/packages/96/63/900c27cfe8be1a1f2433fc77cd46771cf26ba57e6bdc7cf9e63644a61863/websockets-14.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b1f3628a0510bd58968c0f60447e7a692933589b791a6b572fcef374053ca280",
-              "url": "https://files.pythonhosted.org/packages/ff/b8/7185212adad274c2b42b6a24e1ee6b916b7809ed611cbebc33b227e5c215/websockets-14.1-cp311-cp311-macosx_11_0_arm64.whl"
+              "hash": "1c9b6535c0e2cf8a6bf938064fb754aaceb1e6a4a51a80d884cd5db569886910",
+              "url": "https://files.pythonhosted.org/packages/a1/c6/1435ad6f6dcbff80bb95e8986704c3174da8866ddb751184046f5c139ef6/websockets-14.2-cp311-cp311-macosx_11_0_arm64.whl"
             }
           ],
           "project_name": "websockets",
           "requires_dists": [],
           "requires_python": ">=3.9",
-          "version": "14.1"
+          "version": "14.2"
         },
         {
           "artifacts": [
@@ -2336,7 +2313,7 @@
     "libcst==1.4.0",
     "mypy-typing-asserts==0.1.1",
     "node-semver==0.9.0",
-    "packaging==21.3",
+    "packaging==24.2",
     "pex==2.29.0",
     "psutil==5.9.8",
     "pydevd-pycharm==203.5419.8",

--- a/src/python/pants/backend/openapi/codegen/python/generate.py
+++ b/src/python/pants/backend/openapi/codegen/python/generate.py
@@ -257,9 +257,9 @@ async def get_python_requirements(
     result: defaultdict[str, dict[str, Address]] = defaultdict(dict)
     for target in python_targets.third_party:
         for python_requirement in target[PythonRequirementsField].value:
-            project_name = canonicalize_project_name(python_requirement.project_name)
+            name = canonicalize_project_name(python_requirement.name)
             resolve = target[PythonRequirementResolveField].normalized_value(python_setup)
-            result[resolve][project_name] = target.address
+            result[resolve][name] = target.address
 
     return PythonRequirements(
         resolves_to_requirements_to_addresses=FrozenDict(
@@ -314,7 +314,7 @@ async def infer_openapi_python_dependencies(
 
     addresses, missing_requirements = [], []
     for runtime_dependency in compiled_sources.runtime_dependencies:
-        project_name = runtime_dependency.project_name
+        project_name = runtime_dependency.name
         address = requirements_to_addresses.get(project_name.lower())
         if address is not None:
             addresses.append(address)

--- a/src/python/pants/backend/python/dependency_inference/module_mapper.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper.py
@@ -374,8 +374,8 @@ async def map_third_party_modules_to_addresses(
             # NB: We don't use `canonicalize_project_name()` for the fallback value because we
             # want to preserve `.` in the module name. See
             # https://www.python.org/dev/peps/pep-0503/#normalized-names.
-            proj_name = canonicalize_project_name(req.project_name)
-            fallback_value = req.project_name.strip().lower().replace("-", "_")
+            proj_name = canonicalize_project_name(req.name)
+            fallback_value = req.name.strip().lower().replace("-", "_")
 
             modules_to_add: Tuple[str, ...]
             is_type_stub: bool

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -237,7 +237,7 @@ async def validate_pytest_cov_included(_pytest: PyTest):
         if not isinstance(lockfile_metadata, (PythonLockfileMetadataV2, PythonLockfileMetadataV3)):
             return
         requirements = lockfile_metadata.requirements
-    if not any(canonicalize_project_name(req.project_name) == "pytest-cov" for req in requirements):
+    if not any(canonicalize_project_name(req.name) == "pytest-cov" for req in requirements):
         raise ValueError(
             softwrap(
                 f"""\

--- a/src/python/pants/backend/python/goals/run_python_requirement.py
+++ b/src/python/pants/backend/python/goals/run_python_requirement.py
@@ -115,7 +115,7 @@ async def _resolve_entry_point(
         entry_point_module = module_mapping[field_set.address][0]
     elif len(reqs) == 1:
         # Use the canonicalized project name for a single-requirement target
-        entry_point_module = canonicalize_project_name(reqs[0].project_name)
+        entry_point_module = canonicalize_project_name(reqs[0].name)
     else:
         raise Exception(
             "Requirement must provide a single module, specify a single requirement, or specify "

--- a/src/python/pants/backend/python/macros/common_requirements_rule.py
+++ b/src/python/pants/backend/python/macros/common_requirements_rule.py
@@ -150,9 +150,7 @@ async def _generate_requirements(
         )
 
     requirements = parse_requirements_callback(digest_contents[0].content, requirements_full_path)
-    grouped_requirements = itertools.groupby(
-        requirements, lambda parsed_req: parsed_req.project_name
-    )
+    grouped_requirements = itertools.groupby(requirements, lambda parsed_req: parsed_req.name)
     result = tuple(
         generate_tgt(project_name, parsed_reqs_)
         for project_name, parsed_reqs_ in grouped_requirements

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -241,11 +241,11 @@ class PythonToolRequirementsBase(Subsystem, ExportableTool):
         first_default_requirement = PipRequirement.parse(cls.default_requirements[0])
         return next(
             _PackageNameAndVersion(
-                name=first_default_requirement.project_name, version=requirement["version"]
+                name=first_default_requirement.name, version=requirement["version"]
             )
             for resolve in lockfile_contents["locked_resolves"]
             for requirement in resolve["locked_requirements"]
-            if requirement["project_name"] == first_default_requirement.project_name
+            if requirement["project_name"] == first_default_requirement.name
         )
 
     def pex_requirements(

--- a/src/python/pants/backend/python/util_rules/lockfile_diff.py
+++ b/src/python/pants/backend/python/util_rules/lockfile_diff.py
@@ -7,14 +7,9 @@ import itertools
 import json
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Mapping
+from typing import Any, Mapping
 
-from packaging.version import parse
-
-if TYPE_CHECKING:
-    # We seem to get a version of `packaging` that doesn't have `LegacyVersion` when running
-    # pytest..
-    from packaging.version import LegacyVersion, Version
+from packaging.version import Version, parse
 
 from pants.backend.python.util_rules.pex_requirements import (
     LoadedLockfile,
@@ -33,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True, order=True)
 class PythonRequirementVersion:
-    _parsed: LegacyVersion | Version
+    _parsed: Version
 
     @classmethod
     def parse(cls, version: str) -> PythonRequirementVersion:

--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -701,10 +701,10 @@ async def _setup_constraints_repository_pex(
             url_reqs.add(req)
         else:
             name_reqs.add(req)
-            name_req_projects.add(canonicalize_project_name(req.project_name))
+            name_req_projects.add(canonicalize_project_name(req.name))
 
     constraint_file_projects = {
-        canonicalize_project_name(req.project_name) for req in constraints_file_reqs
+        canonicalize_project_name(req.name) for req in constraints_file_reqs
     }
     # Constraints files must only contain name reqs, not URL reqs (those are already
     # constrained by their very nature). See https://github.com/pypa/pip/issues/8210.

--- a/src/python/pants/backend/python/util_rules/pex_test_utils.py
+++ b/src/python/pants/backend/python/util_rules/pex_test_utils.py
@@ -31,26 +31,27 @@ from pants.util.strutil import softwrap
 
 @dataclass(frozen=True)
 class ExactRequirement:
-    project_name: str
+    name: str
     version: str
 
     @classmethod
     def parse(cls, requirement: str) -> ExactRequirement:
         req = PipRequirement.parse(requirement)
-        assert len(req.specs) == 1, softwrap(
+        assert len(req.specifier_set) == 1, softwrap(
             f"""
             Expected an exact requirement with only 1 specifier, given {requirement} with
-            {len(req.specs)} specifiers
+            {len(req.specifier_set)} specifiers
             """
         )
-        operator, version = req.specs[0]
+        specifier = list(req.specifier_set)[0]
+        operator, version = specifier.operator, specifier.version
         assert operator == "==", softwrap(
             f"""
             Expected an exact requirement using only the '==' specifier, given {requirement}
             using the {operator!r} operator
             """
         )
-        return cls(project_name=req.project_name, version=version)
+        return cls(name=req.name, version=version)
 
 
 def parse_requirements(requirements: Iterable[str]) -> Iterator[ExactRequirement]:

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1850,7 +1850,7 @@ class ValidNumbers(Enum):
         if num is None or self == self.all:  # type: ignore[comparison-overlap]
             return
         if self == self.positive_and_zero:  # type: ignore[comparison-overlap]
-            if num < 0:  # type: ignore[unreachable]
+            if num < 0:
                 raise InvalidFieldException(
                     f"The {repr(alias)} field in target {address} must be greater than or equal to "
                     f"zero, but was set to `{num}`."

--- a/src/python/pants/util/pip_requirement.py
+++ b/src/python/pants/util/pip_requirement.py
@@ -1,17 +1,12 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-# mypy: disable-error-code="import-untyped"
-#   Disables checking of the `pkg_resources` below which was awkward to figure out how to disable
-#   with a `# type: ignore[import-untyped]` comment.
-
 from __future__ import annotations
 
 import logging
 import urllib.parse
 
-import pkg_resources
-from pkg_resources.extern.packaging.requirements import InvalidRequirement
+from packaging.requirements import InvalidRequirement, Requirement
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +17,7 @@ class PipRequirement:
     @classmethod
     def parse(cls, line: str, description_of_origin: str = "") -> PipRequirement:
         try:
-            return cls(pkg_resources.Requirement.parse(line))
+            return cls(Requirement(line))
         except InvalidRequirement as e:
             scheme, netloc, path, query, fragment = urllib.parse.urlsplit(line, scheme="file")
             if fragment:
@@ -43,7 +38,7 @@ class PipRequirement:
                     full_url = urllib.parse.urlunsplit((scheme, netloc, path, query, fragment))
                     pep_440_req_str = f"{project}@ {full_url}"
                     try:
-                        return cls(pkg_resources.Requirement.parse(pep_440_req_str))
+                        return cls(Requirement(pep_440_req_str))
                     except InvalidRequirement:
                         # If parsing the converted URL fails for some reason, it's probably less
                         # confusing to the user if we raise the original error instead of one for
@@ -52,19 +47,19 @@ class PipRequirement:
             origin_str = f" in {description_of_origin}" if description_of_origin else ""
             raise ValueError(f"Invalid requirement '{line}'{origin_str}: {e}")
 
-    def __init__(self, req: pkg_resources.Requirement):
+    def __init__(self, req: Requirement):
         self._req = req
 
-    def as_pkg_resources_requirement(self) -> pkg_resources.Requirement:
+    def as_packaging_requirement(self) -> Requirement:
         return self._req
 
     @property
     def project_name(self) -> str:
-        return self._req.project_name
+        return self._req.name
 
     @property
     def specs(self):
-        return self._req.specs
+        return self._req.specifier
 
     @property
     def url(self):

--- a/src/python/pants/util/pip_requirement.py
+++ b/src/python/pants/util/pip_requirement.py
@@ -7,6 +7,7 @@ import logging
 import urllib.parse
 
 from packaging.requirements import InvalidRequirement, Requirement
+from packaging.specifiers import SpecifierSet
 
 logger = logging.getLogger(__name__)
 
@@ -54,11 +55,11 @@ class PipRequirement:
         return self._req
 
     @property
-    def project_name(self) -> str:
+    def name(self) -> str:
         return self._req.name
 
     @property
-    def specs(self):
+    def specifier_set(self) -> SpecifierSet:
         return self._req.specifier
 
     @property

--- a/src/python/pants/util/pip_requirement_test.py
+++ b/src/python/pants/util/pip_requirement_test.py
@@ -1,14 +1,15 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 import pytest
+from packaging.specifiers import SpecifierSet
 
 from pants.util.pip_requirement import PipRequirement
 
 
 def test_parse_simple() -> None:
     req = PipRequirement.parse("Foo.bar==1.2.3")
-    assert req.project_name == "Foo.bar"
-    assert req.specs == [("==", "1.2.3")]
+    assert req.name == "Foo.bar"
+    assert req.specifier_set == SpecifierSet("==1.2.3")
     assert req.url is None
 
 
@@ -22,15 +23,15 @@ def test_parse_simple() -> None:
 )
 def test_parse_old_style_vcs(url: str, expected_project: str, expected_url: str) -> None:
     req = PipRequirement.parse(url)
-    assert req.project_name == expected_project
-    assert req.specs == []
+    assert req.name == expected_project
+    assert req.specifier_set == SpecifierSet()
     assert req.url == expected_url or url
 
 
 def test_parse_pep440_vcs() -> None:
     req = PipRequirement.parse("Django@ git+https://github.com/django/django.git@stable/2.1.x")
-    assert req.project_name == "Django"
-    assert req.specs == []
+    assert req.name == "Django"
+    assert req.specifier_set == SpecifierSet()
     assert req.url == "git+https://github.com/django/django.git@stable/2.1.x"
 
 

--- a/src/python/pants/util/requirements.py
+++ b/src/python/pants/util/requirements.py
@@ -17,4 +17,9 @@ def parse_requirements_file(content: str, *, rel_path: str) -> Iterator[PipRequi
         if not line or line.startswith(("#", "-")):
             continue
 
+        # Strip comments which are othewise on a valid requirement line.
+        comment_pos = line.find("#")
+        if comment_pos != -1:
+            line = line[0:comment_pos].strip()
+
         yield PipRequirement.parse(line, description_of_origin=f"{rel_path} at line {i}")


### PR DESCRIPTION
Upgrade to MyPy v1.14.0.

Due to some deprecation messages regarding `pkg_resources` plus our use of its vendored copy of `packaging`, I also just upgraded `packaging` and switched to using that directly since `pkg_resources` should not be used any more.