### PR TITLE
upgrade to Rust v1.85.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -291,7 +291,7 @@ jobs:
       with:
         key: macOS13-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain')
           }}-v2
-        path: '~/.rustup/toolchains/1.84.1-*
+        path: '~/.rustup/toolchains/1.85.0-*
 
           ~/.rustup/update-hashes
 
@@ -416,7 +416,7 @@ jobs:
       with:
         key: macOS14-ARM64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain')
           }}-v2
-        path: '~/.rustup/toolchains/1.84.1-*
+        path: '~/.rustup/toolchains/1.85.0-*
 
           ~/.rustup/update-hashes
 
@@ -542,7 +542,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.84.1-*
+        path: '~/.rustup/toolchains/1.85.0-*
 
           ~/.rustup/update-hashes
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,7 +40,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: Linux-ARM64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.84.1-*
+        path: '~/.rustup/toolchains/1.85.0-*
 
           ~/.rustup/update-hashes
 
@@ -145,7 +145,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.84.1-*
+        path: '~/.rustup/toolchains/1.85.0-*
 
           ~/.rustup/update-hashes
 
@@ -260,7 +260,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: macOS13-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.84.1-*
+        path: '~/.rustup/toolchains/1.85.0-*
 
           ~/.rustup/update-hashes
 
@@ -520,7 +520,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: macOS13-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.84.1-*
+        path: '~/.rustup/toolchains/1.85.0-*
 
           ~/.rustup/update-hashes
 
@@ -606,7 +606,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: macOS14-ARM64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.84.1-*
+        path: '~/.rustup/toolchains/1.85.0-*
 
           ~/.rustup/update-hashes
 

--- a/src/rust/engine/rust-toolchain
+++ b/src/rust/engine/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.84.1"
+channel = "1.85.0"
 # NB: We don't list the components (namely `clippy` and `rustfmt`) and instead rely on either the
 #  the profile being "default" (by-and-large the default profile) or the nice error message from
 #  `cargo fmt` and `cargo clippy` if the required component isn't installed


### PR DESCRIPTION
Upgrade to [Rust v1.85.0](https://blog.rust-lang.org/2025/02/20/Rust-1.85.0.html). This version of Rust stabilizes the 2024 Edition (but this PR does not migrate any crate to the 2024 Edition).