### PR TITLE
Javascript backend: support dependency inference for scoped npm packages

### DIFF
--- a/docs/notes/2.25.x.md
+++ b/docs/notes/2.25.x.md
@@ -188,6 +188,8 @@ def inject_my_custom_fields(request: MyCustomInjectFieldsRequest) -> InjectedNfp
 
 The dependency inference now considers `.ts` and `.tsx` file extensions.
 
+The dependency inference now considers scoped npm packages.
+
 The NodeJS subsystem now supports configuring additional tools that should be available in the NodeJS process execution. These tools can be configured via two options:
 
 - [`[nodejs].tools`](https://www.pantsbuild.org/2.25/reference/subsystems/nodejs#tools): Specify additional executables required by nodejs processes.

--- a/src/python/pants/backend/javascript/dependency_inference/rules.py
+++ b/src/python/pants/backend/javascript/dependency_inference/rules.py
@@ -190,7 +190,14 @@ async def _determine_import_from_candidates(
     addresses = Addresses(tgt.address for tgt in owning_targets)
     if not local_owners:
         non_path_string_bases = FrozenOrderedSet(
-            non_path_string.partition(os.path.sep)[0]
+            (
+                # Handle scoped packages like "@foo/bar"
+                # Ref: https://docs.npmjs.com/cli/v11/using-npm/scope
+                "/".join(non_path_string.split("/")[:2])
+                if non_path_string.startswith("@")
+                # Handle regular packages like "foo"
+                else non_path_string.partition("/")[0]
+            )
             for non_path_string in candidates.package_imports
         )
         addresses = Addresses(


### PR DESCRIPTION
# Description

Scoped packages in the nodejs ecosystem take the form `@somescope/somepackagename`, e.g. "@types/node" or "@angular/core". After this change, the javascript dependency inference is able to infer scoped dependencies defined in a package.json file.