### PR TITLE
perform tilde expansion on path_metadata_request

### DIFF
--- a/docs/notes/2.25.x.md
+++ b/docs/notes/2.25.x.md
@@ -201,6 +201,7 @@ The version of Python used by Pants itself is now [3.11](https://docs.python.org
 
 The oldest [glibc version](https://www.sourceware.org/glibc/wiki/Glibc%20Timeline) supported by the published Pants wheels is now 2.28.  This should have no effect unless you are running on extremely old Linux distributions.  See <https://github.com/pypa/manylinux> for background context on Python wheels and C libraries.
 
+The `path_metadata_request` intrinsic rule now performs tilde expansion on paths.  For example if one does `PATH="~/.bin:$PATH"` (note the quotes), leaving a literal `~` in one of the `PATH` entries, `path_metadata_request` will now expand that.
 
 ## Full Changelog
 

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1153,6 +1153,7 @@ dependencies = [
  "rule_graph",
  "serde",
  "serde_json",
+ "shellexpand",
  "smallvec",
  "stdio",
  "store",

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -74,6 +74,7 @@ rand = { workspace = true }
 regex = { workspace = true }
 reqwest = { version = "0.12", default-features = false, features = ["stream", "rustls-tls"] }
 rule_graph = { path = "rule_graph" }
+shellexpand = { workspace = true }
 smallvec = { version = "1", features = ["union"] }
 stdio = { path = "stdio" }
 store = { path = "fs/store" }

--- a/src/rust/engine/src/intrinsics/digests.rs
+++ b/src/rust/engine/src/intrinsics/digests.rs
@@ -372,6 +372,7 @@ fn path_metadata_request(single_path: Value) -> PyGeneratorResponseNativeCall {
             let path = externs::getattr_as_optional_string(arg, "path")
                 .map_err(|e| format!("Failed to get `path` for field: {e}"))?;
             let path = path.ok_or_else(|| "Path must not be `None`.".to_string())?;
+            let path = shellexpand::tilde(&path).to_string();
 
             let namespace: PyPathNamespace = externs::getattr(arg, "namespace")
                 .map_err(|e| format!("Failed to get `namespace` for field: {e}"))?;


### PR DESCRIPTION
Within the pants repo itself, the inputs to `path_metadata_request` are commonly used on the components of the `PATH` variable.  These would presumable be valid paths, but people have all sorts of crusty oddities in their shell configs.

In particular if one does something reasonable looking like `export PATH="~/.local/bin:$PATH"` (note the quotes) than the path component will be a literal `~/.local/bin` and not expanded to the home directory.  This is because tilde expansion happened *before* <https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06> the quote removal.

Since bash and friends are cool fine with literal tildes in `PATH`, everyone would reasonable expect pants to be too.