### PR TITLE
back port attestation workflow to 2.25.x

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -100,8 +100,7 @@ jobs:
         echo "PEX_FILENAME=$PEX_FILENAME" | tee -a "$GITHUB_ENV"
 
         '
-    - continue-on-error: true
-      if: needs.release_info.outputs.is-release == 'true'
+    - if: needs.release_info.outputs.is-release == 'true'
       name: Attest the Pants Pex artifact
       uses: actions/attest-build-provenance@v2
       with:
@@ -214,8 +213,7 @@ jobs:
         echo "PEX_FILENAME=$PEX_FILENAME" | tee -a "$GITHUB_ENV"
 
         '
-    - continue-on-error: true
-      if: needs.release_info.outputs.is-release == 'true'
+    - if: needs.release_info.outputs.is-release == 'true'
       name: Attest the Pants Pex artifact
       uses: actions/attest-build-provenance@v2
       with:
@@ -231,8 +229,7 @@ jobs:
         \ }}\" \\\n    -H \"Content-Type: application/octet-stream\" \\\n    \"${{\
         \ needs.release_info.outputs.release-asset-upload-url }}?name=$(basename $WHL)\"\
         \ \\\n    --data-binary \"@$WHL\";\n"
-    - continue-on-error: true
-      if: needs.release_info.outputs.is-release == 'true'
+    - if: needs.release_info.outputs.is-release == 'true'
       name: Attest the pantsbuild.pants.testutil wheel
       uses: actions/attest-build-provenance@v2
       with:
@@ -357,8 +354,7 @@ jobs:
         echo "PEX_FILENAME=$PEX_FILENAME" | tee -a "$GITHUB_ENV"
 
         '
-    - continue-on-error: true
-      if: needs.release_info.outputs.is-release == 'true'
+    - if: needs.release_info.outputs.is-release == 'true'
       name: Attest the Pants Pex artifact
       uses: actions/attest-build-provenance@v2
       with:
@@ -483,8 +479,7 @@ jobs:
         echo "PEX_FILENAME=$PEX_FILENAME" | tee -a "$GITHUB_ENV"
 
         '
-    - continue-on-error: true
-      if: needs.release_info.outputs.is-release == 'true'
+    - if: needs.release_info.outputs.is-release == 'true'
       name: Attest the Pants Pex artifact
       uses: actions/attest-build-provenance@v2
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,10 @@ jobs:
     name: Build wheels (Linux-ARM64)
     needs:
     - release_info
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
     runs-on:
     - self-hosted
     - runs-on
@@ -74,18 +78,41 @@ jobs:
         overwrite: 'true'
         path: .pants.d/workdir/*.log
     - if: needs.release_info.outputs.is-release == 'true'
+      name: Attest the pantsbuild.pants wheel
+      uses: actions/attest-build-provenance@v2
+      with:
+        subject-path: dist/deploy/wheels/pantsbuild.pants/**/pantsbuild.pants-*.whl
+    - if: needs.release_info.outputs.is-release == 'true'
+      name: Rename the Pants Pex to its final name for upload
+      run: 'PANTS_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import
+        pants.version;print(pants.version.VERSION)")
+
+        PY_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import
+        sys;print(f''cp{sys.version_info[0]}{sys.version_info[1]}'')")
+
+        PLAT=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import os;print(f''{os.uname().sysname.lower()}_{os.uname().machine.lower()}'')")
+
+        PEX_FILENAME=pants.$PANTS_VER-$PY_VER-$PLAT.pex
+
+
+        mv dist/src.python.pants/pants-pex.pex dist/src.python.pants/$PEX_FILENAME
+
+        echo "PEX_FILENAME=$PEX_FILENAME" | tee -a "$GITHUB_ENV"
+
+        '
+    - continue-on-error: true
+      if: needs.release_info.outputs.is-release == 'true'
+      name: Attest the Pants Pex artifact
+      uses: actions/attest-build-provenance@v2
+      with:
+        subject-path: dist/src.python.pants/*.pex
+    - if: needs.release_info.outputs.is-release == 'true'
       name: Upload Wheel and Pex
-      run: "PANTS_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c \"\
-        import pants.version;print(pants.version.VERSION)\")\nPY_VER=$(PEX_INTERPRETER=1\
-        \ dist/src.python.pants/pants-pex.pex -c \"import sys;print(f'cp{sys.version_info[0]}{sys.version_info[1]}')\"\
-        )\nPLAT=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c \"import\
-        \ os;print(f'{os.uname().sysname.lower()}_{os.uname().machine.lower()}')\"\
-        )\nPEX_FILENAME=pants.$PANTS_VER-$PY_VER-$PLAT.pex\n\nmv dist/src.python.pants/pants-pex.pex\
-        \ dist/src.python.pants/$PEX_FILENAME\n\ncurl -L --fail \\\n    -X POST \\\
-        \n    -H \"Authorization: Bearer ${{ github.token }}\" \\\n    -H \"Content-Type:\
-        \ application/octet-stream\" \\\n    ${{ needs.release_info.outputs.release-asset-upload-url\
-        \ }}?name=$PEX_FILENAME \\\n    --data-binary \"@dist/src.python.pants/$PEX_FILENAME\"\
-        \n\nWHL=$(find dist/deploy/wheels/pantsbuild.pants -type f -name \"pantsbuild.pants-*.whl\"\
+      run: "curl -L --fail \\\n    -X POST \\\n    -H \"Authorization: Bearer ${{\
+        \ github.token }}\" \\\n    -H \"Content-Type: application/octet-stream\"\
+        \ \\\n    ${{ needs.release_info.outputs.release-asset-upload-url }}?name=$PEX_FILENAME\
+        \ \\\n    --data-binary \"@dist/src.python.pants/$PEX_FILENAME\"\n\nWHL=$(find\
+        \ dist/deploy/wheels/pantsbuild.pants -type f -name \"pantsbuild.pants-*.whl\"\
         )\ncurl -L --fail \\\n    -X POST \\\n    -H \"Authorization: Bearer ${{ github.token\
         \ }}\" \\\n    -H \"Content-Type: application/octet-stream\" \\\n    \"${{\
         \ needs.release_info.outputs.release-asset-upload-url }}?name=$(basename $WHL)\"\
@@ -102,6 +129,10 @@ jobs:
     name: Build wheels (Linux-x86_64)
     needs:
     - release_info
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
     runs-on:
     - ubuntu-22.04
     steps:
@@ -161,22 +192,51 @@ jobs:
         overwrite: 'true'
         path: .pants.d/workdir/*.log
     - if: needs.release_info.outputs.is-release == 'true'
+      name: Attest the pantsbuild.pants wheel
+      uses: actions/attest-build-provenance@v2
+      with:
+        subject-path: dist/deploy/wheels/pantsbuild.pants/**/pantsbuild.pants-*.whl
+    - if: needs.release_info.outputs.is-release == 'true'
+      name: Rename the Pants Pex to its final name for upload
+      run: 'PANTS_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import
+        pants.version;print(pants.version.VERSION)")
+
+        PY_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import
+        sys;print(f''cp{sys.version_info[0]}{sys.version_info[1]}'')")
+
+        PLAT=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import os;print(f''{os.uname().sysname.lower()}_{os.uname().machine.lower()}'')")
+
+        PEX_FILENAME=pants.$PANTS_VER-$PY_VER-$PLAT.pex
+
+
+        mv dist/src.python.pants/pants-pex.pex dist/src.python.pants/$PEX_FILENAME
+
+        echo "PEX_FILENAME=$PEX_FILENAME" | tee -a "$GITHUB_ENV"
+
+        '
+    - continue-on-error: true
+      if: needs.release_info.outputs.is-release == 'true'
+      name: Attest the Pants Pex artifact
+      uses: actions/attest-build-provenance@v2
+      with:
+        subject-path: dist/src.python.pants/*.pex
+    - if: needs.release_info.outputs.is-release == 'true'
       name: Upload Wheel and Pex
-      run: "PANTS_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c \"\
-        import pants.version;print(pants.version.VERSION)\")\nPY_VER=$(PEX_INTERPRETER=1\
-        \ dist/src.python.pants/pants-pex.pex -c \"import sys;print(f'cp{sys.version_info[0]}{sys.version_info[1]}')\"\
-        )\nPLAT=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c \"import\
-        \ os;print(f'{os.uname().sysname.lower()}_{os.uname().machine.lower()}')\"\
-        )\nPEX_FILENAME=pants.$PANTS_VER-$PY_VER-$PLAT.pex\n\nmv dist/src.python.pants/pants-pex.pex\
-        \ dist/src.python.pants/$PEX_FILENAME\n\ncurl -L --fail \\\n    -X POST \\\
-        \n    -H \"Authorization: Bearer ${{ github.token }}\" \\\n    -H \"Content-Type:\
-        \ application/octet-stream\" \\\n    ${{ needs.release_info.outputs.release-asset-upload-url\
-        \ }}?name=$PEX_FILENAME \\\n    --data-binary \"@dist/src.python.pants/$PEX_FILENAME\"\
-        \n\nWHL=$(find dist/deploy/wheels/pantsbuild.pants -type f -name \"pantsbuild.pants-*.whl\"\
+      run: "curl -L --fail \\\n    -X POST \\\n    -H \"Authorization: Bearer ${{\
+        \ github.token }}\" \\\n    -H \"Content-Type: application/octet-stream\"\
+        \ \\\n    ${{ needs.release_info.outputs.release-asset-upload-url }}?name=$PEX_FILENAME\
+        \ \\\n    --data-binary \"@dist/src.python.pants/$PEX_FILENAME\"\n\nWHL=$(find\
+        \ dist/deploy/wheels/pantsbuild.pants -type f -name \"pantsbuild.pants-*.whl\"\
         )\ncurl -L --fail \\\n    -X POST \\\n    -H \"Authorization: Bearer ${{ github.token\
         \ }}\" \\\n    -H \"Content-Type: application/octet-stream\" \\\n    \"${{\
         \ needs.release_info.outputs.release-asset-upload-url }}?name=$(basename $WHL)\"\
         \ \\\n    --data-binary \"@$WHL\";\n"
+    - continue-on-error: true
+      if: needs.release_info.outputs.is-release == 'true'
+      name: Attest the pantsbuild.pants.testutil wheel
+      uses: actions/attest-build-provenance@v2
+      with:
+        subject-path: dist/deploy/wheels/pantsbuild.pants/**/pantsbuild.pants.testutil*.whl
     - if: needs.release_info.outputs.is-release == 'true'
       name: Upload testutil Wheel
       run: "WHL=$(find dist/deploy/wheels/pantsbuild.pants -type f -name \"pantsbuild.pants.testutil*.whl\"\
@@ -194,6 +254,10 @@ jobs:
     name: Build wheels (macOS13-x86_64)
     needs:
     - release_info
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
     runs-on:
     - macos-13
     steps:
@@ -271,18 +335,41 @@ jobs:
         overwrite: 'true'
         path: .pants.d/workdir/*.log
     - if: needs.release_info.outputs.is-release == 'true'
+      name: Attest the pantsbuild.pants wheel
+      uses: actions/attest-build-provenance@v2
+      with:
+        subject-path: dist/deploy/wheels/pantsbuild.pants/**/pantsbuild.pants-*.whl
+    - if: needs.release_info.outputs.is-release == 'true'
+      name: Rename the Pants Pex to its final name for upload
+      run: 'PANTS_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import
+        pants.version;print(pants.version.VERSION)")
+
+        PY_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import
+        sys;print(f''cp{sys.version_info[0]}{sys.version_info[1]}'')")
+
+        PLAT=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import os;print(f''{os.uname().sysname.lower()}_{os.uname().machine.lower()}'')")
+
+        PEX_FILENAME=pants.$PANTS_VER-$PY_VER-$PLAT.pex
+
+
+        mv dist/src.python.pants/pants-pex.pex dist/src.python.pants/$PEX_FILENAME
+
+        echo "PEX_FILENAME=$PEX_FILENAME" | tee -a "$GITHUB_ENV"
+
+        '
+    - continue-on-error: true
+      if: needs.release_info.outputs.is-release == 'true'
+      name: Attest the Pants Pex artifact
+      uses: actions/attest-build-provenance@v2
+      with:
+        subject-path: dist/src.python.pants/*.pex
+    - if: needs.release_info.outputs.is-release == 'true'
       name: Upload Wheel and Pex
-      run: "PANTS_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c \"\
-        import pants.version;print(pants.version.VERSION)\")\nPY_VER=$(PEX_INTERPRETER=1\
-        \ dist/src.python.pants/pants-pex.pex -c \"import sys;print(f'cp{sys.version_info[0]}{sys.version_info[1]}')\"\
-        )\nPLAT=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c \"import\
-        \ os;print(f'{os.uname().sysname.lower()}_{os.uname().machine.lower()}')\"\
-        )\nPEX_FILENAME=pants.$PANTS_VER-$PY_VER-$PLAT.pex\n\nmv dist/src.python.pants/pants-pex.pex\
-        \ dist/src.python.pants/$PEX_FILENAME\n\ncurl -L --fail \\\n    -X POST \\\
-        \n    -H \"Authorization: Bearer ${{ github.token }}\" \\\n    -H \"Content-Type:\
-        \ application/octet-stream\" \\\n    ${{ needs.release_info.outputs.release-asset-upload-url\
-        \ }}?name=$PEX_FILENAME \\\n    --data-binary \"@dist/src.python.pants/$PEX_FILENAME\"\
-        \n\nWHL=$(find dist/deploy/wheels/pantsbuild.pants -type f -name \"pantsbuild.pants-*.whl\"\
+      run: "curl -L --fail \\\n    -X POST \\\n    -H \"Authorization: Bearer ${{\
+        \ github.token }}\" \\\n    -H \"Content-Type: application/octet-stream\"\
+        \ \\\n    ${{ needs.release_info.outputs.release-asset-upload-url }}?name=$PEX_FILENAME\
+        \ \\\n    --data-binary \"@dist/src.python.pants/$PEX_FILENAME\"\n\nWHL=$(find\
+        \ dist/deploy/wheels/pantsbuild.pants -type f -name \"pantsbuild.pants-*.whl\"\
         )\ncurl -L --fail \\\n    -X POST \\\n    -H \"Authorization: Bearer ${{ github.token\
         \ }}\" \\\n    -H \"Content-Type: application/octet-stream\" \\\n    \"${{\
         \ needs.release_info.outputs.release-asset-upload-url }}?name=$(basename $WHL)\"\
@@ -297,6 +384,10 @@ jobs:
     name: Build wheels (macOS14-ARM64)
     needs:
     - release_info
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
     runs-on:
     - macos-14
     steps:
@@ -370,18 +461,41 @@ jobs:
         overwrite: 'true'
         path: .pants.d/workdir/*.log
     - if: needs.release_info.outputs.is-release == 'true'
+      name: Attest the pantsbuild.pants wheel
+      uses: actions/attest-build-provenance@v2
+      with:
+        subject-path: dist/deploy/wheels/pantsbuild.pants/**/pantsbuild.pants-*.whl
+    - if: needs.release_info.outputs.is-release == 'true'
+      name: Rename the Pants Pex to its final name for upload
+      run: 'PANTS_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import
+        pants.version;print(pants.version.VERSION)")
+
+        PY_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import
+        sys;print(f''cp{sys.version_info[0]}{sys.version_info[1]}'')")
+
+        PLAT=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import os;print(f''{os.uname().sysname.lower()}_{os.uname().machine.lower()}'')")
+
+        PEX_FILENAME=pants.$PANTS_VER-$PY_VER-$PLAT.pex
+
+
+        mv dist/src.python.pants/pants-pex.pex dist/src.python.pants/$PEX_FILENAME
+
+        echo "PEX_FILENAME=$PEX_FILENAME" | tee -a "$GITHUB_ENV"
+
+        '
+    - continue-on-error: true
+      if: needs.release_info.outputs.is-release == 'true'
+      name: Attest the Pants Pex artifact
+      uses: actions/attest-build-provenance@v2
+      with:
+        subject-path: dist/src.python.pants/*.pex
+    - if: needs.release_info.outputs.is-release == 'true'
       name: Upload Wheel and Pex
-      run: "PANTS_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c \"\
-        import pants.version;print(pants.version.VERSION)\")\nPY_VER=$(PEX_INTERPRETER=1\
-        \ dist/src.python.pants/pants-pex.pex -c \"import sys;print(f'cp{sys.version_info[0]}{sys.version_info[1]}')\"\
-        )\nPLAT=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c \"import\
-        \ os;print(f'{os.uname().sysname.lower()}_{os.uname().machine.lower()}')\"\
-        )\nPEX_FILENAME=pants.$PANTS_VER-$PY_VER-$PLAT.pex\n\nmv dist/src.python.pants/pants-pex.pex\
-        \ dist/src.python.pants/$PEX_FILENAME\n\ncurl -L --fail \\\n    -X POST \\\
-        \n    -H \"Authorization: Bearer ${{ github.token }}\" \\\n    -H \"Content-Type:\
-        \ application/octet-stream\" \\\n    ${{ needs.release_info.outputs.release-asset-upload-url\
-        \ }}?name=$PEX_FILENAME \\\n    --data-binary \"@dist/src.python.pants/$PEX_FILENAME\"\
-        \n\nWHL=$(find dist/deploy/wheels/pantsbuild.pants -type f -name \"pantsbuild.pants-*.whl\"\
+      run: "curl -L --fail \\\n    -X POST \\\n    -H \"Authorization: Bearer ${{\
+        \ github.token }}\" \\\n    -H \"Content-Type: application/octet-stream\"\
+        \ \\\n    ${{ needs.release_info.outputs.release-asset-upload-url }}?name=$PEX_FILENAME\
+        \ \\\n    --data-binary \"@dist/src.python.pants/$PEX_FILENAME\"\n\nWHL=$(find\
+        \ dist/deploy/wheels/pantsbuild.pants -type f -name \"pantsbuild.pants-*.whl\"\
         )\ncurl -L --fail \\\n    -X POST \\\n    -H \"Authorization: Bearer ${{ github.token\
         \ }}\" \\\n    -H \"Content-Type: application/octet-stream\" \\\n    \"${{\
         \ needs.release_info.outputs.release-asset-upload-url }}?name=$(basename $WHL)\"\

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -336,6 +336,10 @@ jobs:
     name: Build wheels (Linux-ARM64)
     needs:
     - classify_changes
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
     runs-on:
     - self-hosted
     - runs-on
@@ -406,6 +410,10 @@ jobs:
     name: Build wheels (Linux-x86_64)
     needs:
     - classify_changes
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
     runs-on:
     - ubuntu-22.04
     steps:
@@ -474,6 +482,10 @@ jobs:
     name: Build wheels (macOS13-x86_64)
     needs:
     - classify_changes
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
     runs-on:
     - macos-13
     steps:
@@ -560,6 +572,10 @@ jobs:
     name: Build wheels (macOS14-ARM64)
     needs:
     - classify_changes
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
     runs-on:
     - macos-14
     steps:

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -949,8 +949,6 @@ def build_wheels_job(
                             "with": {
                                 "subject-path": "dist/src.python.pants/*.pex",
                             },
-                            # Temporary: Allow errors in this step while we test the release workflow.
-                            "continue-on-error": True,
                         },
                         {
                             "name": "Upload Wheel and Pex",
@@ -987,8 +985,6 @@ def build_wheels_job(
                                     "with": {
                                         "subject-path": "dist/deploy/wheels/pantsbuild.pants/**/pantsbuild.pants.testutil*.whl",
                                     },
-                                    # Temporary: Allow errors in this step while we test the release workflow.
-                                    "continue-on-error": True,
                                 },
                                 {
                                     "name": "Upload testutil Wheel",

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -21,6 +21,7 @@ from pants_release.common import die
 def action(name: str) -> str:
     version_map = {
         "action-send-mail": "dawidd6/action-send-mail@v3.8.0",
+        "attest-build-provenance": "actions/attest-build-provenance@v2",
         "cache": "actions/cache@v4",
         "checkout": "actions/checkout@v4",
         "download-artifact": "actions/download-artifact@v4",
@@ -880,6 +881,11 @@ def build_wheels_job(
             "if": if_condition,
             "name": f"Build wheels ({str(platform.value)})",
             "runs-on": helper.runs_on(),
+            "permissions": {
+                "id-token": "write",
+                "contents": "write",
+                "attestations": "write",
+            },
             **({"container": container} if container else {}),
             **({"needs": needs} if needs else {}),
             "timeout-minutes": 90,
@@ -914,12 +920,16 @@ def build_wheels_job(
                 *(
                     [
                         {
-                            "name": "Upload Wheel and Pex",
+                            "name": "Attest the pantsbuild.pants wheel",
                             "if": "needs.release_info.outputs.is-release == 'true'",
-                            # NB: We can't use `gh` or even `./pants run 3rdparty/tools/gh` reliably
-                            #   in this job. Certain variations run on docker images without `gh`,
-                            #   and we could be building on a tag that doesn't have the `pants run <gh>`
-                            #   support. `curl` is a good lowest-common-denominator way to upload the assets.
+                            "uses": action("attest-build-provenance"),
+                            "with": {
+                                "subject-path": "dist/deploy/wheels/pantsbuild.pants/**/pantsbuild.pants-*.whl",
+                            },
+                        },
+                        {
+                            "name": "Rename the Pants Pex to its final name for upload",
+                            "if": "needs.release_info.outputs.is-release == 'true'",
                             "run": dedent(
                                 """\
                                 PANTS_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import pants.version;print(pants.version.VERSION)")
@@ -928,7 +938,29 @@ def build_wheels_job(
                                 PEX_FILENAME=pants.$PANTS_VER-$PY_VER-$PLAT.pex
 
                                 mv dist/src.python.pants/pants-pex.pex dist/src.python.pants/$PEX_FILENAME
-
+                                echo "PEX_FILENAME=$PEX_FILENAME" | tee -a "$GITHUB_ENV"
+                                """
+                            ),
+                        },
+                        {
+                            "name": "Attest the Pants Pex artifact",
+                            "if": "needs.release_info.outputs.is-release == 'true'",
+                            "uses": action("attest-build-provenance"),
+                            "with": {
+                                "subject-path": "dist/src.python.pants/*.pex",
+                            },
+                            # Temporary: Allow errors in this step while we test the release workflow.
+                            "continue-on-error": True,
+                        },
+                        {
+                            "name": "Upload Wheel and Pex",
+                            "if": "needs.release_info.outputs.is-release == 'true'",
+                            # NB: We can't use `gh` or even `./pants run 3rdparty/tools/gh` reliably
+                            #   in this job. Certain variations run on docker images without `gh`,
+                            #   and we could be building on a tag that doesn't have the `pants run <gh>`
+                            #   support. `curl` is a good lowest-common-denominator way to upload the assets.
+                            "run": dedent(
+                                """\
                                 curl -L --fail \\
                                     -X POST \\
                                     -H "Authorization: Bearer ${{ github.token }}" \\
@@ -948,6 +980,16 @@ def build_wheels_job(
                         },
                         *(
                             [
+                                {
+                                    "name": "Attest the pantsbuild.pants.testutil wheel",
+                                    "if": "needs.release_info.outputs.is-release == 'true'",
+                                    "uses": action("attest-build-provenance"),
+                                    "with": {
+                                        "subject-path": "dist/deploy/wheels/pantsbuild.pants/**/pantsbuild.pants.testutil*.whl",
+                                    },
+                                    # Temporary: Allow errors in this step while we test the release workflow.
+                                    "continue-on-error": True,
+                                },
                                 {
                                     "name": "Upload testutil Wheel",
                                     "if": "needs.release_info.outputs.is-release == 'true'",


### PR DESCRIPTION
Back port the attestations workflow used on `main` to the `2.25.x` release branch.