### PR TITLE
remove temporary `continue-on-error` configs in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -100,8 +100,7 @@ jobs:
         echo "PEX_FILENAME=$PEX_FILENAME" | tee -a "$GITHUB_ENV"
 
         '
-    - continue-on-error: true
-      if: needs.release_info.outputs.is-release == 'true'
+    - if: needs.release_info.outputs.is-release == 'true'
       name: Attest the Pants Pex artifact
       uses: actions/attest-build-provenance@v2
       with:
@@ -214,8 +213,7 @@ jobs:
         echo "PEX_FILENAME=$PEX_FILENAME" | tee -a "$GITHUB_ENV"
 
         '
-    - continue-on-error: true
-      if: needs.release_info.outputs.is-release == 'true'
+    - if: needs.release_info.outputs.is-release == 'true'
       name: Attest the Pants Pex artifact
       uses: actions/attest-build-provenance@v2
       with:
@@ -231,8 +229,7 @@ jobs:
         \ }}\" \\\n    -H \"Content-Type: application/octet-stream\" \\\n    \"${{\
         \ needs.release_info.outputs.release-asset-upload-url }}?name=$(basename $WHL)\"\
         \ \\\n    --data-binary \"@$WHL\";\n"
-    - continue-on-error: true
-      if: needs.release_info.outputs.is-release == 'true'
+    - if: needs.release_info.outputs.is-release == 'true'
       name: Attest the pantsbuild.pants.testutil wheel
       uses: actions/attest-build-provenance@v2
       with:
@@ -357,8 +354,7 @@ jobs:
         echo "PEX_FILENAME=$PEX_FILENAME" | tee -a "$GITHUB_ENV"
 
         '
-    - continue-on-error: true
-      if: needs.release_info.outputs.is-release == 'true'
+    - if: needs.release_info.outputs.is-release == 'true'
       name: Attest the Pants Pex artifact
       uses: actions/attest-build-provenance@v2
       with:
@@ -483,8 +479,7 @@ jobs:
         echo "PEX_FILENAME=$PEX_FILENAME" | tee -a "$GITHUB_ENV"
 
         '
-    - continue-on-error: true
-      if: needs.release_info.outputs.is-release == 'true'
+    - if: needs.release_info.outputs.is-release == 'true'
       name: Attest the Pants Pex artifact
       uses: actions/attest-build-provenance@v2
       with:

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -949,8 +949,6 @@ def build_wheels_job(
                             "with": {
                                 "subject-path": "dist/src.python.pants/*.pex",
                             },
-                            # Temporary: Allow errors in this step while we test the release workflow.
-                            "continue-on-error": True,
                         },
                         {
                             "name": "Upload Wheel and Pex",
@@ -987,8 +985,6 @@ def build_wheels_job(
                                     "with": {
                                         "subject-path": "dist/deploy/wheels/pantsbuild.pants/**/pantsbuild.pants.testutil*.whl",
                                     },
-                                    # Temporary: Allow errors in this step while we test the release workflow.
-                                    "continue-on-error": True,
                                 },
                                 {
                                     "name": "Upload testutil Wheel",


### PR DESCRIPTION
Remove the temporary `continue-on-error` configs in the release workflow which were only included to mitigate release breakage while testing the attestation workflow.