### PR TITLE
update Pex to 2.33.0

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -11,7 +11,7 @@ freezegun==1.2.1
 ijson==3.2.3
 libcst==1.4.0
 packaging==21.3
-pex==2.32.0
+pex==2.33.0
 psutil==5.9.8
 # This should be compatible with pytest.py, although it can be looser so that we don't
 # over-constrain pantsbuild.pants.testutil

--- a/3rdparty/python/user_reqs.lock
+++ b/3rdparty/python/user_reqs.lock
@@ -23,7 +23,7 @@
 //     "mypy-typing-asserts==0.1.1",
 //     "node-semver==0.9.0",
 //     "packaging==21.3",
-//     "pex==2.32.0",
+//     "pex==2.33.0",
 //     "psutil==5.9.8",
 //     "pydevd-pycharm==203.5419.8",
 //     "pytest<7.1.0,>=6.2.4",
@@ -1005,13 +1005,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "83a10fd288a8f1482e831422a6f5e912a4561151a37e1694e187125e757227ee",
-              "url": "https://files.pythonhosted.org/packages/df/cc/85b7bf41b71dd324bd53b5d921dd81146499ce3ddb93d3fc2551ddd3b253/pex-2.32.0-py2.py3-none-any.whl"
+              "hash": "a1132a4a1eaeedcc56b2125a6e75e6820b9728560200043527a2151a8cb389f5",
+              "url": "https://files.pythonhosted.org/packages/95/04/294db01e6db8303a2147a85e3ea4044dda8711fa8eba540f12c8d40aa910/pex-2.33.0-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4f8cd1e0c314c26f213a02b4d0f0dcb4d76cf23e8ac6f2a0e9fabccf58e3ad55",
-              "url": "https://files.pythonhosted.org/packages/98/d3/e9dfe131d50c10eb21b9fdb0aa1039c933fe79291cb193141ecda4631d1f/pex-2.32.0.tar.gz"
+              "hash": "f41f1c79bc4935d444f96f7d53afa5273052b3950dc72e212d28b5c46f4dbb42",
+              "url": "https://files.pythonhosted.org/packages/9a/66/e3d64b05863cb03789d4e74ac165100d4c334b8abe8f0936a74e90155da3/pex-2.33.0.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -1020,7 +1020,7 @@
             "subprocess32>=3.2.7; python_version < \"3\" and extra == \"subprocess\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.14,>=2.7",
-          "version": "2.32.0"
+          "version": "2.33.0"
         },
         {
           "artifacts": [
@@ -2317,8 +2317,8 @@
   "only_wheels": [],
   "overridden": [],
   "path_mappings": {},
-  "pex_version": "2.32.1",
-  "pip_version": "25.0",
+  "pex_version": "2.33.0",
+  "pip_version": "25.0.1",
   "prefer_older_binary": false,
   "requirements": [
     "PyGithub==2.4.0",
@@ -2335,7 +2335,7 @@
     "mypy-typing-asserts==0.1.1",
     "node-semver==0.9.0",
     "packaging==21.3",
-    "pex==2.32.0",
+    "pex==2.33.0",
     "psutil==5.9.8",
     "pydevd-pycharm==203.5419.8",
     "pytest<7.1.0,>=6.2.4",

--- a/docs/notes/2.26.x.md
+++ b/docs/notes/2.26.x.md
@@ -34,6 +34,9 @@ Some deprecations have expired and been removed:
 - the `[export].py_hermetic_scripts` option has been replaced by [the `[export].py_non_hermetic_scripts_in_resolve` option](https://www.pantsbuild.org/2.25/reference/goals/export#py_non_hermetic_scripts_in_resolve)
 - for FaaS targets (AWS Lambda and Google Cloud Functions), automatic fallback to underspecified "platforms" for unknown runtimes without a pre-packaged complete-platforms has been replaced by requiring an [explicit `complete_platforms` value](https://www.pantsbuild.org/2.25/reference/targets/python_aws_lambda_function#complete_platforms)
 
+The default version of the [Pex](https://docs.pex-tool.org/) tool has been updated from 2.32.0 to [2.33.0](https://github.com/pex-tool/pex/releases/tag/v2.33.0).  Among many improvements and bug fixes, this unlocks support for pip [25.0.1](https://pip.pypa.io/en/stable/news/#v25-0-1).
+
+
 #### Terraform
 
 For the `tfsec` linter, the deprecation of support for leading `v`s in the `version` and `known_versions` field has expired and been removed. Write `1.28.13` instead of `v1.28.13`.

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -42,7 +42,7 @@ class PexCli(TemplatedExternalTool):
     name = "pex"
     help = "The PEX (Python EXecutable) tool (https://github.com/pex-tool/pex)."
 
-    default_version = "v2.32.1"
+    default_version = "v2.33.0"
     default_url_template = "https://github.com/pex-tool/pex/releases/download/{version}/pex"
     version_constraints = ">=2.13.0,<3.0"
 
@@ -65,8 +65,8 @@ class PexCli(TemplatedExternalTool):
                 (
                     cls.default_version,
                     plat,
-                    "1e953b668ae930e0472e8a40709adbf7c342de9ad249d8bbbc719dce7e50e0f7",
-                    "4450314",
+                    "349a1cf2a13edeb6237318156773f66d2032d5dfa6b5ce724aa5a11cbecff4a1",
+                    "4556348",
                 )
             )
             for plat in ["macos_arm64", "macos_x86_64", "linux_x86_64", "linux_arm64"]


### PR DESCRIPTION
```
Lockfile diff: 3rdparty/python/user_reqs.lock [python-default]

==                    Upgraded dependencies                     ==

  pex                            2.32.0       -->   2.33.0
```