### PR TITLE
Remove deprecated fallback to underspecified "platforms" for FaaS targets

### DIFF
--- a/docs/notes/2.26.x.md
+++ b/docs/notes/2.26.x.md
@@ -29,6 +29,7 @@ Thank you to [Klayvio](https://www.klaviyo.com/) and [Normal Computing](https://
 Some deprecations have expired and been removed:
 
 - the `[export].py_hermetic_scripts` option has been replaced by [the `[export].py_non_hermetic_scripts_in_resolve` option](https://www.pantsbuild.org/2.25/reference/goals/export#py_non_hermetic_scripts_in_resolve)
+- for FaaS targets (AWS Lambda and Google Cloud Functions), automatic fallback to underspecified "platforms" for unknown runtimes without a pre-packaged complete-platforms has been replaced by requiring an [explicit `complete_platforms` value](https://www.pantsbuild.org/2.25/reference/targets/python_aws_lambda_function#complete_platforms)
 
 #### Terraform
 

--- a/src/python/pants/backend/python/util_rules/faas.py
+++ b/src/python/pants/backend/python/util_rules/faas.py
@@ -29,7 +29,7 @@ from pants.backend.python.target_types import (
     PythonResolveField,
 )
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
-from pants.backend.python.util_rules.pex import CompletePlatforms, Pex, PexPlatforms
+from pants.backend.python.util_rules.pex import CompletePlatforms, Pex
 from pants.backend.python.util_rules.pex_from_targets import (
     InterpreterConstraintsRequest,
     PexFromTargetsRequest,
@@ -368,7 +368,6 @@ class RuntimePlatformsRequest:
 @dataclass(frozen=True)
 class RuntimePlatforms:
     interpreter_version: None | tuple[int, int]
-    pex_platforms: PexPlatforms = PexPlatforms()
     complete_platforms: CompletePlatforms = CompletePlatforms()
 
 
@@ -560,7 +559,6 @@ async def build_python_faas(
         include_requirements=request.include_requirements,
         include_source_files=request.include_sources,
         output_filename=repository_filename,
-        platforms=platforms.pex_platforms,
         complete_platforms=platforms.complete_platforms,
         layout=PexLayout.PACKED,
         additional_args=additional_pex_args,
@@ -582,7 +580,6 @@ async def build_python_faas(
         PexVenvRequest(
             pex=pex_result,
             layout=layout,
-            platforms=platforms.pex_platforms,
             complete_platforms=platforms.complete_platforms,
             extra_args=request.pex3_venv_create_extra_args.value or (),
             prefix=request.prefix_in_artifact,

--- a/src/python/pants/backend/python/util_rules/faas.py
+++ b/src/python/pants/backend/python/util_rules/faas.py
@@ -37,7 +37,6 @@ from pants.backend.python.util_rules.pex_from_targets import (
 from pants.backend.python.util_rules.pex_from_targets import rules as pex_from_targets_rules
 from pants.backend.python.util_rules.pex_venv import PexVenv, PexVenvLayout, PexVenvRequest
 from pants.backend.python.util_rules.pex_venv import rules as pex_venv_rules
-from pants.base.deprecated import warn_or_error
 from pants.core.goals.package import BuiltPackage, BuiltPackageArtifact, OutputPathField
 from pants.engine.addresses import Address, UnparsedAddressInputs
 from pants.engine.fs import (
@@ -445,10 +444,7 @@ async def infer_runtime_platforms(request: RuntimePlatformsRequest) -> RuntimePl
         known_runtimes_str = ", ".join(
             FrozenOrderedSet(r.name for r in request.runtime.known_runtimes)
         )
-        warn_or_error(
-            # Replace this with an unconditional `InvalidTargetException`
-            "2.26.0.dev0",
-            "implicitly resolving platforms for unknown FaaS runtimes",
+        raise InvalidTargetException(
             softwrap(
                 f"""
                 Could not find a known runtime for the {version_adjective} Python version and machine architecture!
@@ -465,11 +461,8 @@ async def infer_runtime_platforms(request: RuntimePlatformsRequest) -> RuntimePl
                 architecture.
                 """
             ),
-        )
-        return RuntimePlatforms(
-            interpreter_version=version,
-            pex_platforms=PexPlatforms((_format_platform_from_major_minor(*version),)),
-        )
+            description_of_origin=f"In the {request.target_name!r} target",
+        ) from None
 
     module = request.runtime.known_runtimes_complete_platforms_module()
 

--- a/src/python/pants/backend/python/util_rules/faas_test.py
+++ b/src/python/pants/backend/python/util_rules/faas_test.py
@@ -346,7 +346,10 @@ def test_infer_runtime_platforms_when_complete_platforms(
             "==3.45.*",
             (3, 45),
             ["complete_platform_faas-test-3-45.json"],
-            id="known 3.45",
+            id="star",
+        ),
+        pytest.param(
+            ">=3.45,<3.46", (3, 45), ["complete_platform_faas-test-3-45.json"], id="range"
         ),
     ],
 )

--- a/src/python/pants/backend/python/util_rules/faas_test.py
+++ b/src/python/pants/backend/python/util_rules/faas_test.py
@@ -35,7 +35,7 @@ from pants.backend.python.util_rules.faas import (
     RuntimePlatformsRequest,
     build_python_faas,
 )
-from pants.backend.python.util_rules.pex import CompletePlatforms, Pex, PexPlatforms
+from pants.backend.python.util_rules.pex import CompletePlatforms, Pex
 from pants.backend.python.util_rules.pex_from_targets import PexFromTargetsRequest
 from pants.backend.python.util_rules.pex_venv import PexVenv, PexVenvLayout, PexVenvRequest
 from pants.build_graph.address import Address
@@ -269,20 +269,17 @@ class TestRuntimeField(PythonFaaSRuntimeField):
 
 
 @pytest.mark.parametrize(
-    ("value", "expected_interpreter_version", "expected_platforms", "expected_complete_platforms"),
+    ("value", "expected_interpreter_version", "expected_complete_platforms"),
     [
+        pytest.param("3.45", (3, 45), ["complete_platform_faas-test-3-45.json"], id="known 3.45"),
         pytest.param(
-            "3.45", (3, 45), [], ["complete_platform_faas-test-3-45.json"], id="known 3.45"
-        ),
-        pytest.param(
-            "67.89", (67, 89), [], ["complete_platform_faas-test-67-89.json"], id="known 67.89"
+            "67.89", (67, 89), ["complete_platform_faas-test-67-89.json"], id="known 67.89"
         ),
     ],
 )
 def test_infer_runtime_platforms_when_known_runtime_and_no_complete_platforms(
     value: str,
     expected_interpreter_version: tuple[int, int],
-    expected_platforms: list[str],
     expected_complete_platforms: list[str],
     rule_runner: RuleRunner,
 ) -> None:
@@ -300,7 +297,6 @@ def test_infer_runtime_platforms_when_known_runtime_and_no_complete_platforms(
 
     assert platforms == RuntimePlatforms(
         expected_interpreter_version,
-        PexPlatforms(expected_platforms),
         CompletePlatforms(expected_complete_platforms),
     )
 
@@ -340,16 +336,15 @@ def test_infer_runtime_platforms_when_complete_platforms(
 
     platforms = rule_runner.request(RuntimePlatforms, [request])
 
-    assert platforms == RuntimePlatforms(None, PexPlatforms(), CompletePlatforms(["path/cp.json"]))
+    assert platforms == RuntimePlatforms(None, CompletePlatforms(["path/cp.json"]))
 
 
 @pytest.mark.parametrize(
-    ("ics", "expected_interpreter_version", "expected_platforms", "expected_complete_platforms"),
+    ("ics", "expected_interpreter_version", "expected_complete_platforms"),
     [
         pytest.param(
             "==3.45.*",
             (3, 45),
-            [],
             ["complete_platform_faas-test-3-45.json"],
             id="known 3.45",
         ),
@@ -358,7 +353,6 @@ def test_infer_runtime_platforms_when_complete_platforms(
 def test_infer_runtime_platforms_when_known_narrow_ics_only(
     ics: str,
     expected_interpreter_version: tuple[int, int],
-    expected_platforms: list[str],
     expected_complete_platforms: list[str],
     rule_runner: RuleRunner,
 ) -> None:
@@ -382,7 +376,6 @@ def test_infer_runtime_platforms_when_known_narrow_ics_only(
 
     assert platforms == RuntimePlatforms(
         expected_interpreter_version,
-        PexPlatforms(expected_platforms),
         CompletePlatforms(expected_complete_platforms),
     )
 

--- a/src/python/pants/backend/python/util_rules/faas_test.py
+++ b/src/python/pants/backend/python/util_rules/faas_test.py
@@ -277,10 +277,9 @@ class TestRuntimeField(PythonFaaSRuntimeField):
         pytest.param(
             "67.89", (67, 89), [], ["complete_platform_faas-test-67-89.json"], id="known 67.89"
         ),
-        pytest.param("98.76", (98, 76), ["linux_x86_64-cp-9876-cp9876"], [], id="unknown 98.76"),
     ],
 )
-def test_infer_runtime_platforms_when_runtime_and_no_complete_platforms(
+def test_infer_runtime_platforms_when_known_runtime_and_no_complete_platforms(
     value: str,
     expected_interpreter_version: tuple[int, int],
     expected_platforms: list[str],
@@ -304,6 +303,26 @@ def test_infer_runtime_platforms_when_runtime_and_no_complete_platforms(
         PexPlatforms(expected_platforms),
         CompletePlatforms(expected_complete_platforms),
     )
+
+
+def test_infer_runtime_platforms_errors_when_unknown_runtime_and_no_complete_platforms(
+    rule_runner: RuleRunner,
+) -> None:
+    address = Address("path", target_name="target")
+
+    request = RuntimePlatformsRequest(
+        address=address,
+        target_name="unused",
+        runtime=TestRuntimeField("98.76", address),
+        complete_platforms=PythonFaaSCompletePlatforms(None, address),
+        architecture=FaaSArchitecture.X86_64,
+    )
+
+    with pytest.raises(
+        ExecutionError,
+        match=r"(?s).*Could not find a known runtime for the specified Python version",
+    ):
+        rule_runner.request(RuntimePlatforms, [request])
 
 
 def test_infer_runtime_platforms_when_complete_platforms(
@@ -334,10 +353,9 @@ def test_infer_runtime_platforms_when_complete_platforms(
             ["complete_platform_faas-test-3-45.json"],
             id="known 3.45",
         ),
-        pytest.param(">=3.33,<3.34", (3, 33), ["linux_x86_64-cp-333-cp333"], [], id="unknown 3.33"),
     ],
 )
-def test_infer_runtime_platforms_when_narrow_ics_only(
+def test_infer_runtime_platforms_when_known_narrow_ics_only(
     ics: str,
     expected_interpreter_version: tuple[int, int],
     expected_platforms: list[str],
@@ -367,6 +385,32 @@ def test_infer_runtime_platforms_when_narrow_ics_only(
         PexPlatforms(expected_platforms),
         CompletePlatforms(expected_complete_platforms),
     )
+
+
+def test_infer_runtime_platforms_errors_when_unknown_narrow_ics(
+    rule_runner: RuleRunner,
+) -> None:
+    rule_runner.write_files(
+        {
+            "path/BUILD": "python_sources(name='target', interpreter_constraints=['==3.33.*'])",
+            "path/x.py": "",
+        }
+    )
+
+    address = Address("path", target_name="target")
+    request = RuntimePlatformsRequest(
+        address=address,
+        target_name="example_target",
+        runtime=TestRuntimeField(None, address),
+        complete_platforms=PythonFaaSCompletePlatforms(None, address),
+        architecture=FaaSArchitecture.X86_64,
+    )
+
+    with pytest.raises(
+        ExecutionError,
+        match=r"(?s).*Could not find a known runtime for the inferred Python version",
+    ):
+        rule_runner.request(RuntimePlatforms, [request])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This removes the fallback to using PEX's `--platform` argument for AWS Lambda or Google Cloud Functions targets that don't have a built-in complete platforms, if the user doesn't provide a complete platforms.

This has been deprecated since 2.23 (#21342).

This removal also unblocks some removal of the support code for this FaaS functionality.