### PR TITLE
Surface stages in Dockerfiles which do not have tags

### DIFF
--- a/docs/notes/2.25.x.md
+++ b/docs/notes/2.25.x.md
@@ -68,6 +68,8 @@ Previously we did ad-hoc coercion of some field values, so that, e.g., you could
 
 Fixed an error which was caused when the same tool appeaed in both the `--docker-tools` and `--docker-optional-tools` options.
 
+Stages in multi-stage builds which only used a hash to identify the image version (that is, no tag) are now surfaced. They can now be used in the `docker_image.target_state` field.
+
 #### Helm
 
 Strict adherence to the [schema of Helm OCI registry configuration](https://www.pantsbuild.org/2.25/reference/subsystems/helm#registries) is now required.

--- a/src/python/pants/backend/docker/subsystems/dockerfile_parser_test.py
+++ b/src/python/pants/backend/docker/subsystems/dockerfile_parser_test.py
@@ -219,7 +219,7 @@ def test_baseimage_tags(rule_runner: RuleRunner) -> None:
     assert info.version_tags == (
         "stage0 latest",
         "stage1 v1.2",
-        # Stage 2 is not pinned with a tag.
+        "stage2",  # Stage 2 is not pinned with a tag.
         "stage3 v0.54.0",
         "python build-arg:PYTHON_VERSION",  # Parse tag from build arg.
         "stage5 $VERSION",

--- a/src/python/pants/backend/docker/subsystems/dockerfile_wrapper_script.py
+++ b/src/python/pants/backend/docker/subsystems/dockerfile_wrapper_script.py
@@ -201,10 +201,9 @@ def main(*dockerfile_names: str) -> Iterator[ParsedDockerfileInfo]:
                 return None
 
             return tuple(
-                f"{stage} {tag}"
+                f"{stage} {tag}" if tag else stage
                 for stage, name_parts in self.from_baseimages()
                 for tag in [_get_tag(name_parts[-1])]
-                if tag
             )
 
         def build_args(self) -> tuple[str, ...]:

--- a/src/rust/engine/src/intrinsics/dep_inference.rs
+++ b/src/rust/engine/src/intrinsics/dep_inference.rs
@@ -166,7 +166,10 @@ fn parse_dockerfile_info(deps_request: Value) -> PyGeneratorResponseNativeCall {
                             result
                                 .version_tags
                                 .into_iter()
-                                .map(|(stage, tag)| format!("{stage} {tag}"))
+                                .map(|(stage, tag)| match tag {
+                                    Some(tag) => format!("{stage} {tag}"),
+                                    None => stage.to_string(),
+                                })
                                 .collect::<Vec<_>>()
                                 .into_pyobject(py)?
                                 .into_any()


### PR DESCRIPTION
This MR surfaces Docker stages which do not have tags (using only a hash). For example, `FROM gcr.io/distroless/python3-debian12@sha256:8e432c787b5c0697dfbfd783120351d90fd5f23ba9fff29532bbdbb87bc13160 AS runtime` can now be used in the `docker_image.target_stage`. This is implemented in both the legacy and rust-based parsers.

fixes #21850