### PR TITLE
Run pyupgrade to 3.11

### DIFF
--- a/pants-plugins/internal_plugins/test_lockfile_fixtures/lockfile_fixture.py
+++ b/pants-plugins/internal_plugins/test_lockfile_fixtures/lockfile_fixture.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import textwrap
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable
 
 from _pytest.fixtures import FixtureRequest
 

--- a/pants-plugins/pants_explorer/server/graphql/query/rules.py
+++ b/pants-plugins/pants_explorer/server/graphql/query/rules.py
@@ -4,8 +4,9 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable, Iterator
 from dataclasses import asdict
-from typing import Iterable, Iterator, List, Optional, cast
+from typing import cast
 
 import strawberry
 from pants_explorer.server.graphql.context import GraphQLContext
@@ -17,12 +18,12 @@ from pants.help import help_info_extracter
 @strawberry.type(description=cast(str, help_info_extracter.RuleInfo.__doc__))
 class RuleInfo:
     name: str
-    description: Optional[str]
-    documentation: Optional[str]
+    description: str | None
+    documentation: str | None
     provider: str
     output_type: str
-    input_types: List[str]
-    awaitables: List[str]
+    input_types: list[str]
+    awaitables: list[str]
 
     @classmethod
     def from_help(cls, info: help_info_extracter.RuleInfo) -> RuleInfo:
@@ -34,10 +35,10 @@ class RuleInfo:
     description="Filter rules based on name and/or limit the number of entries to return."
 )
 class RulesQuery:
-    name_re: Optional[str] = strawberry.field(
+    name_re: str | None = strawberry.field(
         default=None, description="Select rules matching a regexp."
     )
-    limit: Optional[int] = strawberry.field(
+    limit: int | None = strawberry.field(
         default=None, description="Limit the number of entries returned."
     )
 
@@ -66,7 +67,7 @@ class QueryRulesMixin:
     """Get rules related info."""
 
     @strawberry.field
-    def rules(self, info: Info, query: Optional[RulesQuery] = None) -> List[RuleInfo]:
+    def rules(self, info: Info, query: RulesQuery | None = None) -> list[RuleInfo]:
         request_state = GraphQLContext.request_state_from_info(info)
         return list(
             RulesQuery.filter(

--- a/pants-plugins/pants_explorer/server/graphql/setup.py
+++ b/pants-plugins/pants_explorer/server/graphql/setup.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import json
-from typing import Callable
+from collections.abc import Callable
 
 import strawberry
 from pants_explorer.server.browser import Browser

--- a/pants-plugins/pants_explorer/server/uvicorn.py
+++ b/pants-plugins/pants_explorer/server/uvicorn.py
@@ -4,8 +4,9 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any, Callable
+from typing import Any
 
 from fastapi import FastAPI
 from pants_explorer.server.browser import BrowserRequest

--- a/pants.toml
+++ b/pants.toml
@@ -216,7 +216,7 @@ template_by_globs = "@build-support/preambles/config.yaml"
 diff = true
 
 [pyupgrade]
-args = ["--keep-runtime-typing", "--py38-plus"]
+args = ["--keep-runtime-typing", "--py311-plus"]
 
 
 [jvm]

--- a/src/python/pants/backend/adhoc/code_quality_tool.py
+++ b/src/python/pants/backend/adhoc/code_quality_tool.py
@@ -1,7 +1,8 @@
 # Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import ClassVar, Iterable
+from typing import ClassVar
 
 from pants.core.goals.fix import Fix, FixFilesRequest, FixResult
 from pants.core.goals.fmt import Fmt, FmtFilesRequest, FmtResult

--- a/src/python/pants/backend/adhoc/run_system_binary.py
+++ b/src/python/pants/backend/adhoc/run_system_binary.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 
 import logging
 import re
+from collections.abc import Mapping
 from dataclasses import dataclass
 from io import StringIO
-from typing import Mapping
 
 from pants.backend.adhoc.target_types import (
     SystemBinaryExtraSearchPathsField,

--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -6,7 +6,8 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from enum import Enum
-from typing import ClassVar, Match, Optional, Tuple, cast
+from re import Match
+from typing import ClassVar, cast
 
 from pants.backend.python.target_types import PexCompletePlatformsField, PythonResolveField
 from pants.backend.python.util_rules.faas import (
@@ -104,7 +105,7 @@ class PythonAwsLambdaFunctionRuntimes(Enum):
     PYTHON_312 = "python3.12"
     PYTHON_313 = "python3.13"
 
-    def to_interpreter_version(self) -> Tuple[int, int]:
+    def to_interpreter_version(self) -> tuple[int, int]:
         """Returns the Python version implied by the runtime, as (major, minor)."""
         mo = cast(Match, re.match(PYTHON_RUNTIME_REGEX, self.value))
         return int(mo.group("major")), int(mo.group("minor"))
@@ -153,7 +154,7 @@ class PythonAwsLambdaRuntime(PythonFaaSRuntimeField):
     )
 
     @classmethod
-    def compute_value(cls, raw_value: Optional[str], address: Address) -> Optional[str]:
+    def compute_value(cls, raw_value: str | None, address: Address) -> str | None:
         value = super().compute_value(raw_value, address)
         if value is None:
             return None
@@ -168,7 +169,7 @@ class PythonAwsLambdaRuntime(PythonFaaSRuntimeField):
             )
         return value
 
-    def to_interpreter_version(self) -> Optional[Tuple[int, int]]:
+    def to_interpreter_version(self) -> tuple[int, int] | None:
         """Returns the Python version implied by the runtime, as (major, minor)."""
         if self.value is None:
             return None

--- a/src/python/pants/backend/build_files/fix/base.py
+++ b/src/python/pants/backend/build_files/fix/base.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable
+from collections.abc import Iterable
 
 from pants.backend.build_files.utils import _get_build_file_partitioner_rules
 from pants.core.goals.fix import FixFilesRequest

--- a/src/python/pants/backend/build_files/fix/deprecations/renamed_fields_rules.py
+++ b/src/python/pants/backend/build_files/fix/deprecations/renamed_fields_rules.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 
 import tokenize
 from collections import defaultdict
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import DefaultDict, Mapping
+from typing import DefaultDict
 
 from pants.backend.build_files.fix.base import FixBuildFilesRequest
 from pants.backend.build_files.fix.deprecations.base import FixBUILDFileRequest, FixedBUILDFile

--- a/src/python/pants/backend/build_files/fmt/base.py
+++ b/src/python/pants/backend/build_files/fmt/base.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 
-from typing import Iterable
+from collections.abc import Iterable
 
 from pants.backend.build_files.utils import _get_build_file_partitioner_rules
 from pants.core.goals.fmt import FmtFilesRequest

--- a/src/python/pants/backend/build_files/utils.py
+++ b/src/python/pants/backend/build_files/utils.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import os
-from typing import Iterable
+from collections.abc import Iterable
 
 from pants.core.goals.fix import FixFilesRequest, Partitions
 from pants.core.goals.multi_tool_goal_helper import SkippableSubsystem

--- a/src/python/pants/backend/cc/dependency_inference/rules.py
+++ b/src/python/pants/backend/cc/dependency_inference/rules.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import re
 from collections import defaultdict
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import DefaultDict, Iterable
+from typing import DefaultDict
 
 from pants.backend.cc.subsystems.cc_infer import CCInferSubsystem
 from pants.backend.cc.target_types import CCDependenciesField, CCSourceField

--- a/src/python/pants/backend/cc/goals/tailor.py
+++ b/src/python/pants/backend/cc/goals/tailor.py
@@ -3,8 +3,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 from pants.backend.cc.target_types import CC_FILE_EXTENSIONS, CCSourcesGeneratorTarget
 from pants.core.goals.tailor import (

--- a/src/python/pants/backend/cc/lint/clangformat/rules.py
+++ b/src/python/pants/backend/cc/lint/clangformat/rules.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 from pants.backend.cc.lint.clangformat.subsystem import ClangFormat
 from pants.backend.cc.target_types import CCSourceField

--- a/src/python/pants/backend/cc/lint/clangformat/skip_field.py
+++ b/src/python/pants/backend/cc/lint/clangformat/skip_field.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable
+from collections.abc import Iterable
 
 from pants.backend.cc.target_types import CCSourcesGeneratorTarget, CCSourceTarget
 from pants.engine.rules import Rule

--- a/src/python/pants/backend/cc/lint/clangformat/subsystem.py
+++ b/src/python/pants/backend/cc/lint/clangformat/subsystem.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import os
-from typing import Iterable
+from collections.abc import Iterable
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript

--- a/src/python/pants/backend/cc/subsystems/compiler.py
+++ b/src/python/pants/backend/cc/subsystems/compiler.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Iterable
+from collections.abc import Iterable
 
 from pants.core.goals.resolves import ExportableTool
 from pants.core.util_rules.external_tool import TemplatedExternalTool

--- a/src/python/pants/backend/cc/target_types.py
+++ b/src/python/pants/backend/cc/target_types.py
@@ -3,9 +3,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import Enum
-from typing import Iterable
 
 from pants.engine.rules import Rule, collect_rules
 from pants.engine.target import (

--- a/src/python/pants/backend/cc/util_rules/toolchain.py
+++ b/src/python/pants/backend/cc/util_rules/toolchain.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 from pants.backend.cc.subsystems.compiler import CCSubsystem, ExternalCCSubsystem
 from pants.backend.cc.target_types import CCLanguage

--- a/src/python/pants/backend/codegen/avro/java/rules.py
+++ b/src/python/pants/backend/codegen/avro/java/rules.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Iterable
 
 from pants.backend.codegen.avro.java.subsystem import AvroSubsystem
 from pants.backend.codegen.avro.target_types import (

--- a/src/python/pants/backend/codegen/avro/java/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/avro/java/rules_integration_test.py
@@ -2,8 +2,8 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from __future__ import annotations
 
+from collections.abc import Iterable
 from textwrap import dedent
-from typing import Iterable
 
 import pytest
 

--- a/src/python/pants/backend/codegen/protobuf/go/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/go/rules_integration_test.py
@@ -2,8 +2,8 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from __future__ import annotations
 
+from collections.abc import Iterable
 from textwrap import dedent
-from typing import Iterable
 
 import pytest
 

--- a/src/python/pants/backend/codegen/protobuf/java/dependency_inference.py
+++ b/src/python/pants/backend/codegen/protobuf/java/dependency_inference.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import FrozenSet
 
 from pants.backend.codegen.protobuf.target_types import (
     ProtobufDependenciesField,
@@ -51,7 +50,7 @@ class ProtobufJavaRuntimeForResolveRequest:
 
 @dataclass(frozen=True)
 class ProtobufJavaRuntimeForResolve:
-    addresses: FrozenSet[Address]
+    addresses: frozenset[Address]
 
 
 @rule
@@ -83,7 +82,7 @@ class ProtobufJavaGrpcRuntimeForResolveRequest:
 
 @dataclass(frozen=True)
 class ProtobufJavaGrpcRuntimeForResolve:
-    addresses: FrozenSet[Address]
+    addresses: frozenset[Address]
 
 
 @rule

--- a/src/python/pants/backend/codegen/protobuf/jvm_symbol_mapper.py
+++ b/src/python/pants/backend/codegen/protobuf/jvm_symbol_mapper.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import os
 import re
 from collections import defaultdict
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import DefaultDict, Mapping
+from typing import DefaultDict
 
 from pants.backend.codegen.protobuf.target_types import AllProtobufTargets, ProtobufSourceField
 from pants.engine.addresses import Address

--- a/src/python/pants/backend/codegen/protobuf/protobuf_dependency_inference_test.py
+++ b/src/python/pants/backend/codegen/protobuf/protobuf_dependency_inference_test.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from textwrap import dedent
-from typing import Set
 
 import pytest
 
@@ -69,7 +68,7 @@ from pants.util.frozendict import FrozenDict
         ),
     ],
 )
-def test_parse_proto_imports(file_content: str, expected: Set[str]) -> None:
+def test_parse_proto_imports(file_content: str, expected: set[str]) -> None:
     assert set(parse_proto_imports(file_content)) == expected
 
 

--- a/src/python/pants/backend/codegen/protobuf/scala/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/scala/rules_integration_test.py
@@ -2,8 +2,8 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from __future__ import annotations
 
+from collections.abc import Iterable
 from textwrap import dedent
-from typing import Iterable
 
 import pytest
 

--- a/src/python/pants/backend/codegen/soap/java/dependency_inference.py
+++ b/src/python/pants/backend/codegen/soap/java/dependency_inference.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import FrozenSet
 
 from pants.backend.codegen.soap.java.jaxws import JaxWsTools
 from pants.backend.codegen.soap.target_types import WsdlDependenciesField
@@ -41,7 +40,7 @@ class JaxWSJavaRuntimeForResolveRequest:
 
 @dataclass(frozen=True)
 class JaxWSJavaRuntimeForResolve:
-    addresses: FrozenSet[Address]
+    addresses: frozenset[Address]
 
 
 @rule

--- a/src/python/pants/backend/codegen/soap/java/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/soap/java/rules_integration_test.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 import textwrap
+from collections.abc import Iterable
 from textwrap import dedent
-from typing import Iterable
 
 import pytest
 

--- a/src/python/pants/backend/codegen/soap/java/symbol_mapper.py
+++ b/src/python/pants/backend/codegen/soap/java/symbol_mapper.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import DefaultDict, Mapping, Tuple
+from collections.abc import Mapping
+from typing import DefaultDict
 
 from pants.backend.codegen.soap.java.extra_fields import JavaPackageField
 from pants.backend.codegen.soap.target_types import AllWsdlTargets
@@ -27,7 +28,7 @@ class FirstPartyWsdlJaxWsTargetsMappingRequest(FirstPartyMappingRequest):
 async def map_first_party_wsdl_jaxws_targets_to_symbols(
     _: FirstPartyWsdlJaxWsTargetsMappingRequest, wsdl_targets: AllWsdlTargets, jvm: JvmSubsystem
 ) -> SymbolMap:
-    package_mapping: DefaultDict[Tuple[_ResolveName, str], OrderedSet[Address]] = defaultdict(
+    package_mapping: DefaultDict[tuple[_ResolveName, str], OrderedSet[Address]] = defaultdict(
         OrderedSet
     )
     for target in wsdl_targets:

--- a/src/python/pants/backend/codegen/thrift/jvm_symbol_mapper.py
+++ b/src/python/pants/backend/codegen/thrift/jvm_symbol_mapper.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import DefaultDict, Mapping
+from typing import DefaultDict
 
 from pants.backend.codegen.thrift.target_types import AllThriftTargets, ThriftSourceField
 from pants.backend.codegen.thrift.thrift_parser import ParsedThrift, ParsedThriftRequest

--- a/src/python/pants/backend/codegen/thrift/thrift_parser.py
+++ b/src/python/pants/backend/codegen/thrift/thrift_parser.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Mapping
 
 from pants.backend.codegen.thrift.target_types import ThriftSourceField
 from pants.engine.engine_aware import EngineAwareParameter

--- a/src/python/pants/backend/codegen/thrift/thrift_parser_test.py
+++ b/src/python/pants/backend/codegen/thrift/thrift_parser_test.py
@@ -3,8 +3,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from textwrap import dedent
-from typing import Iterable
 
 import pytest
 

--- a/src/python/pants/backend/cue/goals/fix.py
+++ b/src/python/pants/backend/cue/goals/fix.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable
+from collections.abc import Iterable
 
 from pants.backend.cue import subsystem
 from pants.backend.cue.rules import _run_cue

--- a/src/python/pants/backend/cue/goals/fix_test.py
+++ b/src/python/pants/backend/cue/goals/fix_test.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 from collections import namedtuple
+from collections.abc import Iterable
 from textwrap import dedent
-from typing import Iterable
 
 import pytest
 

--- a/src/python/pants/backend/cue/goals/lint.py
+++ b/src/python/pants/backend/cue/goals/lint.py
@@ -3,7 +3,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Iterable
+from collections.abc import Iterable
+from typing import Any
 
 from pants.backend.cue import subsystem
 from pants.backend.cue.rules import _run_cue

--- a/src/python/pants/backend/cue/goals/lint_test.py
+++ b/src/python/pants/backend/cue/goals/lint_test.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from collections import namedtuple
+from collections.abc import Iterable
 from textwrap import dedent
-from typing import Any, Iterable
+from typing import Any
 
 import pytest
 

--- a/src/python/pants/backend/debian/rules.py
+++ b/src/python/pants/backend/debian/rules.py
@@ -3,9 +3,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Iterable
 
 from pants.backend.debian.target_types import (
     DebianInstallPrefix,

--- a/src/python/pants/backend/debian/target_types.py
+++ b/src/python/pants/backend/debian/target_types.py
@@ -1,7 +1,7 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+from collections.abc import Sequence
 from pathlib import PurePath
-from typing import Sequence
 
 from pants.core.goals.package import OutputPathField
 from pants.engine.target import (

--- a/src/python/pants/backend/debian/target_types_test.py
+++ b/src/python/pants/backend/debian/target_types_test.py
@@ -1,6 +1,6 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-from typing import Iterable, Type
+from collections.abc import Iterable
 
 import pytest
 
@@ -41,7 +41,7 @@ def test_sources_expected_num_files(sources_rule_runner: RuleRunner) -> None:
         )
     )
 
-    def hydrate(sources_cls: Type[DebianSources], sources: Iterable[str]) -> HydratedSources:
+    def hydrate(sources_cls: type[DebianSources], sources: Iterable[str]) -> HydratedSources:
         return sources_rule_runner.request(
             HydratedSources,
             [

--- a/src/python/pants/backend/docker/goals/package_image.py
+++ b/src/python/pants/backend/docker/goals/package_image.py
@@ -6,10 +6,11 @@ import json
 import logging
 import os
 import re
+from collections.abc import Iterator
 from dataclasses import asdict, dataclass
 from functools import partial
 from itertools import chain
-from typing import Iterator, Literal, cast
+from typing import Literal, cast
 
 # Re-exporting BuiltDockerImage here, as it has its natural home here, but has moved out to resolve
 # a dependency cycle from docker_build_context.

--- a/src/python/pants/backend/docker/goals/package_image_test.py
+++ b/src/python/pants/backend/docker/goals/package_image_test.py
@@ -7,8 +7,9 @@ import json
 import logging
 import os.path
 from collections import namedtuple
+from collections.abc import Callable
 from textwrap import dedent
-from typing import Callable, ContextManager, cast
+from typing import ContextManager, cast
 
 import pytest
 

--- a/src/python/pants/backend/docker/goals/publish_test.py
+++ b/src/python/pants/backend/docker/goals/publish_test.py
@@ -3,7 +3,8 @@
 
 from __future__ import annotations
 
-from typing import Callable, cast
+from collections.abc import Callable
+from typing import cast
 
 import pytest
 

--- a/src/python/pants/backend/docker/registries.py
+++ b/src/python/pants/backend/docker/registries.py
@@ -3,8 +3,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from dataclasses import dataclass
-from typing import Any, Iterator
+from typing import Any
 
 from pants.util.frozendict import FrozenDict
 from pants.util.strutil import softwrap

--- a/src/python/pants/backend/docker/subsystems/dockerfile_wrapper_script.py
+++ b/src/python/pants/backend/docker/subsystems/dockerfile_wrapper_script.py
@@ -6,9 +6,9 @@ from __future__ import annotations
 import json
 import re
 import sys
+from collections.abc import Iterator
 from dataclasses import asdict, dataclass
 from itertools import chain
-from typing import Iterator
 
 #
 # Note: This file is used as a pex entry point in the execution sandbox.

--- a/src/python/pants/backend/docker/target_types.py
+++ b/src/python/pants/backend/docker/target_types.py
@@ -6,10 +6,9 @@ from __future__ import annotations
 import os
 import re
 from abc import ABC, abstractmethod
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass
-from typing import Callable, ClassVar, Iterator, Optional, cast
-
-from typing_extensions import final
+from typing import ClassVar, cast, final
 
 from pants.backend.docker.registries import ALL_DEFAULT_REGISTRIES
 from pants.backend.docker.subsystems.docker_options import DockerOptions
@@ -81,7 +80,7 @@ class DockerImageContextRootField(StringField):
     )
 
     @classmethod
-    def compute_value(cls, raw_value: Optional[str], address: Address) -> Optional[str]:
+    def compute_value(cls, raw_value: str | None, address: Address) -> str | None:
         value_or_default = super().compute_value(raw_value, address=address)
         if isinstance(value_or_default, str) and value_or_default.startswith("/"):
             val = value_or_default.strip("/")

--- a/src/python/pants/backend/docker/util_rules/docker_binary.py
+++ b/src/python/pants/backend/docker/util_rules/docker_binary.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from typing import Mapping, Sequence, cast
+from typing import cast
 
 from pants.backend.docker.subsystems.docker_options import DockerOptions
 from pants.backend.docker.util_rules.docker_build_args import DockerBuildArgs

--- a/src/python/pants/backend/docker/util_rules/docker_build_args.py
+++ b/src/python/pants/backend/docker/util_rules/docker_build_args.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Union
 
 from pants.backend.docker.subsystems.docker_options import DockerOptions
 from pants.backend.docker.target_types import DockerImageBuildArgsField
@@ -29,7 +28,7 @@ class DockerBuildArgs(KeyValueSequenceUtil):
             {k: overrides_dict.get(k, v) for k, v in self.to_dict().items()}
         )
 
-    def extended(self, more: Union[DockerBuildArgs, list[str]]) -> DockerBuildArgs:
+    def extended(self, more: DockerBuildArgs | list[str]) -> DockerBuildArgs:
         """Create a new DockerBuildArgs out of this and a list of strs to add."""
         if isinstance(more, DockerBuildArgs):
             return DockerBuildArgs.from_strings(*self, *more)

--- a/src/python/pants/backend/docker/util_rules/docker_build_context.py
+++ b/src/python/pants/backend/docker/util_rules/docker_build_context.py
@@ -7,8 +7,8 @@ import logging
 import re
 import shlex
 from abc import ABC
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
-from typing import Iterable, Mapping
 
 from pants.backend.docker.package_types import BuiltDockerImage
 from pants.backend.docker.subsystems.dockerfile_parser import DockerfileInfo, DockerfileInfoRequest

--- a/src/python/pants/backend/docker/util_rules/docker_build_env.py
+++ b/src/python/pants/backend/docker/util_rules/docker_build_env.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Mapping
 
 from pants.backend.docker.subsystems.docker_options import DockerOptions
 from pants.backend.docker.util_rules.docker_build_args import (

--- a/src/python/pants/backend/docker/util_rules/dockerfile_test.py
+++ b/src/python/pants/backend/docker/util_rules/dockerfile_test.py
@@ -3,8 +3,9 @@
 
 # from __future__ import annotations
 
+from collections.abc import Mapping
 from textwrap import dedent
-from typing import Any, Mapping
+from typing import Any
 
 import pytest
 

--- a/src/python/pants/backend/docker/utils.py
+++ b/src/python/pants/backend/docker/utils.py
@@ -6,10 +6,9 @@ from __future__ import annotations
 import difflib
 import os.path
 import re
+from collections.abc import Callable, Iterable, Iterator, Sequence
 from fnmatch import fnmatch
-from typing import Callable, Iterable, Iterator, Sequence, TypeVar
-
-from typing_extensions import Self
+from typing import Self, TypeVar
 
 from pants.help.maybe_color import MaybeColor
 from pants.util.ordered_set import FrozenOrderedSet

--- a/src/python/pants/backend/experimental/cc/lint/clangformat/register.py
+++ b/src/python/pants/backend/experimental/cc/lint/clangformat/register.py
@@ -8,7 +8,7 @@ See https://clang.llvm.org/docs/ClangFormat.html for details.
 
 from __future__ import annotations
 
-from typing import Iterable
+from collections.abc import Iterable
 
 from pants.backend.cc.lint.clangformat import rules as clangformat_rules
 from pants.backend.cc.lint.clangformat import skip_field, subsystem

--- a/src/python/pants/backend/experimental/javascript/lint/prettier/register.py
+++ b/src/python/pants/backend/experimental/javascript/lint/prettier/register.py
@@ -8,7 +8,7 @@ See https://prettier.io/ for details.
 
 from __future__ import annotations
 
-from typing import Iterable
+from collections.abc import Iterable
 
 from pants.backend.javascript.lint.prettier import rules as prettier_rules
 from pants.backend.javascript.lint.prettier import skip_field

--- a/src/python/pants/backend/experimental/javascript/register.py
+++ b/src/python/pants/backend/experimental/javascript/register.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable
+from collections.abc import Iterable
 
 from pants.backend.javascript import package_json
 from pants.backend.javascript.goals import export, lockfile, tailor, test

--- a/src/python/pants/backend/experimental/openapi/register.py
+++ b/src/python/pants/backend/experimental/openapi/register.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable
+from collections.abc import Iterable
 
 from pants.backend.openapi import dependency_inference
 from pants.backend.openapi.goals import tailor

--- a/src/python/pants/backend/experimental/python/typecheck/pyright/register.py
+++ b/src/python/pants/backend/experimental/python/typecheck/pyright/register.py
@@ -8,7 +8,7 @@ See https://github.com/Microsoft/pyright for details.
 
 from __future__ import annotations
 
-from typing import Iterable
+from collections.abc import Iterable
 
 from pants.backend.javascript.subsystems import nodejs
 from pants.backend.python.typecheck.pyright import rules as pyright_rules

--- a/src/python/pants/backend/experimental/swift/register.py
+++ b/src/python/pants/backend/experimental/swift/register.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable
+from collections.abc import Iterable
 
 from pants.backend.swift.goals import tailor
 from pants.backend.swift.target_types import SwiftSourcesGeneratorTarget, SwiftSourceTarget

--- a/src/python/pants/backend/experimental/tools/semgrep/register.py
+++ b/src/python/pants/backend/experimental/tools/semgrep/register.py
@@ -9,7 +9,7 @@ See https://semgrep.dev/ for details.
 
 from __future__ import annotations
 
-from typing import Iterable
+from collections.abc import Iterable
 
 from pants.backend.python.goals import lockfile as python_lockfile
 from pants.backend.tools.semgrep import rules as semgrep_rules

--- a/src/python/pants/backend/experimental/tools/yamllint/register.py
+++ b/src/python/pants/backend/experimental/tools/yamllint/register.py
@@ -8,7 +8,7 @@ See https://yamllint.readthedocs.io/ for details.
 
 from __future__ import annotations
 
-from typing import Iterable
+from collections.abc import Iterable
 
 from pants.backend.python.goals import lockfile as python_lockfile
 from pants.backend.tools.yamllint import rules as yamllint_rules

--- a/src/python/pants/backend/experimental/typescript/register.py
+++ b/src/python/pants/backend/experimental/typescript/register.py
@@ -1,6 +1,6 @@
 # Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-from typing import Iterable, Union
+from collections.abc import Iterable
 
 from pants.backend.tsx.goals import tailor as tsx_tailor
 from pants.backend.tsx.target_types import (
@@ -35,7 +35,7 @@ def target_types() -> Iterable[type[Target]]:
     )
 
 
-def rules() -> Iterable[Union[Rule, UnionRule]]:
+def rules() -> Iterable[Rule | UnionRule]:
     return (
         *dependency_inference_rules.rules(),
         *tailor.rules(),

--- a/src/python/pants/backend/go/go_sources/load_go_binary.py
+++ b/src/python/pants/backend/go/go_sources/load_go_binary.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 from pants.backend.go.util_rules.build_opts import GoBuildOptions
 from pants.backend.go.util_rules.build_pkg import BuildGoPackageRequest, BuiltGoPackage

--- a/src/python/pants/backend/go/goals/generate.py
+++ b/src/python/pants/backend/go/goals/generate.py
@@ -7,8 +7,8 @@ import os
 import re
 import shlex
 import string
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Mapping
 
 from pants.backend.go.target_types import GoPackageSourcesField
 from pants.backend.go.util_rules import first_party_pkg, goroot, sdk

--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -8,8 +8,9 @@ import json
 import logging
 import os
 from collections import deque
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
-from typing import Any, Iterable, Sequence
+from typing import Any
 
 from pants.backend.go.dependency_inference import GoModuleImportPathsMapping
 from pants.backend.go.subsystems.gotest import GoTestSubsystem

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import os
-from typing import Iterable, Optional, Sequence, Tuple
+from collections.abc import Iterable, Sequence
 
 from pants.core.goals.package import OutputPathField
 from pants.core.goals.run import RestartableField
@@ -359,8 +359,8 @@ class GoPackageSourcesField(MultipleSourcesField):
 
     @classmethod
     def compute_value(
-        cls, raw_value: Optional[Iterable[str]], address: Address
-    ) -> Optional[Tuple[str, ...]]:
+        cls, raw_value: Iterable[str] | None, address: Address
+    ) -> tuple[str, ...] | None:
         value_or_default = super().compute_value(raw_value, address)
         if not value_or_default:
             raise InvalidFieldException(

--- a/src/python/pants/backend/go/testutil.py
+++ b/src/python/pants/backend/go/testutil.py
@@ -8,12 +8,12 @@ import hashlib
 import io
 import json
 import zipfile
+from collections.abc import Iterable
 from textwrap import dedent  # noqa: PNT20
-from typing import Dict, Iterable, Tuple
 
 
 # Implements hashing algorithm from https://cs.opensource.google/go/x/mod/+/refs/tags/v0.5.0:sumdb/dirhash/hash.go.
-def compute_module_hash(files: Iterable[Tuple[str, str]]) -> str:
+def compute_module_hash(files: Iterable[tuple[str, str]]) -> str:
     """Compute a module hash that can be used in go.sum for an emulated remote package."""
     sorted_files = sorted(files, key=lambda x: x[0])
     summary = ""
@@ -27,8 +27,8 @@ def compute_module_hash(files: Iterable[Tuple[str, str]]) -> str:
 
 
 def gen_module_gomodproxy(
-    version: str, import_path: str, files: Iterable[Tuple[str, str]]
-) -> Dict[str, str | bytes]:
+    version: str, import_path: str, files: Iterable[tuple[str, str]]
+) -> dict[str, str | bytes]:
     go_mod_content = dedent(
         f"""\
         module {import_path}

--- a/src/python/pants/backend/go/util_rules/assembly.py
+++ b/src/python/pants/backend/go/util_rules/assembly.py
@@ -4,9 +4,9 @@
 from __future__ import annotations
 
 import os.path
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Iterable
 
 from pants.backend.go.util_rules.goroot import GoRoot
 from pants.backend.go.util_rules.sdk import GoSdkProcess, GoSdkToolIDRequest, GoSdkToolIDResult

--- a/src/python/pants/backend/go/util_rules/build_opts.py
+++ b/src/python/pants/backend/go/util_rules/build_opts.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 from pants.backend.go.subsystems.golang import GolangSubsystem
 from pants.backend.go.subsystems.gotest import GoTestSubsystem

--- a/src/python/pants/backend/go/util_rules/build_opts_test.py
+++ b/src/python/pants/backend/go/util_rules/build_opts_test.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import os
 import pprint
 import subprocess
+from collections.abc import Callable, Iterable
 from textwrap import dedent
-from typing import Callable, Iterable
 
 import pytest
 

--- a/src/python/pants/backend/go/util_rules/build_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg.py
@@ -6,9 +6,9 @@ import dataclasses
 import hashlib
 import os.path
 from collections import deque
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Iterable, Mapping
 
 from pants.backend.go.util_rules import cgo, coverage
 from pants.backend.go.util_rules.assembly import (

--- a/src/python/pants/backend/go/util_rules/build_pkg_target.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import dataclasses
 import json
 from dataclasses import dataclass
-from typing import ClassVar, Type, cast
+from typing import ClassVar, cast
 
 from pants.backend.go.dependency_inference import GoModuleImportPathsMapping
 from pants.backend.go.go_sources.load_go_binary import LoadedGoBinary, LoadedGoBinaryRequest
@@ -140,7 +140,7 @@ def maybe_get_codegen_request_type(
     if not tgt.has_field(SourcesField):
         return None
     generate_request_types = cast(
-        FrozenOrderedSet[Type[GoCodegenBuildRequest]], union_membership.get(GoCodegenBuildRequest)
+        FrozenOrderedSet[type[GoCodegenBuildRequest]], union_membership.get(GoCodegenBuildRequest)
     )
     sources_field = tgt[SourcesField]
     relevant_requests = [

--- a/src/python/pants/backend/go/util_rules/cgo.py
+++ b/src/python/pants/backend/go/util_rules/cgo.py
@@ -7,9 +7,9 @@ import logging
 import os
 import shlex
 import textwrap
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Iterable
 
 from pants.backend.go.subsystems.golang import GolangSubsystem
 from pants.backend.go.util_rules import cgo_binaries, cgo_pkgconfig

--- a/src/python/pants/backend/go/util_rules/cgo_security.py
+++ b/src/python/pants/backend/go/util_rules/cgo_security.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 import string
-from typing import Iterable, Sequence
+from collections.abc import Iterable, Sequence
 
 from pants.util.memo import memoized
 

--- a/src/python/pants/backend/go/util_rules/cgo_test.py
+++ b/src/python/pants/backend/go/util_rules/cgo_test.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import os
 import subprocess
+from collections.abc import Iterable
 from pathlib import Path
 from textwrap import dedent
-from typing import Iterable
 
 import pytest
 

--- a/src/python/pants/backend/go/util_rules/coverage_html.py
+++ b/src/python/pants/backend/go/util_rules/coverage_html.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import io
 import math
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Sequence
 
 import chevron
 

--- a/src/python/pants/backend/go/util_rules/embedcfg.py
+++ b/src/python/pants/backend/go/util_rules/embedcfg.py
@@ -4,8 +4,9 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
-from typing import Any, Iterable, Mapping
+from typing import Any
 
 from pants.util.frozendict import FrozenDict
 from pants.util.strutil import strip_prefix

--- a/src/python/pants/backend/go/util_rules/go_bootstrap.py
+++ b/src/python/pants/backend/go/util_rules/go_bootstrap.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Collection
 from dataclasses import dataclass
-from typing import Collection
 
 from pants.backend.go.subsystems.golang import GolangSubsystem
 from pants.core.util_rules import asdf, search_paths

--- a/src/python/pants/backend/go/util_rules/pkg_pattern.py
+++ b/src/python/pants/backend/go/util_rules/pkg_pattern.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from typing import Callable
+from collections.abc import Callable
 
 # Adapted from Go toolchain:
 # https://github.com/golang/go/blob/6a70292d1cb3464e5b2c2c03341e5148730a1889/src/cmd/internal/pkgpattern/pkgpattern.go

--- a/src/python/pants/backend/go/util_rules/pkg_pattern_test.py
+++ b/src/python/pants/backend/go/util_rules/pkg_pattern_test.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from __future__ import annotations
 
-from typing import Callable
+from collections.abc import Callable
 
 from pants.backend.go.util_rules.pkg_pattern import match_pattern, match_simple_pattern
 

--- a/src/python/pants/backend/go/util_rules/sdk.py
+++ b/src/python/pants/backend/go/util_rules/sdk.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 import textwrap
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
-from typing import Iterable, Mapping
 
 from pants.backend.go.subsystems.golang import GolangSubsystem
 from pants.backend.go.util_rules import goroot

--- a/src/python/pants/backend/go/util_rules/testutil.py
+++ b/src/python/pants/backend/go/util_rules/testutil.py
@@ -1,8 +1,8 @@
 # Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 import json
+from collections.abc import Mapping
 from textwrap import dedent  # noqa: PNT20
-from typing import Mapping
 
 EXPECTED_VERSION = "1.17"
 EXPECTED_VERSION_NEXT_RELEASE = "1.18"

--- a/src/python/pants/backend/go/util_rules/vendor.py
+++ b/src/python/pants/backend/go/util_rules/vendor.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 from pants.backend.go.go_sources import load_go_binary
 from pants.backend.go.go_sources.load_go_binary import LoadedGoBinary, LoadedGoBinaryRequest

--- a/src/python/pants/backend/google_cloud_function/python/target_types.py
+++ b/src/python/pants/backend/google_cloud_function/python/target_types.py
@@ -3,7 +3,8 @@
 
 import re
 from enum import Enum
-from typing import Match, Optional, Tuple, cast
+from re import Match
+from typing import cast
 
 from pants.backend.python.target_types import PexCompletePlatformsField, PythonResolveField
 from pants.backend.python.util_rules.faas import (
@@ -56,7 +57,7 @@ class PythonGoogleCloudFunctionRuntimes(Enum):
     PYTHON_311 = "python311"
     PYTHON_312 = "python312"
 
-    def to_interpreter_version(self) -> Tuple[int, int]:
+    def to_interpreter_version(self) -> tuple[int, int]:
         """Returns the Python version implied by the runtime, as (major, minor)."""
         mo = cast(Match, re.match(PYTHON_RUNTIME_REGEX, self.value))
         return int(mo.group("major")), int(mo.group("minor"))
@@ -115,7 +116,7 @@ class PythonGoogleCloudFunctionRuntime(PythonFaaSRuntimeField):
     )
 
     @classmethod
-    def compute_value(cls, raw_value: Optional[str], address: Address) -> Optional[str]:
+    def compute_value(cls, raw_value: str | None, address: Address) -> str | None:
         value = super().compute_value(raw_value, address)
         if value is None:
             return None
@@ -126,7 +127,7 @@ class PythonGoogleCloudFunctionRuntime(PythonFaaSRuntimeField):
             )
         return value
 
-    def to_interpreter_version(self) -> Optional[Tuple[int, int]]:
+    def to_interpreter_version(self) -> tuple[int, int] | None:
         """Returns the Python version implied by the runtime, as (major, minor)."""
         if self.value is None:
             return None

--- a/src/python/pants/backend/helm/check/kubeconform/deployment_test.py
+++ b/src/python/pants/backend/helm/check/kubeconform/deployment_test.py
@@ -3,8 +3,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from textwrap import dedent
-from typing import Iterable
 
 import pytest
 

--- a/src/python/pants/backend/helm/check/kubeconform/extra_fields.py
+++ b/src/python/pants/backend/helm/check/kubeconform/extra_fields.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 from abc import ABCMeta
 from dataclasses import dataclass
-from typing import Type
 
 from pants.backend.helm.target_types import HelmChartTarget, HelmDeploymentTarget
 from pants.engine.target import (
@@ -77,8 +76,8 @@ class KubeconformFieldSet(FieldSet, metaclass=ABCMeta):
         return target[KubeconformSkipField].value
 
 
-_HELM_TARGET_TYPES: list[Type[Target]] = [HelmChartTarget, HelmDeploymentTarget]
-_KUBECONFORM_COMMON_FIELD_TYPES: list[Type[Field]] = [
+_HELM_TARGET_TYPES: list[type[Target]] = [HelmChartTarget, HelmDeploymentTarget]
+_KUBECONFORM_COMMON_FIELD_TYPES: list[type[Field]] = [
     KubeconformSkipField,
     KubeconformIgnoreSourcesField,
     KubeconformIgnoreMissingSchemasField,

--- a/src/python/pants/backend/helm/dependency_inference/chart.py
+++ b/src/python/pants/backend/helm/dependency_inference/chart.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 from pants.backend.helm.resolve import artifacts
 from pants.backend.helm.resolve.artifacts import ThirdPartyHelmArtifactMapping

--- a/src/python/pants/backend/helm/dependency_inference/unittest.py
+++ b/src/python/pants/backend/helm/dependency_inference/unittest.py
@@ -3,9 +3,9 @@
 
 import logging
 import os
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Sequence
 
 from pants.backend.helm.goals.tailor import _SNAPSHOT_FOLDER_NAME, _TESTS_FOLDER_NAME
 from pants.backend.helm.target_types import AllHelmChartTargets, HelmUnitTestDependenciesField

--- a/src/python/pants/backend/helm/goals/deploy_test.py
+++ b/src/python/pants/backend/helm/goals/deploy_test.py
@@ -3,8 +3,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Mapping
 from textwrap import dedent
-from typing import Iterable, Mapping
 
 import pytest
 

--- a/src/python/pants/backend/helm/goals/lint_test.py
+++ b/src/python/pants/backend/helm/goals/lint_test.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable
+from collections.abc import Iterable
 
 import pytest
 

--- a/src/python/pants/backend/helm/resolve/artifacts.py
+++ b/src/python/pants/backend/helm/resolve/artifacts.py
@@ -4,8 +4,9 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Any, Iterable, cast
+from typing import Any, cast
 
 from pants.backend.helm.subsystems.helm import HelmSubsystem
 from pants.backend.helm.target_types import (

--- a/src/python/pants/backend/helm/resolve/remotes.py
+++ b/src/python/pants/backend/helm/resolve/remotes.py
@@ -3,8 +3,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from dataclasses import dataclass
-from typing import Any, Iterator, cast
+from typing import Any, cast
 
 from pants.util.frozendict import FrozenDict
 from pants.util.memo import memoized_method

--- a/src/python/pants/backend/helm/subsystems/helm.py
+++ b/src/python/pants/backend/helm/subsystems/helm.py
@@ -4,7 +4,8 @@
 from __future__ import annotations
 
 import os
-from typing import Any, Iterable
+from collections.abc import Iterable
+from typing import Any
 
 from pants.backend.helm.resolve.remotes import HelmRemotes
 from pants.backend.helm.target_types import HelmChartTarget, HelmRegistriesField

--- a/src/python/pants/backend/helm/subsystems/post_renderer.py
+++ b/src/python/pants/backend/helm/subsystems/post_renderer.py
@@ -7,10 +7,11 @@ import logging
 import os
 import pkgutil
 import shlex
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from pathlib import PurePath
 from textwrap import dedent  # noqa: PNT20
-from typing import Any, Iterable, Mapping
+from typing import Any
 
 import yaml
 

--- a/src/python/pants/backend/helm/util_rules/chart.py
+++ b/src/python/pants/backend/helm/util_rules/chart.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 
 import dataclasses
 import logging
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Any, Iterable
+from typing import Any
 
 from pants.backend.helm.dependency_inference import chart as chart_inference
 from pants.backend.helm.resolve import fetch

--- a/src/python/pants/backend/helm/util_rules/renderer.py
+++ b/src/python/pants/backend/helm/util_rules/renderer.py
@@ -8,10 +8,11 @@ import logging
 import os
 import re
 from collections import defaultdict
+from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import Enum
 from itertools import chain
-from typing import Any, Iterable
+from typing import Any
 
 from pants.backend.helm.subsystems import post_renderer
 from pants.backend.helm.subsystems.post_renderer import HelmPostRenderer

--- a/src/python/pants/backend/helm/util_rules/tool.py
+++ b/src/python/pants/backend/helm/util_rules/tool.py
@@ -7,11 +7,11 @@ import dataclasses
 import logging
 import os
 from abc import ABCMeta
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
-from typing import Any, ClassVar, Generic, Iterable, Mapping, Type, TypeVar
+from typing import Any, ClassVar, Generic, TypeVar, final
 
 import yaml
-from typing_extensions import final
 
 from pants.backend.helm.subsystems.helm import HelmSubsystem
 from pants.backend.helm.utils.yaml import snake_case_attr_dict
@@ -168,13 +168,13 @@ _EHPB = TypeVar("_EHPB", bound="ExternalHelmPluginBinding")
 class ExternalHelmPluginBinding(Generic[_ExternalHelmPlugin], metaclass=ABCMeta):
     """Union type allowing Pants to discover global external Helm plugins."""
 
-    plugin_subsystem_cls: ClassVar[Type[ExternalHelmPlugin]]
+    plugin_subsystem_cls: ClassVar[type[ExternalHelmPlugin]]
 
     name: str
 
     @final
     @classmethod
-    def create(cls: Type[_EHPB]) -> _EHPB:
+    def create(cls: type[_EHPB]) -> _EHPB:
         return cls(name=cls.plugin_subsystem_cls.plugin_name)
 
 

--- a/src/python/pants/backend/helm/utils/yaml.py
+++ b/src/python/pants/backend/helm/utils/yaml.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 
 from abc import ABCMeta
 from collections import defaultdict
+from collections.abc import Callable, Iterable, Iterator, Mapping
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Any, Callable, Generic, Iterable, Iterator, Mapping, Optional, Type, TypeVar
+from typing import Any, Generic, TypeVar
 
 from pants.engine.collection import Collection
 from pants.util.frozendict import FrozenDict
@@ -169,7 +170,7 @@ class _YamlDocumentIndexNode(Generic[T]):
     paths: FrozenDict[YamlPath, T]
 
     @classmethod
-    def empty(cls: Type[_YamlDocumentIndexNode[T]]) -> _YamlDocumentIndexNode[T]:
+    def empty(cls: type[_YamlDocumentIndexNode[T]]) -> _YamlDocumentIndexNode[T]:
         return cls(paths=FrozenDict())
 
     def to_json_dict(self) -> dict[str, dict[str, str]]:
@@ -209,7 +210,7 @@ class FrozenYamlIndex(Generic[T]):
     def empty(cls: type[FrozenYamlIndex[T]]) -> FrozenYamlIndex[T]:
         return FrozenYamlIndex[T](_data=FrozenDict())
 
-    def transform_values(self, func: Callable[[T], Optional[R]]) -> FrozenYamlIndex[R]:
+    def transform_values(self, func: Callable[[T], R | None]) -> FrozenYamlIndex[R]:
         """Transforms the values of the given indexed collection into those that are returned from
         the received function.
 

--- a/src/python/pants/backend/java/dependency_inference/symbol_mapper.py
+++ b/src/python/pants/backend/java/dependency_inference/symbol_mapper.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
-from typing import Mapping
+from collections.abc import Mapping
 
 from pants.backend.java.dependency_inference.types import JavaSourceDependencyAnalysis
 from pants.backend.java.target_types import JavaSourceField

--- a/src/python/pants/backend/java/dependency_inference/types.py
+++ b/src/python/pants/backend/java/dependency_inference/types.py
@@ -3,8 +3,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any, Sequence
+from typing import Any
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/java/goals/tailor.py
+++ b/src/python/pants/backend/java/goals/tailor.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 from pants.backend.java.subsystems.javac import JavacSubsystem
 from pants.backend.java.target_types import (

--- a/src/python/pants/backend/javascript/dependency_inference/rules.py
+++ b/src/python/pants/backend/javascript/dependency_inference/rules.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import itertools
 import logging
 import os.path
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Iterable
 
 from pants.backend.javascript import package_json
 from pants.backend.javascript.package_json import (

--- a/src/python/pants/backend/javascript/goals/lockfile.py
+++ b/src/python/pants/backend/javascript/goals/lockfile.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import os.path
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 from pants.backend.javascript import nodejs_project_environment
 from pants.backend.javascript.nodejs_project import AllNodeJSProjects, NodeJSProject

--- a/src/python/pants/backend/javascript/goals/tailor.py
+++ b/src/python/pants/backend/javascript/goals/tailor.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 
 import dataclasses
 import os
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 from pants.backend.javascript.package_json import PackageJsonTarget
 from pants.backend.javascript.target_types import (

--- a/src/python/pants/backend/javascript/goals/test.py
+++ b/src/python/pants/backend/javascript/goals/test.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import dataclasses
 from collections import defaultdict
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Iterable
 
 from pants.backend.javascript import install_node_package, nodejs_project_environment
 from pants.backend.javascript.install_node_package import (

--- a/src/python/pants/backend/javascript/install_node_package.py
+++ b/src/python/pants/backend/javascript/install_node_package.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import os.path
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 from pants.backend.javascript import nodejs_project_environment
 from pants.backend.javascript.dependency_inference.rules import rules as dependency_inference_rules

--- a/src/python/pants/backend/javascript/lint/prettier/rules.py
+++ b/src/python/pants/backend/javascript/lint/prettier/rules.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 from pants.backend.javascript.lint.prettier.subsystem import Prettier
 from pants.backend.javascript.subsystems import nodejs_tool

--- a/src/python/pants/backend/javascript/lint/prettier/skip_field.py
+++ b/src/python/pants/backend/javascript/lint/prettier/skip_field.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable
+from collections.abc import Iterable
 
 from pants.backend.javascript.target_types import JSSourcesGeneratorTarget, JSSourceTarget
 from pants.engine.rules import Rule

--- a/src/python/pants/backend/javascript/lint/prettier/subsystem.py
+++ b/src/python/pants/backend/javascript/lint/prettier/subsystem.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import os
-from typing import Iterable
+from collections.abc import Iterable
 
 from pants.backend.javascript.subsystems.nodejs_tool import NodeJSToolBase
 from pants.core.util_rules.config_files import ConfigFilesRequest

--- a/src/python/pants/backend/javascript/nodejs_project.py
+++ b/src/python/pants/backend/javascript/nodejs_project.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import itertools
 import os.path
+from collections.abc import Iterable
 from dataclasses import dataclass, replace
 from pathlib import PurePath
-from typing import Iterable
 
 from pants.backend.javascript import package_json
 from pants.backend.javascript.package_json import (

--- a/src/python/pants/backend/javascript/nodejs_project_test.py
+++ b/src/python/pants/backend/javascript/nodejs_project_test.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from typing import Iterable
+from collections.abc import Iterable
 
 import pytest
 

--- a/src/python/pants/backend/javascript/package/rules.py
+++ b/src/python/pants/backend/javascript/package/rules.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import ClassVar, Iterable
+from typing import ClassVar
 
 from pants.backend.javascript import install_node_package
 from pants.backend.javascript.install_node_package import (

--- a/src/python/pants/backend/javascript/package_json.py
+++ b/src/python/pants/backend/javascript/package_json.py
@@ -7,8 +7,9 @@ import json
 import logging
 import os.path
 from abc import ABC
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
-from typing import Any, ClassVar, Iterable, Literal, Mapping, Optional, Tuple
+from typing import Any, ClassVar, Literal
 
 import yaml
 
@@ -209,8 +210,8 @@ class NodePackageScriptsField(SequenceField[NodeScript]):
 
     @classmethod
     def compute_value(
-        cls, raw_value: Optional[Iterable[Any]], address: Address
-    ) -> Optional[Tuple[NodeScript, ...]]:
+        cls, raw_value: Iterable[Any] | None, address: Address
+    ) -> tuple[NodeScript, ...] | None:
         values = super().compute_value(raw_value, address)
         test_scripts = [value for value in values or () if isinstance(value, NodeTestScript)]
         if len(test_scripts) > 1:

--- a/src/python/pants/backend/javascript/package_json_test.py
+++ b/src/python/pants/backend/javascript/package_json_test.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterable
 from textwrap import dedent
-from typing import Iterable
 
 import pytest
 

--- a/src/python/pants/backend/javascript/resolve.py
+++ b/src/python/pants/backend/javascript/resolve.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 from pants.backend.javascript import nodejs_project
 from pants.backend.javascript.nodejs_project import AllNodeJSProjects, NodeJSProject

--- a/src/python/pants/backend/javascript/run/rules.py
+++ b/src/python/pants/backend/javascript/run/rules.py
@@ -2,8 +2,8 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 from pants.backend.javascript import install_node_package
 from pants.backend.javascript.install_node_package import (

--- a/src/python/pants/backend/javascript/subsystems/nodejs.py
+++ b/src/python/pants/backend/javascript/subsystems/nodejs.py
@@ -6,9 +6,10 @@ from __future__ import annotations
 import itertools
 import logging
 import os.path
+from collections.abc import Collection, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from itertools import groupby
-from typing import ClassVar, Collection, Iterable, Mapping, Sequence
+from typing import ClassVar
 
 from nodesemver import min_satisfying
 

--- a/src/python/pants/backend/javascript/subsystems/nodejs_tool.py
+++ b/src/python/pants/backend/javascript/subsystems/nodejs_tool.py
@@ -3,8 +3,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
-from typing import ClassVar, Iterable, Mapping
+from typing import ClassVar
 
 from pants.backend.javascript import install_node_package, nodejs_project_environment
 from pants.backend.javascript.install_node_package import (

--- a/src/python/pants/backend/jsx/goals/tailor.py
+++ b/src/python/pants/backend/jsx/goals/tailor.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 import dataclasses
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 from pants.backend.jsx.target_types import (
     JSX_FILE_EXTENSIONS,

--- a/src/python/pants/backend/kotlin/compile/kotlinc_plugins.py
+++ b/src/python/pants/backend/kotlin/compile/kotlinc_plugins.py
@@ -3,8 +3,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
-from typing import Iterable, Iterator
 
 from pants.backend.kotlin.subsystems.kotlinc import KotlincSubsystem
 from pants.backend.kotlin.target_types import (

--- a/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser.py
+++ b/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import json
 import os
+from collections.abc import Iterator
 from dataclasses import dataclass
-from typing import Any, Iterator
+from typing import Any
 
 from pants.core.goals.resolves import ExportableTool
 from pants.core.util_rules.source_files import SourceFiles

--- a/src/python/pants/backend/kotlin/dependency_inference/symbol_mapper.py
+++ b/src/python/pants/backend/kotlin/dependency_inference/symbol_mapper.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from collections import defaultdict
-from typing import Mapping
+from collections.abc import Mapping
 
 from pants.backend.kotlin.dependency_inference.kotlin_parser import KotlinSourceDependencyAnalysis
 from pants.backend.kotlin.target_types import KotlinSourceField

--- a/src/python/pants/backend/kotlin/goals/tailor.py
+++ b/src/python/pants/backend/kotlin/goals/tailor.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 from pants.backend.kotlin.subsystems.kotlin import KotlinSubsystem
 from pants.backend.kotlin.target_types import (

--- a/src/python/pants/backend/makeself/goals/package.py
+++ b/src/python/pants/backend/makeself/goals/package.py
@@ -6,9 +6,9 @@ from __future__ import annotations
 import dataclasses
 import logging
 import os
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Iterable, Optional, Tuple
 
 from pants.backend.makeself.subsystem import MakeselfTool
 from pants.backend.makeself.system_binaries import MakeselfBinaryShimsRequest
@@ -77,10 +77,10 @@ class CreateMakeselfArchive:
     input_digest: Digest
     description: str = dataclasses.field(compare=False)
     output_filename: str
-    extra_tools: Optional[Tuple[str, ...]] = None
+    extra_tools: tuple[str, ...] | None = None
     level: LogLevel = LogLevel.INFO
-    cache_scope: Optional[ProcessCacheScope] = None
-    timeout_seconds: Optional[int] = None
+    cache_scope: ProcessCacheScope | None = None
+    timeout_seconds: int | None = None
 
 
 @rule

--- a/src/python/pants/backend/makeself/goals/run.py
+++ b/src/python/pants/backend/makeself/goals/run.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import os
-from typing import Iterable, Tuple
+from collections.abc import Iterable
 
 from pants.backend.makeself.goals.package import MakeselfArchiveFieldSet, package_makeself_binary
 from pants.backend.makeself.subsystem import RunMakeselfArchive
@@ -27,7 +27,7 @@ async def run_makeself_archive(request: RunMakeselfArchive) -> Process:
         )
     )
     output_directories = []
-    argv: Tuple[str, ...] = (request.exe,)
+    argv: tuple[str, ...] = (request.exe,)
 
     if output_directory := request.output_directory:
         output_directories = [output_directory]

--- a/src/python/pants/backend/makeself/subsystem.py
+++ b/src/python/pants/backend/makeself/subsystem.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable, Optional
 
 from pants.core.goals.resolves import ExportableTool
 from pants.core.util_rules import external_tool
@@ -75,8 +75,8 @@ class RunMakeselfArchive:
     input_digest: Digest
     description: str
     level: LogLevel = LogLevel.INFO
-    output_directory: Optional[str] = None
-    extra_args: Optional[tuple[str, ...]] = None
+    output_directory: str | None = None
+    extra_args: tuple[str, ...] | None = None
     extra_tools: tuple[str, ...] = ()
 
 

--- a/src/python/pants/backend/makeself/system_binaries.py
+++ b/src/python/pants/backend/makeself/system_binaries.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable, Tuple
 
 from pants.backend.shell.subsystems.shell_setup import ShellSetup
 from pants.backend.shell.util_rules.builtin import BASH_BUILTIN_COMMANDS
@@ -51,7 +51,7 @@ class MakeselfBinaryShimsRequest:
     simplicity.
     """
 
-    extra_tools: Tuple[str, ...]
+    extra_tools: tuple[str, ...]
     rationale: str
 
 

--- a/src/python/pants/backend/nfpm/fields/contents.py
+++ b/src/python/pants/backend/nfpm/fields/contents.py
@@ -6,8 +6,9 @@ from __future__ import annotations
 import os
 import stat
 from abc import ABCMeta
+from collections.abc import Iterable
 from enum import Enum
-from typing import Any, ClassVar, Iterable, Optional, Union, cast
+from typing import Any, ClassVar, cast
 
 from pants.backend.nfpm.fields.all import NfpmDependencies
 from pants.backend.nfpm.subsystem import MTIME_DEFAULT
@@ -156,7 +157,7 @@ class NfpmContentFileModeField(IntField):
     valid_numbers = ValidNumbers.positive_and_zero
 
     @classmethod
-    def compute_value(cls, raw_value: Optional[Union[int, str]], address: Address) -> Optional[int]:
+    def compute_value(cls, raw_value: int | str | None, address: Address) -> int | None:
         if isinstance(raw_value, str):
             try:
                 octal_value = int(raw_value, 8)
@@ -235,7 +236,7 @@ class _SrcDstSequenceField(TupleSequenceField):
 
     @classmethod
     def compute_value(
-        cls, raw_value: Optional[Iterable[Iterable[str]]], address: Address
+        cls, raw_value: Iterable[Iterable[str]] | None, address: Address
     ) -> tuple[tuple[str, str], ...]:
         src_dst_map = super().compute_value(raw_value, address)
         if not src_dst_map:
@@ -272,9 +273,9 @@ class _NfpmContentOverridesField(OverridesField):
     @classmethod
     def compute_value(
         cls,
-        raw_value: Optional[dict[Union[str, tuple[str, ...]], dict[str, Any]]],
+        raw_value: dict[str | tuple[str, ...], dict[str, Any]] | None,
         address: Address,
-    ) -> Optional[FrozenDict[tuple[str, ...], FrozenDict[str, ImmutableValue]]]:
+    ) -> FrozenDict[tuple[str, ...], FrozenDict[str, ImmutableValue]] | None:
         value = super().compute_value(raw_value, address)
         if not value:
             return None
@@ -316,7 +317,7 @@ class NfpmContentFileSourceField(OptionalSingleSourceField):
     )
 
     @classmethod
-    def compute_value(cls, raw_value: Optional[str], address: Address) -> Optional[str]:
+    def compute_value(cls, raw_value: str | None, address: Address) -> str | None:
         value_or_default = super().compute_value(raw_value, address)
         # This field should either have a path to a file or it should be None.
         # If it is a path to a file, we rely on standard glob_match_error_behavior
@@ -585,7 +586,7 @@ class NfpmContentDirsField(StringSequenceField):
     )
 
     @classmethod
-    def compute_value(cls, raw_value: Optional[Iterable[str]], address: Address) -> tuple[str, ...]:
+    def compute_value(cls, raw_value: Iterable[str] | None, address: Address) -> tuple[str, ...]:
         dst_dirs = super().compute_value(raw_value, address)
         assert dst_dirs is not None  # it is required
         # nFPM normalizes paths to be absolute, so "" is effectively the same as "/".

--- a/src/python/pants/backend/nfpm/fields/deb.py
+++ b/src/python/pants/backend/nfpm/fields/deb.py
@@ -3,8 +3,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from enum import Enum
-from typing import ClassVar, Iterable, Optional
+from typing import ClassVar
 
 from pants.backend.nfpm.fields._relationships import NfpmPackageRelationshipsField
 from pants.backend.nfpm.fields.all import NfpmDependencies
@@ -154,8 +155,8 @@ class NfpmDebTriggersField(DictStringToStringSequenceField):
 
     @classmethod
     def compute_value(
-        cls, raw_value: Optional[dict[str, Iterable[str]]], address: Address
-    ) -> Optional[FrozenDict[str, tuple[str, ...]]]:
+        cls, raw_value: dict[str, Iterable[str]] | None, address: Address
+    ) -> FrozenDict[str, tuple[str, ...]] | None:
         value_or_default = super().compute_value(raw_value, address)
         # only certain keys are allowed in this dictionary.
         if value_or_default and not cls.valid_keys.issuperset(value_or_default.keys()):

--- a/src/python/pants/backend/nfpm/fields/rpm.py
+++ b/src/python/pants/backend/nfpm/fields/rpm.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import ClassVar, Optional
+from typing import ClassVar
 
 from pants.backend.nfpm.config import NfpmContent
 from pants.backend.nfpm.fields._relationships import NfpmPackageRelationshipsField
@@ -312,7 +312,7 @@ class NfpmRpmCompressionField(StringField):
     )
 
     @classmethod
-    def compute_value(cls, raw_value: Optional[str], address: Address) -> Optional[str]:
+    def compute_value(cls, raw_value: str | None, address: Address) -> str | None:
         if raw_value is None:
             # valid_choices has only algorithms, not compression level.
             # So, return default value, skipping check for default in valid_choices.

--- a/src/python/pants/backend/nfpm/fields/scripts.py
+++ b/src/python/pants/backend/nfpm/fields/scripts.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import os
-from typing import ClassVar, Optional
+from typing import ClassVar
 
 from pants.engine.internals.native_engine import Address
 from pants.engine.target import AsyncFieldMixin, DictStringToStringField, InvalidFieldException
@@ -27,8 +27,8 @@ class NfpmPackageScriptsField(AsyncFieldMixin, DictStringToStringField):
 
     @classmethod
     def compute_value(
-        cls, raw_value: Optional[dict[str, str]], address: Address
-    ) -> Optional[FrozenDict[str, str]]:
+        cls, raw_value: dict[str, str] | None, address: Address
+    ) -> FrozenDict[str, str] | None:
         value_or_default = super().compute_value(raw_value, address)
         if value_or_default:
             invalid_keys = value_or_default.keys() - cls.nfpm_aliases.keys()

--- a/src/python/pants/backend/nfpm/util_rules/inject_config.py
+++ b/src/python/pants/backend/nfpm/util_rules/inject_config.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 from pants.backend.nfpm.fields.scripts import NfpmPackageScriptsField
 from pants.engine.environment import EnvironmentName

--- a/src/python/pants/backend/openapi/codegen/java/rules_integration_test.py
+++ b/src/python/pants/backend/openapi/codegen/java/rules_integration_test.py
@@ -3,8 +3,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from textwrap import dedent
-from typing import Iterable
 
 import pytest
 

--- a/src/python/pants/backend/openapi/codegen/java/symbol_mapper.py
+++ b/src/python/pants/backend/openapi/codegen/java/symbol_mapper.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import DefaultDict, Mapping, Tuple
+from collections.abc import Mapping
+from typing import DefaultDict
 
 from pants.backend.openapi.codegen.java.extra_fields import (
     OpenApiJavaApiPackageField,
@@ -36,7 +37,7 @@ async def map_first_party_openapi_java_targets_to_symbols(
     all_openapi_document_targets: AllOpenApiDocumentTargets,
     jvm: JvmSubsystem,
 ) -> SymbolMap:
-    package_mapping: DefaultDict[Tuple[_ResolveName, str], OrderedSet[Address]] = defaultdict(
+    package_mapping: DefaultDict[tuple[_ResolveName, str], OrderedSet[Address]] = defaultdict(
         OrderedSet
     )
     for target in all_openapi_document_targets:

--- a/src/python/pants/backend/openapi/codegen/python/generate.py
+++ b/src/python/pants/backend/openapi/codegen/python/generate.py
@@ -8,7 +8,6 @@ import logging
 from collections import defaultdict
 from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Tuple
 
 from packaging.utils import canonicalize_name as canonicalize_project_name
 
@@ -147,7 +146,7 @@ async def compile_openapi_into_python(
         Get(Digest, DigestSubset(normalized_digest, PathGlobs(["**/*.py"]))),
     )
     requirements_contents = await Get(DigestContents, Digest, requirements_digest)
-    runtime_dependencies: Tuple[PipRequirement, ...] = ()
+    runtime_dependencies: tuple[PipRequirement, ...] = ()
     if len(requirements_contents) > 0:
         file = requirements_contents[0]
         runtime_dependencies = tuple(

--- a/src/python/pants/backend/openapi/codegen/python/generate_integration_test.py
+++ b/src/python/pants/backend/openapi/codegen/python/generate_integration_test.py
@@ -3,9 +3,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from importlib import resources
 from textwrap import dedent
-from typing import Iterable
 
 import pytest
 

--- a/src/python/pants/backend/openapi/dependency_inference.py
+++ b/src/python/pants/backend/openapi/dependency_inference.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import contextlib
 import json
 import os.path
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, Mapping
+from typing import Any
 
 import yaml
 

--- a/src/python/pants/backend/openapi/goals/tailor.py
+++ b/src/python/pants/backend/openapi/goals/tailor.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 import itertools
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 from pants.backend.openapi.dependency_inference import OpenApiDependencies, ParseOpenApiSources
 from pants.backend.openapi.subsystems.openapi import OpenApiSubsystem

--- a/src/python/pants/backend/openapi/util_rules/generator_process.py
+++ b/src/python/pants/backend/openapi/util_rules/generator_process.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 
 import dataclasses
 import re
+from collections.abc import Iterable, Iterator, Mapping
 from dataclasses import dataclass
-from typing import Iterable, Iterator, Mapping
 
 from pants.backend.openapi.subsystems import openapi_generator
 from pants.backend.openapi.subsystems.openapi_generator import OpenAPIGenerator

--- a/src/python/pants/backend/project_info/dependencies_test.py
+++ b/src/python/pants/backend/project_info/dependencies_test.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from functools import partial
 from textwrap import dedent
-from typing import Any, List, Optional, Union
+from typing import Any
 
 import pytest
 
@@ -39,7 +39,7 @@ def rule_runner() -> PythonRuleRunner:
 
 
 def create_python_sources(
-    rule_runner: PythonRuleRunner, directory: str, *, dependencies: Optional[List[str]] = None
+    rule_runner: PythonRuleRunner, directory: str, *, dependencies: list[str] | None = None
 ) -> None:
     rule_runner.write_files(
         {
@@ -85,9 +85,9 @@ def assert_dependencies(
     rule_runner: PythonRuleRunner,
     *,
     specs: list[str],
-    expected: Union[list[str], dict[str, Any]],
+    expected: list[str] | dict[str, Any],
     transitive: bool = False,
-    output_file: Optional[str] = None,
+    output_file: str | None = None,
     closed: bool = False,
     output_format: DependenciesOutputFormat = DependenciesOutputFormat.text,
 ) -> None:

--- a/src/python/pants/backend/project_info/dependents.py
+++ b/src/python/pants/backend/project_info/dependents.py
@@ -2,9 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 import json
 from collections import defaultdict
+from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import Enum
-from typing import Iterable, Set
 
 from pants.engine.addresses import Address, Addresses
 from pants.engine.collection import DeduplicatedCollection
@@ -88,7 +88,7 @@ def find_dependents(
     request: DependentsRequest, address_to_dependents: AddressToDependents
 ) -> Dependents:
     check = set(request.addresses)
-    known_dependents: Set[Address] = set()
+    known_dependents: set[Address] = set()
     while True:
         dependents = set(known_dependents)
         for target in check:

--- a/src/python/pants/backend/project_info/dependents_test.py
+++ b/src/python/pants/backend/project_info/dependents_test.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 import json
 from functools import partial
-from typing import Dict, List, Optional, Union
 
 import pytest
 
@@ -41,10 +40,10 @@ def rule_runner() -> RuleRunner:
 def assert_dependents(
     rule_runner: RuleRunner,
     *,
-    targets: List[str],
-    expected: Union[List[str], Dict[str, List[str]]],
+    targets: list[str],
+    expected: list[str] | dict[str, list[str]],
     transitive: bool = False,
-    output_file: Optional[str] = None,
+    output_file: str | None = None,
     closed: bool = False,
     output_format: DependentsOutputFormat = DependentsOutputFormat.text,
 ) -> None:

--- a/src/python/pants/backend/project_info/filedeps.py
+++ b/src/python/pants/backend/project_info/filedeps.py
@@ -2,8 +2,8 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import itertools
+from collections.abc import Iterable
 from pathlib import PurePath
-from typing import Iterable
 
 from pants.base.build_root import BuildRoot
 from pants.build_graph.address import BuildFileAddressRequest

--- a/src/python/pants/backend/project_info/filter_targets.py
+++ b/src/python/pants/backend/project_info/filter_targets.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import re
 from enum import Enum
-from typing import Pattern
+from re import Pattern
 
 from pants.base.deprecated import warn_or_error
 from pants.engine.addresses import Addresses

--- a/src/python/pants/backend/project_info/list_roots_test.py
+++ b/src/python/pants/backend/project_info/list_roots_test.py
@@ -1,7 +1,6 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import List, Optional
 
 import pytest
 
@@ -17,10 +16,10 @@ def rule_runner() -> RuleRunner:
 
 def assert_roots(
     rule_runner: RuleRunner,
-    configured: List[str],
+    configured: list[str],
     *,
-    marker_files: Optional[List[str]] = None,
-    expected: Optional[List[str]] = None,
+    marker_files: list[str] | None = None,
+    expected: list[str] | None = None,
 ) -> None:
     result = rule_runner.run_goal_rule(
         Roots,

--- a/src/python/pants/backend/project_info/list_targets.py
+++ b/src/python/pants/backend/project_info/list_targets.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import logging
-from typing import Dict, cast
+from typing import cast
 
 from pants.engine.addresses import Address, Addresses
 from pants.engine.console import Console
@@ -41,7 +41,7 @@ async def list_targets(
         # We must preserve target generators, not replace with their generated targets.
         targets = await Get(UnexpandedTargets, Addresses, addresses)
         addresses_with_descriptions = cast(
-            Dict[Address, str],
+            dict[Address, str],
             {
                 tgt.address: tgt[DescriptionField].value
                 for tgt in targets

--- a/src/python/pants/backend/project_info/paths.py
+++ b/src/python/pants/backend/project_info/paths.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 
 import json
 from collections import deque
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 from pants.base.specs import Specs
 from pants.base.specs_parser import SpecsParser

--- a/src/python/pants/backend/project_info/paths_test.py
+++ b/src/python/pants/backend/project_info/paths_test.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import json
 from textwrap import dedent
-from typing import ClassVar, List
+from typing import ClassVar
 
 import pytest
 
@@ -86,7 +86,7 @@ def assert_paths(
     *,
     path_from: str,
     path_to: str,
-    expected: List[List[str]] | None = None,
+    expected: list[list[str]] | None = None,
 ) -> None:
     args = []
     if path_from:

--- a/src/python/pants/backend/project_info/peek.py
+++ b/src/python/pants/backend/project_info/peek.py
@@ -8,8 +8,9 @@ import collections.abc
 import json
 import logging
 from abc import ABCMeta
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, fields, is_dataclass, replace
-from typing import Any, Iterable, Mapping, Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 from pants.core.goals.deploy import Deploy, DeployFieldSet
 from pants.core.goals.package import Package, PackageFieldSet

--- a/src/python/pants/backend/project_info/peek_test.py
+++ b/src/python/pants/backend/project_info/peek_test.py
@@ -4,8 +4,9 @@
 from __future__ import annotations
 
 import dataclasses
+from collections.abc import Sequence
 from textwrap import dedent
-from typing import Sequence, cast
+from typing import cast
 
 import pytest
 

--- a/src/python/pants/backend/project_info/regex_lint.py
+++ b/src/python/pants/backend/project_info/regex_lint.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 
 import logging
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Iterable
+from typing import Any
 
 from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE
 from pants.core.goals.lint import LintFilesRequest, LintResult, Partitions

--- a/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
+++ b/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
@@ -5,9 +5,10 @@
 #  https://www.python.org/dev/peps/pep-0503/#normalized-names.
 
 import re
+from collections.abc import Callable
 from enum import Enum
 from functools import partial
-from typing import Callable, Dict, List, Match, Tuple
+from re import Match
 
 
 class PackageSeparator(Enum):
@@ -83,7 +84,7 @@ the replacement. see re.sub for more information
 then if an import in the python code is google.cloud.foo, then the package of
 google-cloud-foo will be used.
 """
-DEFAULT_MODULE_PATTERN_MAPPING: Dict[re.Pattern, List[Callable[[Match[str]], str]]] = {
+DEFAULT_MODULE_PATTERN_MAPPING: dict[re.Pattern, list[Callable[[Match[str]], str]]] = {
     re.compile(r"""^azure-.+"""): [all_hyphen_to_dot],
     re.compile(r"""^django-((.+(-.+)?))"""): [first_group_hyphen_to_underscore],
     # See https://github.com/googleapis/google-cloud-python#libraries for all Google cloud
@@ -103,7 +104,7 @@ DEFAULT_MODULE_PATTERN_MAPPING: Dict[re.Pattern, List[Callable[[Match[str]], str
     re.compile(r"""^apache-(airflow-providers-.+)"""): [first_group_hyphen_to_dot],
 }
 
-DEFAULT_MODULE_MAPPING: Dict[str, Tuple[str, ...]] = {
+DEFAULT_MODULE_MAPPING: dict[str, tuple[str, ...]] = {
     "absl-py": ("absl",),
     "acryl-datahub": ("datahub",),
     "ansicolors": ("colors",),
@@ -249,14 +250,14 @@ DEFAULT_MODULE_MAPPING: Dict[str, Tuple[str, ...]] = {
     "websocket-client": ("websocket",),
 }
 
-DEFAULT_TYPE_STUB_MODULE_PATTERN_MAPPING: Dict[re.Pattern, List[Callable[[Match[str]], str]]] = {
+DEFAULT_TYPE_STUB_MODULE_PATTERN_MAPPING: dict[re.Pattern, list[Callable[[Match[str]], str]]] = {
     re.compile(r"""^stubs[_-](.+)"""): [first_group_hyphen_to_underscore],
     re.compile(r"""^types[_-](.+)"""): [first_group_hyphen_to_underscore],
     re.compile(r"""^(.+)[_-]stubs"""): [first_group_hyphen_to_underscore],
     re.compile(r"""^(.+)[_-]types"""): [first_group_hyphen_to_underscore],
 }
 
-DEFAULT_TYPE_STUB_MODULE_MAPPING: Dict[str, Tuple[str, ...]] = {
+DEFAULT_TYPE_STUB_MODULE_MAPPING: dict[str, tuple[str, ...]] = {
     "djangorestframework-types": ("rest_framework",),
     "lark-stubs": ("lark",),
     "types-beautifulsoup4": ("bs4",),

--- a/src/python/pants/backend/python/dependency_inference/default_unowned_dependencies.py
+++ b/src/python/pants/backend/python/dependency_inference/default_unowned_dependencies.py
@@ -1,7 +1,6 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import List
 
 _STDLIB_MODULES = [
     # See https://docs.python.org/3/library/sys.html#sys.stdlib_module_names
@@ -313,7 +312,7 @@ _STDLIB_MODULES = [
     "zoneinfo",
 ]
 
-_KNOWN_SYSTEM_MODULES: List[str] = [
+_KNOWN_SYSTEM_MODULES: list[str] = [
     # Add the first one, if ye dare!
 ]
 

--- a/src/python/pants/backend/python/dependency_inference/module_mapper.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper.py
@@ -9,10 +9,11 @@ import itertools
 import logging
 import os
 from collections import defaultdict
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from functools import total_ordering
 from pathlib import PurePath
-from typing import DefaultDict, Iterable, Mapping, Tuple
+from typing import DefaultDict
 
 from packaging.utils import canonicalize_name as canonicalize_project_name
 
@@ -103,7 +104,7 @@ def find_all_python_projects(all_targets: AllTargets) -> AllPythonTargets:
 
 
 class FirstPartyPythonMappingImpl(
-    FrozenDict[ResolveName, FrozenDict[str, Tuple[ModuleProvider, ...]]]
+    FrozenDict[ResolveName, FrozenDict[str, tuple[ModuleProvider, ...]]]
 ):
     """A mapping of each resolve name to the first-party module names contained and their owning
     addresses.
@@ -143,7 +144,7 @@ class FirstPartyPythonMappingImplMarker:
 @dataclass(frozen=True)
 class FirstPartyPythonModuleMapping:
     resolves_to_modules_to_providers: FrozenDict[
-        ResolveName, FrozenDict[str, Tuple[ModuleProvider, ...]]
+        ResolveName, FrozenDict[str, tuple[ModuleProvider, ...]]
     ]
 
     """A merged mapping of each resolve name to the first-party module names contained and their
@@ -277,7 +278,7 @@ class ThirdPartyPythonModuleMapping:
     modules."""
 
     resolves_to_modules_to_providers: FrozenDict[
-        ResolveName, FrozenDict[str, Tuple[ModuleProvider, ...]]
+        ResolveName, FrozenDict[str, tuple[ModuleProvider, ...]]
     ]
 
     def _providers_for_resolve(
@@ -317,7 +318,7 @@ class ThirdPartyPythonModuleMapping:
 
 
 @functools.cache
-def generate_mappings_from_pattern(proj_name: str, is_type_stub: bool) -> Tuple[str, ...]:
+def generate_mappings_from_pattern(proj_name: str, is_type_stub: bool) -> tuple[str, ...]:
     """Generate a tuple of possible module mappings from a project name using a regex pattern.
 
     e.g. google-cloud-foo -> [google.cloud.foo, google.cloud.foo_v1, google.cloud.foo_v2]
@@ -377,7 +378,7 @@ async def map_third_party_modules_to_addresses(
             proj_name = canonicalize_project_name(req.project_name)
             fallback_value = req.project_name.strip().lower().replace("-", "_")
 
-            modules_to_add: Tuple[str, ...]
+            modules_to_add: tuple[str, ...]
             is_type_stub: bool
             if proj_name in DEFAULT_MODULE_MAPPING:
                 modules_to_add = DEFAULT_MODULE_MAPPING[proj_name]

--- a/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
@@ -4,10 +4,10 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
 from pathlib import PurePath
 from textwrap import dedent
 from types import FunctionType
-from typing import Iterable, Tuple
 
 import pytest
 from packaging.utils import canonicalize_name as canonicalize_project_name
@@ -994,7 +994,7 @@ def test_issue_15111(rule_runner: RuleRunner) -> None:
     ],
 )
 def test_generate_mappings_from_pattern_matches_para(
-    proj_name: str, expected_modules: Tuple[str]
+    proj_name: str, expected_modules: tuple[str]
 ) -> None:
     assert generate_mappings_from_pattern(proj_name, is_type_stub=False) == expected_modules
 
@@ -1030,7 +1030,7 @@ def test_generate_mappings_from_pattern_matches_para(
     ],
 )
 def test_generate_type_stub_mappings_from_pattern_matches_para(
-    proj_name: str, expected_modules: Tuple[str]
+    proj_name: str, expected_modules: tuple[str]
 ) -> None:
     assert generate_mappings_from_pattern(proj_name, is_type_stub=True) == expected_modules
 

--- a/src/python/pants/backend/python/dependency_inference/parse_python_dependencies.py
+++ b/src/python/pants/backend/python/dependency_inference/parse_python_dependencies.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 from pants.backend.python.dependency_inference.subsystem import PythonInferSubsystem
 from pants.backend.python.target_types import PythonSourceField

--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 
 import itertools
 import logging
+from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import PurePath
-from typing import Dict, Iterable, Optional
 
 from pants.backend.python.dependency_inference import module_mapper, parse_python_dependencies
 from pants.backend.python.dependency_inference.default_unowned_dependencies import (
@@ -248,7 +248,7 @@ class UnownedImportPossibleOwnerRequest:
 
 @dataclass(frozen=True)
 class UnownedImportsPossibleOwners:
-    value: Dict[str, list[tuple[Address, ResolveName]]]
+    value: dict[str, list[tuple[Address, ResolveName]]]
 
 
 @dataclass(frozen=True)
@@ -375,7 +375,7 @@ async def _exec_parse_deps(
 class ResolvedParsedPythonDependenciesRequest:
     field_set: PythonImportDependenciesInferenceFieldSet
     parsed_dependencies: ParsedPythonDependencies
-    resolve: Optional[str]
+    resolve: str | None
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/python/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/python/dependency_inference/rules_test.py
@@ -3,8 +3,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from textwrap import dedent
-from typing import Iterable
 
 import pytest
 

--- a/src/python/pants/backend/python/framework/stevedore/python_target_dependencies.py
+++ b/src/python/pants/backend/python/framework/stevedore/python_target_dependencies.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Mapping
 
 from pants.backend.python.framework.stevedore.target_types import (
     AllStevedoreExtensionTargets,

--- a/src/python/pants/backend/python/goals/coverage_py.py
+++ b/src/python/pants/backend/python/goals/coverage_py.py
@@ -4,11 +4,12 @@
 from __future__ import annotations
 
 import configparser
+from collections.abc import MutableMapping
 from dataclasses import dataclass
 from enum import Enum
 from io import StringIO
 from pathlib import PurePath
-from typing import Any, MutableMapping, cast
+from typing import Any, cast
 
 import toml
 

--- a/src/python/pants/backend/python/goals/debug_goals.py
+++ b/src/python/pants/backend/python/goals/debug_goals.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Optional, Union
+from typing import Any
 
 from pants.backend.project_info.peek import _PeekJsonEncoder
 from pants.backend.python.dependency_inference.module_mapper import ResolveName
@@ -110,9 +110,9 @@ class ImportAnalysis:
     """Information on the inferred imports for a Python file."""
 
     name: str
-    reference: Union[ParsedPythonImportInfo, str]
+    reference: ParsedPythonImportInfo | str
     resolved: ImportResolveResult
-    possible_resolve: Optional[list[tuple[Address, ResolveName]]]
+    possible_resolve: list[tuple[Address, ResolveName]] | None
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/python/goals/export_integration_test.py
+++ b/src/python/pants/backend/python/goals/export_integration_test.py
@@ -7,8 +7,8 @@ import os
 import platform
 import re
 import shutil
+from collections.abc import Mapping, MutableMapping
 from textwrap import dedent
-from typing import Mapping, MutableMapping
 
 import pytest
 

--- a/src/python/pants/backend/python/goals/package_pex_binary.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary.py
@@ -3,7 +3,6 @@
 
 import logging
 from dataclasses import dataclass
-from typing import Tuple
 
 from pants.backend.python.target_types import (
     PexArgsField,
@@ -86,7 +85,7 @@ class PexBinaryFieldSet(PackageFieldSet, RunFieldSet):
     def _execution_mode(self) -> PexExecutionMode:
         return PexExecutionMode(self.execution_mode.value)
 
-    def generate_additional_args(self, pex_binary_defaults: PexBinaryDefaults) -> Tuple[str, ...]:
+    def generate_additional_args(self, pex_binary_defaults: PexBinaryDefaults) -> tuple[str, ...]:
         args = []
         if self.emit_warnings.value_or_global_default(pex_binary_defaults) is False:
             args.append("--no-emit-warnings")

--- a/src/python/pants/backend/python/goals/publish_test.py
+++ b/src/python/pants/backend/python/goals/publish_test.py
@@ -3,8 +3,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from textwrap import dedent
-from typing import Callable
 
 import pytest
 

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -8,7 +8,6 @@ import re
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Optional, Tuple
 
 from packaging.utils import canonicalize_name as canonicalize_project_name
 
@@ -200,18 +199,18 @@ class TestMetadata:
 
 @dataclass(frozen=True)
 class TestSetupRequest:
-    field_sets: Tuple[PythonTestFieldSet, ...]
+    field_sets: tuple[PythonTestFieldSet, ...]
     metadata: TestMetadata
     is_debug: bool
     extra_env: FrozenDict[str, str] = FrozenDict()
-    prepend_argv: Tuple[str, ...] = ()
-    additional_pexes: Tuple[Pex, ...] = ()
+    prepend_argv: tuple[str, ...] = ()
+    additional_pexes: tuple[Pex, ...] = ()
 
 
 @dataclass(frozen=True)
 class TestSetup:
     process: Process
-    results_file_name: Optional[str]
+    results_file_name: str | None
 
     # Prevent this class from being detected by pytest as a test class.
     __test__ = False

--- a/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 import os
 import re
 import unittest.mock
+from collections.abc import Iterable
 from textwrap import dedent
-from typing import Iterable
 
 import pytest
 

--- a/src/python/pants/backend/python/goals/repl.py
+++ b/src/python/pants/backend/python/goals/repl.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import os
-from typing import Iterable
+from collections.abc import Iterable
 
 from pants.backend.python.subsystems import ipython
 from pants.backend.python.subsystems.ipython import IPython

--- a/src/python/pants/backend/python/goals/run_helper.py
+++ b/src/python/pants/backend/python/goals/run_helper.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import dataclasses
 import os
 import textwrap
-from typing import Iterable, Optional
+from collections.abc import Iterable
 
 from pants.backend.python.subsystems.debugpy import DebugPy
 from pants.backend.python.target_types import (
@@ -43,8 +43,8 @@ async def _create_python_source_run_request(
     pex_env: PexEnvironment,
     run_in_sandbox: bool,
     pex_path: Iterable[Pex] = (),
-    console_script: Optional[ConsoleScript] = None,
-    executable: Optional[Executable] = None,
+    console_script: ConsoleScript | None = None,
+    executable: Executable | None = None,
 ) -> RunRequest:
     addresses = [address]
     entry_point, transitive_targets = await MultiGet(

--- a/src/python/pants/backend/python/goals/run_pex_binary_integration_test.py
+++ b/src/python/pants/backend/python/goals/run_pex_binary_integration_test.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from textwrap import dedent
-from typing import Callable, Optional
 
 import pytest
 
@@ -15,9 +15,9 @@ from pants.testutil.pants_integration_test import PantsResult, run_pants, setup_
 def run_generic_test(
     *,
     entry_point: str = "app.py",
-    execution_mode: Optional[PexExecutionMode] = None,
+    execution_mode: PexExecutionMode | None = None,
     include_tools: bool = False,
-    layout: Optional[PexLayout] = None,
+    layout: PexLayout | None = None,
     venv_site_packages_copies: bool = False,
 ) -> Callable[..., PantsResult]:
     sources = {
@@ -105,7 +105,7 @@ def test_entry_point(
 @pytest.mark.parametrize("execution_mode", [None, PexExecutionMode.VENV])
 @pytest.mark.parametrize("include_tools", [True, False])
 def test_execution_mode_and_include_tools(
-    execution_mode: Optional[PexExecutionMode],
+    execution_mode: PexExecutionMode | None,
     include_tools: bool,
 ):
     run = run_generic_test(
@@ -126,7 +126,7 @@ def test_execution_mode_and_include_tools(
 
 @pytest.mark.parametrize("layout", PexLayout)
 def test_layout(
-    layout: Optional[PexLayout],
+    layout: PexLayout | None,
 ):
     run_generic_test(layout=layout)
 

--- a/src/python/pants/backend/python/goals/run_python_requirement.py
+++ b/src/python/pants/backend/python/goals/run_python_requirement.py
@@ -7,10 +7,9 @@ import logging
 import os
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Tuple
+from typing import TypeAlias
 
 from packaging.utils import canonicalize_name as canonicalize_project_name
-from typing_extensions import TypeAlias
 
 from pants.backend.python.dependency_inference.module_mapper import (
     ResolveName,
@@ -41,7 +40,7 @@ from pants.util.memo import memoized
 
 logger = logging.getLogger(__name__)
 
-InvertedModuleMapping: TypeAlias = FrozenDict[Address, Tuple[str, ...]]
+InvertedModuleMapping: TypeAlias = FrozenDict[Address, tuple[str, ...]]
 
 
 def _in_chroot(relpath: str) -> str:

--- a/src/python/pants/backend/python/goals/run_python_source.py
+++ b/src/python/pants/backend/python/goals/run_python_source.py
@@ -3,7 +3,6 @@
 
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Optional
 
 from pants.backend.python.goals.run_helper import (
     _create_python_source_run_dap_request,
@@ -51,7 +50,7 @@ class PythonSourceFieldSet(RunFieldSet):
             return python_setup.default_run_goal_use_sandbox
         return self._run_goal_use_sandbox.value
 
-    def _executable_main(self) -> Optional[Executable]:
+    def _executable_main(self) -> Executable | None:
         source = PurePath(self.source.value)
         source_name = source.stem if source.suffix == ".py" else source.name
         if not all(part.isidentifier() for part in source_name.split(".")):

--- a/src/python/pants/backend/python/goals/run_python_source_integration_test.py
+++ b/src/python/pants/backend/python/goals/run_python_source_integration_test.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import json
 import os
 from textwrap import dedent
-from typing import Tuple
 
 import pytest
 
@@ -75,7 +74,7 @@ def run_run_request(
     rule_runner: PythonRuleRunner,
     target: Target,
     test_debug_adapter: bool = True,
-) -> Tuple[int, str, str]:
+) -> tuple[int, str, str]:
     run_request = rule_runner.request(RunRequest, [PythonSourceFieldSet.create(target)])
     run_process = InteractiveProcess(
         argv=run_request.args,

--- a/src/python/pants/backend/python/goals/tailor.py
+++ b/src/python/pants/backend/python/goals/tailor.py
@@ -6,9 +6,9 @@ from __future__ import annotations
 import logging
 import os
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Iterable
 
 from pants.backend.python.dependency_inference.module_mapper import module_from_stripped_path
 from pants.backend.python.macros.pipenv_requirements import parse_pipenv_requirements

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-from typing import Tuple
-
 from pants.backend.python.lint.bandit.subsystem import Bandit, BanditFieldSet
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.util_rules import pex
@@ -26,7 +24,7 @@ class BanditRequest(LintTargetsRequest):
     tool_subsystem = Bandit
 
 
-def generate_argv(source_files: SourceFiles, bandit: Bandit) -> Tuple[str, ...]:
+def generate_argv(source_files: SourceFiles, bandit: Bandit) -> tuple[str, ...]:
     args = []
     if bandit.config is not None:
         args.append(f"--config={bandit.config}")

--- a/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
@@ -3,8 +3,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from textwrap import dedent
-from typing import Sequence
 
 import pytest
 

--- a/src/python/pants/backend/python/lint/black/subsystem.py
+++ b/src/python/pants/backend/python/lint/black/subsystem.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 import os.path
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 from pants.backend.python.lint.black.skip_field import SkipBlackField
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Tuple
 
 from pants.backend.python.lint.flake8.subsystem import (
     Flake8,
@@ -32,7 +31,7 @@ class Flake8Request(LintTargetsRequest):
     tool_subsystem = Flake8
 
 
-def generate_argv(source_files: SourceFiles, flake8: Flake8) -> Tuple[str, ...]:
+def generate_argv(source_files: SourceFiles, flake8: Flake8) -> tuple[str, ...]:
     args = []
     if flake8.config:
         args.append(f"--config={flake8.config}")

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Tuple
 
 from pants.backend.python.lint.isort.skip_field import SkipIsortField
 from pants.backend.python.lint.isort.subsystem import Isort
@@ -41,7 +40,7 @@ class IsortRequest(FmtTargetsRequest):
 
 def generate_argv(
     source_files: tuple[str, ...], isort: Isort, *, is_isort5: bool
-) -> Tuple[str, ...]:
+) -> tuple[str, ...]:
     args = [*isort.args]
     if is_isort5 and len(isort.config) == 1:
         explicitly_configured_config_args = [

--- a/src/python/pants/backend/python/lint/isort/subsystem.py
+++ b/src/python/pants/backend/python/lint/isort/subsystem.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import os.path
-from typing import Iterable
+from collections.abc import Iterable
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript

--- a/src/python/pants/backend/python/lint/pydocstyle/rules.py
+++ b/src/python/pants/backend/python/lint/pydocstyle/rules.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-from typing import Tuple
-
 from pants.backend.python.lint.pydocstyle.subsystem import Pydocstyle, PydocstyleFieldSet
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
@@ -25,7 +23,7 @@ class PydocstyleRequest(LintTargetsRequest):
     partitioner_type = PartitionerType.DEFAULT_SINGLE_PARTITION
 
 
-def generate_argv(source_files: SourceFiles, pydocstyle: Pydocstyle) -> Tuple[str, ...]:
+def generate_argv(source_files: SourceFiles, pydocstyle: Pydocstyle) -> tuple[str, ...]:
     args = []
     if pydocstyle.config is not None:
         args.append(f"--config={pydocstyle.config}")

--- a/src/python/pants/backend/python/lint/pydocstyle/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pydocstyle/rules_integration_test.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Sequence
+from collections.abc import Sequence
 
 import pytest
 

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Tuple
 
 import packaging
 
@@ -62,7 +61,7 @@ class PylintRequest(LintTargetsRequest):
     tool_subsystem = Pylint
 
 
-def generate_argv(field_sets: tuple[PylintFieldSet, ...], pylint: Pylint) -> Tuple[str, ...]:
+def generate_argv(field_sets: tuple[PylintFieldSet, ...], pylint: Pylint) -> tuple[str, ...]:
     args = []
     if pylint.config is not None:
         args.append(f"--rcfile={pylint.config}")

--- a/src/python/pants/backend/python/lint/pylint/subsystem.py
+++ b/src/python/pants/backend/python/lint/pylint/subsystem.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 import os.path
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 from pants.backend.python.lint.pylint.skip_field import SkipPylintField
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase

--- a/src/python/pants/backend/python/lint/ruff/common.py
+++ b/src/python/pants/backend/python/lint/ruff/common.py
@@ -1,9 +1,7 @@
 # Copyright 2024 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from dataclasses import dataclass
-from typing import Tuple
-
-from typing_extensions import assert_never
+from typing import assert_never
 
 from pants.backend.python.lint.ruff.subsystem import Ruff, RuffMode
 from pants.core.goals.lint import REPORT_DIR
@@ -56,7 +54,7 @@ async def run_ruff(
 
     conf_args = [f"--config={ruff.config}"] if ruff.config else []
 
-    extra_initial_args: Tuple[str, ...] = ()
+    extra_initial_args: tuple[str, ...] = ()
     if request.mode is RuffMode.FORMAT:
         extra_initial_args = ("format",)
     elif request.mode is RuffMode.FIX:

--- a/src/python/pants/backend/python/lint/ruff/subsystem.py
+++ b/src/python/pants/backend/python/lint/ruff/subsystem.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 import os.path
+from collections.abc import Iterable
 from enum import Enum
-from typing import Iterable
 
 from packaging.version import parse
 

--- a/src/python/pants/backend/python/lint/yapf/subsystem.py
+++ b/src/python/pants/backend/python/lint/yapf/subsystem.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import os.path
-from typing import Iterable
+from collections.abc import Iterable
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript

--- a/src/python/pants/backend/python/macros/common_fields.py
+++ b/src/python/pants/backend/python/macros/common_fields.py
@@ -3,7 +3,8 @@
 
 from __future__ import annotations
 
-from typing import ClassVar, Dict, Iterable, Tuple
+from collections.abc import Iterable
+from typing import ClassVar
 
 from pants.backend.python.target_types import (
     PythonRequirementModulesField,
@@ -35,8 +36,8 @@ class ModuleMappingField(DictStringToStringSequenceField):
 
     @classmethod
     def compute_value(  # type: ignore[override]
-        cls, raw_value: Dict[str, Iterable[str]], address: Address
-    ) -> FrozenDict[str, Tuple[str, ...]]:
+        cls, raw_value: dict[str, Iterable[str]], address: Address
+    ) -> FrozenDict[str, tuple[str, ...]]:
         value_or_default = super().compute_value(raw_value, address)
         return normalize_module_mapping(value_or_default)
 
@@ -59,8 +60,8 @@ class TypeStubsModuleMappingField(DictStringToStringSequenceField):
 
     @classmethod
     def compute_value(  # type: ignore[override]
-        cls, raw_value: Dict[str, Iterable[str]], address: Address
-    ) -> FrozenDict[str, Tuple[str, ...]]:
+        cls, raw_value: dict[str, Iterable[str]], address: Address
+    ) -> FrozenDict[str, tuple[str, ...]]:
         value_or_default = super().compute_value(raw_value, address)
         return normalize_module_mapping(value_or_default)
 

--- a/src/python/pants/backend/python/macros/common_requirements_rule.py
+++ b/src/python/pants/backend/python/macros/common_requirements_rule.py
@@ -6,7 +6,8 @@ from __future__ import annotations
 import itertools
 import logging
 import os
-from typing import Callable, Iterable, cast
+from collections.abc import Callable, Iterable
+from typing import cast
 
 from packaging.utils import canonicalize_name as canonicalize_project_name
 

--- a/src/python/pants/backend/python/macros/poetry_requirements.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements.py
@@ -6,10 +6,11 @@ from __future__ import annotations
 import itertools
 import logging
 import urllib.parse
+from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from functools import partial
 from pathlib import Path, PurePath
-from typing import Any, Iterator, Mapping, Sequence, cast
+from typing import Any, cast
 
 import toml
 from packaging.version import InvalidVersion, Version

--- a/src/python/pants/backend/python/macros/python_artifact.py
+++ b/src/python/pants/backend/python/macros/python_artifact.py
@@ -4,14 +4,14 @@
 import collections.abc
 import copy
 import json
-from typing import Any, Dict, List, Union
+from typing import Any
 
 from pants.util.strutil import softwrap
 
 
 def _normalize_entry_points(
-    all_entry_points: Dict[str, Union[List[str], Dict[str, str]]]
-) -> Dict[str, Dict[str, str]]:
+    all_entry_points: dict[str, list[str] | dict[str, str]]
+) -> dict[str, dict[str, str]]:
     """Ensure any entry points are in the form Dict[str, Dict[str, str]]."""
     if not isinstance(all_entry_points, collections.abc.Mapping):
         raise ValueError(
@@ -66,7 +66,7 @@ class PythonArtifact:
             # coerce entry points from Dict[str, List[str]] to Dict[str, Dict[str, str]]
             kwargs["entry_points"] = _normalize_entry_points(kwargs["entry_points"])
 
-        self._kw: Dict[str, Any] = copy.deepcopy(kwargs)
+        self._kw: dict[str, Any] = copy.deepcopy(kwargs)
         # The kwargs come from a BUILD file, and can contain somewhat arbitrary nested structures,
         # so we don't have a principled way to make them into a hashable data structure.
         # E.g., we can't naively turn all lists into tuples because distutils checks that some
@@ -76,10 +76,10 @@ class PythonArtifact:
         self._hash: int = hash(json.dumps(kwargs, sort_keys=True))
 
     @property
-    def kwargs(self) -> Dict[str, Any]:
+    def kwargs(self) -> dict[str, Any]:
         return self._kw
 
-    def asdict(self) -> Dict[str, Any]:
+    def asdict(self) -> dict[str, Any]:
         return self.kwargs
 
     def __eq__(self, other: Any) -> bool:

--- a/src/python/pants/backend/python/macros/python_requirements.py
+++ b/src/python/pants/backend/python/macros/python_requirements.py
@@ -4,8 +4,9 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Callable, Iterator
 from itertools import chain
-from typing import Any, Callable, Iterator
+from typing import Any
 
 import toml
 

--- a/src/python/pants/backend/python/macros/uv_requirements.py
+++ b/src/python/pants/backend/python/macros/uv_requirements.py
@@ -2,9 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import logging
+from collections.abc import Iterator
 from functools import partial
 from pathlib import PurePath
-from typing import Iterator
 
 from pants.backend.python.macros.common_fields import (
     ModuleMappingField,

--- a/src/python/pants/backend/python/providers/python_build_standalone/constraints.py
+++ b/src/python/pants/backend/python/providers/python_build_standalone/constraints.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import operator
-from typing import Callable, Iterable, Protocol, cast
+from collections.abc import Callable, Iterable
+from typing import Protocol, cast
 
 from packaging.version import Version
 

--- a/src/python/pants/backend/python/providers/python_build_standalone/rules.py
+++ b/src/python/pants/backend/python/providers/python_build_standalone/rules.py
@@ -10,9 +10,10 @@ import re
 import textwrap
 import urllib
 import uuid
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Iterable, Mapping, Sequence, TypedDict, TypeVar, cast
+from typing import TypedDict, TypeVar, cast
 
 from packaging.version import InvalidVersion
 

--- a/src/python/pants/backend/python/providers/python_build_standalone/rules_integration_test.py
+++ b/src/python/pants/backend/python/providers/python_build_standalone/rules_integration_test.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 import shutil
+from collections.abc import Iterable
 from textwrap import dedent
-from typing import Iterable
 
 import pytest
 

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 import os.path
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import (

--- a/src/python/pants/backend/python/subsystems/python_native_code.py
+++ b/src/python/pants/backend/python/subsystems/python_native_code.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Sequence
+from collections.abc import Sequence
 
 from pants.option.option_types import StrListOption
 from pants.option.subsystem import Subsystem

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -7,9 +7,10 @@ import importlib.resources
 import json
 import logging
 import os
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
 from functools import cache
-from typing import Callable, ClassVar, Iterable, Optional, Sequence
+from typing import ClassVar
 from urllib.parse import urlparse
 
 from pants.backend.python.target_types import ConsoleScript, EntryPoint, MainSpecification
@@ -212,7 +213,7 @@ class PythonToolRequirementsBase(Subsystem, ExportableTool):
 
     @classmethod
     @cache
-    def _default_package_name_and_version(cls) -> Optional[_PackageNameAndVersion]:
+    def _default_package_name_and_version(cls) -> _PackageNameAndVersion | None:
         if cls.default_lockfile_resource is None:
             return None
 

--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -6,7 +6,8 @@ from __future__ import annotations
 import enum
 import logging
 import os
-from typing import Iterable, List, Optional, TypeVar, cast
+from collections.abc import Iterable
+from typing import Optional, TypeVar, cast
 
 from packaging.utils import canonicalize_name
 
@@ -267,7 +268,7 @@ class PythonSetup(Subsystem):
         ),
         advanced=True,
     )
-    _resolves_to_interpreter_constraints = DictOption[List[str]](
+    _resolves_to_interpreter_constraints = DictOption[list[str]](
         help=softwrap(
             """
             Override the interpreter constraints to use when generating a resolve's lockfile
@@ -315,7 +316,7 @@ class PythonSetup(Subsystem):
         ),
         advanced=True,
     )
-    _resolves_to_no_binary = DictOption[List[str]](
+    _resolves_to_no_binary = DictOption[list[str]](
         help=softwrap(
             f"""
             When generating a resolve's lockfile, do not use binary packages (i.e. wheels) for
@@ -339,7 +340,7 @@ class PythonSetup(Subsystem):
         ),
         advanced=True,
     )
-    _resolves_to_only_binary = DictOption[List[str]](
+    _resolves_to_only_binary = DictOption[list[str]](
         help=softwrap(
             f"""
             When generating a resolve's lockfile, do not use source packages (i.e. sdists) for

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -7,20 +7,10 @@ import collections.abc
 import logging
 import os.path
 from abc import ABC, abstractmethod
+from collections.abc import Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from enum import Enum
-from typing import (
-    TYPE_CHECKING,
-    ClassVar,
-    Iterable,
-    Iterator,
-    Mapping,
-    Optional,
-    Sequence,
-    Tuple,
-    Union,
-    cast,
-)
+from typing import TYPE_CHECKING, ClassVar, cast
 
 from packaging.utils import canonicalize_name as canonicalize_project_name
 
@@ -118,7 +108,7 @@ class InterpreterConstraintsField(StringSequenceField, AsyncFieldMixin):
         """
     )
 
-    def value_or_global_default(self, python_setup: PythonSetup) -> Tuple[str, ...]:
+    def value_or_global_default(self, python_setup: PythonSetup) -> tuple[str, ...]:
         """Return either the given `compatibility` field or the global interpreter constraints.
 
         If interpreter constraints are supplied by the CLI flag, return those only.
@@ -351,7 +341,7 @@ class EntryPointField(AsyncFieldMixin, Field):
     value: EntryPoint | None
 
     @classmethod
-    def compute_value(cls, raw_value: Optional[str], address: Address) -> Optional[EntryPoint]:
+    def compute_value(cls, raw_value: str | None, address: Address) -> EntryPoint | None:
         value = super().compute_value(raw_value, address)
         if value is None:
             return None
@@ -397,7 +387,7 @@ class PexScriptField(Field):
     value: ConsoleScript | None
 
     @classmethod
-    def compute_value(cls, raw_value: Optional[str], address: Address) -> Optional[ConsoleScript]:
+    def compute_value(cls, raw_value: str | None, address: Address) -> ConsoleScript | None:
         value = super().compute_value(raw_value, address)
         if value is None:
             return None
@@ -422,7 +412,7 @@ class PexExecutableField(Field):
     value: Executable | None
 
     @classmethod
-    def compute_value(cls, raw_value: Optional[str], address: Address) -> Optional[Executable]:
+    def compute_value(cls, raw_value: str | None, address: Address) -> Executable | None:
         value = super().compute_value(raw_value, address)
         if value is None:
             return None
@@ -524,9 +514,7 @@ class PexInheritPathField(StringField):
 
     # TODO(#9388): deprecate allowing this to be a `bool`.
     @classmethod
-    def compute_value(
-        cls, raw_value: Optional[Union[str, bool]], address: Address
-    ) -> Optional[str]:
+    def compute_value(cls, raw_value: str | bool | None, address: Address) -> str | None:
         if isinstance(raw_value, bool):
             return "prefer" if raw_value else "false"
         return super().compute_value(raw_value, address)
@@ -972,7 +960,7 @@ class PythonTestsTimeoutField(IntField):
     )
     valid_numbers = ValidNumbers.positive_only
 
-    def calculate_from_global_options(self, test: TestSubsystem, pytest: PyTest) -> Optional[int]:
+    def calculate_from_global_options(self, test: TestSubsystem, pytest: PyTest) -> int | None:
         """Determine the timeout (in seconds) after resolving conflicting global options in the
         `pytest` and `test` scopes.
 
@@ -1244,8 +1232,8 @@ class _PipRequirementSequenceField(Field):
 
     @classmethod
     def compute_value(
-        cls, raw_value: Optional[Iterable[str]], address: Address
-    ) -> Tuple[PipRequirement, ...]:
+        cls, raw_value: Iterable[str] | None, address: Address
+    ) -> tuple[PipRequirement, ...]:
         value = super().compute_value(raw_value, address)
         if value is None:
             return ()
@@ -1452,7 +1440,7 @@ class PythonProvidesField(ScalarField, AsyncFieldMixin):
     )
 
     @classmethod
-    def compute_value(cls, raw_value: Optional[PythonArtifact], address: Address) -> PythonArtifact:
+    def compute_value(cls, raw_value: PythonArtifact | None, address: Address) -> PythonArtifact:
         return cast(PythonArtifact, super().compute_value(raw_value, address))
 
 
@@ -1508,7 +1496,7 @@ class PythonDistributionEntryPoint:
     """Note that this stores if the entry point comes from an address to a `pex_binary` target."""
 
     entry_point: EntryPoint
-    pex_binary_address: Optional[Address]
+    pex_binary_address: Address | None
 
 
 # See `target_type_rules.py` for the `Resolve..Request -> Resolved..` rule
@@ -1556,8 +1544,8 @@ class ResolvePythonDistributionEntryPointsRequest:
     logic for resolving pex_binary addresses etc.
     """
 
-    entry_points_field: Optional[PythonDistributionEntryPointsField] = None
-    provides_field: Optional[PythonProvidesField] = None
+    entry_points_field: PythonDistributionEntryPointsField | None = None
+    provides_field: PythonProvidesField | None = None
 
     def __post_init__(self):
         # Must provide at least one of these fields.

--- a/src/python/pants/backend/python/target_types_rules.py
+++ b/src/python/pants/backend/python/target_types_rules.py
@@ -11,9 +11,10 @@ import dataclasses
 import logging
 import os.path
 from collections import defaultdict
+from collections.abc import Callable, Generator
 from dataclasses import dataclass
 from itertools import chain
-from typing import Callable, DefaultDict, Dict, Generator, Optional, Tuple, cast
+from typing import DefaultDict, cast
 
 from pants.backend.python.dependency_inference.module_mapper import (
     PythonModuleOwners,
@@ -294,10 +295,10 @@ async def infer_pex_binary_entry_point_dependency(
 
 
 def _determine_entry_point_owner(
-    maybe_disambiguated: Optional[Address],
+    maybe_disambiguated: Address | None,
     owners: PythonModuleOwners,
     unresolved_ambiguity_handler: Callable[[], None],
-) -> Tuple[Address, ...]:
+) -> tuple[Address, ...]:
     """Determine what should be the unambiguous owner for a PEX's entrypoint.
 
     This might be empty.
@@ -341,12 +342,12 @@ def _handle_unresolved_pex_entrypoint(
 # -----------------------------------------------------------------------------------------------
 
 
-_EntryPointsDictType = Dict[str, Dict[str, str]]
+_EntryPointsDictType = dict[str, dict[str, str]]
 
 
 def _classify_entry_points(
     all_entry_points: _EntryPointsDictType,
-) -> Generator[Tuple[bool, str, str, str], None, None]:
+) -> Generator[tuple[bool, str, str, str], None, None]:
     """Looks at each entry point to see if it is a target address or not.
 
     Yields tuples: is_target, category, name, entry_point_str.
@@ -445,11 +446,11 @@ async def resolve_python_distribution_entry_points(
         target.address: entry_point for target, entry_point in zip(targets, binary_entry_points)
     }
 
-    entry_points: DefaultDict[str, Dict[str, PythonDistributionEntryPoint]] = defaultdict(dict)
+    entry_points: DefaultDict[str, dict[str, PythonDistributionEntryPoint]] = defaultdict(dict)
 
     # Parse refs/replace with resolved pex entry point, and validate console entry points have function.
     for is_target, category, name, ref in classified_entry_points:
-        owner: Optional[Address] = None
+        owner: Address | None = None
         if is_target:
             owner = address_by_ref[ref]
             entry_point = binary_entry_point_by_address[owner].val

--- a/src/python/pants/backend/python/target_types_test.py
+++ b/src/python/pants/backend/python/target_types_test.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterable
 from textwrap import dedent
-from typing import Iterable
 
 import pytest
 

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 
 import dataclasses
 import itertools
+from collections.abc import Iterable
 from dataclasses import dataclass
 from hashlib import sha256
 from textwrap import dedent  # noqa: PNT20
-from typing import Iterable, Optional, Tuple
 
 import packaging
 
@@ -86,8 +86,8 @@ async def _generate_argv(
     cache_dir: str,
     venv_python: str,
     file_list_path: str,
-    python_version: Optional[str],
-) -> Tuple[str, ...]:
+    python_version: str | None,
+) -> tuple[str, ...]:
     args = [pex.pex.argv0, f"--python-executable={venv_python}", *mypy.args]
     if mypy.config:
         args.append(f"--config-file={mypy.config}")
@@ -111,7 +111,7 @@ async def _generate_argv(
     return tuple(args)
 
 
-def determine_python_files(files: Iterable[str]) -> Tuple[str, ...]:
+def determine_python_files(files: Iterable[str]) -> tuple[str, ...]:
     """We run over all .py and .pyi files, but .pyi files take precedence.
 
     MyPy will error if we say to run over the same module with both its .py and .pyi files, so we

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.subsystems.setup import PythonSetup

--- a/src/python/pants/backend/python/typecheck/pyright/rules.py
+++ b/src/python/pants/backend/python/typecheck/pyright/rules.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 import json
 import logging
 import os
+from collections.abc import Iterable
 from dataclasses import dataclass, replace
-from typing import Iterable
 
 import toml
 

--- a/src/python/pants/backend/python/typecheck/pyright/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/pyright/rules_integration_test.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterable
 from textwrap import dedent
-from typing import Iterable
 
 import pytest
 

--- a/src/python/pants/backend/python/typecheck/pyright/skip_field.py
+++ b/src/python/pants/backend/python/typecheck/pyright/skip_field.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable
+from collections.abc import Iterable
 
 from pants.backend.python.target_types import (
     PythonSourcesGeneratorTarget,

--- a/src/python/pants/backend/python/typecheck/pytype/rules.py
+++ b/src/python/pants/backend/python/typecheck/pytype/rules.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import (

--- a/src/python/pants/backend/python/typecheck/pytype/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/pytype/rules_integration_test.py
@@ -3,8 +3,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from textwrap import dedent
-from typing import Iterable
 
 import pytest
 

--- a/src/python/pants/backend/python/typecheck/pytype/skip_field.py
+++ b/src/python/pants/backend/python/typecheck/pytype/skip_field.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable
+from collections.abc import Iterable
 
 from pants.backend.python.target_types import (
     PythonSourcesGeneratorTarget,

--- a/src/python/pants/backend/python/util_rules/dists.py
+++ b/src/python/pants/backend/python/util_rules/dists.py
@@ -6,8 +6,9 @@ from __future__ import annotations
 import io
 import os
 from collections import abc
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, Mapping
+from typing import Any
 
 import toml
 

--- a/src/python/pants/backend/python/util_rules/entry_points.py
+++ b/src/python/pants/backend/python/util_rules/entry_points.py
@@ -1,8 +1,8 @@
 # Copyright 2024 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from collections import defaultdict
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
-from typing import Callable, Iterable
 
 from pants.backend.python.dependency_inference.module_mapper import (
     PythonModuleOwners,

--- a/src/python/pants/backend/python/util_rules/entry_points_test.py
+++ b/src/python/pants/backend/python/util_rules/entry_points_test.py
@@ -3,8 +3,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from textwrap import dedent
-from typing import Iterable
 
 import pytest
 

--- a/src/python/pants/backend/python/util_rules/faas.py
+++ b/src/python/pants/backend/python/util_rules/faas.py
@@ -11,7 +11,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import ClassVar, Optional, cast
+from typing import ClassVar, cast
 
 from pants.backend.python.dependency_inference.module_mapper import (
     PythonModuleOwners,
@@ -132,7 +132,7 @@ class PythonFaaSHandlerField(StringField, AsyncFieldMixin):
     )
 
     @classmethod
-    def compute_value(cls, raw_value: Optional[str], address: Address) -> str:
+    def compute_value(cls, raw_value: str | None, address: Address) -> str:
         value = cast(str, super().compute_value(raw_value, address))
         if ":" not in value:
             raise InvalidFieldException(

--- a/src/python/pants/backend/python/util_rules/faas_test.py
+++ b/src/python/pants/backend/python/util_rules/faas_test.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from pathlib import Path
 from textwrap import dedent
-from typing import Optional
 from unittest.mock import Mock
 
 import pytest
@@ -171,7 +170,7 @@ def test_infer_handler_dependency(rule_runner: RuleRunner, caplog) -> None:
         }
     )
 
-    def assert_inferred(address: Address, *, expected: Optional[Address]) -> None:
+    def assert_inferred(address: Address, *, expected: Address | None) -> None:
         tgt = rule_runner.get_target(address)
         inferred = rule_runner.request(
             InferredDependencies,

--- a/src/python/pants/backend/python/util_rules/interpreter_constraints.py
+++ b/src/python/pants/backend/python/util_rules/interpreter_constraints.py
@@ -7,7 +7,8 @@ import itertools
 import logging
 import re
 from collections import defaultdict
-from typing import Iterable, Iterator, Protocol, Sequence, Tuple, TypeVar
+from collections.abc import Iterable, Iterator, Sequence
+from typing import Protocol, TypeVar
 
 from packaging.requirements import InvalidRequirement
 from pkg_resources import Requirement
@@ -39,7 +40,7 @@ class FieldSetWithInterpreterConstraints(Protocol):
 _FS = TypeVar("_FS", bound=FieldSetWithInterpreterConstraints)
 
 
-RawConstraints = Tuple[str, ...]
+RawConstraints = tuple[str, ...]
 
 
 # The current maxes are 2.7.18 and 3.6.15.  We go much higher, for safety.

--- a/src/python/pants/backend/python/util_rules/interpreter_constraints_test.py
+++ b/src/python/pants/backend/python/util_rules/interpreter_constraints_test.py
@@ -3,8 +3,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 import pytest
 from packaging.requirements import InvalidRequirement

--- a/src/python/pants/backend/python/util_rules/local_dists.py
+++ b/src/python/pants/backend/python/util_rules/local_dists.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 
 import logging
 import shlex
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 from pants.backend.python.subsystems.setuptools import PythonDistributionFieldSet
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints

--- a/src/python/pants/backend/python/util_rules/lockfile_diff.py
+++ b/src/python/pants/backend/python/util_rules/lockfile_diff.py
@@ -6,8 +6,9 @@ from __future__ import annotations
 import itertools
 import json
 import logging
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Mapping
+from typing import TYPE_CHECKING, Any
 
 from packaging.version import parse
 

--- a/src/python/pants/backend/python/util_rules/lockfile_metadata.py
+++ b/src/python/pants/backend/python/util_rules/lockfile_metadata.py
@@ -3,9 +3,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Iterable, Set, cast
+from typing import Any, cast
 
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.core.util_rules.lockfile_metadata import (
@@ -167,7 +168,7 @@ class PythonLockfileMetadataV2(PythonLockfileMetadata):
 
         requirements = metadata(
             "generated_with_requirements",
-            Set[PipRequirement],
+            set[PipRequirement],
             lambda l: {
                 PipRequirement.parse(i, description_of_origin=lockfile_description) for i in l
             },
@@ -232,13 +233,13 @@ class PythonLockfileMetadataV3(PythonLockfileMetadataV2):
         manylinux = metadata("manylinux", str, lambda l: l)
         requirement_constraints = metadata(
             "requirement_constraints",
-            Set[PipRequirement],
+            set[PipRequirement],
             lambda l: {
                 PipRequirement.parse(i, description_of_origin=lockfile_description) for i in l
             },
         )
-        only_binary = metadata("only_binary", Set[str], lambda l: set(l))
-        no_binary = metadata("no_binary", Set[str], lambda l: set(l))
+        only_binary = metadata("only_binary", set[str], lambda l: set(l))
+        no_binary = metadata("no_binary", set[str], lambda l: set(l))
 
         return PythonLockfileMetadataV3(
             valid_for_interpreter_constraints=v2_metadata.valid_for_interpreter_constraints,

--- a/src/python/pants/backend/python/util_rules/lockfile_metadata_test.py
+++ b/src/python/pants/backend/python/util_rules/lockfile_metadata_test.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import itertools
-from typing import Iterable
+from collections.abc import Iterable
 
 import pytest
 

--- a/src/python/pants/backend/python/util_rules/package_dists.py
+++ b/src/python/pants/backend/python/util_rules/package_dists.py
@@ -9,10 +9,11 @@ import os
 import pickle
 from abc import ABC, abstractmethod
 from collections import defaultdict
+from collections.abc import Mapping
 from dataclasses import dataclass
 from functools import partial
 from pathlib import PurePath
-from typing import Any, DefaultDict, Dict, List, Mapping, Tuple, cast
+from typing import Any, DefaultDict, cast
 
 from pants.backend.python.macros.python_artifact import PythonArtifact
 from pants.backend.python.subsystems.setup import PythonSetup
@@ -217,7 +218,7 @@ class SetupKwargs:
     """The keyword arguments to the `setup()` function in the generated `setup.py`."""
 
     _pickled_bytes: bytes
-    _overwrite_banned_keys: Tuple[str, ...]
+    _overwrite_banned_keys: tuple[str, ...]
 
     def __init__(
         self,
@@ -225,7 +226,7 @@ class SetupKwargs:
         *,
         address: Address,
         _allow_banned_keys: bool = False,
-        _overwrite_banned_keys: Tuple[str, ...] = (),
+        _overwrite_banned_keys: tuple[str, ...] = (),
     ) -> None:
         super().__init__()
         if "name" not in kwargs:
@@ -270,7 +271,7 @@ class SetupKwargs:
 
     @memoized_property
     def kwargs(self) -> dict[str, Any]:
-        return cast(Dict[str, Any], pickle.loads(self._pickled_bytes))
+        return cast(dict[str, Any], pickle.loads(self._pickled_bytes))
 
     @property
     def name(self) -> str:
@@ -303,7 +304,7 @@ class SetupKwargsRequest(ABC):
         """Whether the kwargs implementation should be used for this target or not."""
 
     @property
-    def explicit_kwargs(self) -> Dict[str, Any]:
+    def explicit_kwargs(self) -> dict[str, Any]:
         # We return a dict copy of the underlying FrozenDict, because the caller expects a
         # dict (and we have documented as much).
         return dict(self.target[PythonProvidesField].value.kwargs)
@@ -1017,7 +1018,7 @@ def is_ownable_target(tgt: Target, union_membership: UnionMembership) -> bool:
 
 
 # Convenient type alias for the pair (package name, data files in the package).
-PackageDatum = Tuple[str, Tuple[str, ...]]
+PackageDatum = tuple[str, tuple[str, ...]]
 
 
 def find_packages(
@@ -1136,7 +1137,7 @@ def merge_entry_points(
     """Merge all entry points, throwing ValueError if there are any conflicts."""
     merged = cast(
         # this gives us a two level deep defaultdict with the inner values being of list type
-        DefaultDict[str, DefaultDict[str, List[Tuple[str, str]]]],
+        DefaultDict[str, DefaultDict[str, list[tuple[str, str]]]],
         defaultdict(partial(defaultdict, list)),
     )
 

--- a/src/python/pants/backend/python/util_rules/package_dists_test.py
+++ b/src/python/pants/backend/python/util_rules/package_dists_test.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import textwrap
-from typing import Iterable
+from collections.abc import Iterable
 
 import pytest
 

--- a/src/python/pants/backend/python/util_rules/partition.py
+++ b/src/python/pants/backend/python/util_rules/partition.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 
 import itertools
 from collections import defaultdict
-from typing import Iterable, Mapping, Protocol, Sequence, TypeVar
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Protocol, TypeVar
 
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import InterpreterConstraintsField, PythonResolveField

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -8,10 +8,11 @@ import json
 import logging
 import os
 import shlex
+from collections.abc import Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import PurePath
 from textwrap import dedent  # noqa: PNT20
-from typing import Iterable, Iterator, Mapping, Sequence, TypeVar
+from typing import TypeVar
 
 import packaging.specifiers
 import packaging.version

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 import dataclasses
 import logging
 import os.path
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
-from typing import Iterable, List, Mapping, Optional, Tuple
 
 from pants.backend.python.subsystems.python_native_code import PythonNativeCodeSubsystem
 from pants.backend.python.subsystems.setup import PythonSetup
@@ -78,10 +78,10 @@ class PexCliProcess:
     subcommand: tuple[str, ...]
     extra_args: tuple[str, ...]
     description: str = dataclasses.field(compare=False)
-    additional_input_digest: Optional[Digest]
-    extra_env: Optional[FrozenDict[str, str]]
-    output_files: Optional[Tuple[str, ...]]
-    output_directories: Optional[Tuple[str, ...]]
+    additional_input_digest: Digest | None
+    extra_env: FrozenDict[str, str] | None
+    output_files: tuple[str, ...] | None
+    output_directories: tuple[str, ...] | None
     level: LogLevel
     concurrency_available: int
     cache_scope: ProcessCacheScope
@@ -92,10 +92,10 @@ class PexCliProcess:
         subcommand: Iterable[str],
         extra_args: Iterable[str],
         description: str,
-        additional_input_digest: Optional[Digest] = None,
-        extra_env: Optional[Mapping[str, str]] = None,
-        output_files: Optional[Iterable[str]] = None,
-        output_directories: Optional[Iterable[str]] = None,
+        additional_input_digest: Digest | None = None,
+        extra_env: Mapping[str, str] | None = None,
+        output_files: Iterable[str] | None = None,
+        output_directories: Iterable[str] | None = None,
         level: LogLevel = LogLevel.INFO,
         concurrency_available: int = 0,
         cache_scope: ProcessCacheScope = ProcessCacheScope.SUCCESSFUL,
@@ -143,7 +143,7 @@ async def setup_pex_cli_process(
     python_setup: PythonSetup,
 ) -> Process:
     tmpdir = ".tmp"
-    gets: List[Get] = [Get(Digest, CreateDigest([Directory(tmpdir)]))]
+    gets: list[Get] = [Get(Digest, CreateDigest([Directory(tmpdir)]))]
 
     cert_args = []
     if global_options.ca_certs_path:

--- a/src/python/pants/backend/python/util_rules/pex_environment.py
+++ b/src/python/pants/backend/python/util_rules/pex_environment.py
@@ -4,9 +4,9 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Mapping
 
 from pants.core.subsystems.python_bootstrap import PythonBootstrap
 from pants.core.util_rules import subprocess_environment, system_binaries

--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 
 import dataclasses
 import logging
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
-from typing import Iterable, Mapping
 
 from packaging.utils import canonicalize_name as canonicalize_project_name
 

--- a/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
@@ -6,11 +6,12 @@ from __future__ import annotations
 import importlib.resources
 import subprocess
 import sys
+from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path, PurePath
 from textwrap import dedent
-from typing import Iterable, List, cast
+from typing import cast
 from unittest.mock import Mock
 
 import pytest
@@ -561,7 +562,7 @@ def create_dists(workdir: Path, project: Project, *projects: Project) -> PurePat
 
 
 def requirements(rule_runner: PythonRuleRunner, pex: Pex) -> list[str]:
-    return cast(List[str], get_all_data(rule_runner, pex).info["requirements"])
+    return cast(list[str], get_all_data(rule_runner, pex).info["requirements"])
 
 
 def test_constraints_validation(tmp_path: Path, rule_runner: PythonRuleRunner) -> None:

--- a/src/python/pants/backend/python/util_rules/pex_requirements.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 
 import importlib.resources
 import logging
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Iterable, Iterator
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 from pants.backend.python.subsystems.repos import PythonRepos

--- a/src/python/pants/backend/python/util_rules/pex_test_utils.py
+++ b/src/python/pants/backend/python/util_rules/pex_test_utils.py
@@ -6,9 +6,10 @@ from __future__ import annotations
 import json
 import os.path
 import zipfile
+from collections.abc import Iterable, Iterator, Mapping
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Any, Iterable, Iterator, Mapping
+from typing import Any
 
 from pants.backend.python.target_types import MainSpecification, PexLayout
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints

--- a/src/python/pants/backend/python/util_rules/python_sources.py
+++ b/src/python/pants/backend/python/util_rules/python_sources.py
@@ -3,8 +3,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 from pants.backend.python.target_types import PythonSourceField
 from pants.backend.python.util_rules import ancestor_files

--- a/src/python/pants/backend/python/util_rules/python_sources_test.py
+++ b/src/python/pants/backend/python/util_rules/python_sources_test.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 import os.path
+from collections.abc import Iterable
 from textwrap import dedent
-from typing import Iterable
 
 import pytest
 

--- a/src/python/pants/backend/rust/util_rules/toolchains.py
+++ b/src/python/pants/backend/rust/util_rules/toolchains.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import dataclasses
 import os
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 from pants.backend.rust.subsystems.rust import RustSubsystem
 from pants.core.util_rules.system_binaries import (

--- a/src/python/pants/backend/scala/bsp/rules.py
+++ b/src/python/pants/backend/scala/bsp/rules.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import logging
 import textwrap
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable
 
 from pants.backend.scala.bsp.spec import (
     ScalaBuildTarget,

--- a/src/python/pants/backend/scala/compile/scalac_plugins.py
+++ b/src/python/pants/backend/scala/compile/scalac_plugins.py
@@ -3,8 +3,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
-from typing import Iterable, Iterator
 
 from pants.backend.scala.subsystems.scalac import Scalac
 from pants.backend.scala.target_types import (

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import json
 import logging
 import os
+from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
-from typing import Any, Iterator, Mapping
+from typing import Any
 
 from pants.backend.scala.subsystems.scala import ScalaSubsystem
 from pants.backend.scala.subsystems.scalac import Scalac

--- a/src/python/pants/backend/scala/dependency_inference/symbol_mapper.py
+++ b/src/python/pants/backend/scala/dependency_inference/symbol_mapper.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Mapping
+from collections.abc import Mapping
 
 from pants.backend.scala.dependency_inference.scala_parser import ScalaSourceDependencyAnalysis
 from pants.backend.scala.target_types import ScalaSourceField

--- a/src/python/pants/backend/scala/goals/tailor.py
+++ b/src/python/pants/backend/scala/goals/tailor.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 from pants.backend.scala.subsystems.scala import ScalaSubsystem
 from pants.backend.scala.target_types import (

--- a/src/python/pants/backend/scala/lint/scalafix/rules.py
+++ b/src/python/pants/backend/scala/lint/scalafix/rules.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import os.path
 from collections import defaultdict
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Iterable, cast
+from typing import cast
 
 from pants.backend.scala.lint.scalafix.extra_fields import SkipScalafixField
 from pants.backend.scala.lint.scalafix.subsystem import ScalafixSubsystem

--- a/src/python/pants/backend/scala/lint/scalafix/rules_integration_test.py
+++ b/src/python/pants/backend/scala/lint/scalafix/rules_integration_test.py
@@ -2,8 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from __future__ import annotations
 
+from collections.abc import Callable
 from textwrap import dedent
-from typing import Any, Callable, TypeVar, overload
+from typing import Any, TypeVar, overload
 
 import pytest
 

--- a/src/python/pants/backend/scala/test/scalatest_test.py
+++ b/src/python/pants/backend/scala/test/scalatest_test.py
@@ -3,8 +3,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from textwrap import dedent
-from typing import List, Mapping
 
 import pytest
 
@@ -287,7 +287,7 @@ def run_scalatest_test(
     target_name: str,
     relative_file_path: str,
     *,
-    extra_args: List[str] | None = None,
+    extra_args: list[str] | None = None,
     env: Mapping[str, str] | None = None,
 ) -> TestResult:
     args = extra_args or []

--- a/src/python/pants/backend/shell/goals/tailor.py
+++ b/src/python/pants/backend/shell/goals/tailor.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 from pants.backend.shell.subsystems.shell_setup import ShellSetup
 from pants.backend.shell.target_types import (

--- a/src/python/pants/backend/shell/lint/shellcheck/subsystem.py
+++ b/src/python/pants/backend/shell/lint/shellcheck/subsystem.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import os.path
-from typing import Iterable
+from collections.abc import Iterable
 
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.core.util_rules.external_tool import TemplatedExternalTool

--- a/src/python/pants/backend/shell/lint/shfmt/subsystem.py
+++ b/src/python/pants/backend/shell/lint/shfmt/subsystem.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import os.path
-from typing import Iterable
+from collections.abc import Iterable
 
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.core.util_rules.external_tool import TemplatedExternalTool

--- a/src/python/pants/backend/sql/lint/sqlfluff/rules.py
+++ b/src/python/pants/backend/sql/lint/sqlfluff/rules.py
@@ -2,10 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Any, Iterable, Tuple
-
-from typing_extensions import assert_never
+from typing import Any, assert_never
 
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import PexRequest, VenvPexProcess, create_venv_pex
@@ -73,7 +72,7 @@ async def run_sqlfluff(
         MergeDigests((request.snapshot.digest, config_files.snapshot.digest))
     )
 
-    initial_args: Tuple[str, ...] = ()
+    initial_args: tuple[str, ...] = ()
     if request.mode is SqlfluffMode.FMT:
         initial_args = ("format",)
     elif request.mode is SqlfluffMode.FIX:

--- a/src/python/pants/backend/sql/lint/sqlfluff/skip_field.py
+++ b/src/python/pants/backend/sql/lint/sqlfluff/skip_field.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Iterable
+from collections.abc import Iterable
 
 from pants.backend.sql.target_types import SqlSourcesGeneratorTarget, SqlSourceTarget
 from pants.engine.target import BoolField

--- a/src/python/pants/backend/sql/lint/sqlfluff/subsystem.py
+++ b/src/python/pants/backend/sql/lint/sqlfluff/subsystem.py
@@ -4,9 +4,9 @@
 from __future__ import annotations
 
 import os.path
+from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import Enum
-from typing import Iterable
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript

--- a/src/python/pants/backend/swift/goals/tailor.py
+++ b/src/python/pants/backend/swift/goals/tailor.py
@@ -3,8 +3,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 from pants.backend.swift.target_types import SWIFT_FILE_EXTENSIONS, SwiftSourcesGeneratorTarget
 from pants.core.goals.tailor import (

--- a/src/python/pants/backend/terraform/dependencies.py
+++ b/src/python/pants/backend/terraform/dependencies.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import os
 import os.path
 from dataclasses import dataclass
-from typing import Optional
 
 from pants.backend.terraform.dependency_inference import (
     TerraformDeploymentInvocationFiles,
@@ -37,7 +36,7 @@ from pants.option.global_options import KeepSandboxes
 @dataclass(frozen=True)
 class TerraformDependenciesRequest:
     chdir: str
-    backend_config: Optional[str]
+    backend_config: str | None
     lockfile: bool
     dependencies_files: Digest
 

--- a/src/python/pants/backend/terraform/dependencies_test.py
+++ b/src/python/pants/backend/terraform/dependencies_test.py
@@ -6,7 +6,6 @@ import dataclasses
 import json
 import textwrap
 from pathlib import Path
-from typing import Optional
 
 from pants.backend.terraform.dependencies import TerraformInitRequest, TerraformInitResponse
 from pants.backend.terraform.goals.deploy import DeployTerraformFieldSet
@@ -46,11 +45,11 @@ def _do_init_terraform(
     return initialised_files, initialised_entries
 
 
-def find_file(files: DigestContents, pattern: str) -> Optional[FileContent]:
+def find_file(files: DigestContents, pattern: str) -> FileContent | None:
     return next((file for file in files if Path(file.path).match(pattern)), None)
 
 
-def find_link(entries: DigestEntries, pattern: str) -> Optional[SymlinkEntry]:
+def find_link(entries: DigestEntries, pattern: str) -> SymlinkEntry | None:
     for entry in entries:
         if not isinstance(entry, SymlinkEntry):
             continue

--- a/src/python/pants/backend/terraform/dependency_inference.py
+++ b/src/python/pants/backend/terraform/dependency_inference.py
@@ -2,9 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from __future__ import annotations
 
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Iterable, Optional, Sequence
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolRequirementsBase
 from pants.backend.python.target_types import EntryPoint
@@ -151,7 +151,7 @@ class TerraformDeploymentInvocationFiles:
 
     backend_configs: tuple[TerraformBackendTarget, ...]
     vars_files: tuple[TerraformVarFileTarget, ...]
-    lockfile: Optional[LockfileTarget]
+    lockfile: LockfileTarget | None
 
 
 @rule

--- a/src/python/pants/backend/terraform/goals/check.py
+++ b/src/python/pants/backend/terraform/goals/check.py
@@ -1,7 +1,6 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from dataclasses import dataclass
-from typing import Union
 
 from pants.backend.terraform.dependencies import TerraformInitRequest, TerraformInitResponse
 from pants.backend.terraform.target_types import (
@@ -50,7 +49,7 @@ class TerraformCheckRequest(CheckRequest):
 
 
 def terraform_fieldset_to_init_request(
-    terraform_fieldset: Union[TerraformDeploymentFieldSet, TerraformFieldSet]
+    terraform_fieldset: TerraformDeploymentFieldSet | TerraformFieldSet,
 ) -> TerraformInitRequest:
     if isinstance(terraform_fieldset, TerraformDeploymentFieldSet):
         deployment = terraform_fieldset

--- a/src/python/pants/backend/terraform/goals/check_test.py
+++ b/src/python/pants/backend/terraform/goals/check_test.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import textwrap
-from typing import Dict, Sequence
+from collections.abc import Sequence
 
 import pytest
 
@@ -221,7 +221,7 @@ def test_conflicting_provider_versions(rule_runner: RuleRunner) -> None:
     target_name = "in_folder"
     versions = ["3.2.1", "3.2.2"]
 
-    def make_terraform_module(version: str) -> Dict[str, str]:
+    def make_terraform_module(version: str) -> dict[str, str]:
         return {
             f"folder{version}/BUILD": textwrap.dedent(
                 f"""\

--- a/src/python/pants/backend/terraform/goals/tailor.py
+++ b/src/python/pants/backend/terraform/goals/tailor.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import os.path
 from dataclasses import dataclass
-from typing import List
 
 from pants.backend.terraform.target_types import (
     TerraformBackendTarget,
@@ -40,7 +39,7 @@ async def find_putative_terraform_module_targets(
 ) -> PutativeTargets:
     if not terraform.tailor:
         return PutativeTargets()
-    putative_targets: List[PutativeTarget] = []
+    putative_targets: list[PutativeTarget] = []
 
     all_terraform_files = await Get(Paths, PathGlobs, request.path_globs("*.tf"))
     unowned_terraform_files = set(all_terraform_files.files) - set(all_owned_sources)

--- a/src/python/pants/backend/terraform/hcl2_parser.py
+++ b/src/python/pants/backend/terraform/hcl2_parser.py
@@ -3,7 +3,6 @@
 
 import sys
 from pathlib import PurePath
-from typing import Set
 
 #
 # Note: This file is used as a pex entry point in the execution sandbox.
@@ -27,7 +26,7 @@ def resolve_pure_path(base: PurePath, relative_path: PurePath) -> PurePath:
     return PurePath(*parts)
 
 
-def extract_module_source_paths(path: PurePath, raw_content: bytes) -> Set[str]:
+def extract_module_source_paths(path: PurePath, raw_content: bytes) -> set[str]:
     # Import here so we can still test this file with pytest (since `hcl2` is not present in
     # normal Pants venv.)
     import hcl2  # type: ignore[import-not-found]  # pants: no-infer-dep

--- a/src/python/pants/backend/terraform/lint/tffmt/tffmt_integration_test.py
+++ b/src/python/pants/backend/terraform/lint/tffmt/tffmt_integration_test.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import textwrap
-from typing import List, NewType
+from typing import NewType
 
 import pytest
 
@@ -22,7 +22,7 @@ from pants.engine.internals.native_engine import Snapshot
 from pants.engine.target import Target
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
-RuleRunnerOptions = NewType("RuleRunnerOptions", List[str])
+RuleRunnerOptions = NewType("RuleRunnerOptions", list[str])
 
 
 available_tf_versions = [
@@ -105,7 +105,7 @@ FIXED_BAD_SOURCE = FileContent(
 
 
 def make_target(
-    rule_runner: RuleRunner, source_files: List[FileContent], *, target_name="target"
+    rule_runner: RuleRunner, source_files: list[FileContent], *, target_name="target"
 ) -> Target:
     rule_runner.write_files(
         {
@@ -118,7 +118,7 @@ def make_target(
 
 def run_tffmt(
     rule_runner: RuleRunner,
-    targets: List[Target],
+    targets: list[Target],
     options: RuleRunnerOptions,
 ) -> FmtResult | None:
     rule_runner.set_options(options)
@@ -159,7 +159,7 @@ def get_content(rule_runner: RuleRunner, digest: Digest) -> DigestContents:
     return rule_runner.request(DigestContents, [digest])
 
 
-def get_snapshot(rule_runner: RuleRunner, source_files: List[FileContent]) -> Snapshot:
+def get_snapshot(rule_runner: RuleRunner, source_files: list[FileContent]) -> Snapshot:
     digest = rule_runner.request(Digest, [CreateDigest(source_files)])
     return rule_runner.request(Snapshot, [digest])
 

--- a/src/python/pants/backend/terraform/partition.py
+++ b/src/python/pants/backend/terraform/partition.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import os
 from collections import defaultdict
-from typing import Iterable
+from collections.abc import Iterable
 
 
 def partition_files_by_directory(filepaths: Iterable[str]) -> dict[str, list[str]]:

--- a/src/python/pants/backend/terraform/tool.py
+++ b/src/python/pants/backend/terraform/tool.py
@@ -18,9 +18,9 @@ from __future__ import annotations
 
 import os
 import shlex
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, Tuple
 
 from pants.core.goals.resolves import ExportableTool
 from pants.core.util_rules import external_tool
@@ -456,7 +456,7 @@ async def setup_terraform_process(
         "__terraform": downloaded_terraform.digest,
     }
 
-    def prepend_paths(paths: Tuple[str, ...]) -> Tuple[str, ...]:
+    def prepend_paths(paths: tuple[str, ...]) -> tuple[str, ...]:
         return tuple((Path(request.chdir) / path).as_posix() for path in paths)
 
     # Initialise the Terraform provider cache, since Terraform expects the directory to already exist.

--- a/src/python/pants/backend/tools/preamble/subsystem.py
+++ b/src/python/pants/backend/tools/preamble/subsystem.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from __future__ import annotations
 
-from typing import Sequence
+from collections.abc import Sequence
 
 from pants.option.option_types import DictOption, SkipOption
 from pants.option.subsystem import Subsystem

--- a/src/python/pants/backend/tools/semgrep/rules.py
+++ b/src/python/pants/backend/tools/semgrep/rules.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import itertools
 import logging
 from collections import defaultdict
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Iterable
 
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import VenvPexProcess, create_venv_pex

--- a/src/python/pants/backend/tools/semgrep/rules_integration_test.py
+++ b/src/python/pants/backend/tools/semgrep/rules_integration_test.py
@@ -3,8 +3,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from textwrap import dedent
-from typing import Sequence
 
 import pytest
 

--- a/src/python/pants/backend/tools/semgrep/subsystem.py
+++ b/src/python/pants/backend/tools/semgrep/subsystem.py
@@ -3,8 +3,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript

--- a/src/python/pants/backend/tools/trufflehog/rules.py
+++ b/src/python/pants/backend/tools/trufflehog/rules.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable
+from collections.abc import Iterable
 
 from pants.backend.tools.trufflehog.subsystem import Trufflehog
 from pants.core.goals.lint import LintFilesRequest, LintResult

--- a/src/python/pants/backend/tools/workunit_logger/rules.py
+++ b/src/python/pants/backend/tools/workunit_logger/rules.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 import json
 import logging
-from typing import Any, Dict, Tuple
+from typing import Any
 
 from pants.engine.internals.scheduler import Workunit
 from pants.engine.rules import collect_rules, rule
@@ -48,7 +48,7 @@ class WorkunitLoggerCallback(WorkunitsCallback):
 
     def __init__(self, wulogger: "WorkunitLogger"):
         self.wulogger = wulogger
-        self._completed_workunits: Dict[str, object] = {}
+        self._completed_workunits: dict[str, object] = {}
 
     @property
     def can_finish_async(self) -> bool:
@@ -57,8 +57,8 @@ class WorkunitLoggerCallback(WorkunitsCallback):
     def __call__(
         self,
         *,
-        completed_workunits: Tuple[Workunit, ...],
-        started_workunits: Tuple[Workunit, ...],
+        completed_workunits: tuple[Workunit, ...],
+        started_workunits: tuple[Workunit, ...],
         context: StreamingWorkunitContext,
         finished: bool = False,
         **kwargs: Any,

--- a/src/python/pants/backend/tools/yamllint/subsystem.py
+++ b/src/python/pants/backend/tools/yamllint/subsystem.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable
+from collections.abc import Iterable
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript

--- a/src/python/pants/backend/tsx/goals/tailor.py
+++ b/src/python/pants/backend/tsx/goals/tailor.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 import dataclasses
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 from pants.backend.tsx.target_types import (
     TSX_FILE_EXTENSIONS,

--- a/src/python/pants/backend/typescript/dependency_inference/rules.py
+++ b/src/python/pants/backend/typescript/dependency_inference/rules.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import itertools
 import os.path
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 from pants.backend.javascript import package_json
 from pants.backend.javascript.dependency_inference.rules import (

--- a/src/python/pants/backend/typescript/goals/tailor.py
+++ b/src/python/pants/backend/typescript/goals/tailor.py
@@ -1,8 +1,8 @@
 # Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 import dataclasses
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable, Union
 
 from pants.backend.typescript.target_types import (
     TS_FILE_EXTENSIONS,
@@ -55,7 +55,7 @@ async def find_putative_ts_targets(
     )
 
 
-def rules() -> Iterable[Union[Rule, UnionRule]]:
+def rules() -> Iterable[Rule | UnionRule]:
     return (
         *collect_rules(),
         UnionRule(PutativeTargetsRequest, PutativeTypeScriptTargetsRequest),

--- a/src/python/pants/backend/typescript/tsconfig.py
+++ b/src/python/pants/backend/typescript/tsconfig.py
@@ -14,9 +14,10 @@ import json
 import logging
 import os
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Iterable, Literal
+from typing import Literal
 
 from pants.engine.collection import Collection
 from pants.engine.fs import DigestContents, FileContent, PathGlobs

--- a/src/python/pants/backend/visibility/glob.py
+++ b/src/python/pants/backend/visibility/glob.py
@@ -8,7 +8,8 @@ import re
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Pattern
+from re import Pattern
+from typing import Any
 
 from pants.engine.addresses import Address
 from pants.engine.internals.target_adaptor import TargetAdaptor

--- a/src/python/pants/backend/visibility/glob_test.py
+++ b/src/python/pants/backend/visibility/glob_test.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import os
 import re
-from typing import Any, Mapping
+from collections.abc import Mapping
+from typing import Any
 
 import pytest
 

--- a/src/python/pants/backend/visibility/rule_types.py
+++ b/src/python/pants/backend/visibility/rule_types.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import itertools
 import logging
 import os.path
+from collections.abc import Iterable, Iterator, Sequence
 from dataclasses import dataclass, field
 from pathlib import PurePath
 from pprint import pformat
-from typing import Any, Iterable, Iterator, Sequence, cast
+from typing import Any, cast
 
 from pants.backend.visibility.glob import TargetGlob
 from pants.engine.addresses import Address

--- a/src/python/pants/base/build_root.py
+++ b/src/python/pants/base/build_root.py
@@ -2,9 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
+from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Iterator, Optional
 
 from pants.util.meta import SingletonMetaclass
 
@@ -36,7 +36,7 @@ class BuildRoot(metaclass=SingletonMetaclass):
         return str(buildroot)
 
     def __init__(self) -> None:
-        self._root_dir: Optional[str] = None
+        self._root_dir: str | None = None
 
     @property
     def pathlib_path(self) -> Path:

--- a/src/python/pants/base/deprecated.py
+++ b/src/python/pants/base/deprecated.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 
 import inspect
 import logging
+from collections.abc import Callable
 from functools import wraps
-from typing import Any, Callable, TypeVar
+from typing import Any, TypeVar
 
 from packaging.version import InvalidVersion, Version
 

--- a/src/python/pants/base/exception_sink.py
+++ b/src/python/pants/base/exception_sink.py
@@ -10,8 +10,8 @@ import signal
 import sys
 import threading
 import traceback
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
-from typing import Callable, Dict, Iterator
 
 import psutil
 import setproctitle
@@ -34,7 +34,7 @@ class SignalHandler:
     """
 
     @property
-    def signal_handler_mapping(self) -> Dict[signal.Signals, Callable]:
+    def signal_handler_mapping(self) -> dict[signal.Signals, Callable]:
         """A dict mapping (signal number) -> (a method handling the signal)."""
         # Could use an enum here, but we never end up doing any matching on the specific signal value,
         # instead just iterating over the registered signals to set handlers, so a dict is probably

--- a/src/python/pants/base/exception_sink_integration_test.py
+++ b/src/python/pants/base/exception_sink_integration_test.py
@@ -6,7 +6,6 @@ import re
 import signal
 import time
 from pathlib import Path
-from typing import List, Tuple
 
 import pytest
 
@@ -19,7 +18,7 @@ from pants_test.pantsd.pantsd_integration_test_base import PantsDaemonIntegratio
 pytestmark = pytest.mark.platform_specific_behavior
 
 
-def lifecycle_stub_cmdline() -> List[str]:
+def lifecycle_stub_cmdline() -> list[str]:
     # Load the testprojects pants-plugins to get some testing tasks and subsystems.
     testproject_backend_src_dir = os.path.join(
         get_buildroot(), "testprojects/pants-plugins/src/python"
@@ -36,7 +35,7 @@ def lifecycle_stub_cmdline() -> List[str]:
     return lifecycle_stub_cmdline
 
 
-def get_log_file_paths(workdir: str, pid: int) -> Tuple[str, str]:
+def get_log_file_paths(workdir: str, pid: int) -> tuple[str, str]:
     pid_specific_log_file = ExceptionSink.exceptions_log_path(for_pid=pid, in_dir=workdir)
     assert os.path.isfile(pid_specific_log_file)
 

--- a/src/python/pants/base/parse_context.py
+++ b/src/python/pants/base/parse_context.py
@@ -2,7 +2,8 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-from typing import Any, Mapping, Protocol
+from collections.abc import Mapping
+from typing import Any, Protocol
 
 
 class FilePathOracle(Protocol):

--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 
 import os
 from abc import ABC, abstractmethod
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
-from typing import ClassVar, Iterable, Iterator, Protocol, cast
+from typing import ClassVar, Protocol, cast
 
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.build_graph.address import Address

--- a/src/python/pants/base/specs_parser.py
+++ b/src/python/pants/base/specs_parser.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 import os.path
+from collections.abc import Iterable
 from pathlib import Path, PurePath
-from typing import Iterable
 
 from pants.base.build_environment import get_buildroot
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior

--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -7,7 +7,6 @@ import sys
 import time
 from contextlib import contextmanager
 from threading import Lock
-from typing import Dict, Tuple
 
 from pants.base.exiter import PANTS_FAILED_EXIT_CODE, ExitCode
 from pants.bin.local_pants_runner import LocalPantsRunner
@@ -97,8 +96,8 @@ class DaemonPantsRunner:
 
     def single_daemonized_run(
         self,
-        args: Tuple[str, ...],
-        env: Dict[str, str],
+        args: tuple[str, ...],
+        env: dict[str, str],
         working_dir: str,
         cancellation_latch: PySessionCancellationLatch,
     ) -> ExitCode:
@@ -150,8 +149,8 @@ class DaemonPantsRunner:
     def __call__(
         self,
         command: str,
-        args: Tuple[str, ...],
-        env: Dict[str, str],
+        args: tuple[str, ...],
+        env: dict[str, str],
         working_dir: str,
         cancellation_latch: PySessionCancellationLatch,
         stdin_fileno: int,

--- a/src/python/pants/bin/loader_integration_test.py
+++ b/src/python/pants/bin/loader_integration_test.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-from typing import Union
 
 from pants.bin.pants_env_vars import (
     DAEMON_ENTRYPOINT,
@@ -86,7 +85,7 @@ def test_recursion_limit() -> None:
 
 
 def test_non_utf8_env_vars() -> None:
-    env: dict[Union[str, bytes], Union[str, bytes]] = {
+    env: dict[str | bytes, str | bytes] = {
         "FOO": b"B\xa5R",
         b"F\xa5O": "BAR",
     }

--- a/src/python/pants/bin/local_pants_runner_integration_test.py
+++ b/src/python/pants/bin/local_pants_runner_integration_test.py
@@ -1,7 +1,7 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Sequence
+from collections.abc import Sequence
 
 from pants.testutil.pants_integration_test import PantsResult, run_pants
 

--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -6,8 +6,8 @@ import os
 import platform
 import sys
 import warnings
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import List, Mapping
 
 from packaging.version import Version
 
@@ -35,7 +35,7 @@ class PantsRunner:
     """A higher-level runner that delegates runs to either a LocalPantsRunner or
     RemotePantsRunner."""
 
-    args: List[str]
+    args: list[str]
     env: Mapping[str, str]
 
     # This could be a bootstrap option, but it's preferable to keep these very limited to make it

--- a/src/python/pants/bin/remote_pants_runner.py
+++ b/src/python/pants/bin/remote_pants_runner.py
@@ -7,8 +7,8 @@ import signal
 import sys
 import termios
 import time
+from collections.abc import Mapping
 from contextlib import contextmanager
-from typing import List, Mapping
 
 from pants.base.exiter import ExitCode
 from pants.engine.internals.native_engine import (
@@ -97,7 +97,7 @@ class RemotePantsRunner:
 
     def __init__(
         self,
-        args: List[str],
+        args: list[str],
         env: Mapping[str, str],
         options_bootstrapper: OptionsBootstrapper,
     ) -> None:

--- a/src/python/pants/bsp/context.py
+++ b/src/python/pants/bsp/context.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import threading
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
 
 from pants.bsp.spec.lifecycle import InitializeBuildParams
 from pants.bsp.spec.notification import BSPNotification

--- a/src/python/pants/bsp/goal.py
+++ b/src/python/pants/bsp/goal.py
@@ -8,7 +8,7 @@ import os
 import shlex
 import sys
 import textwrap
-from typing import Mapping
+from collections.abc import Mapping
 
 from pants.base.build_root import BuildRoot
 from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE, ExitCode

--- a/src/python/pants/bsp/testutil.py
+++ b/src/python/pants/bsp/testutil.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 
 import functools
 import os
+from collections.abc import Iterable
 from contextlib import contextmanager
 from dataclasses import dataclass
 from threading import Thread
-from typing import Any, BinaryIO, Dict, Iterable, Tuple
+from typing import Any, BinaryIO
 
 from pylsp_jsonrpc.endpoint import Endpoint  # type: ignore[import-untyped]
 from pylsp_jsonrpc.streams import (  # type: ignore[import-untyped]
@@ -58,7 +59,7 @@ def setup_pipes():
 
 
 # A notification method name, and a subset of its fields.
-NotificationSubset = Tuple[str, Dict[str, Any]]
+NotificationSubset = tuple[str, dict[str, Any]]
 
 
 @dataclass

--- a/src/python/pants/bsp/util_rules/compile.py
+++ b/src/python/pants/bsp/util_rules/compile.py
@@ -7,7 +7,7 @@ import time
 import uuid
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Type, TypeVar
+from typing import TypeVar
 
 from pants.bsp.context import BSPContext
 from pants.bsp.protocol import BSPHandlerMapping
@@ -53,10 +53,10 @@ async def compile_bsp_target(
     union_membership: UnionMembership,
 ) -> BSPCompileResult:
     targets = await Get(Targets, BSPBuildTargetInternal, request.bsp_target)
-    compile_request_types: FrozenOrderedSet[Type[BSPCompileRequest]] = union_membership.get(
+    compile_request_types: FrozenOrderedSet[type[BSPCompileRequest]] = union_membership.get(
         BSPCompileRequest
     )
-    field_sets_by_request_type: dict[Type[BSPCompileRequest], set[FieldSet]] = defaultdict(set)
+    field_sets_by_request_type: dict[type[BSPCompileRequest], set[FieldSet]] = defaultdict(set)
     for target in targets:
         for compile_request_type in compile_request_types:
             field_set_type = compile_request_type.field_set_type

--- a/src/python/pants/bsp/util_rules/queries.py
+++ b/src/python/pants/bsp/util_rules/queries.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from __future__ import annotations
 
-from typing import Iterable
+from collections.abc import Iterable
 
 from pants.bsp.protocol import BSPHandlerMapping
 from pants.engine.environment import EnvironmentName

--- a/src/python/pants/bsp/util_rules/resources.py
+++ b/src/python/pants/bsp/util_rules/resources.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Type, TypeVar
+from typing import TypeVar
 
 from pants.bsp.protocol import BSPHandlerMapping
 from pants.bsp.spec.base import BuildTargetIdentifier
@@ -45,10 +45,10 @@ async def resources_bsp_target(
     union_membership: UnionMembership,
 ) -> BSPResourcesResult:
     targets = await Get(Targets, BSPBuildTargetInternal, request.bsp_target)
-    resources_request_types: FrozenOrderedSet[Type[BSPResourcesRequest]] = union_membership.get(
+    resources_request_types: FrozenOrderedSet[type[BSPResourcesRequest]] = union_membership.get(
         BSPResourcesRequest
     )
-    field_sets_by_request_type: dict[Type[BSPResourcesRequest], set[FieldSet]] = defaultdict(set)
+    field_sets_by_request_type: dict[type[BSPResourcesRequest], set[FieldSet]] = defaultdict(set)
     for target in targets:
         for resources_request_type in resources_request_types:
             field_set_type = resources_request_type.field_set_type

--- a/src/python/pants/bsp/util_rules/targets.py
+++ b/src/python/pants/bsp/util_rules/targets.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import itertools
 import logging
 from collections import defaultdict
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import ClassVar, Generic, Sequence, Type, TypeVar
+from typing import ClassVar, Generic, TypeVar
 
 import toml
 
@@ -74,7 +75,7 @@ class BSPBuildTargetsMetadataRequest(Generic[_FS]):
 
     language_id: ClassVar[str]
     can_merge_metadata_from: ClassVar[tuple[str, ...]]
-    field_set_type: ClassVar[Type[_FS]]  # type: ignore[misc]
+    field_set_type: ClassVar[type[_FS]]  # type: ignore[misc]
 
     resolve_prefix: ClassVar[str]
     resolve_field: ClassVar[type[Field]]
@@ -358,7 +359,7 @@ async def generate_one_bsp_build_target_request(
     field_sets_by_request_type: dict[type[BSPBuildTargetsMetadataRequest], OrderedSet[FieldSet]] = (
         defaultdict(OrderedSet)
     )
-    metadata_request_types: FrozenOrderedSet[Type[BSPBuildTargetsMetadataRequest]] = (
+    metadata_request_types: FrozenOrderedSet[type[BSPBuildTargetsMetadataRequest]] = (
         union_membership.get(BSPBuildTargetsMetadataRequest)
     )
     metadata_request_types_by_lang_id: dict[str, type[BSPBuildTargetsMetadataRequest]] = {}
@@ -375,7 +376,7 @@ async def generate_one_bsp_build_target_request(
 
     for tgt in targets:
         for metadata_request_type in metadata_request_types:
-            field_set_type: Type[FieldSet] = metadata_request_type.field_set_type
+            field_set_type: type[FieldSet] = metadata_request_type.field_set_type
             if field_set_type.is_applicable(tgt):
                 field_sets_by_request_type[metadata_request_type].add(field_set_type.create(tgt))
 
@@ -541,7 +542,7 @@ async def bsp_dependency_sources(request: DependencySourcesParams) -> Dependency
 class BSPDependencyModulesRequest(Generic[_FS]):
     """Hook to allow language backends to provide dependency modules."""
 
-    field_set_type: ClassVar[Type[_FS]]  # type: ignore[misc]
+    field_set_type: ClassVar[type[_FS]]  # type: ignore[misc]
 
     field_sets: tuple[_FS, ...]
 
@@ -577,10 +578,10 @@ async def resolve_one_dependency_module(
 ) -> ResolveOneDependencyModuleResult:
     targets = await Get(Targets, BuildTargetIdentifier, request.bsp_target_id)
 
-    field_sets_by_request_type: dict[Type[BSPDependencyModulesRequest], list[FieldSet]] = (
+    field_sets_by_request_type: dict[type[BSPDependencyModulesRequest], list[FieldSet]] = (
         defaultdict(list)
     )
-    dep_module_request_types: FrozenOrderedSet[Type[BSPDependencyModulesRequest]] = (
+    dep_module_request_types: FrozenOrderedSet[type[BSPDependencyModulesRequest]] = (
         union_membership.get(BSPDependencyModulesRequest)
     )
     for tgt in targets:
@@ -639,7 +640,7 @@ async def bsp_dependency_modules(
 class BSPCompileRequest(Generic[_FS]):
     """Hook to allow language backends to compile targets."""
 
-    field_set_type: ClassVar[Type[_FS]]  # type: ignore[misc]
+    field_set_type: ClassVar[type[_FS]]  # type: ignore[misc]
 
     bsp_target: BSPBuildTargetInternal
     field_sets: tuple[_FS, ...]
@@ -669,7 +670,7 @@ class BSPCompileResult:
 class BSPResourcesRequest(Generic[_FS]):
     """Hook to allow language backends to provide resources for targets."""
 
-    field_set_type: ClassVar[Type[_FS]]  # type: ignore[misc]
+    field_set_type: ClassVar[type[_FS]]  # type: ignore[misc]
 
     bsp_target: BSPBuildTargetInternal
     field_sets: tuple[_FS, ...]

--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 import dataclasses
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 from pants.base.exceptions import MappingError
 from pants.engine.engine_aware import EngineAwareParameter

--- a/src/python/pants/build_graph/build_configuration.py
+++ b/src/python/pants/build_graph/build_configuration.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Callable, DefaultDict
+from typing import Any, DefaultDict
 
 from pants.backend.project_info.filter_targets import FilterSubsystem
 from pants.build_graph.build_file_aliases import BuildFileAliases

--- a/src/python/pants/build_graph/build_configuration_test.py
+++ b/src/python/pants/build_graph/build_configuration_test.py
@@ -1,7 +1,6 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Type
 
 import pytest
 
@@ -79,13 +78,13 @@ def test_register_union_rules(bc_builder: BuildConfiguration.Builder) -> None:
 
 
 def test_validation(caplog, bc_builder: BuildConfiguration.Builder) -> None:
-    def mk_dummy_subsys(_options_scope: str, goal: bool = False) -> Type[Subsystem]:
+    def mk_dummy_subsys(_options_scope: str, goal: bool = False) -> type[Subsystem]:
         class DummySubsystem(GoalSubsystem if goal else Subsystem):  # type: ignore[misc]
             options_scope = _options_scope
 
         return DummySubsystem
 
-    def mk_dummy_tgt(_alias: str) -> Type[Target]:
+    def mk_dummy_tgt(_alias: str) -> type[Target]:
         class DummyTarget(Target):
             alias = _alias
             core_fields = tuple()
@@ -120,7 +119,7 @@ def test_validation(caplog, bc_builder: BuildConfiguration.Builder) -> None:
 
 
 def test_register_subsystems(bc_builder: BuildConfiguration.Builder) -> None:
-    def mk_dummy_subsys(_options_scope: str) -> Type[Subsystem]:
+    def mk_dummy_subsys(_options_scope: str) -> type[Subsystem]:
         class DummySubsystem(Subsystem):
             options_scope = _options_scope
 
@@ -147,7 +146,7 @@ def test_register_subsystems(bc_builder: BuildConfiguration.Builder) -> None:
 
 
 def test_register_target_types(bc_builder: BuildConfiguration.Builder) -> None:
-    def mk_dummy_tgt(_alias: str) -> Type[Target]:
+    def mk_dummy_tgt(_alias: str) -> type[Target]:
         class DummyTarget(Target):
             alias = _alias
             core_fields = tuple()

--- a/src/python/pants/build_graph/build_file_aliases.py
+++ b/src/python/pants/build_graph/build_file_aliases.py
@@ -3,8 +3,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
-from typing import Any, Callable, Mapping
+from typing import Any
 
 from pants.base.parse_context import ParseContext
 from pants.util.frozendict import FrozenDict

--- a/src/python/pants/build_graph/subproject_integration_test.py
+++ b/src/python/pants/build_graph/subproject_integration_test.py
@@ -1,9 +1,9 @@
 # Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from collections.abc import Iterator
 from contextlib import contextmanager
 from textwrap import dedent
-from typing import Iterator
 
 from pants.testutil.pants_integration_test import run_pants
 from pants.util.dirutil import safe_file_dump, safe_rmtree

--- a/src/python/pants/core/goals/check.py
+++ b/src/python/pants/core/goals/check.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Any, ClassVar, Generic, Iterable, TypeVar, cast
+from typing import Any, ClassVar, Generic, TypeVar, cast
 
 from pants.core.goals.lint import REPORT_DIR as REPORT_DIR  # noqa: F401
 from pants.core.goals.multi_tool_goal_helper import (

--- a/src/python/pants/core/goals/check_test.py
+++ b/src/python/pants/core/goals/check_test.py
@@ -4,9 +4,9 @@
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
+from collections.abc import Iterable, Sequence
 from pathlib import Path
 from textwrap import dedent
-from typing import Iterable, Optional, Sequence, Tuple, Type
 
 import pytest
 
@@ -143,7 +143,7 @@ class InvalidRequest(MockCheckRequest):
         return -1
 
 
-def make_target(address: Optional[Address] = None) -> Target:
+def make_target(address: Address | None = None) -> Target:
     if address is None:
         address = Address("", target_name="tests")
     return MockTarget({}, address)
@@ -151,10 +151,10 @@ def make_target(address: Optional[Address] = None) -> Target:
 
 def run_typecheck_rule(
     *,
-    request_types: Sequence[Type[CheckRequest]],
+    request_types: Sequence[type[CheckRequest]],
     targets: list[Target],
     only: list[str] | None = None,
-) -> Tuple[int, str]:
+) -> tuple[int, str]:
     union_membership = UnionMembership({CheckRequest: request_types})
     check_subsystem = create_subsystem(CheckSubsystem, only=only or [])
     rule_runner = RuleRunner(bootstrap_args=["-lwarn"])

--- a/src/python/pants/core/goals/deploy.py
+++ b/src/python/pants/core/goals/deploy.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 
 import logging
 from abc import ABCMeta
+from collections.abc import Iterable
 from dataclasses import dataclass
 from itertools import chain
-from typing import Iterable
 
 from pants.core.goals.package import PackageFieldSet
 from pants.core.goals.publish import PublishFieldSet, PublishProcesses, PublishProcessesRequest

--- a/src/python/pants/core/goals/export.py
+++ b/src/python/pants/core/goals/export.py
@@ -6,9 +6,10 @@ from __future__ import annotations
 import itertools
 import os
 from collections import defaultdict
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, Mapping, Sequence, cast
+from typing import cast
 
 from pants.base.build_root import BuildRoot
 from pants.core.goals.generate_lockfiles import (

--- a/src/python/pants/core/goals/export_test.py
+++ b/src/python/pants/core/goals/export_test.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import os
 import subprocess
 from pathlib import Path
-from typing import List, Tuple
 
 from _pytest.monkeypatch import MonkeyPatch
 
@@ -89,9 +88,9 @@ def list_files_with_paths(directory):
 def run_export_rule(
     rule_runner: RuleRunner,
     monkeypatch: MonkeyPatch,
-    resolves: List[str] | None = None,
-    binaries: List[str] | None = None,
-) -> Tuple[int, str]:
+    resolves: list[str] | None = None,
+    binaries: list[str] | None = None,
+) -> tuple[int, str]:
     resolves = resolves or []
     binaries = binaries or []
     union_membership = UnionMembership({ExportRequest: [MockExportRequest]})

--- a/src/python/pants/core/goals/fix.py
+++ b/src/python/pants/core/goals/fix.py
@@ -6,20 +6,9 @@ from __future__ import annotations
 import itertools
 import logging
 from collections import defaultdict
+from collections.abc import Callable, Iterable, Iterator, Sequence
 from dataclasses import dataclass
-from typing import (
-    Any,
-    Callable,
-    ClassVar,
-    Iterable,
-    Iterator,
-    NamedTuple,
-    Protocol,
-    Sequence,
-    Tuple,
-    Type,
-    TypeVar,
-)
+from typing import Any, ClassVar, NamedTuple, Protocol, TypeVar
 
 from pants.base.specs import Specs
 from pants.core.goals.lint import (
@@ -346,7 +335,7 @@ async def _do_fix(
             yield tuple(batch)
 
     def _make_disjoint_batch_requests() -> Iterable[_FixBatchRequest]:
-        partition_infos: Iterable[Tuple[Type[AbstractFixRequest], Any]]
+        partition_infos: Iterable[tuple[type[AbstractFixRequest], Any]]
         files: Sequence[str]
 
         partition_infos_by_files = defaultdict(list)

--- a/src/python/pants/core/goals/fix_test.py
+++ b/src/python/pants/core/goals/fix_test.py
@@ -7,10 +7,10 @@ import dataclasses
 import itertools
 import logging
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path, PurePath
 from textwrap import dedent
-from typing import Iterable, List, Type
 
 import pytest
 
@@ -254,8 +254,8 @@ async def fix_with_bricky(request: BrickyBuildFileFixer.Batch) -> FixResult:
 
 
 def fix_rule_runner(
-    target_types: List[Type[Target]],
-    request_types: List[Type[AbstractFixRequest]] = [],
+    target_types: list[type[Target]],
+    request_types: list[type[AbstractFixRequest]] = [],
 ) -> RuleRunner:
     return RuleRunner(
         rules=[
@@ -272,7 +272,7 @@ def fix_rule_runner(
 def run_fix(
     rule_runner: RuleRunner,
     *,
-    target_specs: List[str],
+    target_specs: list[str],
     only: list[str] | None = None,
     extra_args: Iterable[str] = (),
 ) -> str:

--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Iterable
+from collections.abc import Iterable
 
 from pants.base.specs import Specs
 from pants.core.goals.fix import AbstractFixRequest, FixFilesRequest, FixResult, FixTargetsRequest

--- a/src/python/pants/core/goals/generate_lockfiles.py
+++ b/src/python/pants/core/goals/generate_lockfiles.py
@@ -6,9 +6,10 @@ from __future__ import annotations
 import itertools
 import logging
 from collections import defaultdict
+from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass, replace
 from enum import Enum
-from typing import Callable, Iterable, Iterator, Mapping, Protocol, Sequence, Tuple, Type, cast
+from typing import Protocol, cast
 
 from pants.core.goals.resolves import ExportableTool
 from pants.engine.collection import Collection, DeduplicatedCollection
@@ -134,7 +135,7 @@ class PackageVersion(Protocol):
 
 PackageName = str
 LockfilePackages = FrozenDict[PackageName, PackageVersion]
-ChangedPackages = FrozenDict[PackageName, Tuple[PackageVersion, PackageVersion]]
+ChangedPackages = FrozenDict[PackageName, tuple[PackageVersion, PackageVersion]]
 
 
 @dataclass(frozen=True)
@@ -379,7 +380,7 @@ def determine_resolves_to_generate(
 
 def filter_lockfiles_for_unconfigured_exportable_tools(
     generate_lockfile_requests: Sequence[GenerateLockfile],
-    exportabletools_by_name: dict[str, Type[ExportableTool]],
+    exportabletools_by_name: dict[str, type[ExportableTool]],
     *,
     resolve_specified: bool,
 ) -> tuple[tuple[str, ...], tuple[GenerateLockfile, ...]]:

--- a/src/python/pants/core/goals/generate_lockfiles_test.py
+++ b/src/python/pants/core/goals/generate_lockfiles_test.py
@@ -4,9 +4,9 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from dataclasses import asdict
-from typing import Any, Iterable
+from typing import Any
 from unittest.mock import Mock
 
 import pytest

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -5,10 +5,9 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
+from collections.abc import Callable, Iterable, Iterator, Sequence
 from dataclasses import dataclass
-from typing import Any, Callable, ClassVar, Iterable, Iterator, Protocol, Sequence, TypeVar, cast
-
-from typing_extensions import final
+from typing import Any, ClassVar, Protocol, TypeVar, cast, final
 
 from pants.base.specs import Specs
 from pants.core.goals.multi_tool_goal_helper import (

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -4,10 +4,11 @@
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 from textwrap import dedent
-from typing import Any, Iterable, Optional, Tuple, Type, TypeVar
+from typing import Any, TypeVar
 
 import pytest
 
@@ -312,7 +313,7 @@ def rule_runner() -> RuleRunner:
     return RuleRunner()
 
 
-def make_target(address: Optional[Address] = None) -> Target:
+def make_target(address: Address | None = None) -> Target:
     return MockTarget(
         {MockRequiredField.alias: "present"}, address or Address("", target_name="tests")
     )
@@ -321,13 +322,13 @@ def make_target(address: Optional[Address] = None) -> Target:
 def run_lint_rule(
     rule_runner: RuleRunner,
     *,
-    lint_request_types: Iterable[Type[_LintRequestT]],
+    lint_request_types: Iterable[type[_LintRequestT]],
     targets: list[Target],
     batch_size: int = 128,
     only: list[str] | None = None,
     skip_formatters: bool = False,
     skip_fixers: bool = False,
-) -> Tuple[int, str]:
+) -> tuple[int, str]:
     union_membership = UnionMembership(
         {
             AbstractLintRequest: lint_request_types,

--- a/src/python/pants/core/goals/multi_tool_goal_helper.py
+++ b/src/python/pants/core/goals/multi_tool_goal_helper.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 
 import logging
 import os.path
-from typing import Iterable, Mapping, Protocol, Sequence, TypeVar
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Protocol, TypeVar
 
 from pants.core.util_rules.distdir import DistDir
 from pants.engine.fs import EMPTY_DIGEST, Digest, Workspace

--- a/src/python/pants/core/goals/package.py
+++ b/src/python/pants/core/goals/package.py
@@ -6,9 +6,9 @@ from __future__ import annotations
 import logging
 import os
 from abc import ABCMeta
+from collections.abc import Iterable
 from dataclasses import dataclass
 from string import Template
-from typing import Iterable
 
 from pants.core.util_rules import distdir
 from pants.core.util_rules.distdir import DistDir

--- a/src/python/pants/core/goals/publish.py
+++ b/src/python/pants/core/goals/publish.py
@@ -25,9 +25,7 @@ import logging
 from abc import ABCMeta
 from dataclasses import asdict, dataclass, field, is_dataclass, replace
 from itertools import chain
-from typing import ClassVar, Generic, Type, TypeVar
-
-from typing_extensions import final
+from typing import ClassVar, Generic, TypeVar, final
 
 from pants.core.goals.package import BuiltPackage, EnvironmentAwarePackageRequest, PackageFieldSet
 from pants.engine.addresses import Address
@@ -98,7 +96,7 @@ class PublishFieldSet(Generic[_T], FieldSet, metaclass=ABCMeta):
     """
 
     # Subclasses must provide this, to a union member (subclass) of `PublishRequest`.
-    publish_request_type: ClassVar[Type[_T]]  # type: ignore[misc]
+    publish_request_type: ClassVar[type[_T]]  # type: ignore[misc]
 
     @final
     def _request(self, packages: tuple[BuiltPackage, ...]) -> _T:

--- a/src/python/pants/core/goals/repl.py
+++ b/src/python/pants/core/goals/repl.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import os
 from abc import ABC
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
-from typing import ClassVar, Iterable, Mapping, Optional, Sequence, Tuple, Type, cast
+from typing import ClassVar, Optional, cast
 
 from pants.core.util_rules.environments import _warn_on_non_local_environments
 from pants.engine.addresses import Addresses
@@ -78,7 +79,7 @@ class Repl(Goal):
 @dataclass(frozen=True)
 class ReplRequest:
     digest: Digest
-    args: Tuple[str, ...]
+    args: tuple[str, ...]
     extra_env: FrozenDict[str, str]
     immutable_input_digests: FrozenDict[str, Digest]
     append_only_caches: FrozenDict[str, str]
@@ -89,7 +90,7 @@ class ReplRequest:
         *,
         digest: Digest,
         args: Iterable[str],
-        extra_env: Optional[Mapping[str, str]] = None,
+        extra_env: Mapping[str, str] | None = None,
         immutable_input_digests: Mapping[str, Digest] | None = None,
         append_only_caches: Mapping[str, str] | None = None,
         run_in_workspace: bool = True,
@@ -119,7 +120,7 @@ async def run_repl(
     repl_shell_name = repl_subsystem.shell or "python"
     implementations = {impl.name: impl for impl in union_membership[ReplImplementation]}
     repl_implementation_cls = cast(
-        Optional[Type[ReplImplementation]], implementations.get(repl_shell_name)
+        Optional[type[ReplImplementation]], implementations.get(repl_shell_name)
     )
     if repl_implementation_cls is None:
         available = sorted(implementations.keys())

--- a/src/python/pants/core/goals/run.py
+++ b/src/python/pants/core/goals/run.py
@@ -5,11 +5,10 @@ from __future__ import annotations
 
 import logging
 from abc import ABCMeta
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, ClassVar, Iterable, Mapping, Optional, Tuple, TypeVar, Union
-
-from typing_extensions import final
+from typing import Any, ClassVar, TypeVar, final
 
 from pants.core.subsystems.debug_adapter import DebugAdapterSubsystem
 from pants.core.util_rules.environments import _warn_on_non_local_environments
@@ -80,7 +79,7 @@ class RunFieldSet(FieldSet, metaclass=ABCMeta):
 
     @final
     @classmethod
-    def rules(cls) -> Iterable[Union[Rule, UnionRule]]:
+    def rules(cls) -> Iterable[Rule | UnionRule]:
         yield UnionRule(RunFieldSet, cls)
         if not cls.supports_debug_adapter:
             yield from _unsupported_debug_adapter_rules(cls)
@@ -103,7 +102,7 @@ class RunRequest:
     digest: Digest
     # Values in args and in env can contain the format specifier "{chroot}", which will
     # be substituted with the (absolute) chroot path.
-    args: Tuple[str, ...]
+    args: tuple[str, ...]
     extra_env: FrozenDict[str, str]
     immutable_input_digests: Mapping[str, Digest] | None = None
     append_only_caches: Mapping[str, str] | None = None
@@ -113,7 +112,7 @@ class RunRequest:
         *,
         digest: Digest,
         args: Iterable[str],
-        extra_env: Optional[Mapping[str, str]] = None,
+        extra_env: Mapping[str, str] | None = None,
         immutable_input_digests: Mapping[str, Digest] | None = None,
         append_only_caches: Mapping[str, str] | None = None,
     ) -> None:

--- a/src/python/pants/core/goals/run_test.py
+++ b/src/python/pants/core/goals/run_test.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 
 import os
 import sys
-from typing import Iterable, Mapping, cast
+from collections.abc import Iterable, Mapping
+from typing import cast
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch

--- a/src/python/pants/core/goals/tailor.py
+++ b/src/python/pants/core/goals/tailor.py
@@ -9,9 +9,10 @@ import logging
 import os
 from abc import ABCMeta
 from collections import defaultdict
+from collections.abc import Iterable, Iterator, Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, Iterator, Mapping, cast
+from typing import cast
 
 from pants.base.specs import AncestorGlobSpec, DirLiteralSpec, RawSpecs, Specs
 from pants.build_graph.address import Address

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -9,11 +9,12 @@ import logging
 import os
 import shlex
 from abc import ABC, ABCMeta
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from pathlib import PurePath
-from typing import Any, ClassVar, Iterable, Optional, Sequence, Tuple, TypeVar, cast
+from typing import Any, ClassVar, TypeVar, cast
 
 from pants.core.goals.multi_tool_goal_helper import SkippableSubsystem
 from pants.core.goals.package import BuiltPackage, EnvironmentAwarePackageRequest, PackageFieldSet
@@ -98,7 +99,7 @@ class TestResult(EngineAwareReturnType):
     # True if the core test rules should log that extra output was written.
     log_extra_output: bool = False
     # All results including failed attempts
-    process_results: Tuple[FallibleProcessResult, ...] = field(default_factory=tuple)
+    process_results: tuple[FallibleProcessResult, ...] = field(default_factory=tuple)
 
     output_simplifier: Simplifier = Simplifier()
 
@@ -138,7 +139,7 @@ class TestResult(EngineAwareReturnType):
 
     @staticmethod
     def from_fallible_process_result(
-        process_results: Tuple[FallibleProcessResult, ...],
+        process_results: tuple[FallibleProcessResult, ...],
         address: Address,
         output_setting: ShowOutput,
         *,
@@ -168,7 +169,7 @@ class TestResult(EngineAwareReturnType):
 
     @staticmethod
     def from_batched_fallible_process_result(
-        process_results: Tuple[FallibleProcessResult, ...],
+        process_results: tuple[FallibleProcessResult, ...],
         batch: TestRequest.Batch[_TestFieldSetT, Any],
         output_setting: ShowOutput,
         *,
@@ -728,7 +729,7 @@ class TestTimeoutField(IntField, metaclass=ABCMeta):
         """
     )
 
-    def calculate_from_global_options(self, test: TestSubsystem) -> Optional[int]:
+    def calculate_from_global_options(self, test: TestSubsystem) -> int | None:
         if not test.timeouts:
             return None
         if self.value is None:

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -4,11 +4,12 @@
 from __future__ import annotations
 
 from abc import abstractmethod
+from collections.abc import Iterable
 from dataclasses import dataclass
 from functools import partial
 from pathlib import Path
 from textwrap import dedent
-from typing import Any, Iterable
+from typing import Any
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch

--- a/src/python/pants/core/goals/update_build_files_test.py
+++ b/src/python/pants/core/goals/update_build_files_test.py
@@ -3,9 +3,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from pathlib import Path
 from textwrap import dedent
-from typing import Iterable
 
 import pytest
 

--- a/src/python/pants/core/subsystems/python_bootstrap.py
+++ b/src/python/pants/core/subsystems/python_bootstrap.py
@@ -7,8 +7,8 @@ import itertools
 import logging
 import os
 import sys
+from collections.abc import Collection
 from dataclasses import dataclass
-from typing import Collection, Optional
 
 from pants.core.util_rules import asdf, search_paths
 from pants.core.util_rules.asdf import AsdfPathString, AsdfToolPathsResult
@@ -227,7 +227,7 @@ async def _expand_interpreter_search_paths(
 
 # This method is copied from the pex package, located at pex.variables.Variables._get_kv().
 # It is copied here to avoid a hard dependency on pex.
-def _get_kv(variable: str) -> Optional[list[str]]:
+def _get_kv(variable: str) -> list[str] | None:
     kv = variable.strip().split("=")
     if len(list(filter(None, kv))) == 2:
         return kv
@@ -237,7 +237,7 @@ def _get_kv(variable: str) -> Optional[list[str]]:
 
 # This method is copied from the pex package, located at pex.variables.Variables.from_rc().
 # It is copied here to avoid a hard dependency on pex.
-def _read_pex_rc(rc: Optional[str] = None) -> dict[str, str]:
+def _read_pex_rc(rc: str | None = None) -> dict[str, str]:
     """Read pex runtime configuration variables from a pexrc file.
 
     :param rc: an absolute path to a pexrc file.

--- a/src/python/pants/core/subsystems/python_bootstrap_test.py
+++ b/src/python/pants/core/subsystems/python_bootstrap_test.py
@@ -4,8 +4,9 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Iterable, Sequence
 from contextlib import contextmanager
-from typing import Iterable, List, Sequence, TypeVar
+from typing import TypeVar
 
 import pytest
 
@@ -86,7 +87,7 @@ def fake_pyenv_root(fake_versions, fake_local_version):
         yield pyenv_root, fake_version_dirs, fake_local_version_dirs
 
 
-def materialize_indices(sequence: Sequence[_T], indices: Iterable[int]) -> List[_T]:
+def materialize_indices(sequence: Sequence[_T], indices: Iterable[int]) -> list[_T]:
     return [sequence[i] for i in indices]
 
 

--- a/src/python/pants/core/target_types.py
+++ b/src/python/pants/core/target_types.py
@@ -7,9 +7,10 @@ import dataclasses
 import os
 import urllib.parse
 from collections import defaultdict
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Generic, Optional, Sequence, TypeVar, Union, cast
+from typing import Generic, TypeVar, cast
 
 from pants.core.goals import package
 from pants.core.goals.package import (
@@ -235,9 +236,9 @@ class AssetSourceField(SingleSourceField):
     @classmethod
     def compute_value(  # type: ignore[override]
         cls,
-        raw_value: Optional[Union[str, http_source, per_platform[http_source]]],
+        raw_value: str | http_source | per_platform[http_source] | None,
         address: Address,
-    ) -> Optional[Union[str, http_source, per_platform[http_source]]]:
+    ) -> str | http_source | per_platform[http_source] | None:
         if raw_value is None or isinstance(raw_value, str):
             return super().compute_value(raw_value, address)
         elif isinstance(raw_value, per_platform):

--- a/src/python/pants/core/util_rules/adhoc_process_support.py
+++ b/src/python/pants/core/util_rules/adhoc_process_support.py
@@ -8,11 +8,12 @@ import json
 import logging
 import os
 import shlex
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
 from textwrap import dedent  # noqa: PNT20
-from typing import Iterable, Mapping, TypeVar, Union
+from typing import TypeVar
 
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.build_graph.address import Address
@@ -858,7 +859,7 @@ def _output_at_build_root(process: Process, bash: BashBinary) -> Process:
     )
 
 
-def parse_relative_directory(workdir_in: str, relative_to: Union[Address, str]) -> str:
+def parse_relative_directory(workdir_in: str, relative_to: Address | str) -> str:
     """Convert the `workdir` field into something that can be understood by `Process`."""
 
     if isinstance(relative_to, Address):

--- a/src/python/pants/core/util_rules/archive_test.py
+++ b/src/python/pants/core/util_rules/archive_test.py
@@ -6,8 +6,9 @@ import gzip
 import subprocess
 import tarfile
 import zipfile
+from collections.abc import Callable
 from io import BytesIO
-from typing import Callable, cast
+from typing import cast
 
 import pytest
 

--- a/src/python/pants/core/util_rules/asdf.py
+++ b/src/python/pants/core/util_rules/asdf.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import logging
 import re
+from collections.abc import Collection
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path, PurePath
-from typing import Collection
 
 from pants.base.build_environment import get_buildroot
 from pants.base.build_root import BuildRoot

--- a/src/python/pants/core/util_rules/asdf_test.py
+++ b/src/python/pants/core/util_rules/asdf_test.py
@@ -2,8 +2,8 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from __future__ import annotations
 
+from collections.abc import Mapping
 from pathlib import PurePath
-from typing import Mapping
 
 import pytest
 

--- a/src/python/pants/core/util_rules/config_files.py
+++ b/src/python/pants/core/util_rules/config_files.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from enum import Enum
-from typing import Iterable, Mapping
 
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.engine.fs import EMPTY_SNAPSHOT, DigestContents, PathGlobs, Snapshot

--- a/src/python/pants/core/util_rules/environments.py
+++ b/src/python/pants/core/util_rules/environments.py
@@ -6,9 +6,10 @@ from __future__ import annotations
 import dataclasses
 import logging
 import shlex
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
 from itertools import groupby
-from typing import Any, Callable, ClassVar, Iterable, Optional, Sequence, Tuple, Type, Union, cast
+from typing import Any, ClassVar, cast
 
 from pants.build_graph.address import Address, AddressInput
 from pants.engine.engine_aware import EngineAwareParameter
@@ -1114,8 +1115,8 @@ class _EnvironmentSensitiveOptionFieldMixin:
 class ShellStringSequenceField(StringSequenceField):
     @classmethod
     def compute_value(
-        cls, raw_value: Optional[Iterable[str]], address: Address
-    ) -> Optional[Tuple[str, ...]]:
+        cls, raw_value: Iterable[str] | None, address: Address
+    ) -> tuple[str, ...] | None:
         """Computes a flattened shlexed arg list from an iterable of strings."""
         if not raw_value:
             return ()
@@ -1124,13 +1125,13 @@ class ShellStringSequenceField(StringSequenceField):
 
 
 # Maps between non-list option value types and corresponding fields
-_SIMPLE_OPTIONS: dict[Union[Type, Callable[[str], Any]], Type[Field]] = {
+_SIMPLE_OPTIONS: dict[type | Callable[[str], Any], type[Field]] = {
     str: StringField,
 }
 
 # Maps between the member types for list options. Each element is the
 # field type, and the `value` type for the field.
-_LIST_OPTIONS: dict[Union[Type, Callable[[str], Any]], Type[Field]] = {
+_LIST_OPTIONS: dict[type | Callable[[str], Any], type[Field]] = {
     str: StringSequenceField,
     custom_types.shell_str: ShellStringSequenceField,
 }

--- a/src/python/pants/core/util_rules/environments_test.py
+++ b/src/python/pants/core/util_rules/environments_test.py
@@ -3,9 +3,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from textwrap import dedent
-from typing import Sequence
 
 import pytest
 

--- a/src/python/pants/core/util_rules/ownership.py
+++ b/src/python/pants/core/util_rules/ownership.py
@@ -1,6 +1,6 @@
 # Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-from typing import Iterable
+from collections.abc import Iterable
 
 from pants.core.goals.tailor import AllOwnedSources, PutativeTargetsRequest
 from pants.engine.fs import PathGlobs, Paths

--- a/src/python/pants/core/util_rules/partitions.py
+++ b/src/python/pants/core/util_rules/partitions.py
@@ -6,9 +6,10 @@
 from __future__ import annotations
 
 import itertools
+from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import Enum
-from typing import Generic, Iterable, Protocol, TypeVar, overload
+from typing import Generic, Protocol, TypeVar, overload
 
 from pants.core.goals.multi_tool_goal_helper import SkippableSubsystem
 from pants.engine.collection import Collection

--- a/src/python/pants/core/util_rules/search_paths.py
+++ b/src/python/pants/core/util_rules/search_paths.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, ClassVar, Iterable
+from typing import Any, ClassVar
 
 from pants.base.build_environment import get_buildroot
 from pants.core.util_rules.environments import EnvironmentTarget

--- a/src/python/pants/core/util_rules/search_paths_test.py
+++ b/src/python/pants/core/util_rules/search_paths_test.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Generator
 from contextlib import contextmanager
-from typing import Generator
 
 import pytest
 

--- a/src/python/pants/core/util_rules/source_files.py
+++ b/src/python/pants/core/util_rules/source_files.py
@@ -1,9 +1,9 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from collections.abc import Collection, Iterable
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Collection, Iterable, Set, Tuple, Type, Union
 
 from pants.engine.fs import MergeDigests, Snapshot
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
@@ -18,24 +18,24 @@ class SourceFiles:
 
     # The subset of files in snapshot that are not intended to have an associated source root.
     # That is, the sources of files() targets.
-    unrooted_files: Tuple[str, ...]
+    unrooted_files: tuple[str, ...]
 
     @property
-    def files(self) -> Tuple[str, ...]:
+    def files(self) -> tuple[str, ...]:
         return self.snapshot.files
 
 
 @dataclass(frozen=True)
 class SourceFilesRequest:
-    sources_fields: Tuple[SourcesField, ...]
-    for_sources_types: Tuple[Type[SourcesField], ...]
+    sources_fields: tuple[SourcesField, ...]
+    for_sources_types: tuple[type[SourcesField], ...]
     enable_codegen: bool
 
     def __init__(
         self,
         sources_fields: Iterable[SourcesField],
         *,
-        for_sources_types: Iterable[Type[SourcesField]] = (SourcesField,),
+        for_sources_types: Iterable[type[SourcesField]] = (SourcesField,),
         enable_codegen: bool = False,
     ) -> None:
         object.__setattr__(self, "sources_fields", tuple(sources_fields))
@@ -46,7 +46,7 @@ class SourceFilesRequest:
 @rule(desc="Get all relevant source files")
 async def determine_source_files(request: SourceFilesRequest) -> SourceFiles:
     """Merge all `SourceBaseField`s into one Snapshot."""
-    unrooted_files: Set[str] = set()
+    unrooted_files: set[str] = set()
     all_hydrated_sources = await MultiGet(
         Get(
             HydratedSources,
@@ -74,7 +74,7 @@ async def determine_source_files(request: SourceFilesRequest) -> SourceFiles:
 class ClassifiedSources:
     target_type: type[Target]
     files: Collection[str]
-    name: Union[str, None] = None
+    name: str | None = None
 
 
 def classify_files_for_sources_and_tests(

--- a/src/python/pants/core/util_rules/source_files_test.py
+++ b/src/python/pants/core/util_rules/source_files_test.py
@@ -4,9 +4,10 @@
 from __future__ import annotations
 
 import itertools
+from collections.abc import Iterable
 from functools import partial
 from pathlib import PurePath
-from typing import Iterable, NamedTuple
+from typing import NamedTuple
 
 import pytest
 

--- a/src/python/pants/core/util_rules/stripped_source_files_test.py
+++ b/src/python/pants/core/util_rules/stripped_source_files_test.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Sequence
+from collections.abc import Sequence
 
 import pytest
 

--- a/src/python/pants/core/util_rules/subprocess_environment.py
+++ b/src/python/pants/core/util_rules/subprocess_environment.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
-from typing import Tuple
 
 from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.rules import Get, collect_rules, rule
@@ -38,7 +37,7 @@ class SubprocessEnvironment(Subsystem):
         )
 
         @property
-        def env_vars_to_pass_to_subprocesses(self) -> Tuple[str, ...]:
+        def env_vars_to_pass_to_subprocesses(self) -> tuple[str, ...]:
             return tuple(sorted(set(self._env_vars)))
 
 

--- a/src/python/pants/core/util_rules/system_binaries.py
+++ b/src/python/pants/core/util_rules/system_binaries.py
@@ -9,13 +9,12 @@ import logging
 import os
 import shlex
 import subprocess
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from enum import Enum
 from itertools import groupby
 from textwrap import dedent  # noqa: PNT20
-from typing import Iterable, Mapping, Sequence
-
-from typing_extensions import Self
+from typing import Self
 
 from pants.core.subsystems import python_bootstrap
 from pants.core.util_rules.environments import EnvironmentTarget

--- a/src/python/pants/core/util_rules/testutil.py
+++ b/src/python/pants/core/util_rules/testutil.py
@@ -2,9 +2,10 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from __future__ import annotations
 
+from collections.abc import Iterable, Sequence
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Iterable, Sequence, TypeVar
+from typing import TypeVar
 
 from pants.util.contextutil import temporary_dir
 

--- a/src/python/pants/core/util_rules/wrap_source.py
+++ b/src/python/pants/core/util_rules/wrap_source.py
@@ -5,8 +5,8 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable, Union
 
 from pants.core.target_types import FileSourceField
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class WrapSource:
-    rules: tuple[Union[Rule, UnionRule], ...]
+    rules: tuple[Rule | UnionRule, ...]
     target_types: tuple[type[Target], ...]
 
 

--- a/src/python/pants/engine/addresses.py
+++ b/src/python/pants/engine/addresses.py
@@ -3,8 +3,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
-from typing import Iterable, Sequence
 
 from pants.build_graph.address import Address as Address
 from pants.build_graph.address import AddressInput as AddressInput  # noqa: F401: rexport.

--- a/src/python/pants/engine/collection.py
+++ b/src/python/pants/engine/collection.py
@@ -3,14 +3,15 @@
 
 from __future__ import annotations
 
-from typing import Any, ClassVar, Iterable, Tuple, TypeVar, cast, overload
+from collections.abc import Iterable
+from typing import Any, ClassVar, TypeVar, cast, overload
 
 from pants.util.ordered_set import FrozenOrderedSet
 
 T = TypeVar("T")
 
 
-class Collection(Tuple[T, ...]):
+class Collection(tuple[T, ...]):
     """A light newtype around immutable sequences for use with the V2 engine.
 
     This should be subclassed when you want to create a distinct collection type, such as:
@@ -35,7 +36,7 @@ class Collection(Tuple[T, ...]):
         result = super().__getitem__(index)
         if isinstance(index, int):
             return cast(T, result)
-        return self.__class__(cast(Tuple[T, ...], result))
+        return self.__class__(cast(tuple[T, ...], result))
 
     def __eq__(self, other: Any) -> bool:
         if self is other:

--- a/src/python/pants/engine/console.py
+++ b/src/python/pants/engine/console.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import sys
-from typing import Callable, TextIO
+from collections.abc import Callable
+from typing import TextIO
 
 from colors import blue, cyan, green, magenta, red, yellow
 

--- a/src/python/pants/engine/desktop.py
+++ b/src/python/pants/engine/desktop.py
@@ -2,9 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import logging
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Iterable, Tuple
 
 from pants.core.util_rules.environments import ChosenLocalEnvironmentName, EnvironmentName
 from pants.core.util_rules.system_binaries import BinaryPathRequest, BinaryPaths
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class OpenFilesRequest:
-    files: Tuple[PurePath, ...]
+    files: tuple[PurePath, ...]
     error_if_open_not_found: bool
 
     def __init__(self, files: Iterable[PurePath], *, error_if_open_not_found: bool = True) -> None:
@@ -28,7 +28,7 @@ class OpenFilesRequest:
 
 @dataclass(frozen=True)
 class OpenFiles:
-    processes: Tuple[InteractiveProcess, ...]
+    processes: tuple[InteractiveProcess, ...]
 
 
 @rule

--- a/src/python/pants/engine/download_file.py
+++ b/src/python/pants/engine/download_file.py
@@ -3,7 +3,7 @@
 
 from dataclasses import dataclass
 from fnmatch import fnmatch
-from typing import ClassVar, Optional
+from typing import ClassVar
 from urllib.parse import urlparse
 
 from pants.engine.fs import Digest, DownloadFile, NativeDownloadFile
@@ -43,14 +43,14 @@ class URLDownloadHandler:
             ]
     """
 
-    match_scheme: ClassVar[Optional[str]] = None
+    match_scheme: ClassVar[str | None] = None
     """The scheme to match (e.g. 'ftp' or 's3') or `None` to match all schemes.
 
     The scheme is matched using `fnmatch`, see https://docs.python.org/3/library/fnmatch.html for more
     information.
     """
 
-    match_authority: ClassVar[Optional[str]] = None
+    match_authority: ClassVar[str | None] = None
     """The authority to match (e.g. 'pantsbuild.org' or 's3.amazonaws.com') or `None` to match all authorities.
 
     The authority is matched using `fnmatch`, see https://docs.python.org/3/library/fnmatch.html for more

--- a/src/python/pants/engine/env_vars.py
+++ b/src/python/pants/engine/env_vars.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 
 import fnmatch
 import re
+from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
-from typing import Dict, Iterator, Optional, Sequence
 
 from pants.util.frozendict import FrozenDict
 from pants.util.ordered_set import FrozenOrderedSet
@@ -29,7 +29,7 @@ class CompleteEnvironmentVars(FrozenDict):
     """
 
     def get_subset(
-        self, requested: Sequence[str], *, allowed: Optional[Sequence[str]] = None
+        self, requested: Sequence[str], *, allowed: Sequence[str] | None = None
     ) -> FrozenDict[str, str]:
         """Extract a subset of named env vars.
 
@@ -44,9 +44,9 @@ class CompleteEnvironmentVars(FrozenDict):
         will be raised.
         """
         allowed_set = None if allowed is None else set(allowed)
-        env_var_subset: Dict[str, str] = {}
+        env_var_subset: dict[str, str] = {}
 
-        def check_and_set(name: str, value: Optional[str]):
+        def check_and_set(name: str, value: str | None):
             if allowed_set is not None and name not in allowed_set:
                 raise ValueError(
                     f"{name} is not in the list of variable names that are allowed to be set. "
@@ -97,9 +97,9 @@ class EnvironmentVarsRequest:
     """
 
     requested: FrozenOrderedSet[str]
-    allowed: Optional[FrozenOrderedSet[str]]
+    allowed: FrozenOrderedSet[str] | None
 
-    def __init__(self, requested: Sequence[str], allowed: Optional[Sequence[str]] = None):
+    def __init__(self, requested: Sequence[str], allowed: Sequence[str] | None = None):
         object.__setattr__(self, "requested", FrozenOrderedSet(requested))
         object.__setattr__(self, "allowed", None if allowed is None else FrozenOrderedSet(allowed))
 

--- a/src/python/pants/engine/environment_test.py
+++ b/src/python/pants/engine/environment_test.py
@@ -1,7 +1,6 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Dict, List
 
 import pytest
 
@@ -21,7 +20,7 @@ from pants.engine.env_vars import CompleteEnvironmentVars
         (['A=has a " in it'], {"A": 'has a " in it'}),
     ],
 )
-def test_complete_environment(input_strs: List[str], expected: Dict[str, str]) -> None:
+def test_complete_environment(input_strs: list[str], expected: dict[str, str]) -> None:
     pants_env = CompleteEnvironmentVars({"A": "a", "B": "b", "C": "c"})
 
     subset = pants_env.get_subset(input_strs)

--- a/src/python/pants/engine/explorer.py
+++ b/src/python/pants/engine/explorer.py
@@ -3,8 +3,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
-from typing import Any, Callable, Iterable, TypeVar, cast
+from typing import Any, TypeVar, cast
 
 from pants.base.exiter import ExitCode
 from pants.build_graph.build_configuration import BuildConfiguration

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -3,10 +3,11 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import timedelta
 from enum import Enum
-from typing import TYPE_CHECKING, Iterable, Mapping, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Union
 
 # Note: several of these types are re-exported as the public API of `engine/fs.py`.
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior as GlobMatchErrorBehavior
@@ -38,8 +39,8 @@ class Paths:
     or save them to the LMDB store.
     """
 
-    files: Tuple[str, ...]
-    dirs: Tuple[str, ...]
+    files: tuple[str, ...]
+    dirs: tuple[str, ...]
 
 
 @dataclass(frozen=True)
@@ -155,7 +156,7 @@ class GlobExpansionConjunction(Enum):
 
 @dataclass(frozen=True)
 class PathGlobs:
-    globs: Tuple[str, ...]
+    globs: tuple[str, ...]
     glob_match_error_behavior: GlobMatchErrorBehavior
     conjunction: GlobExpansionConjunction
     description_of_origin: str | None
@@ -221,7 +222,7 @@ class PathGlobsAndRoot:
 
     path_globs: PathGlobs
     root: str
-    digest_hint: Optional[Digest] = None
+    digest_hint: Digest | None = None
 
 
 @dataclass(frozen=True)
@@ -302,7 +303,7 @@ class Workspace(SideEffecting):
         self,
         digest: Digest,
         *,
-        path_prefix: Optional[str] = None,
+        path_prefix: str | None = None,
         clear_paths: Sequence[str] = (),
         side_effecting: bool = True,
     ) -> None:

--- a/src/python/pants/engine/fs_test.py
+++ b/src/python/pants/engine/fs_test.py
@@ -11,11 +11,12 @@ import socket
 import ssl
 import tarfile
 import time
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler
 from io import BytesIO
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterable, Optional, Set, Union
+from typing import Any
 
 import pytest
 
@@ -408,7 +409,7 @@ def test_path_globs_symlink_loop(rule_runner: RuleRunner) -> None:
 def test_path_globs_to_digest_contents(rule_runner: RuleRunner) -> None:
     setup_fs_test_tar(rule_runner)
 
-    def get_contents(globs: Iterable[str]) -> Set[FileContent]:
+    def get_contents(globs: Iterable[str]) -> set[FileContent]:
         return set(rule_runner.request(DigestContents, [PathGlobs(globs)]))
 
     assert get_contents(["4.txt", "a/4.txt.ln"]) == {
@@ -425,7 +426,7 @@ def test_path_globs_to_digest_contents(rule_runner: RuleRunner) -> None:
 def test_path_globs_to_digest_entries(rule_runner: RuleRunner) -> None:
     setup_fs_test_tar(rule_runner)
 
-    def get_entries(globs: Iterable[str]) -> Set[Union[FileEntry, Directory, SymlinkEntry]]:
+    def get_entries(globs: Iterable[str]) -> set[FileEntry | Directory | SymlinkEntry]:
         return set(rule_runner.request(DigestEntries, [PathGlobs(globs)]))
 
     assert get_entries(["4.txt", "a/4.txt.ln"]) == {
@@ -1332,7 +1333,7 @@ def test_invalidated_after_parent_deletion(rule_runner: RuleRunner) -> None:
     """Test that FileContent is invalidated after deleting the parent directory."""
     setup_fs_test_tar(rule_runner)
 
-    def read_file() -> Optional[str]:
+    def read_file() -> str | None:
         digest_contents = rule_runner.request(DigestContents, [PathGlobs(["a/b/1.txt"])])
         if not digest_contents:
             return None
@@ -1491,8 +1492,8 @@ def test_snapshot_hash_and_eq() -> None:
 )
 def test_snapshot_diff(
     rule_runner: RuleRunner,
-    before: Dict[str, str],
-    after: Dict[str, str],
+    before: dict[str, str],
+    after: dict[str, str],
     expected_diff: SnapshotDiff,
 ) -> None:
     diff = SnapshotDiff.from_snapshots(

--- a/src/python/pants/engine/goal.py
+++ b/src/python/pants/engine/goal.py
@@ -3,12 +3,11 @@
 from __future__ import annotations
 
 from abc import abstractmethod
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, Callable, ClassVar, Iterator, Type, cast
-
-from typing_extensions import final
+from typing import TYPE_CHECKING, ClassVar, cast, final
 
 from pants.engine.engine_aware import EngineAwareReturnType
 from pants.engine.unions import UnionMembership
@@ -99,7 +98,7 @@ class Goal:
         USES_ENVIRONMENTS = 3
 
     exit_code: int
-    subsystem_cls: ClassVar[Type[GoalSubsystem]]
+    subsystem_cls: ClassVar[type[GoalSubsystem]]
 
     f"""Indicates that a Goal has been migrated to compute EnvironmentNames to build targets in.
 

--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -11,9 +11,10 @@ import os.path
 import sys
 import typing
 from collections import defaultdict
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Any, Sequence, cast
+from typing import Any, cast
 
 import typing_extensions
 

--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 
 import logging
 import re
+from collections.abc import Mapping
 from textwrap import dedent
-from typing import Any, Mapping, cast
+from typing import Any, cast
 
 import pytest
 

--- a/src/python/pants/engine/internals/defaults.py
+++ b/src/python/pants/engine/internals/defaults.py
@@ -12,8 +12,9 @@ parser.
 """
 from __future__ import annotations
 
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
-from typing import Any, Callable, Iterable, Mapping, Tuple, Union
+from typing import Any, Union
 
 from pants.engine.addresses import Address
 from pants.engine.internals.parametrize import Parametrize
@@ -29,7 +30,7 @@ from pants.engine.unions import UnionMembership
 from pants.util.frozendict import FrozenDict
 
 SetDefaultsValueT = Mapping[str, Any]
-SetDefaultsKeyT = Union[str, Tuple[str, ...]]
+SetDefaultsKeyT = Union[str, tuple[str, ...]]
 SetDefaultsT = Mapping[SetDefaultsKeyT, SetDefaultsValueT]
 
 

--- a/src/python/pants/engine/internals/defaults_test.py
+++ b/src/python/pants/engine/internals/defaults_test.py
@@ -4,7 +4,8 @@
 from __future__ import annotations
 
 from collections import namedtuple
-from typing import Any, Mapping
+from collections.abc import Mapping
+from typing import Any
 
 import pytest
 

--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -6,7 +6,6 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from textwrap import dedent
-from typing import List, Optional, Tuple
 
 import pytest
 
@@ -274,8 +273,8 @@ class WorkunitTracker(WorkunitsCallback):
     """This class records every non-empty batch of started and completed workunits received from the
     engine."""
 
-    finished_workunit_chunks: List[List[dict]] = field(default_factory=list)
-    started_workunit_chunks: List[List[dict]] = field(default_factory=list)
+    finished_workunit_chunks: list[list[dict]] = field(default_factory=list)
+    started_workunit_chunks: list[list[dict]] = field(default_factory=list)
     finished: bool = False
 
     @property
@@ -310,7 +309,7 @@ def run_tracker() -> RunTracker:
 class TestStreamingWorkunit(SchedulerTestBase):
     def _fixture_for_rules(
         self, tmp_path: Path, rules, max_workunit_verbosity: LogLevel = LogLevel.INFO
-    ) -> Tuple[SchedulerSession, WorkunitTracker, StreamingWorkunitHandler]:
+    ) -> tuple[SchedulerSession, WorkunitTracker, StreamingWorkunitHandler]:
         scheduler = self.mk_scheduler(
             tmp_path,
             rules,
@@ -547,7 +546,7 @@ class TestStreamingWorkunit(SchedulerTestBase):
         # If level() returns None, the engine shouldn't try to set
         # a new workunit level.
         class ModifiedOutput(EngineAwareReturnType):
-            _level: Optional[LogLevel]
+            _level: LogLevel | None
             val: int
 
             def level(self):

--- a/src/python/pants/engine/internals/engine_testutil.py
+++ b/src/python/pants/engine/internals/engine_testutil.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import re
-from typing import Callable
+from collections.abc import Callable
 
 
 def assert_equal_with_printing(

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -10,21 +10,10 @@ import json
 import logging
 import os.path
 from collections import defaultdict
+from collections.abc import Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import (
-    Any,
-    DefaultDict,
-    FrozenSet,
-    Iterable,
-    Iterator,
-    Mapping,
-    NamedTuple,
-    Sequence,
-    Type,
-    TypeVar,
-    cast,
-)
+from typing import Any, DefaultDict, NamedTuple, Type, TypeVar, cast
 
 from pants.base.deprecated import warn_or_error
 from pants.base.specs import AncestorGlobSpec, RawSpecsWithoutFileOwners, RecursiveGlobSpec
@@ -1042,7 +1031,7 @@ def calc_source_block_mapping(
     )
 
 
-class FilesWithSourceBlocks(FrozenSet[str]):
+class FilesWithSourceBlocks(frozenset[str]):
     pass
 
 

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -6,10 +6,10 @@ from __future__ import annotations
 import dataclasses
 import itertools
 import os.path
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import PurePath
 from textwrap import dedent
-from typing import Iterable, List, Set, Tuple, Type
 
 import pytest
 
@@ -484,7 +484,7 @@ def test_coarsened_targets(transitive_targets_rule_runner: RuleRunner) -> None:
     )
 
     def assert_coarsened(
-        a: Address, expected_members: List[Address], expected_dependencies: List[Address]
+        a: Address, expected_members: list[Address], expected_dependencies: list[Address]
     ) -> None:
         coarsened_targets = transitive_targets_rule_runner.request(
             CoarsenedTargets,
@@ -551,7 +551,7 @@ def assert_failed_cycle(
     *,
     root_target_name: str,
     subject_target_name: str,
-    path_target_names: Tuple[str, ...],
+    path_target_names: tuple[str, ...],
 ) -> None:
     with pytest.raises(ExecutionError) as e:
         rule_runner.request(
@@ -845,7 +845,7 @@ def assert_owners(
     rule_runner: RuleRunner,
     requested: Iterable[str],
     *,
-    expected: Set[Address],
+    expected: set[Address],
     match_if_owning_build_file_included_in_sources: bool = False,
 ) -> None:
     result = rule_runner.request(
@@ -1884,7 +1884,7 @@ def test_sources_expected_num_files(sources_rule_runner: RuleRunner) -> None:
 
     sources_rule_runner.write_files(dict.fromkeys(["f1.txt", "f2.txt", "f3.txt", "f4.txt"], ""))
 
-    def hydrate(sources_cls: Type[MultipleSourcesField], sources: Iterable[str]) -> HydratedSources:
+    def hydrate(sources_cls: type[MultipleSourcesField], sources: Iterable[str]) -> HydratedSources:
         return sources_rule_runner.request(
             HydratedSources,
             [

--- a/src/python/pants/engine/internals/mapper.py
+++ b/src/python/pants/engine/internals/mapper.py
@@ -4,8 +4,9 @@
 from __future__ import annotations
 
 import os.path
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
-from typing import Iterable, Mapping, TypeVar
+from typing import TypeVar
 
 from pants.backend.project_info.filter_targets import FilterSubsystem
 from pants.base.exceptions import MappingError

--- a/src/python/pants/engine/internals/native_engine.pyi
+++ b/src/python/pants/engine/internals/native_engine.pyi
@@ -3,26 +3,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from datetime import datetime
 from io import RawIOBase
-from typing import (
-    Any,
-    Callable,
-    ClassVar,
-    FrozenSet,
-    Generic,
-    Iterable,
-    Mapping,
-    Optional,
-    Protocol,
-    Sequence,
-    TextIO,
-    Tuple,
-    TypeVar,
-    overload,
-)
-
-from typing_extensions import Self
+from typing import Any, ClassVar, Generic, Optional, Protocol, Self, TextIO, TypeVar, overload
 
 from pants.engine.fs import (
     CreateDigest,
@@ -65,9 +49,9 @@ class PyFailure:
 # Address
 # ------------------------------------------------------------------------------
 
-BANNED_CHARS_IN_TARGET_NAME: FrozenSet
-BANNED_CHARS_IN_GENERATED_NAME: FrozenSet
-BANNED_CHARS_IN_PARAMETERS: FrozenSet
+BANNED_CHARS_IN_TARGET_NAME: frozenset
+BANNED_CHARS_IN_GENERATED_NAME: frozenset
+BANNED_CHARS_IN_PARAMETERS: frozenset
 
 def address_spec_parse(
     spec: str,
@@ -668,7 +652,7 @@ class PyOptionId:
     ) -> None: ...
 
 class PyPantsCommand:
-    def builtin_or_auxiliary_goal(self) -> Optional[str]: ...
+    def builtin_or_auxiliary_goal(self) -> str | None: ...
     def goals(self) -> list[str]: ...
     def unknown_goals(self) -> list[str]: ...
     def specs(self) -> list[str]: ...
@@ -681,28 +665,28 @@ class PyConfigSource:
 T = TypeVar("T")
 
 # List of tuples of (value, rank, details string).
-OptionValueDerivation = list[Tuple[T, int, str]]
+OptionValueDerivation = list[tuple[T, int, str]]
 
 # A tuple (value, rank of value, optional derivation of value).
-OptionValue = Tuple[Optional[T], int, Optional[OptionValueDerivation]]
+OptionValue = tuple[Optional[T], int, Optional[OptionValueDerivation]]
 
 def py_bin_name() -> str: ...
 
 class PyOptionParser:
     def __init__(
         self,
-        args: Optional[Sequence[str]],
+        args: Sequence[str] | None,
         env: dict[str, str],
-        configs: Optional[Sequence[PyConfigSource]],
+        configs: Sequence[PyConfigSource] | None,
         allow_pantsrc: bool,
         include_derivation: bool,
-        known_scopes_to_flags: Optional[dict[str, frozenset[str]]],
-        known_goals: Optional[Sequence[PyGoalInfo]],
+        known_scopes_to_flags: dict[str, frozenset[str]] | None,
+        known_goals: Sequence[PyGoalInfo] | None,
     ) -> None: ...
-    def get_bool(self, option_id: PyOptionId, default: Optional[bool]) -> OptionValue[bool]: ...
-    def get_int(self, option_id: PyOptionId, default: Optional[int]) -> OptionValue[int]: ...
-    def get_float(self, option_id: PyOptionId, default: Optional[float]) -> OptionValue[float]: ...
-    def get_string(self, option_id: PyOptionId, default: Optional[str]) -> OptionValue[str]: ...
+    def get_bool(self, option_id: PyOptionId, default: bool | None) -> OptionValue[bool]: ...
+    def get_int(self, option_id: PyOptionId, default: int | None) -> OptionValue[int]: ...
+    def get_float(self, option_id: PyOptionId, default: float | None) -> OptionValue[float]: ...
+    def get_string(self, option_id: PyOptionId, default: str | None) -> OptionValue[str]: ...
     def get_bool_list(
         self, option_id: PyOptionId, default: list[bool]
     ) -> OptionValue[list[bool]]: ...
@@ -921,7 +905,7 @@ def rule_subgraph_visualize(
 def garbage_collect_store(scheduler: PyScheduler, target_size_bytes: int) -> None: ...
 def lease_files_in_graph(scheduler: PyScheduler, session: PySession) -> None: ...
 def strongly_connected_components(
-    adjacency_lists: Sequence[Tuple[Any, Sequence[Any]]]
+    adjacency_lists: Sequence[tuple[Any, Sequence[Any]]]
 ) -> Sequence[Sequence[Any]]: ...
 def hash_prefix_zero_bits(item: str) -> int: ...
 

--- a/src/python/pants/engine/internals/nodes.py
+++ b/src/python/pants/engine/internals/nodes.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Optional, Tuple
+from typing import Any, Optional
 
 
 @dataclass(frozen=True)
@@ -14,7 +14,7 @@ class Return:
     value: Any
 
 
-_Frame = Tuple[str, Optional[str]]
+_Frame = tuple[str, Optional[str]]
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/engine/internals/parametrize.py
+++ b/src/python/pants/engine/internals/parametrize.py
@@ -7,12 +7,11 @@ import dataclasses
 import itertools
 import operator
 from collections import abc, defaultdict
+from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
 from enum import Enum
 from functools import reduce
-from typing import Any, Iterator, Mapping, cast
-
-from typing_extensions import Self
+from typing import Any, Self, cast
 
 from pants.build_graph.address import BANNED_CHARS_IN_PARAMETERS
 from pants.engine.addresses import Address

--- a/src/python/pants/engine/internals/parser.py
+++ b/src/python/pants/engine/internals/parser.py
@@ -11,11 +11,12 @@ import threading
 import tokenize
 import traceback
 import typing
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import InitVar, dataclass, field
 from difflib import get_close_matches
 from io import StringIO
 from pathlib import PurePath
-from typing import Annotated, Any, Callable, Iterable, Mapping, TypeVar
+from typing import Annotated, Any, TypeVar
 
 import typing_extensions
 

--- a/src/python/pants/engine/internals/rule_visitor.py
+++ b/src/python/pants/engine/internals/rule_visitor.py
@@ -7,9 +7,10 @@ import inspect
 import itertools
 import logging
 import sys
+from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager
 from functools import partial
-from typing import Any, Callable, Iterator, List, Sequence, get_type_hints
+from typing import Any, get_type_hints
 
 import typing_extensions
 
@@ -144,7 +145,7 @@ class _AwaitableCollector(ast.NodeVisitor):
         self.source_file = inspect.getsourcefile(func) or "<unknown>"
 
         self.types = _TypeStack(func)
-        self.awaitables: List[AwaitableConstraints] = []
+        self.awaitables: list[AwaitableConstraints] = []
         self.visit(ast.parse(source))
 
     def _format(self, node: ast.AST, msg: str) -> str:
@@ -201,7 +202,7 @@ class _AwaitableCollector(ast.NodeVisitor):
             )
         return resolved
 
-    def _get_inputs(self, input_nodes: Sequence[Any]) -> tuple[Sequence[Any], List[Any]]:
+    def _get_inputs(self, input_nodes: Sequence[Any]) -> tuple[Sequence[Any], list[Any]]:
         if not input_nodes:
             return input_nodes, []
         if len(input_nodes) != 1:
@@ -390,5 +391,5 @@ class _AwaitableCollector(ast.NodeVisitor):
 
 
 @memoized
-def collect_awaitables(func: Callable) -> List[AwaitableConstraints]:
+def collect_awaitables(func: Callable) -> list[AwaitableConstraints]:
     return _AwaitableCollector(func).awaitables

--- a/src/python/pants/engine/internals/rule_visitor_test.py
+++ b/src/python/pants/engine/internals/rule_visitor_test.py
@@ -3,8 +3,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 import pytest
 

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -6,10 +6,11 @@ from __future__ import annotations
 import logging
 import os
 import time
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
 from pathlib import PurePath
 from types import CoroutineType
-from typing import Any, Callable, Dict, Iterable, NoReturn, Sequence, cast
+from typing import Any, NoReturn, cast
 
 from typing_extensions import TypedDict
 
@@ -80,7 +81,7 @@ from pants.util.strutil import pluralize
 logger = logging.getLogger(__name__)
 
 
-Workunit = Dict[str, Any]
+Workunit = dict[str, Any]
 
 
 class PolledWorkunits(TypedDict):

--- a/src/python/pants/engine/internals/selectors.py
+++ b/src/python/pants/engine/internals/selectors.py
@@ -5,20 +5,9 @@ from __future__ import annotations
 
 import ast
 import itertools
+from collections.abc import Coroutine, Generator, Iterable, Sequence
 from dataclasses import dataclass
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Coroutine,
-    Generator,
-    Generic,
-    Iterable,
-    Sequence,
-    Tuple,
-    TypeVar,
-    cast,
-    overload,
-)
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast, overload
 
 from pants.engine.internals.native_engine import PyGeneratorResponseCall, PyGeneratorResponseGet
 from pants.util.strutil import softwrap
@@ -172,7 +161,7 @@ class _MultiGet:
 
     def __await__(self) -> Generator[tuple[Get | Coroutine, ...], None, tuple]:
         result = yield self.gets
-        return cast(Tuple, result)
+        return cast(tuple, result)
 
 
 # These type variables are used to parametrize from 1 to 10 Gets when used in a tuple-style

--- a/src/python/pants/engine/internals/selectors_test.py
+++ b/src/python/pants/engine/internals/selectors_test.py
@@ -2,8 +2,8 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import re
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Callable
 
 import pytest
 

--- a/src/python/pants/engine/internals/session.py
+++ b/src/python/pants/engine/internals/session.py
@@ -1,7 +1,7 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Any, Type, TypeVar, cast
+from typing import Any, TypeVar, cast
 
 from pants.util.frozendict import FrozenDict
 
@@ -16,7 +16,7 @@ class RunId(int):
     """
 
 
-class SessionValues(FrozenDict[Type, Any]):
+class SessionValues(FrozenDict[type, Any]):
     """Values set for the Session, and exposed to @rules.
 
     Generally, each type provided via `SessionValues` should have a simple rule that returns the
@@ -24,7 +24,7 @@ class SessionValues(FrozenDict[Type, Any]):
     `SessionValues`.
     """
 
-    def __getitem__(self, item: Type[_T]) -> _T:
+    def __getitem__(self, item: type[_T]) -> _T:
         try:
             return cast(_T, super().__getitem__(item))
         except KeyError:

--- a/src/python/pants/engine/internals/specs_rules.py
+++ b/src/python/pants/engine/internals/specs_rules.py
@@ -8,7 +8,7 @@ import itertools
 import logging
 import os
 from collections import defaultdict
-from typing import Iterable
+from collections.abc import Iterable
 
 from pants.backend.project_info.filter_targets import FilterSubsystem
 from pants.base.specs import (

--- a/src/python/pants/engine/internals/specs_rules_test.py
+++ b/src/python/pants/engine/internals/specs_rules_test.py
@@ -3,9 +3,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from textwrap import dedent
-from typing import Iterable, Type
 
 import pytest
 
@@ -877,7 +877,7 @@ def test_find_valid_field_sets(caplog) -> None:
     invalid_spec = AddressLiteralSpec("", "invalid")
 
     def find_valid_field_sets(
-        superclass: Type,
+        superclass: type,
         specs: Iterable[Spec],
         *,
         no_applicable_behavior: NoApplicableTargetsBehavior = NoApplicableTargetsBehavior.ignore,

--- a/src/python/pants/engine/internals/synthetic_targets.py
+++ b/src/python/pants/engine/internals/synthetic_targets.py
@@ -75,8 +75,9 @@ from __future__ import annotations
 
 import itertools
 import os.path
+from collections.abc import Iterable, Iterator, Sequence
 from dataclasses import dataclass
-from typing import ClassVar, Iterable, Iterator, Sequence
+from typing import ClassVar
 
 from pants.base.specs import GlobSpecsProtocol
 from pants.engine.collection import Collection

--- a/src/python/pants/engine/internals/target_adaptor.py
+++ b/src/python/pants/engine/internals/target_adaptor.py
@@ -5,9 +5,7 @@ from __future__ import annotations
 
 import dataclasses
 from dataclasses import dataclass
-from typing import Any
-
-from typing_extensions import final
+from typing import Any, final
 
 from pants.build_graph.address import Address
 from pants.engine.engine_aware import EngineAwareParameter

--- a/src/python/pants/engine/internals/testutil.py
+++ b/src/python/pants/engine/internals/testutil.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable
+from collections.abc import Iterable
 
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.base.specs import RawSpecs, RawSpecsWithoutFileOwners, Spec

--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 
 import dataclasses
 import logging
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Iterable, List, Mapping, Tuple
 
 from pants.engine.engine_aware import SideEffecting
 from pants.engine.fs import EMPTY_DIGEST, Digest, FileDigest
@@ -201,7 +201,7 @@ class FallibleProcessResult:
 
 @dataclass(frozen=True)
 class ProcessResultWithRetries:
-    results: Tuple[FallibleProcessResult, ...]
+    results: tuple[FallibleProcessResult, ...]
 
     @property
     def last(self):
@@ -354,7 +354,7 @@ execute_process_or_raise = fallible_to_exec_result_or_raise
 
 @rule
 async def execute_process_with_retry(req: ProcessWithRetries) -> ProcessResultWithRetries:
-    results: List[FallibleProcessResult] = []
+    results: list[FallibleProcessResult] = []
     for attempt in range(0, req.attempts):
         proc = dataclasses.replace(req.proc, attempt=attempt)
         result = (

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -6,26 +6,11 @@ from __future__ import annotations
 import functools
 import inspect
 import sys
+from collections.abc import Callable, Coroutine, Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from enum import Enum
 from types import FrameType, ModuleType
-from typing import (
-    Any,
-    Callable,
-    Coroutine,
-    Iterable,
-    Mapping,
-    Optional,
-    Protocol,
-    Sequence,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-    cast,
-    get_type_hints,
-    overload,
-)
+from typing import Any, Protocol, TypeVar, Union, cast, get_type_hints, overload
 
 from typing_extensions import ParamSpec
 
@@ -79,13 +64,13 @@ def _rule_call_trampoline(rule_id: str, output_type: type, func: Callable[P, R])
 def _make_rule(
     func_id: str,
     rule_type: RuleType,
-    return_type: Type,
-    parameter_types: dict[str, Type],
-    masked_types: Iterable[Type],
+    return_type: type,
+    parameter_types: dict[str, type],
+    masked_types: Iterable[type],
     *,
     cacheable: bool,
     canonical_name: str,
-    desc: Optional[str],
+    desc: str | None,
     level: LogLevel,
 ) -> RuleDecorator:
     """A @decorator that declares that a particular static function may be used as a TaskRule.
@@ -167,10 +152,10 @@ class DuplicateRuleError(TypeError):
 
 def _ensure_type_annotation(
     *,
-    type_annotation: Optional[Type],
+    type_annotation: type | None,
     name: str,
-    raise_type: Type[InvalidTypeAnnotation],
-) -> Type:
+    raise_type: type[InvalidTypeAnnotation],
+) -> type:
     if type_annotation is None:
         raise raise_type(f"{name} is missing a type annotation.")
     if not isinstance(type_annotation, type):
@@ -312,8 +297,8 @@ def rule_decorator(func: SyncRuleT | AsyncRuleT, **kwargs) -> AsyncRuleT:
 
 def validate_requirements(
     func_id: str,
-    parameter_types: dict[str, Type],
-    awaitables: Tuple[AwaitableConstraints, ...],
+    parameter_types: dict[str, type],
+    awaitables: tuple[AwaitableConstraints, ...],
     cacheable: bool,
 ) -> None:
     # TODO: Technically this will also fire for an @_uncacheable_rule, but we don't expose those as
@@ -367,7 +352,7 @@ def rule(func: Callable[P, R]) -> Callable[P, Coroutine[Any, Any, R]]: ...
 @overload
 def rule(
     *args, func: None = None, **kwargs: Any
-) -> Callable[[Union[SyncRuleT, AsyncRuleT]], AsyncRuleT]: ...
+) -> Callable[[SyncRuleT | AsyncRuleT], AsyncRuleT]: ...
 
 
 def rule(*args, **kwargs):
@@ -385,7 +370,7 @@ def goal_rule(func: Callable[P, R]) -> Callable[P, Coroutine[Any, Any, R]]: ...
 @overload
 def goal_rule(
     *args, func: None = None, **kwargs: Any
-) -> Callable[[Union[SyncRuleT, AsyncRuleT]], AsyncRuleT]: ...
+) -> Callable[[SyncRuleT | AsyncRuleT], AsyncRuleT]: ...
 
 
 def goal_rule(*args, **kwargs):
@@ -407,7 +392,7 @@ def _uncacheable_rule(func: Callable[P, R]) -> Callable[P, Coroutine[Any, Any, R
 @overload
 def _uncacheable_rule(
     *args, func: None = None, **kwargs: Any
-) -> Callable[[Union[SyncRuleT, AsyncRuleT]], AsyncRuleT]: ...
+) -> Callable[[SyncRuleT | AsyncRuleT], AsyncRuleT]: ...
 
 
 # This has a "private" name, as we don't (yet?) want it to be part of the rule API, at least
@@ -428,7 +413,7 @@ class Rule(Protocol):
         """An output `type` for the rule."""
 
 
-def collect_rules(*namespaces: Union[ModuleType, Mapping[str, Any]]) -> Iterable[Rule]:
+def collect_rules(*namespaces: ModuleType | Mapping[str, Any]) -> Iterable[Rule]:
     """Collects all @rules in the given namespaces.
 
     If no namespaces are given, collects all the @rules in the caller's module namespace.
@@ -471,13 +456,13 @@ class TaskRule:
     prefer the `@rule` constructor.
     """
 
-    output_type: Type
-    parameters: FrozenDict[str, Type]
-    awaitables: Tuple[AwaitableConstraints, ...]
-    masked_types: Tuple[Type, ...]
+    output_type: type
+    parameters: FrozenDict[str, type]
+    awaitables: tuple[AwaitableConstraints, ...]
+    masked_types: tuple[type, ...]
     func: Callable
     canonical_name: str
-    desc: Optional[str] = None
+    desc: str | None = None
     level: LogLevel = LogLevel.TRACE
     cacheable: bool = True
 
@@ -499,10 +484,10 @@ class QueryRule:
     that the relevant portions of the RuleGraph are generated.
     """
 
-    output_type: Type
-    input_types: Tuple[Type, ...]
+    output_type: type
+    input_types: tuple[type, ...]
 
-    def __init__(self, output_type: Type, input_types: Iterable[Type]) -> None:
+    def __init__(self, output_type: type, input_types: Iterable[type]) -> None:
         object.__setattr__(self, "output_type", output_type)
         object.__setattr__(self, "input_types", tuple(input_types))
 

--- a/src/python/pants/engine/rules_test.py
+++ b/src/python/pants/engine/rules_test.py
@@ -2,11 +2,12 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import re
+from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from textwrap import dedent
-from typing import Callable, List, Optional, Tuple, Type, Union, get_type_hints
+from typing import get_type_hints
 
 import pytest
 
@@ -52,7 +53,7 @@ def create_scheduler(rules, validate=True):
 
 
 def fmt_rule(
-    rule: Callable, *, gets: Optional[List[Tuple[str, str]]] = None, multiline: bool = False
+    rule: Callable, *, gets: list[tuple[str, str]] | None = None, multiline: bool = False
 ) -> str:
     """Generate the str that the engine will use for the rule.
 
@@ -86,8 +87,8 @@ def fmt_rule(
 @dataclass(frozen=True)
 class RuleFormatRequest:
     rule: Callable
-    for_param: Optional[Union[Type, Tuple[Type, ...]]] = None
-    gets: Optional[List[Tuple[str, str]]] = None
+    for_param: type | tuple[type, ...] | None = None
+    gets: list[tuple[str, str]] | None = None
 
     def format(self) -> str:
         msg = fmt_rule(self.rule, gets=self.gets, multiline=True)
@@ -111,10 +112,10 @@ class RuleFormatRequest:
 
 
 def fmt_param_edge(
-    param: Type,
-    product: Union[Type, Tuple[Type, ...]],
-    via_func: Union[Type, RuleFormatRequest],
-    return_func: Optional[RuleFormatRequest] = None,
+    param: type,
+    product: type | tuple[type, ...],
+    via_func: type | RuleFormatRequest,
+    return_func: RuleFormatRequest | None = None,
 ) -> str:
     if isinstance(via_func, type):
         via_func_str = f"Select({via_func.__name__})"
@@ -150,7 +151,7 @@ class GraphVertexType(Enum):
     intrinsic = "intrinsic"
     param = "param"
 
-    def graph_vertex_color_fmt_str(self) -> Optional[str]:
+    def graph_vertex_color_fmt_str(self) -> str | None:
         olive = "0.2214,0.7179,0.8528"
         gray = "0.576,0,0.6242"
         orange = "0.08,0.5,0.976"
@@ -172,9 +173,9 @@ class GraphVertexType(Enum):
 
 
 def fmt_non_param_edge(
-    subject: Union[Type, Callable, RuleFormatRequest],
-    product: Union[Type, Tuple[Type, ...]],
-    return_func: Optional[RuleFormatRequest] = None,
+    subject: type | Callable | RuleFormatRequest,
+    product: type | tuple[type, ...],
+    return_func: RuleFormatRequest | None = None,
     rule_type: GraphVertexType = GraphVertexType.task,
     append_for_product: bool = True,
 ) -> str:

--- a/src/python/pants/engine/streaming_workunit_handler.py
+++ b/src/python/pants/engine/streaming_workunit_handler.py
@@ -6,8 +6,9 @@ from __future__ import annotations
 import logging
 import threading
 from abc import ABC, abstractmethod
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
-from typing import Any, Callable, Iterable, Sequence, Tuple
+from typing import Any
 
 from pants.base.specs import Specs
 from pants.core.util_rules.environments import determine_bootstrap_environment
@@ -195,7 +196,7 @@ class WorkunitsCallbackFactory:
     callback_factory: Callable[[], WorkunitsCallback | None]
 
 
-class WorkunitsCallbackFactories(Tuple[WorkunitsCallbackFactory, ...]):
+class WorkunitsCallbackFactories(tuple[WorkunitsCallbackFactory, ...]):
     """A list of registered factories for WorkunitsCallback instances."""
 
 

--- a/src/python/pants/engine/streaming_workunit_handler_integration_test.py
+++ b/src/python/pants/engine/streaming_workunit_handler_integration_test.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import os
 import signal
-from typing import Mapping
+from collections.abc import Mapping
 
 import pytest
 from workunit_logger.register import FINISHED_SUCCESSFULLY

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -14,6 +14,7 @@ import textwrap
 import zlib
 from abc import ABC, ABCMeta, abstractmethod
 from collections import deque
+from collections.abc import Callable, Iterable, Iterator, KeysView, Mapping, Sequence
 from dataclasses import dataclass
 from enum import Enum
 from operator import attrgetter
@@ -21,27 +22,15 @@ from pathlib import PurePath
 from typing import (
     AbstractSet,
     Any,
-    Callable,
     ClassVar,
-    Dict,
     Generic,
-    Iterable,
-    Iterator,
-    KeysView,
-    Mapping,
-    Optional,
     Protocol,
-    Sequence,
-    Set,
-    Tuple,
-    Type,
+    Self,
     TypeVar,
-    Union,
     cast,
+    final,
     get_type_hints,
 )
-
-from typing_extensions import Self, final
 
 from pants.base.deprecated import warn_or_error
 from pants.engine.addresses import Address, Addresses, UnparsedAddressInputs, assert_single_address
@@ -135,7 +124,7 @@ class AsyncFieldMixin(Field):
     address: Address
 
     @final
-    def __new__(cls, raw_value: Optional[Any], address: Address) -> Self:
+    def __new__(cls, raw_value: Any | None, address: Address) -> Self:
         obj = super().__new__(cls, raw_value, address)  # type: ignore[call-arg]
         # N.B.: We store the address here and not in the Field base class, because the memory usage
         # of storing this value in every field was shown to be excessive / lead to performance
@@ -255,7 +244,7 @@ class Target:
 
     # Subclasses must define these
     alias: ClassVar[str]
-    core_fields: ClassVar[Tuple[Type[Field], ...]]
+    core_fields: ClassVar[tuple[type[Field], ...]]
     help: ClassVar[str | Callable[[], str]]
 
     removal_version: ClassVar[str | None] = None
@@ -410,7 +399,7 @@ class Target:
 
     @final
     @property
-    def field_types(self) -> KeysView[Type[Field]]:
+    def field_types(self) -> KeysView[type[Field]]:
         return self.field_values.keys()
 
     @distinct_union_type_per_subclass
@@ -436,7 +425,7 @@ class Target:
     def __hash__(self) -> int:
         return hash((self.__class__, self.address, self.residence_dir, self.field_values))
 
-    def __eq__(self, other: Union[Target, Any]) -> bool:
+    def __eq__(self, other: Target | Any) -> bool:
         if not isinstance(other, Target):
             return NotImplemented
         return (self.__class__, self.address, self.residence_dir, self.field_values) == (
@@ -472,8 +461,8 @@ class Target:
     @final
     @classmethod
     def _find_registered_field_subclass(
-        cls, requested_field: Type[_F], *, registered_fields: Iterable[Type[Field]]
-    ) -> Optional[Type[_F]]:
+        cls, requested_field: type[_F], *, registered_fields: Iterable[type[Field]]
+    ) -> type[_F] | None:
         """Check if the Target has registered a subclass of the requested Field.
 
         This is necessary to allow targets to override the functionality of common fields. For
@@ -492,7 +481,7 @@ class Target:
         return subclass
 
     @final
-    def _maybe_get(self, field: Type[_F]) -> Optional[_F]:
+    def _maybe_get(self, field: type[_F]) -> _F | None:
         result = self.field_values.get(field, None)
         if result is not None:
             return cast(_F, result)
@@ -504,7 +493,7 @@ class Target:
         return None
 
     @final
-    def __getitem__(self, field: Type[_F]) -> _F:
+    def __getitem__(self, field: type[_F]) -> _F:
         """Get the requested `Field` instance belonging to this target.
 
         If the `Field` is not registered on this `Target` type, this method will raise a
@@ -525,7 +514,7 @@ class Target:
         )
 
     @final
-    def get(self, field: Type[_F], *, default_raw_value: Optional[Any] = None) -> _F:
+    def get(self, field: type[_F], *, default_raw_value: Any | None = None) -> _F:
         """Get the requested `Field` instance belonging to this target.
 
         This will return an instance of the requested field type, e.g. an instance of
@@ -551,7 +540,7 @@ class Target:
     @final
     @classmethod
     def _has_fields(
-        cls, fields: Iterable[Type[Field]], *, registered_fields: AbstractSet[Type[Field]]
+        cls, fields: Iterable[type[Field]], *, registered_fields: AbstractSet[type[Field]]
     ) -> bool:
         unrecognized_fields = [field for field in fields if field not in registered_fields]
         if not unrecognized_fields:
@@ -565,7 +554,7 @@ class Target:
         return True
 
     @final
-    def has_field(self, field: Type[Field]) -> bool:
+    def has_field(self, field: type[Field]) -> bool:
         """Check that this target has registered the requested field.
 
         This works with subclasses of `Field`. For example, if you subclass `Tags` to define a
@@ -575,7 +564,7 @@ class Target:
         return self.has_fields([field])
 
     @final
-    def has_fields(self, fields: Iterable[Type[Field]]) -> bool:
+    def has_fields(self, fields: Iterable[type[Field]]) -> bool:
         """Check that this target has registered all of the requested fields.
 
         This works with subclasses of `Field`. For example, if you subclass `Tags` to define a
@@ -589,7 +578,7 @@ class Target:
     @memoized_method
     def class_field_types(
         cls, union_membership: UnionMembership | None
-    ) -> FrozenOrderedSet[Type[Field]]:
+    ) -> FrozenOrderedSet[type[Field]]:
         """Return all registered Fields belonging to this target type.
 
         You can also use the instance property `tgt.field_types` to avoid having to pass the
@@ -602,7 +591,7 @@ class Target:
 
     @final
     @classmethod
-    def class_has_field(cls, field: Type[Field], union_membership: UnionMembership) -> bool:
+    def class_has_field(cls, field: type[Field], union_membership: UnionMembership) -> bool:
         """Behaves like `Target.has_field()`, but works as a classmethod rather than an instance
         method."""
         return cls.class_has_fields([field], union_membership)
@@ -610,7 +599,7 @@ class Target:
     @final
     @classmethod
     def class_has_fields(
-        cls, fields: Iterable[Type[Field]], union_membership: UnionMembership
+        cls, fields: Iterable[type[Field]], union_membership: UnionMembership
     ) -> bool:
         """Behaves like `Target.has_fields()`, but works as a classmethod rather than an instance
         method."""
@@ -618,7 +607,7 @@ class Target:
 
     @final
     @classmethod
-    def class_get_field(cls, field: Type[_F], union_membership: UnionMembership) -> Type[_F]:
+    def class_get_field(cls, field: type[_F], union_membership: UnionMembership) -> type[_F]:
         """Get the requested Field type registered with this target type.
 
         This will error if the field is not registered, so you should call Target.class_has_field()
@@ -642,7 +631,7 @@ class Target:
         return result
 
     @classmethod
-    def register_plugin_field(cls, field: Type[Field]) -> UnionRule:
+    def register_plugin_field(cls, field: type[Field]) -> UnionRule:
         """Register a new field on the target type.
 
         In the `rules()` register.py entry-point, include
@@ -839,7 +828,7 @@ class CoarsenedTarget(EngineAwareParameter):
     def debug_hint(self) -> str:
         return str(self)
 
-    def metadata(self) -> Dict[str, Any]:
+    def metadata(self) -> dict[str, Any]:
         return {"addresses": [t.address.spec for t in self.members]}
 
     @property
@@ -851,12 +840,12 @@ class CoarsenedTarget(EngineAwareParameter):
         """The addresses and type aliases of all members of the cycle."""
         return bullet_list(sorted(f"{t.address.spec}\t({type(t).alias})" for t in self.members))
 
-    def closure(self, visited: Set[CoarsenedTarget] | None = None) -> Iterator[Target]:
+    def closure(self, visited: set[CoarsenedTarget] | None = None) -> Iterator[Target]:
         """All Targets reachable from this root."""
         return (t for ct in self.coarsened_closure(visited) for t in ct.members)
 
     def coarsened_closure(
-        self, visited: Set[CoarsenedTarget] | None = None
+        self, visited: set[CoarsenedTarget] | None = None
     ) -> Iterator[CoarsenedTarget]:
         """All CoarsenedTargets reachable from this root."""
 
@@ -920,12 +909,12 @@ class CoarsenedTargets(Collection[CoarsenedTarget]):
 
     def closure(self) -> Iterator[Target]:
         """All Targets reachable from these CoarsenedTarget roots."""
-        visited: Set[CoarsenedTarget] = set()
+        visited: set[CoarsenedTarget] = set()
         return (t for root in self for t in root.closure(visited))
 
     def coarsened_closure(self) -> Iterator[CoarsenedTarget]:
         """All CoarsenedTargets reachable from these CoarsenedTarget roots."""
-        visited: Set[CoarsenedTarget] = set()
+        visited: set[CoarsenedTarget] = set()
         return (ct for root in self for ct in root.coarsened_closure(visited))
 
     def __eq__(self, other: Any) -> bool:
@@ -944,7 +933,7 @@ class CoarsenedTargets(Collection[CoarsenedTarget]):
 class CoarsenedTargetsRequest:
     """A request to get CoarsenedTargets for input roots."""
 
-    roots: Tuple[Address, ...]
+    roots: tuple[Address, ...]
     expanded_targets: bool
     should_traverse_deps_predicate: ShouldTraverseDepsPredicate
 
@@ -968,7 +957,7 @@ class TransitiveTargets:
     and in `dependencies`.
     """
 
-    roots: Tuple[Target, ...]
+    roots: tuple[Target, ...]
     dependencies: FrozenOrderedSet[Target]
 
     @memoized_property
@@ -985,7 +974,7 @@ class TransitiveTargetsRequest:
     TransitiveTargetsRequest([addr1, addr2]))`.
     """
 
-    roots: Tuple[Address, ...]
+    roots: tuple[Address, ...]
     should_traverse_deps_predicate: ShouldTraverseDepsPredicate
 
     def __init__(
@@ -1000,13 +989,13 @@ class TransitiveTargetsRequest:
 
 @dataclass(frozen=True)
 class RegisteredTargetTypes:
-    aliases_to_types: FrozenDict[str, Type[Target]]
+    aliases_to_types: FrozenDict[str, type[Target]]
 
-    def __init__(self, aliases_to_types: Mapping[str, Type[Target]]) -> None:
+    def __init__(self, aliases_to_types: Mapping[str, type[Target]]) -> None:
         object.__setattr__(self, "aliases_to_types", FrozenDict(aliases_to_types))
 
     @classmethod
-    def create(cls, target_types: Iterable[Type[Target]]) -> RegisteredTargetTypes:
+    def create(cls, target_types: Iterable[type[Target]]) -> RegisteredTargetTypes:
         result = {}
         for target_type in sorted(target_types, key=lambda tt: tt.alias):
             result[target_type.alias] = target_type
@@ -1067,7 +1056,7 @@ class TargetGenerator(Target):
     # Fields should be copied from the generator to the generated when their semantic meaning is
     # the same for both Target types, and when it is valuable for them to be introspected on
     # either the generator or generated target (such as by `peek`, or in `filter`).
-    copied_fields: ClassVar[Tuple[Type[Field], ...]]
+    copied_fields: ClassVar[tuple[type[Field], ...]]
 
     # Fields which are specified to instances of the generator Target, but which are propagated
     # to generated Targets rather than being stored on the generator Target.
@@ -1078,7 +1067,7 @@ class TargetGenerator(Target):
     # it can also be the case that a Field only makes sense semantically when it is applied to
     # the generated Target (for example, for an individual file), and the generator Target is just
     # acting as a convenient place for them to be specified.
-    moved_fields: ClassVar[Tuple[Type[Field], ...]]
+    moved_fields: ClassVar[tuple[type[Field], ...]]
 
     @distinct_union_type_per_subclass
     class MovedPluginField:
@@ -1100,7 +1089,7 @@ class TargetGenerator(Target):
             )
 
     @classmethod
-    def register_plugin_field(cls, field: Type[Field], *, as_moved_field=False) -> UnionRule:
+    def register_plugin_field(cls, field: type[Field], *, as_moved_field=False) -> UnionRule:
         if as_moved_field:
             return UnionRule(cls.MovedPluginField, field)
         else:
@@ -1259,7 +1248,7 @@ class GeneratedTargets(FrozenDict[Address, Target]):
 
 
 class TargetTypesToGenerateTargetsRequests(
-    FrozenDict[Type[TargetGenerator], Type[GenerateTargetsRequest]]
+    FrozenDict[type[TargetGenerator], type[GenerateTargetsRequest]]
 ):
     def is_generator(self, tgt: Target) -> bool:
         """Does this target type generate other targets?"""
@@ -1388,8 +1377,8 @@ def _generate_file_level_targets(
 # FieldSet
 # -----------------------------------------------------------------------------------------------
 def _get_field_set_fields_from_target(
-    field_set: Type[FieldSet], target: Target
-) -> Dict[str, Field]:
+    field_set: type[FieldSet], target: Target
+) -> dict[str, Field]:
     return {
         dataclass_field_name: (
             target[field_cls] if field_cls in field_set.required_fields else target.get(field_cls)
@@ -1442,7 +1431,7 @@ class FieldSet(EngineAwareParameter, metaclass=ABCMeta):
         print(field_set.sources)
     """
 
-    required_fields: ClassVar[Tuple[Type[Field], ...]]
+    required_fields: ClassVar[tuple[type[Field], ...]]
 
     address: Address
 
@@ -1467,8 +1456,8 @@ class FieldSet(EngineAwareParameter, metaclass=ABCMeta):
     @final
     @classmethod
     def applicable_target_types(
-        cls, target_types: Iterable[Type[Target]], union_membership: UnionMembership
-    ) -> Tuple[Type[Target], ...]:
+        cls, target_types: Iterable[type[Target]], union_membership: UnionMembership
+    ) -> tuple[type[Target], ...]:
         return tuple(
             tgt_type
             for tgt_type in target_types
@@ -1477,12 +1466,12 @@ class FieldSet(EngineAwareParameter, metaclass=ABCMeta):
 
     @final
     @classmethod
-    def create(cls: Type[_FS], tgt: Target) -> _FS:
+    def create(cls: type[_FS], tgt: Target) -> _FS:
         return cls(address=tgt.address, **_get_field_set_fields_from_target(cls, tgt))
 
     @final
     @memoized_classproperty
-    def fields(cls) -> FrozenDict[str, Type[Field]]:
+    def fields(cls) -> FrozenDict[str, type[Field]]:
         return FrozenDict(
             (
                 (name, field_type)
@@ -1494,7 +1483,7 @@ class FieldSet(EngineAwareParameter, metaclass=ABCMeta):
     def debug_hint(self) -> str:
         return self.address.spec
 
-    def metadata(self) -> Dict[str, Any]:
+    def metadata(self) -> dict[str, Any]:
         return {"address": self.address.spec}
 
     def __repr__(self) -> str:
@@ -1505,7 +1494,7 @@ class FieldSet(EngineAwareParameter, metaclass=ABCMeta):
 
 @dataclass(frozen=True)
 class TargetRootsToFieldSets(Generic[_FS]):
-    mapping: FrozenDict[Target, Tuple[_FS, ...]]
+    mapping: FrozenDict[Target, tuple[_FS, ...]]
 
     def __init__(self, mapping: Mapping[Target, Iterable[_FS]]) -> None:
         object.__setattr__(
@@ -1515,7 +1504,7 @@ class TargetRootsToFieldSets(Generic[_FS]):
         )
 
     @memoized_property
-    def field_sets(self) -> Tuple[_FS, ...]:
+    def field_sets(self) -> tuple[_FS, ...]:
         return tuple(
             itertools.chain.from_iterable(
                 field_sets_per_target for field_sets_per_target in self.mapping.values()
@@ -1523,7 +1512,7 @@ class TargetRootsToFieldSets(Generic[_FS]):
         )
 
     @memoized_property
-    def targets(self) -> Tuple[Target, ...]:
+    def targets(self) -> tuple[Target, ...]:
         return tuple(self.mapping.keys())
 
 
@@ -1533,7 +1522,7 @@ class NoApplicableTargetsBehavior(Enum):
     error = "error"
 
 
-def parse_shard_spec(shard_spec: str, origin: str = "") -> Tuple[int, int]:
+def parse_shard_spec(shard_spec: str, origin: str = "") -> tuple[int, int]:
     def invalid():
         origin_str = f" from {origin}" if origin else ""
         return ValueError(
@@ -1562,7 +1551,7 @@ def get_shard(key: str, num_shards: int) -> int:
 
 @dataclass(frozen=True)
 class TargetRootsToFieldSetsRequest(Generic[_FS]):
-    field_set_superclass: Type[_FS]
+    field_set_superclass: type[_FS]
     goal_description: str
     no_applicable_targets_behavior: NoApplicableTargetsBehavior
     shard: int
@@ -1570,7 +1559,7 @@ class TargetRootsToFieldSetsRequest(Generic[_FS]):
 
     def __init__(
         self,
-        field_set_superclass: Type[_FS],
+        field_set_superclass: type[_FS],
         *,
         goal_description: str,
         no_applicable_targets_behavior: NoApplicableTargetsBehavior,
@@ -1590,22 +1579,22 @@ class TargetRootsToFieldSetsRequest(Generic[_FS]):
 @dataclass(frozen=True)
 class FieldSetsPerTarget(Generic[_FS]):
     # One tuple of FieldSet instances per input target.
-    collection: Tuple[Tuple[_FS, ...], ...]
+    collection: tuple[tuple[_FS, ...], ...]
 
     def __init__(self, collection: Iterable[Iterable[_FS]]):
         object.__setattr__(self, "collection", tuple(tuple(iterable) for iterable in collection))
 
     @memoized_property
-    def field_sets(self) -> Tuple[_FS, ...]:
+    def field_sets(self) -> tuple[_FS, ...]:
         return tuple(itertools.chain.from_iterable(self.collection))
 
 
 @dataclass(frozen=True)
 class FieldSetsPerTargetRequest(Generic[_FS]):
-    field_set_superclass: Type[_FS]
-    targets: Tuple[Target, ...]
+    field_set_superclass: type[_FS]
+    targets: tuple[Target, ...]
 
-    def __init__(self, field_set_superclass: Type[_FS], targets: Iterable[Target]):
+    def __init__(self, field_set_superclass: type[_FS], targets: Iterable[Target]):
         object.__setattr__(self, "field_set_superclass", field_set_superclass)
         object.__setattr__(self, "targets", tuple(targets))
 
@@ -1673,7 +1662,7 @@ class InvalidFieldTypeException(InvalidFieldException):
         self,
         address: Address,
         field_alias: str,
-        raw_value: Optional[Any],
+        raw_value: Any | None,
         *,
         expected_type: str,
         description_of_origin: str | None = None,
@@ -1692,7 +1681,7 @@ class InvalidFieldMemberTypeException(InvalidFieldException):
         self,
         address: Address,
         field_alias: str,
-        raw_value: Optional[Any],
+        raw_value: Any | None,
         *,
         expected_type: str,
         at_index: int,
@@ -1727,7 +1716,7 @@ class InvalidFieldChoiceException(InvalidFieldException):
         self,
         address: Address,
         field_alias: str,
-        raw_value: Optional[Any],
+        raw_value: Any | None,
         *,
         valid_choices: Iterable[Any],
         description_of_origin: str | None = None,
@@ -1790,13 +1779,13 @@ class ScalarField(Generic[T], Field):
                 return super().compute_value(raw_value, address=address)
     """
 
-    expected_type: ClassVar[Type[T]]  # type: ignore[misc]
+    expected_type: ClassVar[type[T]]  # type: ignore[misc]
     expected_type_description: ClassVar[str]
-    value: Optional[T]
-    default: ClassVar[Optional[T]] = None  # type: ignore[misc]
+    value: T | None
+    default: ClassVar[T | None] = None  # type: ignore[misc]
 
     @classmethod
-    def compute_value(cls, raw_value: Optional[Any], address: Address) -> Optional[T]:
+    def compute_value(cls, raw_value: Any | None, address: Address) -> T | None:
         value_or_default = super().compute_value(raw_value, address)
         if value_or_default is not None and not isinstance(value_or_default, cls.expected_type):
             raise InvalidFieldTypeException(
@@ -1835,7 +1824,7 @@ class TriBoolField(ScalarField[bool]):
     expected_type_description = "a boolean or None"
 
     @classmethod
-    def compute_value(cls, raw_value: Optional[bool], address: Address) -> Optional[bool]:
+    def compute_value(cls, raw_value: bool | None, address: Address) -> bool | None:
         return super().compute_value(raw_value, address)
 
 
@@ -1869,7 +1858,7 @@ class IntField(ScalarField[int]):
     valid_numbers: ClassVar[ValidNumbers] = ValidNumbers.all
 
     @classmethod
-    def compute_value(cls, raw_value: Optional[int], address: Address) -> Optional[int]:
+    def compute_value(cls, raw_value: int | None, address: Address) -> int | None:
         value_or_default = super().compute_value(raw_value, address)
         cls.valid_numbers.validate(value_or_default, cls.alias, address)
         return value_or_default
@@ -1881,7 +1870,7 @@ class FloatField(ScalarField[float]):
     valid_numbers: ClassVar[ValidNumbers] = ValidNumbers.all
 
     @classmethod
-    def compute_value(cls, raw_value: Optional[float], address: Address) -> Optional[float]:
+    def compute_value(cls, raw_value: float | None, address: Address) -> float | None:
         value_or_default = super().compute_value(raw_value, address)
         cls.valid_numbers.validate(value_or_default, cls.alias, address)
         return value_or_default
@@ -1896,10 +1885,10 @@ class StringField(ScalarField[str]):
 
     expected_type = str
     expected_type_description = "a string"
-    valid_choices: ClassVar[Optional[Union[Type[Enum], Tuple[str, ...]]]] = None
+    valid_choices: ClassVar[type[Enum] | tuple[str, ...] | None] = None
 
     @classmethod
-    def compute_value(cls, raw_value: Optional[str], address: Address) -> Optional[str]:
+    def compute_value(cls, raw_value: str | None, address: Address) -> str | None:
         value_or_default = super().compute_value(raw_value, address)
         if value_or_default is not None and cls.valid_choices is not None:
             _validate_choices(
@@ -1927,15 +1916,15 @@ class SequenceField(Generic[T], Field):
                 return super().compute_value(raw_value, address=address)
     """
 
-    expected_element_type: ClassVar[Type]
+    expected_element_type: ClassVar[type]
     expected_type_description: ClassVar[str]
-    value: Optional[Tuple[T, ...]]
-    default: ClassVar[Optional[Tuple[T, ...]]] = None  # type: ignore[misc]
+    value: tuple[T, ...] | None
+    default: ClassVar[tuple[T, ...] | None] = None  # type: ignore[misc]
 
     @classmethod
     def compute_value(
-        cls, raw_value: Optional[Iterable[Any]], address: Address
-    ) -> Optional[Tuple[T, ...]]:
+        cls, raw_value: Iterable[Any] | None, address: Address
+    ) -> tuple[T, ...] | None:
         value_or_default = super().compute_value(raw_value, address)
         if value_or_default is None:
             return None
@@ -1955,18 +1944,18 @@ class TupleSequenceField(Generic[T], Field):
     # this cannot be a SequenceField as compute_value's use of ensure_list
     # does not work with expected_element_type=tuple when the value itself
     # is already a tuple.
-    expected_element_type: ClassVar[Type]
+    expected_element_type: ClassVar[type]
     expected_element_count: ClassVar[int]  # -1 for unlimited
     expected_type_description: ClassVar[str]
     expected_element_type_description: ClassVar[str]
 
-    value: Optional[Tuple[Tuple[T, ...], ...]]
-    default: ClassVar[Optional[Tuple[Tuple[T, ...], ...]]] = None  # type: ignore[misc]
+    value: tuple[tuple[T, ...], ...] | None
+    default: ClassVar[tuple[tuple[T, ...], ...] | None] = None  # type: ignore[misc]
 
     @classmethod
     def compute_value(
-        cls, raw_value: Optional[Iterable[Iterable[T]]], address: Address
-    ) -> Optional[tuple[tuple[T, ...], ...]]:
+        cls, raw_value: Iterable[Iterable[T]] | None, address: Address
+    ) -> tuple[tuple[T, ...], ...] | None:
         value_or_default = super().compute_value(raw_value, address)
         if value_or_default is None:
             return value_or_default
@@ -2010,12 +1999,12 @@ class TupleSequenceField(Generic[T], Field):
 class StringSequenceField(SequenceField[str]):
     expected_element_type = str
     expected_type_description = "an iterable of strings (e.g. a list of strings)"
-    valid_choices: ClassVar[Optional[Union[Type[Enum], Tuple[str, ...]]]] = None
+    valid_choices: ClassVar[type[Enum] | tuple[str, ...] | None] = None
 
     @classmethod
     def compute_value(
-        cls, raw_value: Optional[Iterable[str]], address: Address
-    ) -> Optional[Tuple[str, ...]]:
+        cls, raw_value: Iterable[str] | None, address: Address
+    ) -> tuple[str, ...] | None:
         value_or_default = super().compute_value(raw_value, address)
         if value_or_default and cls.valid_choices is not None:
             _validate_choices(address, cls.alias, value_or_default, valid_choices=cls.valid_choices)
@@ -2023,13 +2012,13 @@ class StringSequenceField(SequenceField[str]):
 
 
 class DictStringToStringField(Field):
-    value: Optional[FrozenDict[str, str]]
-    default: ClassVar[Optional[FrozenDict[str, str]]] = None
+    value: FrozenDict[str, str] | None
+    default: ClassVar[FrozenDict[str, str] | None] = None
 
     @classmethod
     def compute_value(
-        cls, raw_value: Optional[Dict[str, str]], address: Address
-    ) -> Optional[FrozenDict[str, str]]:
+        cls, raw_value: dict[str, str] | None, address: Address
+    ) -> FrozenDict[str, str] | None:
         value_or_default = super().compute_value(raw_value, address)
         if value_or_default is None:
             return None
@@ -2044,13 +2033,13 @@ class DictStringToStringField(Field):
 
 
 class ListOfDictStringToStringField(Field):
-    value: Optional[Tuple[FrozenDict[str, str]]]
-    default: ClassVar[Optional[list[FrozenDict[str, str]]]] = None
+    value: tuple[FrozenDict[str, str]] | None
+    default: ClassVar[list[FrozenDict[str, str]] | None] = None
 
     @classmethod
     def compute_value(
-        cls, raw_value: Optional[list[Dict[str, str]]], address: Address
-    ) -> Optional[Tuple[FrozenDict[str, str], ...]]:
+        cls, raw_value: list[dict[str, str]] | None, address: Address
+    ) -> tuple[FrozenDict[str, str], ...] | None:
         value_or_default = super().compute_value(raw_value, address)
         if value_or_default is None:
             return None
@@ -2077,13 +2066,13 @@ class ListOfDictStringToStringField(Field):
 
 
 class NestedDictStringToStringField(Field):
-    value: Optional[FrozenDict[str, FrozenDict[str, str]]]
-    default: ClassVar[Optional[FrozenDict[str, FrozenDict[str, str]]]] = None
+    value: FrozenDict[str, FrozenDict[str, str]] | None
+    default: ClassVar[FrozenDict[str, FrozenDict[str, str]] | None] = None
 
     @classmethod
     def compute_value(
-        cls, raw_value: Optional[Dict[str, Dict[str, str]]], address: Address
-    ) -> Optional[FrozenDict[str, FrozenDict[str, str]]]:
+        cls, raw_value: dict[str, dict[str, str]] | None, address: Address
+    ) -> FrozenDict[str, FrozenDict[str, str]] | None:
         value_or_default = super().compute_value(raw_value, address)
         if value_or_default is None:
             return None
@@ -2106,13 +2095,13 @@ class NestedDictStringToStringField(Field):
 
 
 class DictStringToStringSequenceField(Field):
-    value: Optional[FrozenDict[str, Tuple[str, ...]]]
-    default: ClassVar[Optional[FrozenDict[str, Tuple[str, ...]]]] = None
+    value: FrozenDict[str, tuple[str, ...]] | None
+    default: ClassVar[FrozenDict[str, tuple[str, ...]] | None] = None
 
     @classmethod
     def compute_value(
-        cls, raw_value: Optional[Dict[str, Iterable[str]]], address: Address
-    ) -> Optional[FrozenDict[str, Tuple[str, ...]]]:
+        cls, raw_value: dict[str, Iterable[str]] | None, address: Address
+    ) -> FrozenDict[str, tuple[str, ...]] | None:
         value_or_default = super().compute_value(raw_value, address)
         if value_or_default is None:
             return None
@@ -2140,7 +2129,7 @@ def _validate_choices(
     field_alias: str,
     values: Iterable[Any],
     *,
-    valid_choices: Union[Type[Enum], Tuple[Any, ...]],
+    valid_choices: type[Enum] | tuple[Any, ...],
 ) -> None:
     _valid_choices = set(
         valid_choices
@@ -2363,8 +2352,8 @@ class MultipleSourcesField(SourcesField, StringSequenceField):
 
     @classmethod
     def compute_value(
-        cls, raw_value: Optional[Iterable[str]], address: Address
-    ) -> Optional[Tuple[str, ...]]:
+        cls, raw_value: Iterable[str] | None, address: Address
+    ) -> tuple[str, ...] | None:
         value = super().compute_value(raw_value, address)
         invalid_globs = [glob for glob in (value or ()) if glob.startswith("../") or "/../" in glob]
         if invalid_globs:
@@ -2417,7 +2406,7 @@ class OptionalSingleSourceField(SourcesField, StringField):
     expected_num_files: ClassVar[int | range] = range(0, 2)
 
     @classmethod
-    def compute_value(cls, raw_value: Optional[str], address: Address) -> Optional[str]:
+    def compute_value(cls, raw_value: str | None, address: Address) -> str | None:
         value_or_default = super().compute_value(raw_value, address)
         if value_or_default is None:
             return None
@@ -2868,7 +2857,7 @@ class InferDependenciesRequest(Generic[FS], EngineAwareParameter):
             ]
     """
 
-    infer_from: ClassVar[Type[FS]]  # type: ignore[misc]
+    infer_from: ClassVar[type[FS]]  # type: ignore[misc]
 
     field_set: FS
 
@@ -2900,7 +2889,7 @@ class TransitivelyExcludeDependenciesRequest(Generic[FS], EngineAwareParameter):
     This mirrors the public facing "transitive exclude" dependency feature (i.e. `!!<address>`).
     """
 
-    infer_from: ClassVar[Type[FS]]  # type: ignore[misc]
+    infer_from: ClassVar[type[FS]]  # type: ignore[misc]
 
     field_set: FS
 
@@ -2917,7 +2906,7 @@ class ValidateDependenciesRequest(Generic[FS], ABC):
     An implementing rule should raise an exception if dependencies are invalid.
     """
 
-    field_set_type: ClassVar[Type[FS]]  # type: ignore[misc]
+    field_set_type: ClassVar[type[FS]]  # type: ignore[misc]
 
     field_set: FS
     dependencies: Addresses
@@ -3051,9 +3040,9 @@ class OverridesField(AsyncFieldMixin, Field):
     @classmethod
     def compute_value(
         cls,
-        raw_value: Optional[Dict[Union[str, Tuple[str, ...]], Dict[str, Any]]],
+        raw_value: dict[str | tuple[str, ...], dict[str, Any]] | None,
         address: Address,
-    ) -> Optional[FrozenDict[Tuple[str, ...], FrozenDict[str, ImmutableValue]]]:
+    ) -> FrozenDict[tuple[str, ...], FrozenDict[str, ImmutableValue]] | None:
         value_or_default = super().compute_value(raw_value, address)
         if value_or_default is None:
             return None

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -4,9 +4,10 @@
 import re
 import string
 from collections import namedtuple
+from collections.abc import Iterable, Sequence
 from dataclasses import FrozenInstanceError, dataclass
 from enum import Enum
-from typing import Any, ClassVar, Dict, Iterable, List, Optional, Sequence, Set, Tuple, cast
+from typing import Any, ClassVar, cast
 
 import pytest
 
@@ -66,11 +67,11 @@ from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
 
 class FortranExtensions(Field):
     alias = "fortran_extensions"
-    value: Tuple[str, ...]
+    value: tuple[str, ...]
     default = ()
 
     @classmethod
-    def compute_value(cls, raw_value: Optional[Iterable[str]], address: Address) -> Tuple[str, ...]:
+    def compute_value(cls, raw_value: Iterable[str] | None, address: Address) -> tuple[str, ...]:
         value_or_default = super().compute_value(raw_value, address)
         # Add some arbitrary validation to test that hydration/validation works properly.
         bad_extensions = [
@@ -340,8 +341,8 @@ def test_override_preexisting_field_via_new_target() -> None:
 
         @classmethod
         def compute_value(
-            cls, raw_value: Optional[Iterable[str]], address: Address
-        ) -> Tuple[str, ...]:
+            cls, raw_value: Iterable[str] | None, address: Address
+        ) -> tuple[str, ...]:
             # Ensure that we avoid certain problematic extensions and always use some defaults.
             specified_extensions = super().compute_value(raw_value, address)
             banned = [
@@ -484,7 +485,7 @@ def test_target_residence_dir() -> None:
 def test_coarsened_target_equality() -> None:
     a, b = (FortranTarget({}, Address(name)) for name in string.ascii_lowercase[:2])
 
-    def ct(members: List[Target], dependencies: List[CoarsenedTarget] = []):
+    def ct(members: list[Target], dependencies: list[CoarsenedTarget] = []):
         return CoarsenedTarget(members, dependencies)
 
     assert ct([]) == ct([])
@@ -509,7 +510,7 @@ def test_coarsened_target_closure() -> None:
     all_targets = [FortranTarget({}, Address(name)) for name in string.ascii_lowercase[:5]]
     a, b, c, d, e = all_targets
 
-    def ct(members: List[Target], dependencies: List[CoarsenedTarget] = []) -> CoarsenedTarget:
+    def ct(members: list[Target], dependencies: list[CoarsenedTarget] = []) -> CoarsenedTarget:
         return CoarsenedTarget(members, dependencies)
 
     def assert_closure(cts: Sequence[CoarsenedTarget], expected: Sequence[Target]) -> None:
@@ -698,8 +699,8 @@ def test_scalar_field() -> None:
 
         @classmethod
         def compute_value(
-            cls, raw_value: Optional[CustomObject], address: Address
-        ) -> Optional[CustomObject]:
+            cls, raw_value: CustomObject | None, address: Address
+        ) -> CustomObject | None:
             return super().compute_value(raw_value, address)
 
     addr = Address("", target_name="example")
@@ -786,8 +787,8 @@ def test_sequence_field() -> None:
 
         @classmethod
         def compute_value(
-            cls, raw_value: Optional[Iterable[CustomObject]], address: Address
-        ) -> Optional[Tuple[CustomObject, ...]]:
+            cls, raw_value: Iterable[CustomObject] | None, address: Address
+        ) -> tuple[CustomObject, ...] | None:
             return super().compute_value(raw_value, address)
 
     addr = Address("", target_name="example")
@@ -968,7 +969,7 @@ def test_dict_string_to_string_sequence_field() -> None:
 
     addr = Address("", target_name="example")
 
-    def assert_flexible_constructor(raw_value: Dict[str, Iterable[str]]) -> None:
+    def assert_flexible_constructor(raw_value: dict[str, Iterable[str]]) -> None:
         assert Example(raw_value, addr).value == FrozenDict(
             {k: tuple(v) for k, v in raw_value.items()}
         )
@@ -1256,7 +1257,7 @@ def test_explicitly_provided_dependencies_remaining_after_disambiguation() -> No
         ignores=FrozenOrderedSet([addr, generated_addr]),
     )
 
-    def assert_disambiguated_via_ignores(ambiguous: List[Address], expected: Set[Address]) -> None:
+    def assert_disambiguated_via_ignores(ambiguous: list[Address], expected: set[Address]) -> None:
         assert (
             epd.remaining_after_disambiguation(tuple(ambiguous), owners_must_be_ancestors=False)
             == expected
@@ -1301,12 +1302,12 @@ def test_explicitly_provided_dependencies_remaining_after_disambiguation() -> No
 
 def test_explicitly_provided_dependencies_disambiguated() -> None:
     def get_disambiguated(
-        ambiguous: List[Address],
+        ambiguous: list[Address],
         *,
-        ignores: Optional[List[Address]] = None,
-        includes: Optional[List[Address]] = None,
+        ignores: list[Address] | None = None,
+        includes: list[Address] | None = None,
         owners_must_be_ancestors: bool = False,
-    ) -> Optional[Address]:
+    ) -> Address | None:
         epd = ExplicitlyProvidedDependencies(
             address=Address("dir", target_name="input_tgt"),
             includes=FrozenOrderedSet(includes or []),
@@ -1361,10 +1362,10 @@ def test_explicitly_provided_dependencies_maybe_warn_of_ambiguous_dependency_inf
     caplog,
 ) -> None:
     def maybe_warn(
-        ambiguous: List[Address],
+        ambiguous: list[Address],
         *,
-        ignores: Optional[List[Address]] = None,
-        includes: Optional[List[Address]] = None,
+        ignores: list[Address] | None = None,
+        includes: list[Address] | None = None,
         owners_must_be_ancestors: bool = False,
     ) -> None:
         caplog.clear()
@@ -1491,7 +1492,7 @@ def test_overrides_field_normalization() -> None:
     assert OverridesField.flatten_paths(
         addr,
         [
-            (paths, globs, cast(Dict[str, Any], overrides))
+            (paths, globs, cast(dict[str, Any], overrides))
             for (paths, overrides), globs in zip(
                 [
                     (Paths(("dir/foo.ext",), ()), tgt1_override),

--- a/src/python/pants/engine/unions.py
+++ b/src/python/pants/engine/unions.py
@@ -4,8 +4,9 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
-from typing import Any, Callable, DefaultDict, Generic, Iterable, Mapping, TypeVar, cast, overload
+from typing import Any, DefaultDict, Generic, TypeVar, cast, overload
 
 from pants.util.frozendict import FrozenDict
 from pants.util.memo import memoized_method

--- a/src/python/pants/goal/migrate_call_by_name.py
+++ b/src/python/pants/goal/migrate_call_by_name.py
@@ -6,10 +6,11 @@ from __future__ import annotations
 import importlib.util
 import json
 import logging
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from functools import partial
 from pathlib import Path, PurePath
-from typing import Callable, Iterable, TypedDict
+from typing import TypedDict
 
 import libcst as cst
 import libcst.helpers as h

--- a/src/python/pants/goal/migrate_call_by_name_test.py
+++ b/src/python/pants/goal/migrate_call_by_name_test.py
@@ -3,9 +3,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from copy import deepcopy
 from pathlib import PurePath
-from typing import Final, Iterable
+from typing import Final
 
 import libcst as cst
 import pytest

--- a/src/python/pants/goal/stats_aggregator.py
+++ b/src/python/pants/goal/stats_aggregator.py
@@ -11,7 +11,7 @@ from collections import Counter
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Optional, TypedDict
+from typing import TypedDict
 
 from pants.engine.internals.scheduler import Workunit
 from pants.engine.rules import collect_rules, rule
@@ -114,7 +114,7 @@ class StatsAggregatorSubsystem(Subsystem):
     )
 
 
-def _log_or_write_to_file_plain(output_file: Optional[str], lines: list[str]) -> None:
+def _log_or_write_to_file_plain(output_file: str | None, lines: list[str]) -> None:
     """Send text to the stdout or write to the output file (plain text)."""
     if lines:
         text = "\n".join(lines)
@@ -126,7 +126,7 @@ def _log_or_write_to_file_plain(output_file: Optional[str], lines: list[str]) ->
             logger.info(text)
 
 
-def _log_or_write_to_file_json(output_file: Optional[str], stats_object: StatsObject) -> None:
+def _log_or_write_to_file_json(output_file: str | None, stats_object: StatsObject) -> None:
     """Send JSON Lines single line object to the stdout or write to the file."""
     if not stats_object:
         return
@@ -147,7 +147,7 @@ class StatsAggregatorCallback(WorkunitsCallback):
         *,
         log: bool,
         memory: bool,
-        output_file: Optional[str],
+        output_file: str | None,
         has_histogram_module: bool,
         format: StatsOutputFormat,
     ) -> None:

--- a/src/python/pants/help/help_formatter_test.py
+++ b/src/python/pants/help/help_formatter_test.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import replace
-from typing import Tuple
 
 from pants.help.help_formatter import HelpFormatter
 from pants.help.help_info_extracter import HelpInfoExtracter, OptionHelpInfo
@@ -58,7 +57,7 @@ class TestOptionHelpFormatter:
         assert default_line.lstrip() == "default: kiwi"
 
     @classmethod
-    def _get_registrar_and_parser(cls) -> Tuple[OptionRegistrar, NativeOptionParser]:
+    def _get_registrar_and_parser(cls) -> tuple[OptionRegistrar, NativeOptionParser]:
         return OptionRegistrar(
             scope=GlobalOptions.options_scope,
         ), NativeOptionParser(

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -11,25 +11,13 @@ import itertools
 import json
 import re
 from collections import defaultdict, namedtuple
+from collections.abc import Callable, Iterator, Sequence
 from dataclasses import dataclass
 from enum import Enum
 from functools import reduce
 from itertools import chain
 from pathlib import Path
-from typing import (
-    Any,
-    Callable,
-    DefaultDict,
-    Iterator,
-    Optional,
-    Sequence,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-    cast,
-    get_type_hints,
-)
+from typing import Any, DefaultDict, TypeVar, Union, cast, get_type_hints
 
 import pkg_resources
 
@@ -146,7 +134,7 @@ class OptionScopeHelpInfo:
     description: str
     provider: str
     is_goal: bool  # True iff the scope belongs to a GoalSubsystem.
-    deprecated_scope: Optional[str]
+    deprecated_scope: str | None
     basic: tuple[OptionHelpInfo, ...]
     advanced: tuple[OptionHelpInfo, ...]
     deprecated: tuple[OptionHelpInfo, ...]
@@ -470,7 +458,7 @@ class AllHelpInfo:
         }
 
 
-ConsumedScopesMapper = Callable[[str], Tuple[str, ...]]
+ConsumedScopesMapper = Callable[[str], tuple[str, ...]]
 
 
 class HelpInfoExtracter:
@@ -529,7 +517,7 @@ class HelpInfoExtracter:
                         build_configuration.subsystem_to_providers.get(subsystem_cls),
                         subsystem_cls.__module__,
                     )
-                goal_subsystem_cls = cast(Type[GoalSubsystem], subsystem_cls)
+                goal_subsystem_cls = cast(type[GoalSubsystem], subsystem_cls)
                 return GoalHelpInfo(
                     goal_subsystem_cls.name,
                     scope_info.description,
@@ -1008,7 +996,7 @@ class HelpInfoExtracter:
         native_parser: NativeOptionParser,
         is_goal: bool,
         provider: str = "",
-        deprecated_scope: Optional[str] = None,
+        deprecated_scope: str | None = None,
     ) -> OptionScopeHelpInfo:
         """Returns an OptionScopeHelpInfo for the options parsed by the given parser."""
 

--- a/src/python/pants/help/help_info_extracter_test.py
+++ b/src/python/pants/help/help_info_extracter_test.py
@@ -1,8 +1,9 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from collections.abc import Iterable
 from enum import Enum
-from typing import Any, Iterable, List, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 from pants.base.build_environment import get_buildroot
 from pants.build_graph.build_configuration import BuildConfiguration
@@ -134,7 +135,7 @@ def test_default() -> None:
 
 
 def test_compute_default():
-    def do_test(expected_default: Optional[Any], **kwargs):
+    def do_test(expected_default: Any | None, **kwargs):
         assert expected_default == HelpInfoExtracter.compute_default(**kwargs)
 
     do_test(False, type=bool, default=False)
@@ -286,7 +287,7 @@ def test_get_all_help_info(tmp_path) -> None:
         """This rule is for testing info extraction only."""
         ...
 
-    def fake_consumed_scopes_mapper(scope: str) -> Tuple[str, ...]:
+    def fake_consumed_scopes_mapper(scope: str) -> tuple[str, ...]:
         return ("somescope", f"used_by_{scope or 'GLOBAL_SCOPE'}")
 
     bc_builder = BuildConfiguration.Builder()
@@ -810,6 +811,6 @@ def test_pretty_print_type_hint() -> None:
         f"{__name__}.{test_pretty_print_type_hint.__name__}.<locals>.{ExampleCls.__name__}"
     )
     assert (
-        pretty_print_type_hint(Union[Iterable[List[ExampleCls]], Optional[float], Any])
+        pretty_print_type_hint(Union[Iterable[list[ExampleCls]], Optional[float], Any])
         == f"Iterable[List[{example_cls_repr}]] | float | None | Any"
     )

--- a/src/python/pants/help/help_printer.py
+++ b/src/python/pants/help/help_printer.py
@@ -6,9 +6,10 @@ import json
 import re
 import textwrap
 from abc import ABC
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from itertools import cycle
-from typing import Callable, Dict, Iterable, List, Literal, Optional, Set, Tuple, cast
+from typing import Literal, cast
 
 from pants.base.build_environment import pants_version
 from pants.help.help_formatter import HelpFormatter
@@ -119,7 +120,7 @@ class HelpPrinter(MaybeColor):
         title = self.maybe_green(f"{title_text}\n{'-' * len(title_text)}")
         print(f"\n{title}\n")
 
-    def _print_table(self, table: Dict[str, Optional[str]]) -> None:
+    def _print_table(self, table: dict[str, str | None]) -> None:
         longest_key = max(len(key) for key, value in table.items() if value is not None)
         for key, value in table.items():
             if value is None:
@@ -133,10 +134,10 @@ class HelpPrinter(MaybeColor):
                 ),
             )
 
-    def _get_thing_help_table(self) -> Dict[str, Callable[[str, bool], None]]:
+    def _get_thing_help_table(self) -> dict[str, Callable[[str, bool], None]]:
         def _help_table(
             things: Iterable[str], help_printer: Callable[[str, bool], None]
-        ) -> Dict[str, Callable[[str, bool], None]]:
+        ) -> dict[str, Callable[[str, bool], None]]:
             return dict(zip(things, cycle((help_printer,))))
 
         top_level_help_items = _help_table(self._reserved_names, self._print_top_level_help)
@@ -159,11 +160,11 @@ class HelpPrinter(MaybeColor):
     @staticmethod
     def _disambiguate_things(
         things: Iterable[str], all_things: Iterable[str]
-    ) -> Tuple[Set[str], Set[str]]:
+    ) -> tuple[set[str], set[str]]:
         """Returns two sets of strings, one with disambiguated things and the second with
         unresolvable things."""
-        disambiguated: Set[str] = set()
-        unknown: Set[str] = set()
+        disambiguated: set[str] = set()
+        unknown: set[str] = set()
 
         for thing in things:
             # Look for typos and close matches first.
@@ -173,7 +174,7 @@ class HelpPrinter(MaybeColor):
                 continue
 
             # For api types and rules, see if we get a match, by ignoring the leading module path.
-            found_things: List[str] = []
+            found_things: list[str] = []
             suffix = f".{thing}"
             for known_thing in all_things:
                 if known_thing.endswith(suffix):
@@ -259,7 +260,7 @@ class HelpPrinter(MaybeColor):
             self._print_all_symbols(show_advanced)
 
     def _print_all_goals(self) -> None:
-        goal_descriptions: Dict[str, str] = {}
+        goal_descriptions: dict[str, str] = {}
 
         for goal_info in self._all_help_info.name_to_goal_info.values():
             if goal_info.is_implemented:
@@ -291,7 +292,7 @@ class HelpPrinter(MaybeColor):
     def _print_all_subsystems(self) -> None:
         self._print_title("Subsystems")
 
-        subsystem_description: Dict[str, str] = {}
+        subsystem_description: dict[str, str] = {}
         for help_info in self._all_help_info.non_deprecated_option_scope_help_infos():
             if not help_info.is_goal and help_info.scope:
                 subsystem_description[help_info.scope] = first_paragraph(help_info.description)
@@ -340,7 +341,7 @@ class HelpPrinter(MaybeColor):
 
     def _print_all_api_types(self) -> None:
         self._print_title("Plugin API Types")
-        api_type_descriptions: Dict[str, Tuple[str, str]] = {}
+        api_type_descriptions: dict[str, tuple[str, str]] = {}
         indent_api_summary = 0
         for api_info in self._all_help_info.name_to_api_type_info.values():
             name = api_info.name

--- a/src/python/pants/help/help_tools.py
+++ b/src/python/pants/help/help_tools.py
@@ -2,11 +2,12 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from __future__ import annotations
 
+from collections.abc import Generator, Iterable
 from dataclasses import dataclass
 from functools import partial
 from itertools import chain
 from textwrap import wrap
-from typing import Generator, Iterable, cast
+from typing import cast
 
 from pants.help.help_info_extracter import AllHelpInfo, OptionScopeHelpInfo
 from pants.help.maybe_color import MaybeColor

--- a/src/python/pants/help/maybe_color.py
+++ b/src/python/pants/help/maybe_color.py
@@ -1,7 +1,6 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import List
 
 from colors import color as ansicolor
 from colors import cyan, green, magenta, red, yellow
@@ -28,7 +27,7 @@ class MaybeColor:
         self.maybe_magenta = magenta if color else noop
         self.maybe_yellow = yellow if color else noop
 
-    def _format_did_you_mean_matches(self, did_you_mean: List[str]) -> str:
+    def _format_did_you_mean_matches(self, did_you_mean: list[str]) -> str:
         if len(did_you_mean) == 1:
             formatted_candidates = self.maybe_cyan(did_you_mean[0])
         elif len(did_you_mean) == 2:

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -4,9 +4,10 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, ClassVar, Iterable, Mapping, cast
+from typing import Any, ClassVar, cast
 
 from pants.base.build_environment import get_buildroot
 from pants.base.build_root import BuildRoot

--- a/src/python/pants/init/extension_loader.py
+++ b/src/python/pants/init/extension_loader.py
@@ -4,7 +4,6 @@
 import importlib
 import logging
 import traceback
-from typing import Dict, List, Optional
 
 from pkg_resources import Requirement, WorkingSet
 
@@ -29,10 +28,10 @@ class PluginLoadOrderError(PluginLoadingError):
 
 
 def load_backends_and_plugins(
-    plugins: List[str],
+    plugins: list[str],
     working_set: WorkingSet,
-    backends: List[str],
-    bc_builder: Optional[BuildConfiguration.Builder] = None,
+    backends: list[str],
+    bc_builder: BuildConfiguration.Builder | None = None,
 ) -> BuildConfiguration:
     """Load named plugins and source backends.
 
@@ -50,7 +49,7 @@ def load_backends_and_plugins(
 
 def load_plugins(
     build_configuration: BuildConfiguration.Builder,
-    plugins: List[str],
+    plugins: list[str],
     working_set: WorkingSet,
 ) -> None:
     """Load named plugins from the current working_set into the supplied build_configuration.
@@ -76,7 +75,7 @@ def load_plugins(
                               eg ['widgetpublish', 'widgetgen==1.2'].
     :param working_set: A pkg_resources.WorkingSet to load plugins from.
     """
-    loaded: Dict = {}
+    loaded: dict = {}
     for plugin in plugins or []:
         req = Requirement.parse(plugin)
         dist = working_set.find(req)
@@ -115,7 +114,7 @@ def load_plugins(
 
 
 def load_build_configuration_from_source(
-    build_configuration: BuildConfiguration.Builder, backends: List[str]
+    build_configuration: BuildConfiguration.Builder, backends: list[str]
 ) -> None:
     """Installs pants backend packages to provide BUILD file symbols and cli goals.
 

--- a/src/python/pants/init/load_backends_integration_test.py
+++ b/src/python/pants/init/load_backends_integration_test.py
@@ -2,14 +2,13 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pathlib import Path
-from typing import List
 
 import pytest
 
 from pants.testutil.pants_integration_test import run_pants
 
 
-def discover_backends() -> List[str]:
+def discover_backends() -> list[str]:
     register_pys = Path().glob("src/python/**/register.py")
     backends = {
         str(register_py.parent).replace("src/python/", "").replace("/", ".")
@@ -20,7 +19,7 @@ def discover_backends() -> List[str]:
     return sorted(backends - always_activated)
 
 
-def assert_backends_load(backends: List[str]) -> None:
+def assert_backends_load(backends: list[str]) -> None:
     run_pants(
         ["--no-verify-config", "help-all"], config={"GLOBAL": {"backend_packages": backends}}
     ).assert_success(f"Failed to load: {backends}")

--- a/src/python/pants/init/logging.py
+++ b/src/python/pants/init/logging.py
@@ -7,11 +7,11 @@ import http.client
 import locale
 import logging
 import sys
+from collections.abc import Iterator
 from contextlib import contextmanager
 from io import BufferedReader, TextIOWrapper
 from logging import Formatter, Handler, LogRecord
 from pathlib import PurePath
-from typing import Iterator
 
 import pants.util.logging as pants_logging
 from pants.engine.internals import native_engine

--- a/src/python/pants/init/options_initializer.py
+++ b/src/python/pants/init/options_initializer.py
@@ -7,9 +7,9 @@ import dataclasses
 import importlib
 import logging
 import sys
+from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Iterator, List
 
 import pkg_resources
 
@@ -66,7 +66,7 @@ def _initialize_build_configuration(
     )
 
 
-def _collect_backends_requirements(backends: List[str]) -> List[str]:
+def _collect_backends_requirements(backends: list[str]) -> list[str]:
     """Collects backend package dependencies, in case those are declared in an adjacent
     requirements.txt. Ignores any loading errors, assuming those will be later on handled by the
     backends loader.

--- a/src/python/pants/init/plugin_resolver.py
+++ b/src/python/pants/init/plugin_resolver.py
@@ -6,8 +6,9 @@ from __future__ import annotations
 import logging
 import site
 import sys
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable, Optional, cast
+from typing import cast
 
 from pkg_resources import Requirement, WorkingSet
 from pkg_resources import working_set as global_working_set
@@ -118,8 +119,8 @@ class PluginResolver:
     def __init__(
         self,
         scheduler: BootstrapScheduler,
-        interpreter_constraints: Optional[InterpreterConstraints] = None,
-        working_set: Optional[WorkingSet] = None,
+        interpreter_constraints: InterpreterConstraints | None = None,
+        working_set: WorkingSet | None = None,
     ) -> None:
         self._scheduler = scheduler
         self._working_set = working_set or global_working_set

--- a/src/python/pants/jvm/classpath.py
+++ b/src/python/pants/jvm/classpath.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterator
 from dataclasses import dataclass
-from typing import Iterator
 
 from pants.core.util_rules import system_binaries
 from pants.core.util_rules.system_binaries import UnzipBinary

--- a/src/python/pants/jvm/compile.py
+++ b/src/python/pants/jvm/compile.py
@@ -7,9 +7,10 @@ import logging
 import os
 from abc import ABCMeta
 from collections import defaultdict, deque
+from collections.abc import Iterable, Iterator, Sequence
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import ClassVar, Iterable, Iterator, Sequence
+from typing import ClassVar
 
 from pants.core.target_types import (
     FilesGeneratingSourcesField,

--- a/src/python/pants/jvm/compile_test.py
+++ b/src/python/pants/jvm/compile_test.py
@@ -11,8 +11,9 @@ But this module should include `@rules` for multiple languages, even though the 
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from textwrap import dedent
-from typing import Sequence, Type, cast
+from typing import cast
 
 import chevron
 import pytest
@@ -262,7 +263,7 @@ def test_request_classification(
     all_members = [CompileJavaSourceRequest, CompileScalaSourceRequest, CoursierFetchRequest]
     generators = FrozenDict(
         {
-            CompileJavaSourceRequest: frozenset([cast(Type[SourcesField], ProtobufSourceField)]),
+            CompileJavaSourceRequest: frozenset([cast(type[SourcesField], ProtobufSourceField)]),
             CompileScalaSourceRequest: frozenset(),
         }
     )

--- a/src/python/pants/jvm/dependency_inference/artifact_mapper.py
+++ b/src/python/pants/jvm/dependency_inference/artifact_mapper.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
-from typing import Any, DefaultDict, Iterable, Iterator, Tuple
+from typing import Any, DefaultDict
 
 from pants.backend.java.subsystems.java_infer import JavaInferSubsystem
 from pants.build_graph.address import Address
@@ -44,7 +45,7 @@ class UnversionedCoordinate:
 
 class AvailableThirdPartyArtifacts(
     FrozenDict[
-        Tuple[_ResolveName, UnversionedCoordinate], Tuple[Tuple[Address, ...], Tuple[str, ...]]
+        tuple[_ResolveName, UnversionedCoordinate], tuple[tuple[Address, ...], tuple[str, ...]]
     ]
 ):
     """Maps coordinates and resolve names to target `Address`es and declared packages."""
@@ -104,7 +105,7 @@ class MutableTrieNode:
         return FrozenTrieNode(self)
 
 
-FrozenTrieNodeItem = Tuple[str, bool, FrozenDict[SymbolNamespace, FrozenOrderedSet[Address]], bool]
+FrozenTrieNodeItem = tuple[str, bool, FrozenDict[SymbolNamespace, FrozenOrderedSet[Address]], bool]
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/jvm/goals/lockfile.py
+++ b/src/python/pants/jvm/goals/lockfile.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Mapping
 
 from pants.core.goals.generate_lockfiles import (
     DEFAULT_TOOL_LOCKFILE,

--- a/src/python/pants/jvm/jar_tool/jar_tool.py
+++ b/src/python/pants/jvm/jar_tool/jar_tool.py
@@ -4,9 +4,9 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from enum import Enum, unique
-from typing import Iterable, Mapping
 
 import pkg_resources
 

--- a/src/python/pants/jvm/jdk_rules.py
+++ b/src/python/pants/jvm/jdk_rules.py
@@ -9,9 +9,10 @@ import os
 import re
 import shlex
 import textwrap
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from enum import Enum
-from typing import ClassVar, Iterable, Mapping
+from typing import ClassVar
 
 from pants.core.util_rules.environments import EnvironmentTarget
 from pants.core.util_rules.system_binaries import BashBinary, LnBinary

--- a/src/python/pants/jvm/package/deploy_jar_test.py
+++ b/src/python/pants/jvm/package/deploy_jar_test.py
@@ -3,8 +3,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from textwrap import dedent
-from typing import Iterable
 
 import pytest
 

--- a/src/python/pants/jvm/package/war.py
+++ b/src/python/pants/jvm/package/war.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 
 import logging
 import textwrap
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Iterable
 
 from pants.build_graph.address import Address
 from pants.core.goals.package import (

--- a/src/python/pants/jvm/resolve/common.py
+++ b/src/python/pants/jvm/resolve/common.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 import dataclasses
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 from urllib.parse import quote_plus as url_quote_plus
 
 from pants.engine.collection import DeduplicatedCollection

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -10,9 +10,10 @@ import json
 import logging
 import os
 from collections import defaultdict
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from itertools import chain
-from typing import TYPE_CHECKING, Any, Iterable, Iterator, List, Tuple
+from typing import TYPE_CHECKING, Any
 
 import toml
 
@@ -329,9 +330,9 @@ async def prepare_coursier_resolve_info(
 ) -> CoursierResolveInfo:
     # Transform requirements that correspond to local JAR files into coordinates with `file:/`
     # URLs, and put the files in the place specified by the URLs.
-    no_jars: List[ArtifactRequirement] = []
-    jars: List[Tuple[ArtifactRequirement, JvmArtifactJarSourceField]] = []
-    extra_args: List[str] = []
+    no_jars: list[ArtifactRequirement] = []
+    jars: list[tuple[ArtifactRequirement, JvmArtifactJarSourceField]] = []
+    extra_args: list[str] = []
 
     LOCAL_EXCLUDE_FILE = "PANTS_RESOLVE_EXCLUDES"
 

--- a/src/python/pants/jvm/resolve/coursier_fetch_filter_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_filter_test.py
@@ -3,7 +3,8 @@
 
 from __future__ import annotations
 
-from typing import DefaultDict, Sequence
+from collections.abc import Sequence
+from typing import DefaultDict
 from unittest import mock
 
 import pytest

--- a/src/python/pants/jvm/resolve/coursier_setup.py
+++ b/src/python/pants/jvm/resolve/coursier_setup.py
@@ -6,9 +6,10 @@ from __future__ import annotations
 import os
 import shlex
 import textwrap
+from collections.abc import Iterable
 from dataclasses import dataclass
 from hashlib import sha256
-from typing import ClassVar, Iterable, Tuple
+from typing import ClassVar
 
 from pants.core.goals.resolves import ExportableTool
 from pants.core.util_rules import external_tool
@@ -239,10 +240,10 @@ class Coursier:
 
 @dataclass(frozen=True)
 class CoursierFetchProcess:
-    args: Tuple[str, ...]
+    args: tuple[str, ...]
     input_digest: Digest
-    output_directories: Tuple[str, ...]
-    output_files: Tuple[str, ...]
+    output_directories: tuple[str, ...]
+    output_files: tuple[str, ...]
     description: str
 
 

--- a/src/python/pants/jvm/resolve/lockfile_metadata.py
+++ b/src/python/pants/jvm/resolve/lockfile_metadata.py
@@ -3,9 +3,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Iterable, cast
+from typing import Any, cast
 
 from pants.core.util_rules.lockfile_metadata import (
     LockfileMetadata,

--- a/src/python/pants/jvm/run.py
+++ b/src/python/pants/jvm/run.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Iterable, Optional, Tuple
+from collections.abc import Iterable
 
 from pants.core.goals.run import RunRequest
 from pants.core.util_rules.system_binaries import UnzipBinary
@@ -50,7 +50,7 @@ async def _find_main(
 
 async def _find_main_by_manifest(
     unzip: UnzipBinary, input_digest: Digest, jarfile: str
-) -> Optional[str]:
+) -> str | None:
     # jvm only allows `-cp` or `-jar` to be specified, and `-jar` takes precedence. So, even for a
     # JAR with a valid `Main-Class` in the manifest, we need to peek inside the manifest and
     # extract `main` ourself.
@@ -84,7 +84,7 @@ async def _find_main_by_manifest(
 
 async def _find_main_by_javap(
     unzip: UnzipBinary, jdk: JdkEnvironment, input_digest: Digest, jarfile: str
-) -> Tuple[str, ...]:
+) -> tuple[str, ...]:
     # Finds the `main` class by inspecting all of the classes inside the specified JAR
     # to find one with a JVM main method.
 

--- a/src/python/pants/jvm/shading/rules.py
+++ b/src/python/pants/jvm/shading/rules.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Iterable
 
 from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.fs import (

--- a/src/python/pants/jvm/strip_jar/strip_jar.py
+++ b/src/python/pants/jvm/strip_jar/strip_jar.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
-from typing import Tuple
 
 import pkg_resources
 
@@ -33,7 +32,7 @@ class StripJarTool(JvmToolBase):
 @dataclass(frozen=True)
 class StripJarRequest:
     digest: Digest
-    filenames: Tuple[str, ...]
+    filenames: tuple[str, ...]
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/jvm/target_types.py
+++ b/src/python/pants/jvm/target_types.py
@@ -7,8 +7,9 @@ import dataclasses
 import re
 import xml.etree.ElementTree as ET
 from abc import ABC, ABCMeta, abstractmethod
+from collections.abc import Callable, Iterable, Iterator
 from dataclasses import dataclass
-from typing import Callable, ClassVar, Iterable, Iterator, Optional, Tuple, Type, Union
+from typing import ClassVar
 
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.core.goals.generate_lockfiles import UnrecognizedResolveNamesError
@@ -130,7 +131,7 @@ class JvmRunnableSourceFieldSet(RunFieldSet):
     main_class: JvmMainClassNameField
 
     @classmethod
-    def jvm_rules(cls) -> Iterable[Union[Rule, UnionRule]]:
+    def jvm_rules(cls) -> Iterable[Rule | UnionRule]:
         yield from _jvm_source_run_request_rule(cls)
         yield from cls.rules()
 
@@ -222,7 +223,7 @@ class JvmArtifactJarSourceField(OptionalSingleSourceField):
     )
 
     @classmethod
-    def compute_value(cls, raw_value: Optional[str], address: Address) -> Optional[str]:
+    def compute_value(cls, raw_value: str | None, address: Address) -> str | None:
         value_or_default = super().compute_value(raw_value, address)
         if value_or_default and value_or_default.startswith("file:"):
             raise InvalidFieldException(
@@ -346,8 +347,8 @@ class JvmArtifactExclusionsField(SequenceField[JvmArtifactExclusion]):
 
     @classmethod
     def compute_value(
-        cls, raw_value: Optional[Iterable[JvmArtifactExclusion]], address: Address
-    ) -> Optional[Tuple[JvmArtifactExclusion, ...]]:
+        cls, raw_value: Iterable[JvmArtifactExclusion] | None, address: Address
+    ) -> tuple[JvmArtifactExclusion, ...] | None:
         computed_value = super().compute_value(raw_value, address)
 
         if computed_value:
@@ -462,7 +463,7 @@ class JvmArtifactsPackageMappingField(DictStringToStringSequenceField):
         """
     )
     value: FrozenDict[str, tuple[str, ...]]
-    default: ClassVar[Optional[FrozenDict[str, tuple[str, ...]]]] = FrozenDict()
+    default: ClassVar[FrozenDict[str, tuple[str, ...]] | None] = FrozenDict()
 
     @classmethod
     def compute_value(  # type: ignore[override]
@@ -722,7 +723,7 @@ class JvmShadingKeepRule(JvmShadingRule):
         return JvmShadingRule._validate_field(self.pattern, name="pattern", invalid_chars="/")
 
 
-JVM_SHADING_RULE_TYPES: list[Type[JvmShadingRule]] = [
+JVM_SHADING_RULE_TYPES: list[type[JvmShadingRule]] = [
     JvmShadingRelocateRule,
     JvmShadingRenameRule,
     JvmShadingZapRule,
@@ -770,8 +771,8 @@ class JvmShadingRulesField(SequenceField[JvmShadingRule], metaclass=ABCMeta):
 
     @classmethod
     def compute_value(
-        cls, raw_value: Optional[Iterable[JvmShadingRule]], address: Address
-    ) -> Optional[Tuple[JvmShadingRule, ...]]:
+        cls, raw_value: Iterable[JvmShadingRule] | None, address: Address
+    ) -> tuple[JvmShadingRule, ...] | None:
         computed_value = super().compute_value(raw_value, address)
 
         if computed_value:
@@ -856,8 +857,8 @@ class DeployJarDuplicatePolicyField(SequenceField[DeployJarDuplicateRule]):
 
     @classmethod
     def compute_value(
-        cls, raw_value: Optional[Iterable[DeployJarDuplicateRule]], address: Address
-    ) -> Optional[Tuple[DeployJarDuplicateRule, ...]]:
+        cls, raw_value: Iterable[DeployJarDuplicateRule] | None, address: Address
+    ) -> tuple[DeployJarDuplicateRule, ...] | None:
         value = super().compute_value(raw_value, address)
         if value:
             errors = []

--- a/src/python/pants/jvm/test/junit_test.py
+++ b/src/python/pants/jvm/test/junit_test.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
 from textwrap import dedent
-from typing import Iterable
 
 import pytest
 

--- a/src/python/pants/jvm/test/testutil.py
+++ b/src/python/pants/jvm/test/testutil.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from __future__ import annotations
 
-from typing import Iterable, Mapping
+from collections.abc import Iterable, Mapping
 
 from pants.core.goals.test import TestResult
 from pants.engine.internals.native_engine import Address

--- a/src/python/pants/option/custom_types.py
+++ b/src/python/pants/option/custom_types.py
@@ -7,8 +7,9 @@ import inspect
 import os
 import re
 import shlex
+from collections.abc import Iterable, Sequence
 from enum import Enum
-from typing import Iterable, Pattern, Sequence
+from re import Pattern
 
 from pants.option.errors import ParseError
 from pants.util.eval import parse_expression

--- a/src/python/pants/option/custom_types_test.py
+++ b/src/python/pants/option/custom_types_test.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from textwrap import dedent
-from typing import Dict, List, Union
+from typing import Union
 
 import pytest
 
@@ -16,8 +16,8 @@ from pants.option.custom_types import (
 from pants.option.errors import ParseError
 
 ValidPrimitives = Union[int, str]
-ParsedList = List[ValidPrimitives]
-ParsedDict = Dict[str, Union[ValidPrimitives, ParsedList]]
+ParsedList = list[ValidPrimitives]
+ParsedDict = dict[str, Union[ValidPrimitives, ParsedList]]
 
 
 def test_memory_size() -> None:
@@ -70,7 +70,7 @@ class TestCustomTypes:
         assert expected == ListValueComponent.create(s).val
 
     @staticmethod
-    def assert_split_list(s: str, *, expected: List[str]) -> None:
+    def assert_split_list(s: str, *, expected: list[str]) -> None:
         assert expected == ListValueComponent._split_modifier_expr(s)
 
     def test_unset_bool(self):

--- a/src/python/pants/option/errors.py
+++ b/src/python/pants/option/errors.py
@@ -1,7 +1,6 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Tuple
 
 from pants.option.scope import GLOBAL_SCOPE
 from pants.util.strutil import softwrap
@@ -112,7 +111,7 @@ class MutuallyExclusiveOptionError(ParseError):
 class UnknownFlagsError(ParseError):
     """Indicates that unknown command-line flags were encountered in some scope."""
 
-    def __init__(self, flags: Tuple[str, ...], arg_scope: str):
+    def __init__(self, flags: tuple[str, ...], arg_scope: str):
         self.flags = flags
         self.arg_scope = arg_scope
         scope = f"scope {self.arg_scope}" if self.arg_scope else "global scope"

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -9,13 +9,12 @@ import os
 import re
 import sys
 import tempfile
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from enum import Enum
 from pathlib import Path, PurePath
-from typing import Any, Callable, Type, TypeVar, cast
-
-from typing_extensions import assert_never
+from typing import Any, Type, TypeVar, assert_never, cast
 
 from pants.base.build_environment import (
     get_buildroot,

--- a/src/python/pants/option/native_options.py
+++ b/src/python/pants/option/native_options.py
@@ -6,9 +6,10 @@ from __future__ import annotations
 import inspect
 import logging
 import shlex
+from collections.abc import Mapping, Sequence
 from enum import Enum
 from pathlib import Path
-from typing import Any, Mapping, Optional, Sequence, Tuple
+from typing import Any
 
 from pants.base.build_environment import get_buildroot
 from pants.engine.fs import FileContent
@@ -58,9 +59,9 @@ class NativeOptionParser:
 
     def __init__(
         self,
-        args: Optional[Sequence[str]],
+        args: Sequence[str] | None,
         env: Mapping[str, str],
-        config_sources: Optional[Sequence[FileContent]],
+        config_sources: Sequence[FileContent] | None,
         allow_pantsrc: bool,
         include_derivation: bool,
         known_scopes_to_flags: dict[str, frozenset[str]],
@@ -126,7 +127,7 @@ class NativeOptionParser:
             known_goals=self._known_goals,
         )
 
-    def get_value(self, *, scope: str, option_info: OptionInfo) -> Tuple[Any, Rank]:
+    def get_value(self, *, scope: str, option_info: OptionInfo) -> tuple[Any, Rank]:
         val, rank, _ = self._get_value_and_derivation(scope, option_info)
         return (val, rank)
 
@@ -134,7 +135,7 @@ class NativeOptionParser:
         self,
         scope: str,
         option_info: OptionInfo,
-    ) -> list[Tuple[Any, Rank, Optional[str]]]:
+    ) -> list[tuple[Any, Rank, str | None]]:
         _, _, derivation = self._get_value_and_derivation(scope, option_info)
         return derivation
 
@@ -142,7 +143,7 @@ class NativeOptionParser:
         self,
         scope: str,
         option_info: OptionInfo,
-    ) -> Tuple[Any, Rank, list[Tuple[Any, Rank, Optional[str]]]]:
+    ) -> tuple[Any, Rank, list[tuple[Any, Rank, str | None]]]:
         return self._get(
             scope=scope,
             dest=parse_dest(option_info),
@@ -165,7 +166,7 @@ class NativeOptionParser:
         member_type=None,
         choices=None,
         passthrough=False,
-    ) -> Tuple[Any, Rank, list[Tuple[Any, Rank, Optional[str]]]]:
+    ) -> tuple[Any, Rank, list[tuple[Any, Rank, str | None]]]:
         def scope_str() -> str:
             return "global scope" if scope == GLOBAL_SCOPE else f"scope '{scope}'"
 

--- a/src/python/pants/option/option_types.py
+++ b/src/python/pants/option/option_types.py
@@ -4,9 +4,10 @@
 from __future__ import annotations
 
 import inspect
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Callable, Generic, Iterator, TypeVar, Union, cast, overload
+from typing import Any, Generic, TypeVar, Union, cast, overload
 
 from pants.option import custom_types
 from pants.util.docutil import bin_name

--- a/src/python/pants/option/option_value_container.py
+++ b/src/python/pants/option/option_value_container.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 import copy
+from collections.abc import Iterator
 from dataclasses import dataclass
-from typing import Iterator
 
 from pants.option.ranked_value import Rank, RankedValue, Value
 

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -6,8 +6,9 @@ from __future__ import annotations
 import dataclasses
 import logging
 from collections import defaultdict
+from collections.abc import Iterable, Mapping, Sequence
 from enum import Enum
-from typing import Any, Iterable, Mapping, Sequence
+from typing import Any
 
 from pants.base.deprecated import warn_or_error
 from pants.engine.fs import FileContent

--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -3,8 +3,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Iterable, Mapping, Sequence
+from typing import TYPE_CHECKING
 
 from pants.base.build_environment import pants_version
 from pants.base.exceptions import BuildConfigurationError

--- a/src/python/pants/option/options_test.py
+++ b/src/python/pants/option/options_test.py
@@ -6,12 +6,13 @@ from __future__ import annotations
 import json
 import shlex
 import unittest.mock
+from collections.abc import Callable
 from contextlib import contextmanager
 from enum import Enum
 from functools import partial
 from pathlib import Path
 from textwrap import dedent
-from typing import Any, Callable, Dict, List, cast
+from typing import Any, cast
 
 import pytest
 import toml
@@ -449,7 +450,7 @@ def test_scope_deprecation(caplog) -> None:
 def _create_config(
     config: dict[str, dict[str, str]] | None = None,
     config2: dict[str, dict[str, str]] | None = None,
-) -> List[FileContent]:
+) -> list[FileContent]:
     return [
         FileContent("test_config.toml", toml.dumps(config or {}).encode()),
         FileContent("test_config2.toml", toml.dumps(config2 or {}).encode()),
@@ -1478,7 +1479,7 @@ def test_pants_global_with_default() -> None:
     # This cast shouldn't be necessary - likely a bug in MyPy. Once this gets fixed, MyPy will
     # tell us that we can remove the cast.
     config = cast(
-        Dict[str, Dict[str, Any]],
+        dict[str, dict[str, Any]],
         {"DEFAULT": {"num": "99"}, "GLOBAL": {"store_true_flag": True}},
     )
     global_options = _parse(config=config).for_global_scope()

--- a/src/python/pants/option/ranked_value.py
+++ b/src/python/pants/option/ranked_value.py
@@ -3,10 +3,11 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from dataclasses import dataclass
 from enum import Enum
 from functools import total_ordering
-from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 
 # NB: Must mirror the Rank enum in src/rust/engine/options/src/lib.rs.
@@ -33,7 +34,7 @@ class Rank(Enum):
             return NotImplemented
         return self._rank < other._rank
 
-    def description(self) -> Optional[str]:
+    def description(self) -> str | None:
         """The source descriptions used to display option value derivation to users."""
         # These specific strings are for compatibility with the legacy parser's tests.
         # We may revisit them once that is gone.
@@ -46,8 +47,8 @@ class Rank(Enum):
         return None
 
 
-Value = Union[str, int, float, None, Dict, Enum, List]
-ValueAndDetails = Tuple[Optional[Value], Optional[str]]
+Value = Union[str, int, float, None, dict, Enum, list]
+ValueAndDetails = tuple[Optional[Value], Optional[str]]
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/option/registrar.py
+++ b/src/python/pants/option/registrar.py
@@ -7,9 +7,10 @@ import copy
 import inspect
 import logging
 import typing
+from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Iterator, Mapping
+from typing import Any
 
 from pants.base.deprecated import validate_deprecation_semver
 from pants.option.custom_types import (

--- a/src/python/pants/option/scope.py
+++ b/src/python/pants/option/scope.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
-from typing import Optional, Tuple, Type, cast
+from typing import Optional, cast
 
 from pants.option.option_value_container import OptionValueContainer
 
@@ -26,12 +26,12 @@ class ScopeInfo:
     """Information about a scope."""
 
     scope: str
-    subsystem_cls: Optional[Type] = None
+    subsystem_cls: type | None = None
     # A ScopeInfo may have a deprecated_scope (from its associated subsystem_cls), which represents
     # a previous/deprecated name for a current/non-deprecated ScopeInfo. It may also be directly
     # deprecated via this `removal_version`, which allows for the deprecation of an entire scope.
-    removal_version: Optional[str] = None
-    removal_hint: Optional[str] = None
+    removal_version: str | None = None
+    removal_hint: str | None = None
 
     # Command line goal scope flag.
     is_goal: bool = False
@@ -47,20 +47,20 @@ class ScopeInfo:
         return cast(str, self._subsystem_cls_attr("help"))
 
     @property
-    def deprecated_scope(self) -> Optional[str]:
+    def deprecated_scope(self) -> str | None:
         return cast(Optional[str], self._subsystem_cls_attr("deprecated_options_scope"))
 
     @property
-    def deprecated_scope_removal_version(self) -> Optional[str]:
+    def deprecated_scope_removal_version(self) -> str | None:
         return cast(
             Optional[str],
             self._subsystem_cls_attr("deprecated_options_scope_removal_version"),
         )
 
     @property
-    def scope_aliases(self) -> Tuple[str, ...]:
+    def scope_aliases(self) -> tuple[str, ...]:
         """BuiltinGoal subsystems may define aliases."""
-        return cast(Tuple[str, ...], self._subsystem_cls_attr("aliases", ()))
+        return cast(tuple[str, ...], self._subsystem_cls_attr("aliases", ()))
 
     def _subsystem_cls_attr(self, name: str, default=None):
         return getattr(self.subsystem_cls, name, default) if self.subsystem_cls else default

--- a/src/python/pants/option/subsystem.py
+++ b/src/python/pants/option/subsystem.py
@@ -7,7 +7,8 @@ import functools
 import inspect
 import re
 from abc import ABCMeta
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Iterable, Sequence, TypeVar, cast
+from collections.abc import Callable, Iterable, Sequence
+from typing import TYPE_CHECKING, Any, ClassVar, TypeVar, cast
 
 from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.internals.selectors import AwaitableConstraints, Get

--- a/src/python/pants/pantsd/pants_daemon_core.py
+++ b/src/python/pants/pantsd/pants_daemon_core.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 
 import logging
 import threading
+from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import Iterator, Protocol
+from typing import Protocol
 
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.engine.env_vars import CompleteEnvironmentVars

--- a/src/python/pants/pantsd/process_manager.py
+++ b/src/python/pants/pantsd/process_manager.py
@@ -10,8 +10,9 @@ import sys
 import time
 import traceback
 from abc import ABCMeta
+from collections.abc import Callable
 from hashlib import sha256
-from typing import Callable, cast
+from typing import cast
 
 import psutil
 

--- a/src/python/pants/pantsd/service/pants_service.py
+++ b/src/python/pants/pantsd/service/pants_service.py
@@ -5,8 +5,8 @@ import logging
 import threading
 import time
 from abc import ABC, abstractmethod
+from collections.abc import KeysView
 from dataclasses import dataclass
-from typing import Dict, KeysView, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +34,7 @@ class PantsService(ABC):
         self.name = self.__class__.__name__
         self._state = _ServiceState()
 
-    def setup(self, services: Tuple["PantsService", ...]):
+    def setup(self, services: tuple["PantsService", ...]):
         """Called before `run` to allow for service->service or other side-effecting setup."""
         self.services = services
 
@@ -199,9 +199,9 @@ class PantsServices:
 
     JOIN_TIMEOUT_SECONDS = 1
 
-    _service_threads: Dict[PantsService, threading.Thread]
+    _service_threads: dict[PantsService, threading.Thread]
 
-    def __init__(self, services: Tuple[PantsService, ...] = ()) -> None:
+    def __init__(self, services: tuple[PantsService, ...] = ()) -> None:
         object.__setattr__(self, "_service_threads", self._start(services))
 
     @classmethod
@@ -212,7 +212,7 @@ class PantsServices:
         return t
 
     @classmethod
-    def _start(cls, services: Tuple[PantsService, ...]) -> Dict[PantsService, threading.Thread]:
+    def _start(cls, services: tuple[PantsService, ...]) -> dict[PantsService, threading.Thread]:
         """Launch a thread per service."""
 
         for service in services:

--- a/src/python/pants/pantsd/service/scheduler_service.py
+++ b/src/python/pants/pantsd/service/scheduler_service.py
@@ -3,7 +3,7 @@
 
 import logging
 import time
-from typing import Optional, Tuple, cast
+from typing import cast
 
 import psutil
 
@@ -33,7 +33,7 @@ class SchedulerService(PantsService):
         *,
         graph_scheduler: GraphScheduler,
         build_root: str,
-        invalidation_globs: Tuple[str, ...],
+        invalidation_globs: tuple[str, ...],
         pidfile: str,
         pid: int,
         max_memory_usage_in_bytes: int,
@@ -62,7 +62,7 @@ class SchedulerService(PantsService):
         self._logger = logging.getLogger(__name__)
 
         # NB: We declare these as a single field so that they can be changed atomically.
-        self._invalidation_globs_and_snapshot: Tuple[Tuple[str, ...], Optional[Snapshot]] = (
+        self._invalidation_globs_and_snapshot: tuple[tuple[str, ...], Snapshot | None] = (
             invalidation_globs,
             None,
         )
@@ -71,7 +71,7 @@ class SchedulerService(PantsService):
         self._pid = pid
         self._max_memory_usage_in_bytes = max_memory_usage_in_bytes
 
-    def _get_snapshot(self, globs: Tuple[str, ...], poll: bool) -> Optional[Snapshot]:
+    def _get_snapshot(self, globs: tuple[str, ...], poll: bool) -> Snapshot | None:
         """Returns a Snapshot of the input globs.
 
         If poll=True, will wait for up to INVALIDATION_POLL_INTERVAL for the globs to have changed,

--- a/src/python/pants/source/filespec_test.py
+++ b/src/python/pants/source/filespec_test.py
@@ -1,7 +1,6 @@
 # Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Tuple
 
 import pytest
 
@@ -16,7 +15,7 @@ def rule_runner() -> RuleRunner:
 
 
 def assert_rule_match(
-    rule_runner: RuleRunner, glob: str, paths: Tuple[str, ...], *, should_match: bool
+    rule_runner: RuleRunner, glob: str, paths: tuple[str, ...], *, should_match: bool
 ) -> None:
     # Confirm in-memory behavior.
     matched_filespec = tuple(FilespecMatcher([glob], ()).matches(paths))
@@ -63,7 +62,7 @@ def assert_rule_match(
         ("a/b/c.py", ("a/b/c.py",)),
     ],
 )
-def test_valid_matches(rule_runner: RuleRunner, glob: str, paths: Tuple[str, ...]) -> None:
+def test_valid_matches(rule_runner: RuleRunner, glob: str, paths: tuple[str, ...]) -> None:
     assert_rule_match(rule_runner, glob, paths, should_match=True)
 
 
@@ -96,5 +95,5 @@ def test_valid_matches(rule_runner: RuleRunner, glob: str, paths: Tuple[str, ...
         ("**/BUILD", ("src/rust/build.rs",)),
     ],
 )
-def test_invalid_matches(rule_runner: RuleRunner, glob: str, paths: Tuple[str, ...]) -> None:
+def test_invalid_matches(rule_runner: RuleRunner, glob: str, paths: tuple[str, ...]) -> None:
     assert_rule_match(rule_runner, glob, paths, should_match=False)

--- a/src/python/pants/source/source_root.py
+++ b/src/python/pants/source/source_root.py
@@ -6,9 +6,9 @@ from __future__ import annotations
 import itertools
 import logging
 import os
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Iterable
 
 from pants.build_graph.address import Address
 from pants.engine.collection import DeduplicatedCollection

--- a/src/python/pants/source/source_root_test.py
+++ b/src/python/pants/source/source_root_test.py
@@ -2,8 +2,8 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
+from collections.abc import Iterable
 from pathlib import PurePath
-from typing import Iterable, Optional
 
 import pytest
 
@@ -27,9 +27,9 @@ from pants.testutil.rule_runner import MockGet, RuleRunner, run_rule_with_mocks
 def _find_root(
     path: str,
     patterns: Iterable[str],
-    marker_filenames: Optional[Iterable[str]] = None,
-    existing_marker_files: Optional[Iterable[str]] = None,
-) -> Optional[str]:
+    marker_filenames: Iterable[str] | None = None,
+    existing_marker_files: Iterable[str] | None = None,
+) -> str | None:
     source_root_config = create_subsystem(
         SourceRootConfig,
         root_patterns=list(patterns),

--- a/src/python/pants/testutil/option_util.py
+++ b/src/python/pants/testutil/option_util.py
@@ -3,7 +3,8 @@
 
 from __future__ import annotations
 
-from typing import Iterable, Mapping, TypeVar
+from collections.abc import Iterable, Mapping
+from typing import TypeVar
 
 from pants.engine.goal import GoalSubsystem
 from pants.option.option_value_container import OptionValueContainer, OptionValueContainerBuilder

--- a/src/python/pants/testutil/pants_integration_test.py
+++ b/src/python/pants/testutil/pants_integration_test.py
@@ -7,9 +7,10 @@ import glob
 import os
 import subprocess
 import sys
+from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, Iterator, List, Mapping, Union, cast
+from typing import Any, Union, cast
 
 import pytest
 import toml
@@ -24,7 +25,7 @@ from pants.util.osutil import Pid
 from pants.util.strutil import ensure_binary
 
 # NB: If `shell=True`, it's a single `str`.
-Command = Union[str, List[str]]
+Command = Union[str, list[str]]
 
 # Sometimes we mix strings and bytes as keys and/or values, but in most
 # cases we pass strict str->str, and we want both to typecheck.
@@ -143,7 +144,7 @@ def run_pants_with_workdir_without_waiting(
     # Only allow-listed entries will be included in the environment if hermetic=True. Note that
     # the env will already be fairly hermetic thanks to the v2 engine; this provides an
     # additional layer of hermiticity.
-    env: dict[Union[str, bytes], Union[str, bytes]]
+    env: dict[str | bytes, str | bytes]
     if hermetic:
         # With an empty environment, we would generally get the true underlying system default
         # encoding, which is unlikely to be what we want (it's generally ASCII, still). So we

--- a/src/python/pants/testutil/process_util.py
+++ b/src/python/pants/testutil/process_util.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Callable
+from collections.abc import Callable
 
 from pants.engine.process import Process
 

--- a/src/python/pants/testutil/python_interpreter_selection.py
+++ b/src/python/pants/testutil/python_interpreter_selection.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 
 import os
 import subprocess
+from collections.abc import Iterable
 from functools import lru_cache
-from typing import Iterable
 from unittest import skipIf
 
 import _pytest.mark.structures

--- a/src/python/pants/testutil/python_rule_runner.py
+++ b/src/python/pants/testutil/python_rule_runner.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable, Mapping
+from collections.abc import Iterable, Mapping
 
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.testutil.rule_runner import RuleRunner

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -9,29 +9,14 @@ import functools
 import os
 import re
 import sys
+from collections.abc import Callable, Coroutine, Generator, Iterable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
 from io import StringIO
 from pathlib import Path, PurePath
 from pprint import pformat
 from tempfile import mkdtemp
-from typing import (
-    Any,
-    Callable,
-    Coroutine,
-    Generator,
-    Generic,
-    Iterable,
-    Iterator,
-    Literal,
-    Mapping,
-    Sequence,
-    Type,
-    TypeVar,
-    Union,
-    cast,
-    overload,
-)
+from typing import Any, Generic, Literal, TypeVar, cast, overload
 
 from pants.base.build_environment import get_buildroot
 from pants.base.build_root import BuildRoot
@@ -638,7 +623,7 @@ class RuleRunner:
                 ),
             )
 
-    def do_not_use_mock(self, output_type: Type, input_types: Iterable[type]) -> MockGet:
+    def do_not_use_mock(self, output_type: type, input_types: Iterable[type]) -> MockGet:
         """Returns a `MockGet` whose behavior is to run the actual rule using this `RuleRunner`"""
         return MockGet(
             output_type=output_type,
@@ -668,7 +653,7 @@ class MockGet(Generic[_O]):
 
 @dataclass(frozen=True)
 class MockRequestExceptionComparable:
-    category: Union[Literal["Get"], Literal["Effect"], str]
+    category: Literal["Get"] | Literal["Effect"] | str
     output_type: str | None
     input_types: tuple[str, ...]
 
@@ -678,13 +663,13 @@ class MockRequestExceptionComparable:
 
 
 def _compare_expected_mocks(
-    expected: Sequence[Union[Get, Effect, AwaitableConstraints]],
-    actual: Sequence[Union[MockGet, MockEffect]],
+    expected: Sequence[Get | Effect | AwaitableConstraints],
+    actual: Sequence[MockGet | MockEffect],
 ) -> str:
     """Try to be helpful with identifying the problem with supplied mocks."""
 
     def as_comparable(
-        o: Union[Get, Effect, MockGet, MockEffect, AwaitableConstraints, type]
+        o: Get | Effect | MockGet | MockEffect | AwaitableConstraints | type,
     ) -> MockRequestExceptionComparable:
         if isinstance(o, MockGet) or isinstance(o, Get):
             category = "Get"

--- a/src/python/pants/util/collections.py
+++ b/src/python/pants/util/collections.py
@@ -7,8 +7,9 @@ import collections
 import collections.abc
 import gc
 import math
+from collections.abc import Callable, Iterable, Iterator, MutableMapping
 from sys import getsizeof
-from typing import Any, Callable, Iterable, Iterator, MutableMapping, TypeVar
+from typing import Any, TypeVar
 
 from pants.engine.internals import native_engine
 from pants.util.strutil import softwrap

--- a/src/python/pants/util/contextutil.py
+++ b/src/python/pants/util/contextutil.py
@@ -10,11 +10,12 @@ import sys
 import tempfile
 import threading
 import zipfile
+from collections.abc import Callable, Iterator, Mapping
 from contextlib import contextmanager
 from pathlib import Path
 from queue import Queue
 from socketserver import TCPServer
-from typing import IO, Any, Callable, Iterator, Mapping
+from typing import IO, Any
 
 from pants.util.dirutil import safe_delete
 

--- a/src/python/pants/util/contextutil_test.py
+++ b/src/python/pants/util/contextutil_test.py
@@ -6,8 +6,8 @@ import shutil
 import subprocess
 import sys
 import zipfile
+from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import Iterator
 
 import pytest
 

--- a/src/python/pants/util/cstutil.py
+++ b/src/python/pants/util/cstutil.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import importlib.util
 import logging
-from typing import Union
 
 import libcst as cst
 import libcst.matchers as m
@@ -30,7 +29,7 @@ def make_importfrom_attr(module: str) -> cst.Attribute | cst.Name:
     return cst.Attribute(value=make_importfrom_attr(partial_module), attr=cst.Name(parts[-1]))
 
 
-def make_importfrom_attr_matcher(module: str) -> Union[m.Attribute, m.Name]:
+def make_importfrom_attr_matcher(module: str) -> m.Attribute | m.Name:
     """Generates a cst matcher.Attribute or matcher.Name from a module string."""
     parts = module.split(".")
     if len(parts) == 1:

--- a/src/python/pants/util/dirutil.py
+++ b/src/python/pants/util/dirutil.py
@@ -12,9 +12,10 @@ import tempfile
 import threading
 import uuid
 from collections import defaultdict
+from collections.abc import Callable, Iterable, Iterator, Sequence
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Callable, DefaultDict, Iterable, Iterator, Literal, Sequence, overload
+from typing import Any, DefaultDict, Literal, overload
 
 from pants.util.strutil import ensure_text
 

--- a/src/python/pants/util/dirutil_test.py
+++ b/src/python/pants/util/dirutil_test.py
@@ -7,9 +7,9 @@ import errno
 import os
 import unittest
 import unittest.mock
+from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Iterator
 
 import pytest
 

--- a/src/python/pants/util/enums.py
+++ b/src/python/pants/util/enums.py
@@ -1,8 +1,9 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from collections.abc import Mapping
 from enum import Enum
-from typing import FrozenSet, Mapping, TypeVar
+from typing import TypeVar
 
 
 class EnumMatchError(ValueError):
@@ -24,7 +25,7 @@ _V = TypeVar("_V")
 def match(enum_instance: _E, enum_values_to_results: Mapping[_E, _V]) -> _V:
     # TODO: consider memoizing the result of this entire method, as well as the value of
     # `all_instances` for a given enum class!
-    all_instances: FrozenSet[_E] = frozenset(type(enum_instance))
+    all_instances: frozenset[_E] = frozenset(type(enum_instance))
     unrecognized_values = [value for value in enum_values_to_results if value not in all_instances]
     missing_values = [value for value in all_instances if value not in enum_values_to_results]
     if unrecognized_values:

--- a/src/python/pants/util/filtering.py
+++ b/src/python/pants/util/filtering.py
@@ -4,17 +4,15 @@
 from __future__ import annotations
 
 import operator
-from typing import TYPE_CHECKING, Callable, Iterable, Tuple, TypeVar
-
-if TYPE_CHECKING:
-    from pants.engine.target import Target
+from collections.abc import Callable, Iterable
+from typing import TypeVar
 
 _T = TypeVar("_T")
 Filter = Callable[[_T], bool]
 TargetFilter = Callable[["Target"], bool]
 
 
-def _extract_modifier(modified_param: str) -> Tuple[Callable[[bool], bool], str]:
+def _extract_modifier(modified_param: str) -> tuple[Callable[[bool], bool], str]:
     if modified_param.startswith("-"):
         return operator.not_, modified_param[1:]
 

--- a/src/python/pants/util/filtering_test.py
+++ b/src/python/pants/util/filtering_test.py
@@ -1,7 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Callable
+from collections.abc import Callable
 
 from pants.util.filtering import and_filters, create_filter, create_filters
 

--- a/src/python/pants/util/frozendict.py
+++ b/src/python/pants/util/frozendict.py
@@ -3,7 +3,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, Iterable, Iterator, Mapping, TypeVar, cast, overload
+from collections.abc import Callable, Iterable, Iterator, Mapping
+from typing import Any, TypeVar, cast, overload
 
 from pants.util.memo import memoized_method
 from pants.util.strutil import softwrap

--- a/src/python/pants/util/memo.py
+++ b/src/python/pants/util/memo.py
@@ -3,8 +3,9 @@
 
 import functools
 import inspect
+from collections.abc import Callable
 from contextlib import contextmanager
-from typing import Any, Callable, Optional, TypeVar
+from typing import Any, TypeVar
 
 from pants.util.meta import T, classproperty
 
@@ -61,7 +62,7 @@ def per_instance(*args, **kwargs):
     return equal_args(*instance_and_rest, **kwargs)
 
 
-def memoized(func: Optional[F] = None, key_factory=equal_args, cache_factory=dict) -> F:
+def memoized(func: F | None = None, key_factory=equal_args, cache_factory=dict) -> F:
     """Memoizes the results of a function call.
 
     By default, exactly one result is memoized for each unique combination of function arguments.
@@ -146,7 +147,7 @@ def memoized(func: Optional[F] = None, key_factory=equal_args, cache_factory=dic
     return memoize  # type: ignore[return-value]
 
 
-def memoized_method(func: Optional[F] = None, key_factory=per_instance, cache_factory=dict) -> F:
+def memoized_method(func: F | None = None, key_factory=per_instance, cache_factory=dict) -> F:
     """A convenience wrapper for memoizing instance methods.
 
     Typically you'd expect a memoized instance method to hold a cached value per class instance;
@@ -183,7 +184,7 @@ def memoized_method(func: Optional[F] = None, key_factory=per_instance, cache_fa
 
 
 def memoized_property(
-    func: Optional[Callable[..., T]] = None, key_factory=per_instance, cache_factory=dict
+    func: Callable[..., T] | None = None, key_factory=per_instance, cache_factory=dict
 ) -> T:
     """A convenience wrapper for memoizing properties.
 
@@ -254,16 +255,14 @@ def memoized_property(
 
 
 # TODO[13244]: fix type hint issue when using @memoized_classmethod and friends
-def memoized_classmethod(
-    func: Optional[F] = None, key_factory=per_instance, cache_factory=dict
-) -> F:
+def memoized_classmethod(func: F | None = None, key_factory=per_instance, cache_factory=dict) -> F:
     return classmethod(  # type: ignore[return-value]
         memoized_method(func, key_factory=key_factory, cache_factory=cache_factory)
     )
 
 
 def memoized_classproperty(
-    func: Optional[Callable[..., T]] = None, key_factory=per_instance, cache_factory=dict
+    func: Callable[..., T] | None = None, key_factory=per_instance, cache_factory=dict
 ) -> T:
     return classproperty(
         memoized_classmethod(func, key_factory=key_factory, cache_factory=cache_factory)
@@ -271,7 +270,7 @@ def memoized_classproperty(
 
 
 def testable_memoized_property(
-    func: Optional[Callable[..., T]] = None, key_factory=per_instance, cache_factory=dict
+    func: Callable[..., T] | None = None, key_factory=per_instance, cache_factory=dict
 ) -> T:
     """A variant of `memoized_property` that allows for setting of properties (for tests, etc)."""
     getter = memoized_method(func=func, key_factory=key_factory, cache_factory=cache_factory)

--- a/src/python/pants/util/meta.py
+++ b/src/python/pants/util/meta.py
@@ -2,10 +2,11 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Optional, Type, TypeVar, Union
+from collections.abc import Callable
+from typing import Any, TypeVar
 
 T = TypeVar("T")
-C = TypeVar("C", bound=Type)
+C = TypeVar("C", bound=type)
 
 
 class SingletonMetaclass(type):
@@ -32,12 +33,12 @@ class _ClassPropertyDescriptor:
     # definition beyond declaring a @classproperty.  It seems overriding __set__ and __delete__ would
     # require defining a metaclass or overriding __setattr__/__delattr__ (see
     # https://stackoverflow.com/questions/5189699/how-to-make-a-class-property).
-    def __init__(self, fget: Union[classmethod, staticmethod], doc: Optional[str]) -> None:
+    def __init__(self, fget: classmethod | staticmethod, doc: str | None) -> None:
         self.fget = fget
         self.__doc__ = doc
 
     # See https://docs.python.org/3/howto/descriptor.html for more details.
-    def __get__(self, obj: T, objtype: Optional[Type[T]] = None) -> Any:
+    def __get__(self, obj: T, objtype: type[T] | None = None) -> Any:
         if objtype is None:
             objtype = type(obj)
             # Get the callable field for this object, which may be a property.
@@ -122,10 +123,10 @@ class _ClassDecoratorWithSentinelAttribute(ABC):
     """
 
     @abstractmethod
-    def __call__(self, cls: Type) -> Type: ...
+    def __call__(self, cls: type) -> type: ...
 
-    def define_instance_of(self, obj: Type, **kwargs) -> Type:
+    def define_instance_of(self, obj: type, **kwargs) -> type:
         return type(obj.__name__, (obj,), {"_decorated_type_checkable_type": type(self), **kwargs})
 
-    def is_instance(self, obj: Type) -> bool:
+    def is_instance(self, obj: type) -> bool:
         return getattr(obj, "_decorated_type_checkable_type", None) is type(self)

--- a/src/python/pants/util/ordered_set.py
+++ b/src/python/pants/util/ordered_set.py
@@ -15,7 +15,8 @@ http://code.activestate.com/recipes/576694/.
 from __future__ import annotations
 
 import itertools
-from typing import AbstractSet, Any, Hashable, Iterable, Iterator, MutableSet, Set, TypeVar, cast
+from collections.abc import Hashable, Iterable, Iterator, MutableSet
+from typing import AbstractSet, Any, TypeVar, cast
 
 T = TypeVar("T")
 T_co = TypeVar("T_co", covariant=True)
@@ -190,7 +191,7 @@ class OrderedSet(_AbstractOrderedSet[T], MutableSet[T]):
         """Update this OrderedSet to remove items from another set, then add items from the other
         set that were not present in this set."""
         items_to_add = [item for item in other if item not in self]
-        items_to_remove = cast(Set[T], set(other))
+        items_to_remove = cast(set[T], set(other))
         self._items = {item: None for item in self._items.keys() if item not in items_to_remove}
         for item in items_to_add:
             self._items[item] = None

--- a/src/python/pants/util/ordered_set_test.py
+++ b/src/python/pants/util/ordered_set_test.py
@@ -3,8 +3,9 @@
 
 import itertools
 import random
+from collections.abc import Iterator, Sequence
 from copy import copy
-from typing import AbstractSet, Iterator, Sequence, Tuple, Type, Union
+from typing import AbstractSet, Union
 
 import pytest
 
@@ -12,7 +13,7 @@ from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
 from pants.util.strutil import softwrap
 
 OrderedSetInstance = Union[OrderedSet, FrozenOrderedSet]
-OrderedSetCls = Union[Type[OrderedSet], Type[FrozenOrderedSet]]
+OrderedSetCls = Union[type[OrderedSet], type[FrozenOrderedSet]]
 
 
 @pytest.mark.parametrize("cls", [OrderedSet, FrozenOrderedSet])
@@ -179,9 +180,9 @@ def test_clear() -> None:
 
 
 def assert_results_are_the_same(
-    results: Union[Sequence[AbstractSet], Sequence[bool]],
+    results: Sequence[AbstractSet] | Sequence[bool],
     *,
-    sets: Tuple[OrderedSetInstance, OrderedSetInstance],
+    sets: tuple[OrderedSetInstance, OrderedSetInstance],
 ) -> None:
     """Check that all results have the same value, but are different items."""
     assert all(
@@ -200,7 +201,7 @@ def assert_results_are_the_same(
 
 def generate_testdata(
     cls: OrderedSetCls,
-) -> Iterator[Tuple[OrderedSetInstance, OrderedSetInstance]]:
+) -> Iterator[tuple[OrderedSetInstance, OrderedSetInstance]]:
     data1 = cls([5, 3, 1, 4])
     data2 = cls([1, 4])
     yield data1, data2

--- a/src/python/pants/util/requirements.py
+++ b/src/python/pants/util/requirements.py
@@ -1,6 +1,6 @@
 # Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-from typing import Iterator
+from collections.abc import Iterator
 
 from pants.util.pip_requirement import PipRequirement
 

--- a/src/python/pants/util/strutil.py
+++ b/src/python/pants/util/strutil.py
@@ -10,8 +10,9 @@ import re
 import shlex
 import textwrap
 from collections import abc
+from collections.abc import Callable, Iterable, Mapping
 from logging import Logger
-from typing import Any, Callable, Iterable, Mapping, TypeVar
+from typing import Any, TypeVar
 
 import colors
 from typing_extensions import ParamSpec

--- a/src/python/pants/util/value_interpolation.py
+++ b/src/python/pants/util/value_interpolation.py
@@ -3,8 +3,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import ClassVar, Mapping, TypeVar, Union
+from typing import ClassVar, TypeVar, Union
 
 from pants.engine.addresses import Address
 from pants.util.frozendict import FrozenDict

--- a/src/python/pants/vcs/changed.py
+++ b/src/python/pants/vcs/changed.py
@@ -3,9 +3,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import Enum
-from typing import Iterable
 
 from pants.backend.project_info import dependents
 from pants.backend.project_info.dependents import Dependents, DependentsRequest

--- a/src/python/pants/vcs/changed_integration_test.py
+++ b/src/python/pants/vcs/changed_integration_test.py
@@ -4,9 +4,9 @@
 from __future__ import annotations
 
 import subprocess
+from collections.abc import Iterator
 from pathlib import Path
 from textwrap import dedent
-from typing import Iterator
 
 import pytest
 

--- a/src/python/pants/vcs/git.py
+++ b/src/python/pants/vcs/git.py
@@ -8,12 +8,13 @@ import logging
 import os
 import re
 from collections import defaultdict
+from collections.abc import Iterable
 from dataclasses import dataclass
 from functools import cached_property
 from io import StringIO
 from os import PathLike
 from pathlib import Path, PurePath
-from typing import Any, DefaultDict, Iterable
+from typing import Any, DefaultDict
 
 from pants.core.util_rules.system_binaries import GitBinary, GitBinaryException, MaybeGitBinary
 from pants.engine.engine_aware import EngineAwareReturnType

--- a/src/python/pants/vcs/git_test.py
+++ b/src/python/pants/vcs/git_test.py
@@ -6,10 +6,11 @@ from __future__ import annotations
 import os
 import re
 import subprocess
+from collections.abc import Callable, Iterator
 from functools import partial
 from pathlib import Path, PurePath
 from textwrap import dedent
-from typing import Any, Callable, Iterator
+from typing import Any
 
 import pytest
 

--- a/src/python/pants/vcs/hunk.py
+++ b/src/python/pants/vcs/hunk.py
@@ -1,7 +1,6 @@
 # Copyright 2024 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from dataclasses import dataclass
-from typing import Optional
 
 from pants.engine.collection import Collection
 
@@ -49,5 +48,5 @@ class Hunk:
     In the special case when file is deleted right = None.
     """
 
-    left: Optional[TextBlock]
-    right: Optional[TextBlock]
+    left: TextBlock | None
+    right: TextBlock | None

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -7,11 +7,12 @@ import argparse
 import difflib
 import os
 import re
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from enum import Enum, ReprEnum
 from pathlib import Path
 from textwrap import dedent  # noqa: PNT20
-from typing import Any, Dict, Sequence, cast
+from typing import Any, cast
 
 import toml
 import yaml
@@ -52,9 +53,9 @@ HEADER = dedent(
 )
 
 
-Step = Dict[str, Any]
-Jobs = Dict[str, Any]
-Env = Dict[str, str]
+Step = dict[str, Any]
+Jobs = dict[str, Any]
+Env = dict[str, str]
 
 
 class Platform(Enum):

--- a/src/python/pants_release/release.py
+++ b/src/python/pants_release/release.py
@@ -12,6 +12,7 @@ import shutil
 import subprocess
 import sys
 import venv
+from collections.abc import Callable, Iterable, Iterator, Sequence
 from configparser import ConfigParser
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -20,7 +21,7 @@ from enum import Enum
 from functools import total_ordering
 from math import ceil
 from pathlib import Path
-from typing import Any, Callable, Iterable, Iterator, Sequence, cast
+from typing import Any, cast
 
 import requests
 from packaging.version import Version

--- a/tests/python/pants_test/init/test_plugin_resolver.py
+++ b/tests/python/pants_test/init/test_plugin_resolver.py
@@ -6,11 +6,11 @@ from __future__ import annotations
 import os
 import shutil
 import sys
+from collections.abc import Iterable, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path, PurePath
 from textwrap import dedent
-from typing import Dict, Iterable, Sequence
 
 import pytest
 from pkg_resources import Distribution, Requirement, WorkingSet
@@ -148,7 +148,7 @@ def plugin_resolution(
     )
 
     with provide_chroot(chroot) as (root_dir, create_artifacts):
-        env: Dict[str, str] = {}
+        env: dict[str, str] = {}
         repo_dir = os.path.join(root_dir, "repo")
 
         def _create_artifact(name, version, install_requires):

--- a/tests/python/pants_test/init/test_util.py
+++ b/tests/python/pants_test/init/test_util.py
@@ -2,8 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
+from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import Iterator, cast
+from typing import cast
 
 from pants.fs.fs import safe_filename_from_path
 from pants.init.util import init_workdir

--- a/tests/python/pants_test/integration/graph_integration_test.py
+++ b/tests/python/pants_test/integration/graph_integration_test.py
@@ -2,10 +2,10 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
+from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 from textwrap import dedent
-from typing import Iterator
 
 from pants.option.scope import GLOBAL_SCOPE_CONFIG_SECTION
 from pants.testutil.pants_integration_test import run_pants

--- a/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
+++ b/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
@@ -7,9 +7,10 @@ import functools
 import os
 import time
 import unittest
+from collections.abc import Callable, Iterator, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, Callable, Iterator, Mapping
+from typing import Any
 
 from colors import bold, cyan, magenta
 


### PR DESCRIPTION
As we have upgraded the Pants Python to 3.11, makes sense to update pyupgrade to that too.

The upgrade was performed using the following commands (twice each, to make autoflake happy)

```bash
pants fix fmt lint src/python::
pants fix fmt lint tests::
pants fix fmt lint pants-plugins::
```

The overwhelming number of entries are import reorganization from `typing` to `collections.abc`, the remainder are capital to lowercase (`Dict` -> `dict`, `Tuple` -> `tuple`, etc), `Optional` to pipe, and `Union` to pipe. 

`target.py` is the worst offender for upgrades, and the only one that gave me pause was in filtering.py - where it no-ops a `TYPE_CHECKING` import.

I've split the 474 files into 5 commits covering pants-plugins, tests, backends, everything else.