### PR TITLE
Execute or postpone most deprecation-removals scheduled for 2.26

### DIFF
--- a/docs/notes/2.26.x.md
+++ b/docs/notes/2.26.x.md
@@ -24,6 +24,11 @@ Thank you to [Klayvio](https://www.klaviyo.com/) and [Normal Computing](https://
 
 ### Backends
 
+#### Python
+
+Some deprecations have expired and been removed:
+
+- the `[export].py_hermetic_scripts` option has been replaced by [the `[export].py_non_hermetic_scripts_in_resolve` option](https://www.pantsbuild.org/2.25/reference/goals/export#py_non_hermetic_scripts_in_resolve)
 
 ### Plugin API changes
 

--- a/docs/notes/2.26.x.md
+++ b/docs/notes/2.26.x.md
@@ -30,6 +30,10 @@ Some deprecations have expired and been removed:
 
 - the `[export].py_hermetic_scripts` option has been replaced by [the `[export].py_non_hermetic_scripts_in_resolve` option](https://www.pantsbuild.org/2.25/reference/goals/export#py_non_hermetic_scripts_in_resolve)
 
+#### Terraform
+
+For the `tfsec` linter, the deprecation of support for leading `v`s in the `version` and `known_versions` field has expired and been removed. Write `1.28.13` instead of `v1.28.13`.
+
 ### Plugin API changes
 
 

--- a/src/python/pants/backend/python/goals/export.py
+++ b/src/python/pants/backend/python/goals/export.py
@@ -50,7 +50,7 @@ from pants.engine.process import Process, ProcessCacheScope, ProcessResult
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import AllTargets, HydratedSources, HydrateSourcesRequest, SourcesField
 from pants.engine.unions import UnionMembership, UnionRule
-from pants.option.option_types import BoolOption, EnumOption, StrListOption
+from pants.option.option_types import EnumOption, StrListOption
 from pants.util.strutil import path_safe, softwrap
 
 logger = logging.getLogger(__name__)
@@ -108,38 +108,6 @@ class ExportPluginOptions:
             """
         ),
         advanced=True,
-    )
-
-    py_hermetic_scripts = BoolOption(
-        default=True,
-        help=softwrap(
-            """
-            When exporting a mutable virtualenv for a resolve, by default
-            modify console script shebang lines to make them "hermetic".
-            The shebang of hermetic console scripts uses the python args: `-sE`:
-
-              - `-s` skips inclusion of the user site-packages directory,
-              - `-E` ignores all `PYTHON*` env vars like `PYTHONPATH`.
-
-            Set this to false if you need non-hermetic scripts with
-            simple python shebangs that respect vars like `PYTHONPATH`,
-            to, for example, allow IDEs like PyCharm to inject its debugger,
-            coverage, or other IDE-specific libs when running a script.
-
-            This only applies when when exporting a `mutable_virtualenv`
-            (`symlinked_immutable_virtualenv` exports are not "full"
-            virtualenvs because they are used internally by pants itself.
-            Pants requires hermetic scripts to provide its reproduciblity
-            guarantee, fine-grained caching, and other features).
-            """
-        ),
-        advanced=True,
-        removal_version="2.26.0.dev0",
-        removal_hint=softwrap(
-            """
-            Use `--export-py-non-hermetic-scripts-in-resolve` instead.
-            """
-        ),
     )
 
     py_non_hermetic_scripts_in_resolve = StrListOption(
@@ -284,10 +252,7 @@ async def do_export(
             f"--prompt={venv_prompt}",
             output_path,
         ]
-        if (
-            req.resolve_name in export_subsys.options.py_non_hermetic_scripts_in_resolve
-            or not export_subsys.options.py_hermetic_scripts
-        ):
+        if req.resolve_name in export_subsys.options.py_non_hermetic_scripts_in_resolve:
             pex_args.insert(-1, "--non-hermetic-scripts")
 
         post_processing_cmds = [

--- a/src/python/pants/backend/python/lint/ruff/subsystem.py
+++ b/src/python/pants/backend/python/lint/ruff/subsystem.py
@@ -153,7 +153,7 @@ class Ruff(TemplatedExternalTool):
     install_from_resolve = StrOption(
         advanced=True,
         default=None,
-        removal_version="2.26.0.dev0",
+        removal_version="2.27.0.dev0",
         removal_hint=_removal_hint,
         help="Formerly used to customise the version of Ruff to install.",
     )
@@ -161,28 +161,28 @@ class Ruff(TemplatedExternalTool):
     requirements = StrListOption(
         advanced=True,
         default=None,
-        removal_version="2.26.0.dev0",
+        removal_version="2.27.0.dev0",
         removal_hint=_removal_hint,
         help="Formerly used to customise the version of Ruff to install.",
     )
     interpreter_constraints = StrListOption(
         advanced=True,
         default=None,
-        removal_version="2.26.0.dev0",
+        removal_version="2.27.0.dev0",
         removal_hint=_removal_hint,
         help="Formerly used to customise the version of Ruff to install.",
     )
     console_script = StrOption(
         advanced=True,
         default=None,
-        removal_version="2.26.0.dev0",
+        removal_version="2.27.0.dev0",
         removal_hint=_removal_hint,
         help="Formerly used to customise the version of Ruff to install.",
     )
     entry_point = StrOption(
         advanced=True,
         default=None,
-        removal_version="2.26.0.dev0",
+        removal_version="2.27.0.dev0",
         removal_hint=_removal_hint,
         help="Formerly used to customise the version of Ruff to install.",
     )

--- a/src/python/pants/backend/terraform/lint/tfsec/tfsec.py
+++ b/src/python/pants/backend/terraform/lint/tfsec/tfsec.py
@@ -4,7 +4,6 @@ import logging
 from dataclasses import dataclass
 
 from pants.backend.terraform.target_types import TerraformFieldSet
-from pants.base.deprecated import deprecated_conditional
 from pants.core.goals.lint import LintTargetsRequest
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.core.util_rules.external_tool import ExternalTool
@@ -100,13 +99,6 @@ class TFSec(ExternalTool):
         )
 
     def generate_url(self, plat: Platform) -> str:
-        deprecated_conditional(
-            lambda: self.version.startswith("v"),
-            removal_version="2.26.0.dev0",
-            entity="using a version beginning with 'v'",
-            hint=f"Remove the leading 'v' from `[{self.options_scope}].version` and from versions in `[{self.options_scope}].known_versions`",
-        )
-
         plat_str = {
             "macos_arm64": "darwin_arm64",
             "macos_x86_64": "darwin_amd64",
@@ -114,12 +106,7 @@ class TFSec(ExternalTool):
             "linux_x86_64": "linux_amd64",
         }[plat.value]
 
-        # backwards compatibility with version strings beginning with 'v'
-        version = self.version
-        if version.startswith("v"):
-            version = version[1:]
-
-        return f"https://github.com/aquasecurity/tfsec/releases/download/v{version}/tfsec_{version}_{plat_str}.tar.gz"
+        return f"https://github.com/aquasecurity/tfsec/releases/download/v{self.version}/tfsec_{self.version}_{plat_str}.tar.gz"
 
     def generate_exe(self, _: Platform) -> str:
         return "./tfsec"

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1809,7 +1809,7 @@ class BootstrapOptions:
             {doc_url("community/getting-help")}.
             """
         ),
-        removal_version="2.26.0.dev0",
+        removal_version="2.27.0.dev0",
         removal_hint='Upgrade your operating system or write `allow_deprecated_macos_versions = ["10", "11"]` instead.',
     )
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -984,7 +984,7 @@ class BootstrapOptions:
     )
     native_options_validation = EnumOption(
         default=NativeOptionsValidation.warning,
-        removal_version="2.26.0.dev0",
+        removal_version="2.28.0.dev0",
         removal_hint="The legacy parser has been removed so this option has no effect.",
         help=softwrap(
             """

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -984,7 +984,7 @@ class BootstrapOptions:
     )
     native_options_validation = EnumOption(
         default=NativeOptionsValidation.warning,
-        removal_version="2.28.0.dev0",
+        removal_version="2.27.0.dev0",
         removal_hint="The legacy parser has been removed so this option has no effect.",
         help=softwrap(
             """


### PR DESCRIPTION
We're starting the 2.26.x release series so the deprecations that were scheduled for removal can be removed. This PR does handles of them.

I've postponed a few, since they were only relatively recently deprecated and require very minimal code on our side, so we can be a little more generous to any users. (e.g. the `[GLOBAL].native_options_validation` and `[ruff]` options are unused, so it's just some option definitions that can hang around to be deleted later.)

There's an extra deprecation ready for removal in the Python FaaS code, which is done in #21928 instead, because it's more fiddly/extensive.