### PR TITLE
don't fail automatic cherry picks for lack of release notes

### DIFF
--- a/build-support/cherry_pick/make_pr.sh
+++ b/build-support/cherry_pick/make_pr.sh
@@ -37,6 +37,7 @@ gh pr create \
   --base "$MILESTONE" \
   --title "$TITLE (Cherry-pick of #$PR_NUM)" \
   --label "$CATEGORY_LABEL" \
+  --label "release-notes:not-required" \
   --milestone "$MILESTONE" \
   --body-file "$BODY_FILE" \
   --reviewer "$REVIEWERS" \


### PR DESCRIPTION
We explicitly remove release notes when they cause a git conflict, and rely on the GitHub "release" as the effective point release notes.

Unsure how to test, but setting `--label` multiple times should work per the test in https://github.com/cli/cli/commit/1ff37be361fb7253b8ce6a3f1aaf744b8c6cbfb8.