### PR TITLE
migrate `pkg_resources.resource_string` usages to `importlib.resources`

### DIFF
--- a/src/python/pants/backend/java/dependency_inference/java_parser.py
+++ b/src/python/pants/backend/java/dependency_inference/java_parser.py
@@ -3,12 +3,11 @@
 
 from __future__ import annotations
 
+import importlib.resources
 import json
 import logging
 import os.path
 from dataclasses import dataclass
-
-import pkg_resources
 
 from pants.backend.java.dependency_inference.types import JavaSourceDependencyAnalysis
 from pants.core.goals.resolves import ExportableTool
@@ -142,7 +141,8 @@ async def analyze_java_source_dependencies(
 
 
 def _load_javaparser_launcher_source() -> bytes:
-    return pkg_resources.resource_string(__name__, _LAUNCHER_BASENAME)
+    parent_module = ".".join(__name__.split(".")[:-1])
+    return importlib.resources.files(parent_module).joinpath(_LAUNCHER_BASENAME).read_bytes()
 
 
 # TODO(13879): Consolidate compilation of wrapper binaries to common rules.

--- a/src/python/pants/jvm/jar_tool/jar_tool.py
+++ b/src/python/pants/jvm/jar_tool/jar_tool.py
@@ -220,7 +220,7 @@ def _load_jar_tool_sources() -> list[FileContent]:
                 continue
             result.append(
                 FileContent(
-                    path=resource.name,
+                    path=os.path.join(package, resource.name),
                     content=resource.read_bytes(),
                 )
             )

--- a/src/python/pants/jvm/jar_tool/jar_tool.py
+++ b/src/python/pants/jvm/jar_tool/jar_tool.py
@@ -3,12 +3,11 @@
 
 from __future__ import annotations
 
+import importlib.resources
 import os
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from enum import Enum, unique
-
-import pkg_resources
 
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.core.goals.resolves import ExportableTool
@@ -211,17 +210,18 @@ _JAR_TOOL_SRC_PACKAGES = ["args4j", "jar_tool_source"]
 
 
 def _load_jar_tool_sources() -> list[FileContent]:
+    parent_module = ".".join(__name__.split(".")[:-1])
     result = []
     for package in _JAR_TOOL_SRC_PACKAGES:
         # pkg_path = package.replace(".", os.path.sep)
         # relative_folder = os.path.join("src", pkg_path)
-        for basename in pkg_resources.resource_listdir(__name__, package):
+        for resource in importlib.resources.files(parent_module).joinpath(package).iterdir():
+            if not resource.is_file():
+                continue
             result.append(
                 FileContent(
-                    path=os.path.join(package, basename),
-                    content=pkg_resources.resource_string(
-                        __name__, os.path.join(package, basename)
-                    ),
+                    path=resource.name,
+                    content=resource.read_bytes(),
                 )
             )
     return result

--- a/src/python/pants/jvm/strip_jar/strip_jar.py
+++ b/src/python/pants/jvm/strip_jar/strip_jar.py
@@ -1,9 +1,8 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import importlib.resources
 from dataclasses import dataclass
-
-import pkg_resources
 
 from pants.core.goals.resolves import ExportableTool
 from pants.engine.fs import AddPrefix, CreateDigest, Digest, Directory, FileContent
@@ -97,7 +96,8 @@ async def strip_jar(
 
 
 def _load_strip_jar_source() -> bytes:
-    return pkg_resources.resource_string(__name__, _STRIP_JAR_BASENAME)
+    parent_module = ".".join(__name__.split(".")[:-1])
+    return importlib.resources.files(parent_module).joinpath(_STRIP_JAR_BASENAME).read_bytes()
 
 
 # TODO(13879): Consolidate compilation of wrapper binaries to common rules.


### PR DESCRIPTION
Migrate `pkg_resources.resource_string` usages to use the `importlib.resources` API instead.

Part of https://github.com/pantsbuild/pants/issues/22030.