### PR TITLE
warn instead of erroring out on almost certainly unintended PATH pref…

### DIFF
--- a/docs/notes/2.25.x.md
+++ b/docs/notes/2.25.x.md
@@ -22,6 +22,7 @@ Thank you to [Klayvio](https://www.klaviyo.com/) and [Normal Computing](https://
 - [Fixed](https://github.com/pantsbuild/pants/pull/21665) bug where `pants --export-resolve=<resolve> --export-py-generated-sources-in-resolve=<resolve>` fails (see [#21659](https://github.com/pantsbuild/pants/issues/21659) for more info).
 - [Fixed](https://github.com/pantsbuild/pants/pull/21694) bug where an `archive` target is unable to produce a ZIP file with no extension (see [#21693](https://github.com/pantsbuild/pants/issues/21693) for more info).
 - `[subprocess-environment].env_vars` and `extra_env_vars` (on many subsystems and targets) now supports a generalised glob syntax using Python [fnmatch](https://docs.python.org/3/library/fnmatch.html) to construct patterns like `AWS_*`, `TF_*`, and `S2TESTS_*`.
+- Suspicious values now generate a warning instead of hard error when using the `<PATH>` special value to inject shell `PATH` values to the `system-binaries` subsystem.
 
 #### Remote Caching/Execution
 

--- a/src/python/pants/core/util_rules/system_binaries.py
+++ b/src/python/pants/core/util_rules/system_binaries.py
@@ -68,7 +68,7 @@ class SystemBinariesSubsystem(Subsystem):
                             for prefix in path.split(os.pathsep):
                                 if prefix.startswith("$") or prefix.startswith("~"):
                                     logger.warning(
-                                        f"unescaped literal prefix {prefix} in PATH ignored. Check the value of the PATH variable in your SHELL"
+                                        f"Ignored unexpanded path prefix `{prefix}` in the `PATH` environment variable while processing the `<PATH>` marker from the `[system-binaries].system_binary_paths` option. Please check the value of the `PATH` environment variable in your shell."
                                     )
                                 else:
                                     yield prefix

--- a/src/python/pants/core/util_rules/system_binaries.py
+++ b/src/python/pants/core/util_rules/system_binaries.py
@@ -65,7 +65,13 @@ class SystemBinariesSubsystem(Subsystem):
                     if entry == "<PATH>":
                         path = self._options_env.get("PATH")
                         if path:
-                            yield from path.split(os.pathsep)
+                            for prefix in path.split(os.pathsep):
+                                if prefix.startswith("$") or prefix.startswith("~"):
+                                    logger.warning(
+                                        f"unescaped literal prefix {prefix} in PATH ignored. Check the value of the PATH variable in your SHELL"
+                                    )
+                                else:
+                                    yield prefix
                     else:
                         yield entry
 


### PR DESCRIPTION
…ixes

There are a myriad reasons why one of the prefixes in PATH might not be a "real" path: shell quoting rules are of the occult, it is easy to copy-paste something wrong, and IDEs might inject something whacky. Most tools (ex: bash!) will happily and silently ignore all of this, so throwing an error is outside of norms.

The catch here of course is that a directory really could start with `$`, `~`, or any other character.  I think trying to combine relative paths with obvious footgun names intentionally is too unlikely to merit a configuration option.

ref #21907