### PR TITLE
Add extra buildInputs needed to use nix-shell on mac.

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -8,4 +8,9 @@ pkgs.mkShell {
     rustup
     protobuf
   ];
+  buildInputs = with pkgs; lib.optionals pkgs.stdenv.isDarwin [
+            pkgs.libiconv
+            pkgs.darwin.apple_sdk.frameworks.DiskArbitration
+            pkgs.darwin.apple_sdk.frameworks.Foundation
+          ];
 }


### PR DESCRIPTION
Fixes https://github.com/pantsbuild/pants/issues/21398.

There were a couple other needed to get this working. I just iteratively added these as I encountered them.