### PR TITLE
refactor adhoc process rules to allow "preparation" of requests

### DIFF
--- a/src/python/pants/backend/shell/util_rules/shell_command.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command.py
@@ -36,27 +36,34 @@ from pants.core.goals.run import RunFieldSet, RunInSandboxBehavior, RunRequest
 from pants.core.target_types import FileSourceField
 from pants.core.util_rules.adhoc_process_support import (
     AdhocProcessRequest,
-    AdhocProcessResult,
     ExtraSandboxContents,
     MergeExtraSandboxContents,
     ResolvedExecutionDependencies,
     ResolveExecutionDependenciesRequest,
+    convert_fallible_adhoc_process_result,
+    merge_extra_sandbox_contents,
     parse_relative_directory,
     prepare_env_vars,
+    resolve_execution_environment,
 )
 from pants.core.util_rules.adhoc_process_support import rules as adhoc_process_support_rules
-from pants.core.util_rules.environments import EnvironmentNameRequest, EnvironmentTarget
+from pants.core.util_rules.environments import (
+    EnvironmentNameRequest,
+    EnvironmentTarget,
+    resolve_environment_name,
+)
 from pants.core.util_rules.system_binaries import BashBinary, BinaryShims, BinaryShimsRequest
 from pants.engine.environment import EnvironmentName
-from pants.engine.fs import Digest, PathGlobs, Snapshot
+from pants.engine.fs import PathGlobs
+from pants.engine.internals.graph import resolve_target
 from pants.engine.internals.native_engine import EMPTY_DIGEST
+from pants.engine.intrinsics import digest_to_snapshot
 from pants.engine.process import Process
-from pants.engine.rules import Get, collect_rules, rule
+from pants.engine.rules import Get, collect_rules, implicitly, rule
 from pants.engine.target import (
     GeneratedSources,
     GenerateSourcesRequest,
     Target,
-    WrappedTarget,
     WrappedTargetRequest,
 )
 from pants.engine.unions import UnionRule
@@ -95,13 +102,13 @@ async def prepare_process_request_from_target(
     if not command:
         raise ValueError(f"Missing `command` line in `{description}.")
 
-    execution_environment = await Get(
-        ResolvedExecutionDependencies,
+    execution_environment = await resolve_execution_environment(
         ResolveExecutionDependenciesRequest(
             shell_command.address,
             shell_command.get(ShellCommandExecutionDependenciesField).value,
             shell_command.get(ShellCommandRunnableDependenciesField).value,
         ),
+        **implicitly(),
     )
     dependencies_digest = execution_environment.digest
 
@@ -145,8 +152,8 @@ async def prepare_process_request_from_target(
             )
         )
 
-    merged_extras = await Get(
-        ExtraSandboxContents, MergeExtraSandboxContents(tuple(extra_sandbox_contents))
+    merged_extras = await merge_extra_sandbox_contents(
+        MergeExtraSandboxContents(tuple(extra_sandbox_contents))
     )
 
     env_vars = await prepare_env_vars(
@@ -219,21 +226,23 @@ async def shell_command_in_sandbox(
     request: GenerateFilesFromShellCommandRequest,
 ) -> GeneratedSources:
     shell_command = request.protocol_target
-    environment_name = await Get(
-        EnvironmentName, EnvironmentNameRequest, EnvironmentNameRequest.from_target(shell_command)
+    environment_name = await resolve_environment_name(
+        EnvironmentNameRequest.from_target(shell_command),
+        **implicitly(),
     )
 
-    adhoc_result = await Get(
-        AdhocProcessResult,
-        {
-            environment_name: EnvironmentName,
-            ShellCommandProcessFromTargetRequest(
-                shell_command
-            ): ShellCommandProcessFromTargetRequest,
-        },
+    adhoc_result = await convert_fallible_adhoc_process_result(
+        **implicitly(
+            {
+                environment_name: EnvironmentName,
+                ShellCommandProcessFromTargetRequest(
+                    shell_command
+                ): ShellCommandProcessFromTargetRequest,
+            }
+        )
     )
 
-    output = await Get(Snapshot, Digest, adhoc_result.adjusted_digest)
+    output = await digest_to_snapshot(adhoc_result.adjusted_digest)
     return GeneratedSources(output)
 
 
@@ -283,9 +292,9 @@ async def _interactive_shell_command(
 
 @rule
 async def run_shell_command_request(bash: BashBinary, shell_command: RunShellCommand) -> RunRequest:
-    wrapped_tgt = await Get(
-        WrappedTarget,
+    wrapped_tgt = await resolve_target(
         WrappedTargetRequest(shell_command.address, description_of_origin="<infallible>"),
+        **implicitly(),
     )
     process = await _interactive_shell_command(wrapped_tgt.target, bash)
     return RunRequest(

--- a/src/python/pants/backend/shell/util_rules/shell_command.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command.py
@@ -42,7 +42,6 @@ from pants.core.util_rules.adhoc_process_support import (
     convert_fallible_adhoc_process_result,
     merge_extra_sandbox_contents,
     parse_relative_directory,
-    prepare_adhoc_process,
     prepare_env_vars,
     resolve_execution_environment,
 )
@@ -52,7 +51,6 @@ from pants.core.util_rules.environments import (
     EnvironmentTarget,
     resolve_environment_name,
 )
-from pants.core.util_rules.system_binaries import BashBinary, BinaryShims, BinaryShimsRequest
 from pants.core.util_rules.system_binaries import (
     BashBinary,
     BinaryShimsRequest,
@@ -64,7 +62,6 @@ from pants.engine.internals.graph import resolve_target
 from pants.engine.internals.native_engine import EMPTY_DIGEST
 from pants.engine.intrinsics import digest_to_snapshot
 from pants.engine.process import Process
-from pants.engine.rules import Get, collect_rules, implicitly, rule
 from pants.engine.rules import collect_rules, implicitly, rule
 from pants.engine.target import (
     GeneratedSources,

--- a/src/python/pants/backend/shell/util_rules/shell_command.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command.py
@@ -77,12 +77,15 @@ class ShellCommandProcessFromTargetRequest:
     target: Target
 
 
-async def _prepare_process_request_from_target(
-    shell_command: Target,
+@rule
+async def prepare_process_request_from_target(
+    request: ShellCommandProcessFromTargetRequest,
     shell_setup: ShellSetup.EnvironmentAware,
     bash: BashBinary,
     env_target: EnvironmentTarget,
 ) -> AdhocProcessRequest:
+    shell_command = request.target
+
     description = f"the `{shell_command.alias}` at `{shell_command.address}`"
 
     working_directory = shell_command[ShellCommandWorkdirField].value
@@ -201,29 +204,6 @@ async def _prepare_process_request_from_target(
         outputs_match_error_behavior=outputs_match_mode.glob_match_error_behavior,
         outputs_match_conjunction=outputs_match_mode.glob_expansion_conjunction,
     )
-
-
-@rule
-async def run_adhoc_result_from_target(
-    request: ShellCommandProcessFromTargetRequest,
-    shell_setup: ShellSetup.EnvironmentAware,
-    bash: BashBinary,
-    env_target: EnvironmentTarget,
-) -> AdhocProcessResult:
-    scpr = await _prepare_process_request_from_target(request.target, shell_setup, bash, env_target)
-    return await Get(AdhocProcessResult, AdhocProcessRequest, scpr)
-
-
-@rule
-async def prepare_process_request_from_target(
-    request: ShellCommandProcessFromTargetRequest,
-    shell_setup: ShellSetup.EnvironmentAware,
-    bash: BashBinary,
-    env_target: EnvironmentTarget,
-) -> Process:
-    # Needed to support `experimental_test_shell_command`
-    scpr = await _prepare_process_request_from_target(request.target, shell_setup, bash, env_target)
-    return await Get(Process, AdhocProcessRequest, scpr)
 
 
 class RunShellCommand(RunFieldSet):

--- a/src/python/pants/backend/shell/util_rules/shell_command_test.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command_test.py
@@ -27,7 +27,10 @@ from pants.core.goals.run import RunRequest
 from pants.core.target_types import ArchiveTarget, FilesGeneratorTarget, FileSourceField
 from pants.core.target_types import rules as core_target_type_rules
 from pants.core.util_rules import archive, source_files
-from pants.core.util_rules.adhoc_process_support import AdhocProcessRequest
+from pants.core.util_rules.adhoc_process_support import (
+    AdhocProcessRequest,
+    PreparedAdhocProcessRequest,
+)
 from pants.core.util_rules.environments import LocalWorkspaceEnvironmentTarget
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
@@ -35,7 +38,7 @@ from pants.engine.environment import EnvironmentName
 from pants.engine.fs import EMPTY_SNAPSHOT, DigestContents
 from pants.engine.internals.native_engine import IntrinsicError
 from pants.engine.internals.scheduler import ExecutionError
-from pants.engine.process import Process, ProcessExecutionFailure
+from pants.engine.process import ProcessExecutionFailure
 from pants.engine.target import (
     GeneratedSources,
     GenerateSourcesRequest,
@@ -55,8 +58,10 @@ def rule_runner() -> RuleRunner:
             *source_files.rules(),
             *core_target_type_rules(),
             QueryRule(GeneratedSources, [GenerateFilesFromShellCommandRequest]),
-            QueryRule(Process, [AdhocProcessRequest]),
-            QueryRule(Process, [EnvironmentName, ShellCommandProcessFromTargetRequest]),
+            QueryRule(PreparedAdhocProcessRequest, [AdhocProcessRequest]),
+            QueryRule(
+                PreparedAdhocProcessRequest, [EnvironmentName, ShellCommandProcessFromTargetRequest]
+            ),
             QueryRule(RunRequest, [RunShellCommand]),
             QueryRule(SourceFiles, [SourceFilesRequest]),
             QueryRule(TransitiveTargets, [TransitiveTargetsRequest]),
@@ -617,7 +622,10 @@ def test_shell_command_boot_script(rule_runner: RuleRunner) -> None:
     )
 
     tgt = rule_runner.get_target(Address("src", target_name="boot-script-test"))
-    res = rule_runner.request(Process, [ShellCommandProcessFromTargetRequest(tgt)])
+    prepred_request = rule_runner.request(
+        PreparedAdhocProcessRequest, [ShellCommandProcessFromTargetRequest(tgt)]
+    )
+    res = prepred_request.process
     assert "bash" in res.argv[0]
     assert res.argv[1] == "-c"
     assert res.argv[2].startswith("cd src &&")
@@ -645,7 +653,10 @@ def test_shell_command_boot_script_in_build_root(rule_runner: RuleRunner) -> Non
     )
 
     tgt = rule_runner.get_target(Address("", target_name="boot-script-test"))
-    res = rule_runner.request(Process, [ShellCommandProcessFromTargetRequest(tgt)])
+    prepared_request = rule_runner.request(
+        PreparedAdhocProcessRequest, [ShellCommandProcessFromTargetRequest(tgt)]
+    )
+    res = prepared_request.process
     assert "bash" in res.argv[0]
     assert res.argv[1] == "-c"
     assert "bash -c" in res.argv[2]


### PR DESCRIPTION
To better support downstream rules, refactor the adhoc process rules to insert "preparation" of requests so that a downstream user can inspect the generated `Process` dataclass while still retaining the ability to use the adhoc process rules to execute that `AdhocProcessRequest` with the prepared `Process`.