### PR TITLE
warn instead of erroring out on almost certainly unintended PATH pref… (Cherry-pick of #21916)

### DIFF
--- a/src/python/pants/core/util_rules/system_binaries.py
+++ b/src/python/pants/core/util_rules/system_binaries.py
@@ -65,7 +65,13 @@ class SystemBinariesSubsystem(Subsystem):
                     if entry == "<PATH>":
                         path = self._options_env.get("PATH")
                         if path:
-                            yield from path.split(os.pathsep)
+                            for prefix in path.split(os.pathsep):
+                                if prefix.startswith("$") or prefix.startswith("~"):
+                                    logger.warning(
+                                        f"Ignored unexpanded path prefix `{prefix}` in the `PATH` environment variable while processing the `<PATH>` marker from the `[system-binaries].system_binary_paths` option. Please check the value of the `PATH` environment variable in your shell."
+                                    )
+                                else:
+                                    yield prefix
                     else:
                         yield entry
 


### PR DESCRIPTION
…ixes

There are a myriad reasons why one of the prefixes in PATH might not be a "real" path: shell quoting rules are of the occult, it is easy to copy-paste something wrong, and IDEs might inject something whacky. Most tools (ex: bash!) will happily and silently ignore all of this, so throwing an error is outside of norms.

The catch here of course is that a directory really could start with `$`, `~`, or any other character.  I think trying to combine relative paths with obvious footgun names intentionally is too unlikely to merit a configuration option.

ref #21907
