### PR TITLE
explicitly resolve Python for pex run/package

### DIFF
--- a/src/python/pants/backend/python/goals/run_pex_binary.py
+++ b/src/python/pants/backend/python/goals/run_pex_binary.py
@@ -18,15 +18,14 @@ from pants.util.logging import LogLevel
 
 @rule(level=LogLevel.DEBUG)
 async def create_pex_binary_run_request(field_set: PexBinaryFieldSet) -> RunRequest:
-    pex_request = await Get(PexFromTargetsRequestForBuiltPackage, PexBinaryFieldSet, field_set)
-    built_pex = await Get(BuiltPackage, PexFromTargetsRequestForBuiltPackage, pex_request)
-
+    pex_request = await Get(
+        PexFromTargetsRequestForBuiltPackage, PexBinaryFieldSet, field_set
+    )
     # We need a Python executable to fulfil `adhoc_tool`/`runnable_dependency` requests
     # as sandboxed processes will not have a `python` available on the `PATH`.
-    python = await Get(
-        PythonExecutable,
-        InterpreterConstraintsRequest,
-        pex_request.request.to_interpreter_constraints_request(),
+
+    built_pex = await Get(
+        BuiltPackage, PexFromTargetsRequestForBuiltPackage, pex_request
     )
 
     relpath = built_pex.artifacts[0].relpath
@@ -36,7 +35,7 @@ async def create_pex_binary_run_request(field_set: PexBinaryFieldSet) -> RunRequ
 
     return RunRequest(
         digest=built_pex.digest,
-        args=[python.path, os.path.join("{chroot}", relpath)],
+        args=[pex_request.request.python.path, os.path.join("{chroot}", relpath)],
     )
 
 

--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -93,6 +93,7 @@ class PexFromTargetsRequest:
     # This field doesn't participate in comparison (and therefore hashing), as it doesn't affect
     # the result.
     description: str | None = dataclasses.field(compare=False)
+    python: PythonExecutable | None
 
     def __init__(
         self,
@@ -116,6 +117,7 @@ class PexFromTargetsRequest:
         hardcoded_interpreter_constraints: InterpreterConstraints | None = None,
         description: str | None = None,
         warn_for_transitive_files_targets: bool = False,
+        python: PythonExecutable | None = None,
     ) -> None:
         """Request to create a Pex from the transitive closure of the given addresses.
 
@@ -179,7 +181,7 @@ class PexFromTargetsRequest:
         object.__setattr__(
             self, "warn_for_transitive_files_targets", warn_for_transitive_files_targets
         )
-
+        object.__setattr__(self, "python", python)
         self.__post_init__()
 
     def __post_init__(self):
@@ -606,7 +608,7 @@ async def create_pex_from_targets(
         internal_only=request.internal_only,
         layout=request.layout,
         requirements=requirements,
-        interpreter_constraints=interpreter_constraints,
+        #        interpreter_constraints=interpreter_constraints,
         platforms=request.platforms,
         complete_platforms=request.complete_platforms,
         main=request.main,
@@ -617,6 +619,7 @@ async def create_pex_from_targets(
         additional_args=additional_args,
         description=description,
         pex_path=additional_pexes,
+        python=request.python,
     )
 
 


### PR DESCRIPTION
This effectively ensures that when we try to build a pex, it's done using the executable that *we're resolving either way*. I'm sure this *specific* implementation is suboptimal, but it resolves the specific issues seens in #21048 and makes my repro pass. 

As I noted on the issue, what is currently happening is that if we pick a pyenv interpreter to *run* the pex, it won't be available in the Pex (i.e., the tool) invocation sandbox. This causes Pex to barf when finding a compatible interpreter for its work. 