### PR TITLE
[Call-by-name] Rust, Visibility, Tools backends

### DIFF
--- a/docs/notes/2.26.x.md
+++ b/docs/notes/2.26.x.md
@@ -36,6 +36,7 @@ Pants has a new mechanism for `@rule` invocation in backends. In this release th
 - [docformatter](https://www.pantsbuild.org/stable/reference/subsystems/docformatter)
 - [flake8](https://www.pantsbuild.org/stable/reference/subsystems/flake8)
 - [isort](https://www.pantsbuild.org/stable/reference/subsystems/isort)
+- [preamble](https://www.pantsbuild.org/stable/reference/subsystems/preamble)
 - [pydocstyle](https://www.pantsbuild.org/stable/reference/subsystems/pydocstyle)
 - [pyoxidizer](https://www.pantsbuild.org/stable/reference/subsystems/pyoxidizer)
 - [pyright](https://www.pantsbuild.org/stable/reference/subsystems/pyright)

--- a/docs/notes/2.26.x.md
+++ b/docs/notes/2.26.x.md
@@ -47,6 +47,7 @@ Pants has a new mechanism for `@rule` invocation in backends. In this release th
 - [shell](https://www.pantsbuild.org/stable/docs/shell) (including [adhoc_tool](https://www.pantsbuild.org/stable/reference/targets/adhoc_tool))
 - [stevedore](https://www.pantsbuild.org/stable/reference/build-file-symbols/stevedore_namespace)
 - [taplo](https://www.pantsbuild.org/stable/reference/subsystems/taplo)
+- [visibility](https://www.pantsbuild.org/stable/reference/subsystems/visibility)
 - [yapf](https://www.pantsbuild.org/stable/reference/subsystems/yapf)
 
 ### Goals

--- a/docs/notes/2.26.x.md
+++ b/docs/notes/2.26.x.md
@@ -45,6 +45,7 @@ Pants has a new mechanism for `@rule` invocation in backends. In this release th
 - [ruff](https://www.pantsbuild.org/stable/reference/subsystems/ruff)
 - [shell](https://www.pantsbuild.org/stable/docs/shell) (including [adhoc_tool](https://www.pantsbuild.org/stable/reference/targets/adhoc_tool))
 - [stevedore](https://www.pantsbuild.org/stable/reference/build-file-symbols/stevedore_namespace)
+- [taplo](https://www.pantsbuild.org/stable/reference/subsystems/taplo)
 - [yapf](https://www.pantsbuild.org/stable/reference/subsystems/yapf)
 
 ### Goals

--- a/docs/notes/2.26.x.md
+++ b/docs/notes/2.26.x.md
@@ -43,6 +43,7 @@ Pants has a new mechanism for `@rule` invocation in backends. In this release th
 - [pytype](https://www.pantsbuild.org/stable/reference/subsystems/pytype)
 - [pyupgrade](https://www.pantsbuild.org/stable/reference/subsystems/pyupgrade)
 - [ruff](https://www.pantsbuild.org/stable/reference/subsystems/ruff)
+- [rust](https://www.pantsbuild.org/stable/reference/subsystems/rust)
 - [shell](https://www.pantsbuild.org/stable/docs/shell) (including [adhoc_tool](https://www.pantsbuild.org/stable/reference/targets/adhoc_tool))
 - [stevedore](https://www.pantsbuild.org/stable/reference/build-file-symbols/stevedore_namespace)
 - [taplo](https://www.pantsbuild.org/stable/reference/subsystems/taplo)

--- a/src/python/pants/backend/rust/util_rules/toolchains.py
+++ b/src/python/pants/backend/rust/util_rules/toolchains.py
@@ -11,15 +11,15 @@ from pants.backend.rust.subsystems.rust import RustSubsystem
 from pants.core.util_rules.system_binaries import (
     BinaryPath,
     BinaryPathRequest,
-    BinaryPaths,
     BinaryPathTest,
+    find_binary,
 )
-from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
+from pants.engine.env_vars import EnvironmentVarsRequest
 from pants.engine.internals.native_engine import Digest
-from pants.engine.internals.selectors import Get
+from pants.engine.internals.platform_rules import environment_vars_subset
 from pants.engine.platform import Platform
-from pants.engine.process import Process, ProcessCacheScope, ProcessResult
-from pants.engine.rules import collect_rules, rule
+from pants.engine.process import Process, ProcessCacheScope, execute_process_or_raise
+from pants.engine.rules import Rule, collect_rules, implicitly, rule
 from pants.util.logging import LogLevel
 
 
@@ -64,13 +64,13 @@ class RustToolchainProcess:
 
 @rule
 async def find_rustup(rust_subsystem: RustSubsystem) -> RustupBinary:
-    env = await Get(EnvironmentVars, EnvironmentVarsRequest(["PATH"]))
+    env = await environment_vars_subset(**implicitly(EnvironmentVarsRequest(["PATH"])))
     request = BinaryPathRequest(
         binary_name="rustup",
         search_path=rust_subsystem.rustup_search_paths(env),
         test=BinaryPathTest(args=["-V"]),
     )
-    paths = await Get(BinaryPaths, BinaryPathRequest, request)
+    paths = await find_binary(request, **implicitly())
     first_path = paths.first_path_or_raise(request, rationale="invoke rustup, rust installer")
     return RustupBinary(first_path.path, first_path.fingerprint)
 
@@ -84,26 +84,32 @@ class RustBinaryPathRequest:
 async def rust_binary_path(
     request: RustBinaryPathRequest, rustup: RustupBinary, rust_subsystem: RustSubsystem
 ) -> BinaryPath:
-    which_result = await Get(
-        ProcessResult,
-        Process(
-            argv=(rustup.path, "which", f"--toolchain={rust_subsystem.toolchain}", request.binary),
-            description=f"Find path to Rust binary `{request.binary}` in toolchain `{rust_subsystem.toolchain}`",
-        ),
+    which_result = await execute_process_or_raise(
+        **implicitly(
+            Process(
+                argv=(
+                    rustup.path,
+                    "which",
+                    f"--toolchain={rust_subsystem.toolchain}",
+                    request.binary,
+                ),
+                description=f"Find path to Rust binary `{request.binary}` in toolchain `{rust_subsystem.toolchain}`",
+            )
+        )
     )
     binary_full_path = which_result.stdout.decode().strip()
     binary_path_request = BinaryPathRequest(
         binary_name=os.path.basename(binary_full_path),
         search_path=[os.path.dirname(binary_full_path)],
     )
-    paths = await Get(BinaryPaths, BinaryPathRequest, binary_path_request)
+    paths = await find_binary(binary_path_request, **implicitly())
     binary_path = paths.first_path_or_raise(binary_path_request, rationale="invoke Rust")
     return binary_path
 
 
 @rule
 async def rust_toolchain_process(request: RustToolchainProcess) -> Process:
-    binary_path = await Get(BinaryPath, RustBinaryPathRequest(request.binary))
+    binary_path = await rust_binary_path(RustBinaryPathRequest(request.binary), **implicitly())
     return Process(
         argv=[binary_path.path, *request.args],
         description=request.description,
@@ -115,5 +121,5 @@ async def rust_toolchain_process(request: RustToolchainProcess) -> Process:
     )
 
 
-def rules():
+def rules() -> Iterable[Rule]:
     return collect_rules()

--- a/src/python/pants/backend/tools/taplo/rules.py
+++ b/src/python/pants/backend/tools/taplo/rules.py
@@ -6,12 +6,13 @@ from typing import Any
 from pants.backend.tools.taplo.subsystem import Taplo
 from pants.core.goals.fmt import FmtFilesRequest, FmtResult, Partitions
 from pants.core.goals.resolves import ExportableTool
-from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
-from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
-from pants.engine.fs import Digest, MergeDigests
+from pants.core.util_rules.config_files import find_config_file
+from pants.core.util_rules.external_tool import download_external_tool
+from pants.engine.fs import MergeDigests
+from pants.engine.intrinsics import merge_digests
 from pants.engine.platform import Platform
-from pants.engine.process import Process, ProcessResult
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.process import Process, execute_process_or_raise
+from pants.engine.rules import collect_rules, concurrently, implicitly, rule
 from pants.engine.unions import UnionRule
 from pants.source.filespec import FilespecMatcher
 from pants.util.logging import LogLevel
@@ -43,40 +44,38 @@ async def partition_inputs(
 
 @rule(desc="Format with taplo", level=LogLevel.DEBUG)
 async def taplo_fmt(request: TaploFmtRequest.Batch, taplo: Taplo, platform: Platform) -> FmtResult:
-    download_taplo_get = Get(
-        DownloadedExternalTool,
-        ExternalToolRequest,
-        taplo.get_request(platform),
-    )
-    config_files_get = Get(ConfigFiles, ConfigFilesRequest, taplo.config_request())
-    downloaded_taplo, config_digest = await MultiGet(download_taplo_get, config_files_get)
-    input_digest = await Get(
-        Digest,
+    download_taplo_get = download_external_tool(taplo.get_request(platform))
+    config_files_get = find_config_file(taplo.config_request())
+    downloaded_taplo, config_digest = await concurrently(download_taplo_get, config_files_get)
+    input_digest = await merge_digests(
         MergeDigests(
             (request.snapshot.digest, downloaded_taplo.digest, config_digest.snapshot.digest)
-        ),
+        )
     )
-    argv = [
+
+    argv = (
         downloaded_taplo.exe,
         "fmt",
         *taplo.args,
         *request.files,
-    ]
-    process = Process(
-        argv=argv,
-        input_digest=input_digest,
-        output_files=request.files,
-        description=f"Run taplo on {pluralize(len(request.files), 'file')}.",
-        level=LogLevel.DEBUG,
     )
-
-    result = await Get(ProcessResult, Process, process)
+    result = await execute_process_or_raise(
+        **implicitly(
+            Process(
+                argv=argv,
+                input_digest=input_digest,
+                output_files=request.files,
+                description=f"Run taplo on {pluralize(len(request.files), 'file')}.",
+                level=LogLevel.DEBUG,
+            )
+        )
+    )
     return await FmtResult.create(request, result)
 
 
 def rules():
-    return [
+    return (
         *collect_rules(),
         *TaploFmtRequest.rules(),
         UnionRule(ExportableTool, Taplo),
-    ]
+    )


### PR DESCRIPTION
This is a PR for the call-by-name migration on the Rust, Visibility, and remaining Tools backend.

Tested on https://github.com/sureshjoshi/pantsanity (as much as reasonably possible) via `pants sanity ::`

See issue https://github.com/pantsbuild/pants/issues/21065 for tracking list.