### PR TITLE
Installing cargo-audit as per the Github instructions

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -13,7 +13,7 @@ jobs:
       with:
         fetch-depth: 10
     - name: Cargo audit (for security vulnerabilities)
-      run: './cargo install --version 0.17.5 cargo-audit
+      run: './cargo install cargo-audit --locked
 
         ./cargo audit --ignore RUSTSEC-2020-0128
 

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -1811,7 +1811,7 @@ def generate() -> dict[Path, str]:
                         *checkout(),
                         {
                             "name": "Cargo audit (for security vulnerabilities)",
-                            "run": f"./cargo install --version 0.17.5 cargo-audit\n./cargo audit {ignore_advisories}\n",
+                            "run": f"./cargo install cargo-audit --locked\n./cargo audit {ignore_advisories}\n",
                         },
                     ],
                 }


### PR DESCRIPTION
Closes #21823

This still errors out with an error, and it also has 14 warnings. But, just want to get this working first

Current error: https://rustsec.org/advisories/RUSTSEC-2024-0421