### PR TITLE
use a more common spelling of "inferable"

### DIFF
--- a/src/python/pants/backend/helm/dependency_inference/subsystem.py
+++ b/src/python/pants/backend/helm/dependency_inference/subsystem.py
@@ -38,7 +38,7 @@ class HelmInferSubsystem(Subsystem):
         default=UnownedHelmDependencyUsage.RaiseError,
         help=softwrap(
             """
-            How to handle inferred dependencies that don't have an inferrable owner.
+            How to handle inferred dependencies that don't have an inferable owner.
 
             Usually when an import cannot be inferred, it represents an issue like Pants not being
             properly configured, e.g. targets not set up. Often, missing dependencies will result

--- a/src/python/pants/backend/javascript/dependency_inference/rules.py
+++ b/src/python/pants/backend/javascript/dependency_inference/rules.py
@@ -225,7 +225,7 @@ def _handle_unowned_imports(
 
         {bullet_list(sorted(unowned_imports))}
 
-        If you do not expect an import to be inferrable, add `// pants: no-infer-dep` to the
+        If you do not expect an import to be inferable, add `// pants: no-infer-dep` to the
         import line. Otherwise, see {url} for common problems.
         """
     )

--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -343,7 +343,7 @@ async def _handle_unowned_imports(
 
         {bullet_list(unowned_imports_with_lines)}{other_resolves_snippet}
 
-        If you do not expect an import to be inferrable, add `# pants: no-infer-dep` to the
+        If you do not expect an import to be inferable, add `# pants: no-infer-dep` to the
         import line. Otherwise, see
         {doc_url('docs/using-pants/troubleshooting-common-issues#import-errors-and-missing-dependencies')} for common problems.
         """

--- a/src/python/pants/core/util_rules/unowned_dependency_behavior.py
+++ b/src/python/pants/core/util_rules/unowned_dependency_behavior.py
@@ -23,7 +23,7 @@ class UnownedDependencyUsageOption(EnumOption[UnownedDependencyUsage, UnownedDep
             default=UnownedDependencyUsage.LogWarning,
             help=softwrap(
                 f"""
-                How to handle imports that don't have an inferrable owner.
+                How to handle imports that don't have an inferable owner.
 
                 Usually when an import cannot be inferred, it represents an issue like Pants not being
                 properly configured, e.g. targets not set up. Often, missing dependencies will result

--- a/src/python/pants/version.py
+++ b/src/python/pants/version.py
@@ -8,7 +8,7 @@ from packaging.version import Version as _Version
 
 import pants._version
 
-# Generate an inferrable dependency on the `pants._version` package and its associated resources.
+# Generate an inferable dependency on the `pants._version` package and its associated resources.
 from pants.util.resources import read_resource
 
 


### PR DESCRIPTION
This came up in the context of
https://github.com/SchemaStore/schemastore/pull/4411

Variant spelling rabbit hole: https://en.wiktionary.org/wiki/Talk:inferable

![image](https://github.com/user-attachments/assets/f00a4df1-12c6-4c2b-a12c-b2818ac4e4d4)
