### PR TITLE
fix link format in aarch64 runner instructions

### DIFF
--- a/docs/docs/contributions/releases/github-actions-linux-aarch64-runners.mdx
+++ b/docs/docs/contributions/releases/github-actions-linux-aarch64-runners.mdx
@@ -23,7 +23,7 @@ Ubuntu 22 ARM64 AMI.
 It may occasionally be necessary to update this AMI, for example to pick up updates to the underlying standard
 AMI.
 
-To do so with Packer, see instructions in [build-support/packer/runson/runson.pkr.hcl]()
+To do so with Packer, see instructions in `build-support/packer/runson/runson.pkr.hcl`
 
 To do so manually:
 


### PR DESCRIPTION
This fixes the docs workflow: https://github.com/pantsbuild/pantsbuild.org/actions/runs/13019671126/job/36317230829?pr=312
```
Error:  Client bundle compiled with errors therefore further build is impossible.
Error: MDX compilation failed for file "/home/runner/work/pantsbuild.org/pantsbuild.org/docs/docs/contributions/releases/github-actions-linux-aarch64-runners.mdx"
Cause: Markdown link URL is mandatory in "docs/docs/contributions/releases/github-actions-linux-aarch64-runners.mdx" file (title: build-support/packer/runson/runson.pkr.hcl, line: 26).
Details:
Error: Markdown link URL is mandatory in "docs/docs/contributions/releases/github-actions-linux-aarch64-runners.mdx" file (title: build-support/packer/runson/runson.pkr.hcl, line: 26).
Error: Process completed with exit code 1.
```