### PR TITLE
shell: support `runnable_dependencies` for `experimental_test_shell_command`

### DIFF
--- a/docs/notes/2.26.x.md
+++ b/docs/notes/2.26.x.md
@@ -67,6 +67,8 @@ The Pants repo now uses Ruff format in lieu of Black. This was not a drop-in rep
 
 The `experiemental_test_shell_command` target type may now be used with the `test` goal's `--debug` flag to execute the test interactively.
 
+The `experiemental_test_shell_command` target type now supports the same `runnable_dependencies` field already supported by the `shell_command` target type.
+
 #### Terraform
 
 For the `tfsec` linter, the deprecation of support for leading `v`s in the `version` and `known_versions` field has expired and been removed. Write `1.28.13` instead of `v1.28.13`.

--- a/src/python/pants/backend/shell/goals/test_test.py
+++ b/src/python/pants/backend/shell/goals/test_test.py
@@ -86,8 +86,8 @@ def test_shell_command_as_test(rule_runner: RuleRunner) -> None:
 
                 # Check whether `runnable_dependencies` works.
                 system_binary(
-                    name="sed",
-                    binary_name="sed",
+                    name="cat",
+                    binary_name="cat",
                 )
                 system_binary(
                     name="test",
@@ -98,8 +98,8 @@ def test_shell_command_as_test(rule_runner: RuleRunner) -> None:
                   name="pass_with_runnable_dependency",
                   execution_dependencies=[":msg-gen", ":src"],
                   tools=["echo"],
-                  runnable_dependencies=[":sed", ":test"],
-                  command="value=$(sed -e 's/ss/SS/;' < msg.txt) && test $value = meSSage",
+                  runnable_dependencies=[":cat", ":test"],
+                  command="value=$(cat msg.txt) && test $value = message",
                 )
                 """
             ),

--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -490,6 +490,7 @@ class ShellCommandTestTarget(Target):
     core_fields = (
         *COMMON_TARGET_FIELDS,
         ShellCommandTestDependenciesField,
+        ShellCommandRunnableDependenciesField,
         ShellCommandCommandField,
         ShellCommandLogOutputField,
         ShellCommandSourcesField,


### PR DESCRIPTION
The `runnable_dependencies` field on the `shell_command` target type was inadvertently omitted from `experimental_test_shell_command`. Add it to correct the omission.