### PR TITLE
docs: s/mac/linux/ for aarch64 links (Cherry-pick of #21882)

### DIFF
--- a/docs/docs/contributions/releases/index.mdx
+++ b/docs/docs/contributions/releases/index.mdx
@@ -8,4 +8,4 @@
 - [Release strategy](./release-strategy.mdx)
 - [Release process](./release-process.mdx)
 - [GitHub Actions macOS runners](./github-actions-macos-arm64-runners.mdx)
-- [GitHub Actions aarch64 runners](./github-actions-macos-aarch64-runners.mdx)
+- [GitHub Actions Linux aarch64 runners](./github-actions-linux-aarch64-runners.mdx)


### PR DESCRIPTION
Resolving the following warnings during docs sync:
```
Warning:  Docs markdown link couldn't be resolved: (./github-actions-macos-aarch64-runners.mdx) in source file "/home/runner/work/pantsbuild.org/pantsbuild.org/docs/docs/contributions/releases/index.mdx" for version current
Warning:  Docs markdown link couldn't be resolved: (./github-actions-macos-aarch64-runners.mdx) in source file "/home/runner/work/pantsbuild.org/pantsbuild.org/docs/docs/contributions/releases/index.mdx" for version current
Warning:  Docs markdown link couldn't be resolved: (./github-actions-macos-aarch64-runners.mdx) in source file "/home/runner/work/pantsbuild.org/pantsbuild.org/versioned_docs/version-2.24/docs/contributions/releases/index.mdx" for version 2.24
Warning:  Docs markdown link couldn't be resolved: (./github-actions-macos-aarch64-runners.mdx) in source file "/home/runner/work/pantsbuild.org/pantsbuild.org/versioned_docs/version-2.24/docs/contributions/releases/index.mdx" for version 2.24
Warning:  Docs markdown link couldn't be resolved: (./github-actions-macos-aarch64-runners.mdx) in source file "/home/runner/work/pantsbuild.org/pantsbuild.org/versioned_docs/version-2.23/docs/contributions/releases/index.mdx" for version 2.23
Warning:  Docs markdown link couldn't be resolved: (./github-actions-macos-aarch64-runners.mdx) in source file "/home/runner/work/pantsbuild.org/pantsbuild.org/versioned_docs/version-2.23/docs/contributions/releases/index.mdx" for version 2.23
```
