### PR TITLE
support debug mode for `experimental_test_shell_command` target type

### DIFF
--- a/docs/notes/2.26.x.md
+++ b/docs/notes/2.26.x.md
@@ -36,6 +36,9 @@ Some deprecations have expired and been removed:
 
 The default version of the [Pex](https://docs.pex-tool.org/) tool has been updated from 2.32.0 to [2.33.0](https://github.com/pex-tool/pex/releases/tag/v2.33.0).  Among many improvements and bug fixes, this unlocks support for pip [25.0.1](https://pip.pypa.io/en/stable/news/#v25-0-1).
 
+#### Shell
+
+The `experiemental_test_shell_command` target type may now be used with the `test` goal's `--debug` flag to execute the test interactively.
 
 #### Terraform
 

--- a/src/python/pants/backend/shell/goals/test_test.py
+++ b/src/python/pants/backend/shell/goals/test_test.py
@@ -119,7 +119,7 @@ def test_shell_command_as_test(rule_runner: RuleRunner) -> None:
         pass_debug_result = rule_runner.run_interactive_process(pass_debug_request.process)
         assert pass_debug_result.exit_code == 0
 
-    fail_debug_request = rule_runner.request(TestDebugRequest, [test_batch_for_target(pass_target)])
+    fail_debug_request = rule_runner.request(TestDebugRequest, [test_batch_for_target(fail_target)])
     with mock_console(rule_runner.options_bootstrapper):
         fail_debug_result = rule_runner.run_interactive_process(fail_debug_request.process)
-        assert fail_debug_result.exit_code == 0
+        assert fail_debug_result.exit_code == 1


### PR DESCRIPTION
Support debug mode for the `experimental_test_shell_command` target type so that users can execute the tests in interactive mode.