### PR TITLE
Initialise 2.26.x release notes file

### DIFF
--- a/docs/notes/2.26.x.md
+++ b/docs/notes/2.26.x.md
@@ -1,0 +1,33 @@
+# 2.26.x Release Series
+
+Pants is a fast, scalable, user-friendly build system for codebases of all sizes.
+
+Pants is an open-source project that is not owned or controlled by any one company or organization, and does incur some expenses. These expenses are managed by Pants Build, a non-profit that was established for this purpose. This non-profit's only source of revenue is [sponsorship](https://www.pantsbuild.org/sponsorship) by individuals and companies that use Pants.
+
+We offer [formal sponsorship tiers for companies](https://www.pantsbuild.org/sponsorship), as well as individual sponsorships via [GitHub](https://github.com/sponsors/pantsbuild).
+
+Thank you to [Klayvio](https://www.klaviyo.com/) and [Normal Computing](https://normalcomputing.ai/) for their Platinum tier support through throughout this release.
+
+## What's New
+
+### Highlights
+
+
+### Deprecations
+
+
+### General
+
+
+### Goals
+
+
+### Backends
+
+
+### Plugin API changes
+
+
+## Full Changelog
+
+For the full changelog, see the individual GitHub Releases for this series: <https://github.com/pantsbuild/pants/releases>


### PR DESCRIPTION
This creates a new empty release notes file for 2.26, since we're cutting the `2.25.x` branch (#21911) and starting the 2.26.x series.