### PR TITLE
update Pex to 2.32.1

### DIFF
--- a/3rdparty/python/user_reqs.lock
+++ b/3rdparty/python/user_reqs.lock
@@ -246,19 +246,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "1275f7a45be9464efc1173084eaa30f866fe2e47d389406136d332ed4967ec56",
-              "url": "https://files.pythonhosted.org/packages/a5/32/8f6669fc4798494966bf446c8c4a162e0b5d893dff088afddf76414f70e1/certifi-2024.12.14-py3-none-any.whl"
+              "hash": "ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe",
+              "url": "https://files.pythonhosted.org/packages/38/fc/bce832fd4fd99766c04d1ee0eead6b0ec6486fb100ae5e74c1d91292b982/certifi-2025.1.31-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b650d30f370c2b724812bee08008be0c4163b163ddaec3f2546c1caf65f191db",
-              "url": "https://files.pythonhosted.org/packages/0f/bd/1d41ee578ce09523c81a15426705dd20969f5abf006d1afe8aeff0dd776a/certifi-2024.12.14.tar.gz"
+              "hash": "3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651",
+              "url": "https://files.pythonhosted.org/packages/1c/ab/c9f1e32b7b1bf505bf26f0ef697775960db7932abeb7b516de930ba2705f/certifi-2025.1.31.tar.gz"
             }
           ],
           "project_name": "certifi",
           "requires_dists": [],
           "requires_python": ">=3.6",
-          "version": "2024.12.14"
+          "version": "2025.1.31"
         },
         {
           "artifacts": [
@@ -2317,7 +2317,7 @@
   "only_wheels": [],
   "overridden": [],
   "path_mappings": {},
-  "pex_version": "2.32.0",
+  "pex_version": "2.32.1",
   "pip_version": "25.0",
   "prefer_older_binary": false,
   "requirements": [

--- a/docs/notes/2.25.x.md
+++ b/docs/notes/2.25.x.md
@@ -97,7 +97,7 @@ Several improvements to the Python Build Standalone backend (`pants.backend.pyth
 
 Changed references to Python Build Standalone to not refer to the [GitHub organization](https://github.com/astral-sh/python-build-standalone) as described in [Transferring Python Build Standalone Stewardship to Astral](https://gregoryszorc.com/blog/2024/12/03/transferring-python-build-standalone-stewardship-to-astral/).
 
-The default version of the [Pex](https://docs.pex-tool.org/) tool has been updated from 2.20.3 to [2.32.0](https://github.com/pex-tool/pex/releases/tag/v2.32.0).  Among many improvements and bug fixes, this unlocks support for pip [24.3.1](https://pip.pypa.io/en/stable/news/#v24-3-1) and Pip [25.0](https://pip.pypa.io/en/stable/news/#v25).
+The default version of the [Pex](https://docs.pex-tool.org/) tool has been updated from 2.20.3 to [2.32.1](https://github.com/pex-tool/pex/releases/tag/v2.32.1).  Among many improvements and bug fixes, this unlocks support for pip [24.3.1](https://pip.pypa.io/en/stable/news/#v24-3-1) and Pip [25.0](https://pip.pypa.io/en/stable/news/#v25).
 
 The `pants.backend.experimental.python.lint.ruff.check` backend [now supports](https://github.com/pantsbuild/pants/pull/21783) including [Ruff's output file as a report](https://www.pantsbuild.org/2.25/docs/python/overview/linters-and-formatters#bandit-flake8-pylint-and-ruff-report-files).
 

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -42,7 +42,7 @@ class PexCli(TemplatedExternalTool):
     name = "pex"
     help = "The PEX (Python EXecutable) tool (https://github.com/pex-tool/pex)."
 
-    default_version = "v2.32.0"
+    default_version = "v2.32.1"
     default_url_template = "https://github.com/pex-tool/pex/releases/download/{version}/pex"
     version_constraints = ">=2.13.0,<3.0"
 
@@ -65,8 +65,8 @@ class PexCli(TemplatedExternalTool):
                 (
                     cls.default_version,
                     plat,
-                    "9f692a652ef6af7e48f1ef392145b4e55145bc72d3ddc540eeb5ec01a09da15c",
-                    "4376835",
+                    "1e953b668ae930e0472e8a40709adbf7c342de9ad249d8bbbc719dce7e50e0f7",
+                    "4450314",
                 )
             )
             for plat in ["macos_arm64", "macos_x86_64", "linux_x86_64", "linux_arm64"]


### PR DESCRIPTION
```
Lockfile diff: 3rdparty/python/user_reqs.lock [python-default]

==                    Upgraded dependencies                     ==

  certifi                        2024.12.14   -->   2025.1.31
```

fixes #21851