### PR TITLE
New `python_format_string` codegen for kubernetes

### DIFF
--- a/docs/docs/kubernetes/index.mdx
+++ b/docs/docs/kubernetes/index.mdx
@@ -187,12 +187,25 @@ python_format_string(
 k8s_bundle(
     name="webpages",
     context="kind-kind",
-    **parametrize("default", sources=("src/k8s:webpages-template@parametrize=web",)),
+    **parametrize("default", sources=("src/k8s:webpages-template@parametrize=default",)),
     **parametrize("web", sources=("src/k8s:webpages-template@parametrize=web",)),
 )
 ```
 
 ## Docker images
+
+Before we continue, add the docker backend:
+
+```toml title="pants.toml"
+[GLOBAL]
+backend_packages = [
+  ...
+  "pants.backend.docker",
+]
+
+[dockerfile-parser]
+use_rust_parser = true
+```
 
 To use docker images you most likely will need some templating. This is because
 your docker image tags will be probably versioned.
@@ -212,11 +225,60 @@ This script will run before every pants command, so you can now use the
 `VERSION` env var in the BUILD file:
 
 ```python title="src/k8s/BUILD"
+...
 docker_image(
-    name="nginx",
+    name="custom-nginx",
     instructions=["FROM nginx"],
     image_tags=[env("VERSION")],
 )
-# TODO
+python_format_string(
+    name="webserver-template",
+    source="deployment.yaml",
+    values={"VERSION": env("VERSION")},
+)
+k8s_bundle(
+    name="webserver",
+    context="kind-kind",
+    sources=("src/k8s:webserver-template",),
+    dependencies=(":custom-nginx",),
+)
 ```
 
+Create the deployment:
+
+```yaml title="src/k8s/deployment.yaml"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: webserver
+  namespace: web
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: webserver
+  template:
+    metadata:
+      labels:
+        app: webserver
+    spec:
+      containers:
+        - name: nginx
+          image: custom-nginx:{VERSION}
+```
+
+Now deploy the bundle:
+
+```bash
+pants experimental-deploy src/k8s:webserver
+```
+
+Notice, that pants will automatically publish the image. This happens because
+we've configured `dependencies=(":custom-nginx",)` field on `k8s_bundle`
+target. You can disable this behaviour and publish the image manually:
+
+```bash
+pants publish src/k8s:custom-nginx
+pants experimental-deploy --no-publish-dependencies src/k8s:webserver
+```

--- a/docs/docs/kubernetes/index.mdx
+++ b/docs/docs/kubernetes/index.mdx
@@ -113,3 +113,61 @@ which will only have access to a single context, set the
 `[kubectl].pass_context` to false in `pants.toml` to have them use their
 default context.
 :::
+
+## Simple templates
+
+To use docker images you most likely will need some templating. This is because
+your docker image tags will be probably versioned. The simplest way to
+introduce templating is to use `python_format_string` target that will generate
+`k8s_sources` based on values you provide in the BUILD file.
+
+First, add the codegen backend:
+
+```toml title="pants.toml"
+backend_packages = [
+    ...
+    "pants.backend.experimental.k8s",
+    "pants.backend.experimental.codegen.python_format_string",
+    "pants.backend.experimental.codegen.python_format_string.k8s",
+    ...
+]
+```
+
+Then parametrize the yaml using python format string syntax:
+
+```yaml title="src/k8s/webpages.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: webpages
+  namespace: {namespace}
+data:
+  index.html: |
+    <html>
+      <head>Hello pants!</head>
+      <body>Hello pants!</body>
+    </html>
+```
+
+Now replace `k8s_sources` with a `python_format_string` target and pass the
+namespace value:
+
+```python title="src/k8s/BUILD"
+python_format_string(
+    name="webpages-template",
+    source="webpages.yaml",
+    values={"namespace": "web"},
+)
+k8s_bundle(
+    name="webpages",
+    sources=("src/k8s:webpages-template",),
+    context="kind-kind",
+)
+```
+
+Now you can deploy the bundle:
+
+```bash
+pants experimental-deploy src/k8s/:webpages
+```

--- a/docs/docs/kubernetes/index.mdx
+++ b/docs/docs/kubernetes/index.mdx
@@ -129,7 +129,6 @@ backend_packages = [
     "pants.backend.experimental.k8s",
     "pants.backend.experimental.codegen.python_format_string",
     "pants.backend.experimental.codegen.python_format_string.k8s",
-    ...
 ]
 ```
 

--- a/docs/docs/kubernetes/index.mdx
+++ b/docs/docs/kubernetes/index.mdx
@@ -116,10 +116,10 @@ default context.
 
 ## Simple templates
 
-To use docker images you most likely will need some templating. This is because
-your docker image tags will be probably versioned. The simplest way to
-introduce templating is to use `python_format_string` target that will generate
-`k8s_sources` based on values you provide in the BUILD file.
+At some point, you may need to inject variables from a BUILD file into
+Kubernetes resources — also known as templating. The simplest way to achieve
+this is by using the `python_format_string` target, which generates
+`k8s_sources` by substituting the values you specify in the BUILD file.
 
 First, add the codegen backend:
 
@@ -133,7 +133,8 @@ backend_packages = [
 ]
 ```
 
-Then parametrize the yaml using python format string syntax:
+Then parametrize the yaml using python format string syntax, e.g. the
+namespace:
 
 ```yaml title="src/k8s/webpages.yaml
 ---
@@ -171,3 +172,51 @@ Now you can deploy the bundle:
 ```bash
 pants experimental-deploy src/k8s/:webpages
 ```
+
+This setup can now be used to deploy the same resource to multiple namespaces
+with [`parametrize`
+builtin](../using-pants/key-concepts/targets-and-build-files.mdx#parametrizing-targets):
+
+```python title="src/k8s/BUILD"
+python_format_string(
+    name="webpages-template",
+    source="webpages.yaml",
+    **parametrize("default", values={"namespace": "default"}),
+    **parametrize("web", values={"namespace": "web"}),
+)
+k8s_bundle(
+    name="webpages",
+    context="kind-kind",
+    **parametrize("default", sources=("src/k8s:webpages-template@parametrize=web",)),
+    **parametrize("web", sources=("src/k8s:webpages-template@parametrize=web",)),
+)
+```
+
+## Docker images
+
+To use docker images you most likely will need some templating. This is because
+your docker image tags will be probably versioned.
+
+You might want to use git to generate the version for your images, but you
+can't directly run git commands in a BUILD file. You can use a
+`.pants.bootstrap` file as a workaround:
+
+```python title=".pants.bootstrap"
+#!/bin/sh
+
+VERSION="${VERSION:-$(git describe --tags --dirty --match "[0-9\.]*" || echo 0.0.1)}"
+export VERSION
+```
+
+This script will run before every pants command, so you can now use the
+`VERSION` env var in the BUILD file:
+
+```python title="src/k8s/BUILD"
+docker_image(
+    name="nginx",
+    instructions=["FROM nginx"],
+    image_tags=[env("VERSION")],
+)
+# TODO
+```
+

--- a/docs/notes/2.26.x.md
+++ b/docs/notes/2.26.x.md
@@ -14,6 +14,8 @@ Thank you to [Klaviyo](https://www.klaviyo.com/) and [Normal Computing](https://
 
 New kubernetes backend! See [docs](https://www.pantsbuild.org/stable/docs/kubernetes) for details.
 
+New `python_format_string` codegen for the kubernetes backend! See [docs](https://www.pantsbuild.org/stable/docs/kubernetes) for details.
+
 ### Remote caching/execution
 
 - Remote cache: `FindMissingBlobsRequest` will now make multiple request if the number of files is large. (https://github.com/pantsbuild/pants/pull/20708)

--- a/src/python/pants/backend/codegen/python_format_string/BUILD
+++ b/src/python/pants/backend/codegen/python_format_string/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/src/python/pants/backend/codegen/python_format_string/BUILD
+++ b/src/python/pants/backend/codegen/python_format_string/BUILD
@@ -1,1 +1,3 @@
+# Copyright 2025 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
 python_sources()

--- a/src/python/pants/backend/codegen/python_format_string/k8s/BUILD
+++ b/src/python/pants/backend/codegen/python_format_string/k8s/BUILD
@@ -1,0 +1,2 @@
+python_sources()
+python_tests(name="tests")

--- a/src/python/pants/backend/codegen/python_format_string/k8s/BUILD
+++ b/src/python/pants/backend/codegen/python_format_string/k8s/BUILD
@@ -1,2 +1,4 @@
+# Copyright 2025 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
 python_sources()
 python_tests(name="tests")

--- a/src/python/pants/backend/codegen/python_format_string/k8s/generate_k8s_source.py
+++ b/src/python/pants/backend/codegen/python_format_string/k8s/generate_k8s_source.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from pants.engine.fs import CreateDigest, Digest, DigestContents, FileContent, Snapshot
+from pants.engine.rules import Get, collect_rules, rule
+from pants.engine.target import (
+    GeneratedSources,
+    GenerateSourcesRequest,
+    HydratedSources,
+    HydrateSourcesRequest,
+)
+from pants.engine.unions import UnionRule
+
+from experimental.codegen.python_format_string.target_types import (
+    PythonFormatStringOutputPathField,
+    PythonFormatStringSourceField,
+    PythonFormatStringValuesField,
+)
+from experimental.k8s.targets import K8sSourceField
+
+
+class GenerateK8sSourceFromPythonFormatStringRequest(GenerateSourcesRequest):
+    input = PythonFormatStringSourceField
+    output = K8sSourceField
+
+
+@rule
+async def generate_k8s_source(request: GenerateK8sSourceFromPythonFormatStringRequest) -> GeneratedSources:
+    format_string_target = request.protocol_target
+    hydrated_sources = await Get(
+        HydratedSources, HydrateSourcesRequest(format_string_target[PythonFormatStringSourceField])
+    )
+
+    if len(hydrated_sources.snapshot.files) != 1:
+        raise ValueError(f"Expected single source, got {hydrated_sources.snapshot.files}")
+
+    values = format_string_target[PythonFormatStringValuesField].value
+    if values is None:
+        raise ValueError(f"`{PythonFormatStringValuesField.alias}` is required")
+
+    contents = await Get(DigestContents, Digest, hydrated_sources.snapshot.digest)
+    content = contents[0].content.decode("utf-8")
+    try:
+        rendered = content.format(**values)
+    except KeyError as e:
+        raise ValueError(
+            f"missing key in target `{format_string_target.address}`: {e}, provided values: {values}"
+        ) from e
+    except IndexError as e:
+        raise ValueError(f"failed to render target `{format_string_target.address}`") from e
+
+    path = format_string_target[PythonFormatStringOutputPathField].value_or_default(file_ending="rendered")
+    snapshot = await Get(
+        Snapshot,
+        CreateDigest([FileContent(path=path, content=rendered.encode("utf-8"))]),
+    )
+    return GeneratedSources(snapshot)
+
+
+def rules():
+    return (
+        *collect_rules(),
+        UnionRule(GenerateSourcesRequest, GenerateK8sSourceFromPythonFormatStringRequest),
+    )

--- a/src/python/pants/backend/codegen/python_format_string/k8s/register.py
+++ b/src/python/pants/backend/codegen/python_format_string/k8s/register.py
@@ -1,5 +1,0 @@
-from . import generate_k8s_source
-
-
-def rules():
-    return (*generate_k8s_source.rules(),)

--- a/src/python/pants/backend/codegen/python_format_string/k8s/register.py
+++ b/src/python/pants/backend/codegen/python_format_string/k8s/register.py
@@ -1,0 +1,5 @@
+from . import generate_k8s_source
+
+
+def rules():
+    return (*generate_k8s_source.rules(),)

--- a/src/python/pants/backend/codegen/python_format_string/k8s/rules.py
+++ b/src/python/pants/backend/codegen/python_format_string/k8s/rules.py
@@ -2,6 +2,12 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from __future__ import annotations
 
+from pants.backend.codegen.python_format_string.target_types import (
+    PythonFormatStringOutputPathField,
+    PythonFormatStringSourceField,
+    PythonFormatStringValuesField,
+)
+from pants.backend.k8s.target_types import K8sSourceField
 from pants.engine.fs import CreateDigest, Digest, DigestContents, FileContent, Snapshot
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import (
@@ -12,13 +18,6 @@ from pants.engine.target import (
 )
 from pants.engine.unions import UnionRule
 
-from pants.backend.codegen.python_format_string.target_types import (
-    PythonFormatStringOutputPathField,
-    PythonFormatStringSourceField,
-    PythonFormatStringValuesField,
-)
-from pants.backend.k8s.target_types import K8sSourceField
-
 
 class GenerateK8sSourceFromPythonFormatStringRequest(GenerateSourcesRequest):
     input = PythonFormatStringSourceField
@@ -26,7 +25,9 @@ class GenerateK8sSourceFromPythonFormatStringRequest(GenerateSourcesRequest):
 
 
 @rule
-async def generate_k8s_source(request: GenerateK8sSourceFromPythonFormatStringRequest) -> GeneratedSources:
+async def generate_k8s_source(
+    request: GenerateK8sSourceFromPythonFormatStringRequest,
+) -> GeneratedSources:
     format_string_target = request.protocol_target
     hydrated_sources = await Get(
         HydratedSources, HydrateSourcesRequest(format_string_target[PythonFormatStringSourceField])
@@ -50,7 +51,9 @@ async def generate_k8s_source(request: GenerateK8sSourceFromPythonFormatStringRe
     except IndexError as e:
         raise ValueError(f"Failed to render target `{format_string_target.address}`") from e
 
-    path = format_string_target[PythonFormatStringOutputPathField].value_or_default(file_ending="rendered")
+    path = format_string_target[PythonFormatStringOutputPathField].value_or_default(
+        file_ending="rendered"
+    )
     snapshot = await Get(
         Snapshot,
         CreateDigest([FileContent(path=path, content=rendered.encode("utf-8"))]),

--- a/src/python/pants/backend/codegen/python_format_string/k8s/rules.py
+++ b/src/python/pants/backend/codegen/python_format_string/k8s/rules.py
@@ -1,3 +1,5 @@
+# Copyright 2025 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
 from __future__ import annotations
 
 from pants.engine.fs import CreateDigest, Digest, DigestContents, FileContent, Snapshot
@@ -10,12 +12,12 @@ from pants.engine.target import (
 )
 from pants.engine.unions import UnionRule
 
-from experimental.codegen.python_format_string.target_types import (
+from pants.backend.codegen.python_format_string.target_types import (
     PythonFormatStringOutputPathField,
     PythonFormatStringSourceField,
     PythonFormatStringValuesField,
 )
-from experimental.k8s.targets import K8sSourceField
+from pants.backend.k8s.target_types import K8sSourceField
 
 
 class GenerateK8sSourceFromPythonFormatStringRequest(GenerateSourcesRequest):
@@ -43,10 +45,10 @@ async def generate_k8s_source(request: GenerateK8sSourceFromPythonFormatStringRe
         rendered = content.format(**values)
     except KeyError as e:
         raise ValueError(
-            f"missing key in target `{format_string_target.address}`: {e}, provided values: {values}"
+            f"Missing key in target `{format_string_target.address}`: {e}, provided values: {values}"
         ) from e
     except IndexError as e:
-        raise ValueError(f"failed to render target `{format_string_target.address}`") from e
+        raise ValueError(f"Failed to render target `{format_string_target.address}`") from e
 
     path = format_string_target[PythonFormatStringOutputPathField].value_or_default(file_ending="rendered")
     snapshot = await Get(

--- a/src/python/pants/backend/codegen/python_format_string/k8s/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/python_format_string/k8s/rules_integration_test.py
@@ -1,20 +1,22 @@
-from pants.backend.codegen.python_format_string.target_types import (
-    PythonFormatStringSourceField,
-    PythonFormatStringTarget,
-)
+# Copyright 2025 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
 from textwrap import dedent
+
+import pytest
+
 from pants.backend.codegen.python_format_string.k8s import rules as k8s_rules
 from pants.backend.codegen.python_format_string.k8s.rules import (
     GenerateK8sSourceFromPythonFormatStringRequest,
 )
+from pants.backend.codegen.python_format_string.target_types import (
+    PythonFormatStringSourceField,
+    PythonFormatStringTarget,
+)
 from pants.engine.fs import DigestContents
 from pants.engine.internals.native_engine import Address
 from pants.engine.rules import QueryRule
-from pants.engine.target import GeneratedSources, HydrateSourcesRequest, HydratedSources
+from pants.engine.target import GeneratedSources, HydratedSources, HydrateSourcesRequest
 from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, RuleRunner
-
-
-import pytest
 
 
 @pytest.fixture

--- a/src/python/pants/backend/codegen/python_format_string/k8s/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/python_format_string/k8s/rules_integration_test.py
@@ -1,0 +1,82 @@
+from pants.backend.codegen.python_format_string.target_types import (
+    PythonFormatStringSourceField,
+    PythonFormatStringTarget,
+)
+from textwrap import dedent
+from pants.backend.codegen.python_format_string.k8s import rules as k8s_rules
+from pants.backend.codegen.python_format_string.k8s.rules import (
+    GenerateK8sSourceFromPythonFormatStringRequest,
+)
+from pants.engine.fs import DigestContents
+from pants.engine.internals.native_engine import Address
+from pants.engine.rules import QueryRule
+from pants.engine.target import GeneratedSources, HydrateSourcesRequest, HydratedSources
+from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, RuleRunner
+
+
+import pytest
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    rule_runner = RuleRunner(
+        target_types=[
+            PythonFormatStringTarget,
+        ],
+        rules=[
+            *k8s_rules.rules(),
+            QueryRule(HydratedSources, (HydrateSourcesRequest,)),
+            QueryRule(GeneratedSources, (GenerateK8sSourceFromPythonFormatStringRequest,)),
+        ],
+    )
+    rule_runner.set_options(args=[], env_inherit=PYTHON_BOOTSTRAP_ENV)
+    return rule_runner
+
+
+@pytest.fixture
+def input_files() -> dict[str, str]:
+    return {
+        "BUILD": dedent("""\
+            python_format_string(
+                name="deployment",
+                source="deployment.yaml",
+                values={"VERSION": "1.2.3"}
+            )
+        """),
+        "deployment.yaml": dedent("""\
+            kind: Deployment
+            ...
+            image: my-image:{VERSION}
+        """),
+    }
+
+
+@pytest.fixture
+def expected_files() -> dict[str, str]:
+    return {
+        "deployment.rendered": dedent("""\
+            kind: Deployment
+            ...
+            image: my-image:1.2.3
+        """)
+    }
+
+
+def test_generate_k8s(
+    rule_runner: RuleRunner,
+    input_files: dict[str, str],
+    expected_files: dict[str, str],
+) -> None:
+    rule_runner.write_files(input_files)
+    address = Address("", target_name="deployment")
+    target = rule_runner.get_target(address)
+    protocol_sources = rule_runner.request(
+        HydratedSources, [HydrateSourcesRequest(target[PythonFormatStringSourceField])]
+    )
+    generated_sources = rule_runner.request(
+        GeneratedSources,
+        [GenerateK8sSourceFromPythonFormatStringRequest(protocol_sources.snapshot, target)],
+    )
+    assert generated_sources.snapshot.files == tuple(expected_files)
+    contents = rule_runner.request(DigestContents, [generated_sources.snapshot.digest])
+    assert {f.path: f.content.decode("utf-8") for f in contents} == expected_files

--- a/src/python/pants/backend/codegen/python_format_string/register.py
+++ b/src/python/pants/backend/codegen/python_format_string/register.py
@@ -1,0 +1,9 @@
+from experimental.codegen.python_format_string import target_types as python_format_string_target_types
+
+
+def target_types():
+    return python_format_string_target_types.target_types()
+
+
+def rules():
+    pass

--- a/src/python/pants/backend/codegen/python_format_string/register.py
+++ b/src/python/pants/backend/codegen/python_format_string/register.py
@@ -1,9 +1,0 @@
-from experimental.codegen.python_format_string import target_types as python_format_string_target_types
-
-
-def target_types():
-    return python_format_string_target_types.target_types()
-
-
-def rules():
-    pass

--- a/src/python/pants/backend/codegen/python_format_string/target_types.py
+++ b/src/python/pants/backend/codegen/python_format_string/target_types.py
@@ -1,0 +1,64 @@
+import logging
+from typing import Optional
+
+from pants.core.goals.package import OutputPathField
+from pants.engine.target import (
+    COMMON_TARGET_FIELDS,
+    DictStringToStringField,
+    MultipleSourcesField,
+    SingleSourceField,
+    Target,
+    TargetFilesGenerator,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class PythonFormatStringSourceField(SingleSourceField):
+    pass
+
+
+class PythonFormatStringValuesField(DictStringToStringField):
+    alias = "values"
+    required = True
+
+
+class PythonFormatStringOutputPathField(OutputPathField):
+    def value_or_default(self, *, file_ending: Optional[str]) -> str:
+        if self.address.is_generated_target:
+            if self.address.is_parametrized:
+                return f"{self.address.filename}.{file_ending}{self.address.parameters_repr}"
+            return f"{self.address.filename}.{file_ending}"
+        return super().value_or_default(file_ending=file_ending)
+
+
+class PythonFormatStringTarget(Target):
+    alias = "python_format_string"
+    core_fields = (
+        *COMMON_TARGET_FIELDS,
+        PythonFormatStringSourceField,
+        PythonFormatStringValuesField,
+        PythonFormatStringOutputPathField,
+    )
+
+
+class PythonFormatStringsSourcesField(MultipleSourcesField):
+    pass
+
+
+class PythonFormatStringTargetGenerator(TargetFilesGenerator):
+    alias = "python_format_strings"
+    generated_target_cls = PythonFormatStringTarget
+    core_fields = (
+        *COMMON_TARGET_FIELDS,
+        PythonFormatStringsSourcesField,
+    )
+    copied_fields = COMMON_TARGET_FIELDS
+    moved_fields = (PythonFormatStringValuesField,)
+
+
+def target_types():
+    return (
+        PythonFormatStringTarget,
+        PythonFormatStringTargetGenerator,
+    )

--- a/src/python/pants/backend/codegen/python_format_string/target_types.py
+++ b/src/python/pants/backend/codegen/python_format_string/target_types.py
@@ -1,7 +1,6 @@
 # Copyright 2025 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 import logging
-from typing import Optional
 
 from pants.core.goals.package import OutputPathField
 from pants.engine.target import (
@@ -26,7 +25,7 @@ class PythonFormatStringValuesField(DictStringToStringField):
 
 
 class PythonFormatStringOutputPathField(OutputPathField):
-    def value_or_default(self, *, file_ending: Optional[str]) -> str:
+    def value_or_default(self, *, file_ending: str | None) -> str:
         if self.address.is_generated_target:
             if self.address.is_parametrized:
                 return f"{self.address.filename}.{file_ending}{self.address.parameters_repr}"

--- a/src/python/pants/backend/codegen/python_format_string/target_types.py
+++ b/src/python/pants/backend/codegen/python_format_string/target_types.py
@@ -1,3 +1,5 @@
+# Copyright 2025 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
 import logging
 from typing import Optional
 

--- a/src/python/pants/backend/experimental/codegen/python_format_string/k8s/register.py
+++ b/src/python/pants/backend/experimental/codegen/python_format_string/k8s/register.py
@@ -1,0 +1,7 @@
+# Copyright 2025 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from pants.backend.codegen.python_format_string.k8s import rules as k8s_rules
+
+
+def rules():
+    return k8s_rules.rules()

--- a/src/python/pants/backend/experimental/codegen/python_format_string/register.py
+++ b/src/python/pants/backend/experimental/codegen/python_format_string/register.py
@@ -1,0 +1,7 @@
+# Copyright 2025 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from pants.backend.codegen.python_format_string import target_types as python_format_string_target_types
+
+def target_types():
+    return python_format_string_target_types.target_types()
+


### PR DESCRIPTION
The pr introduces a new `python_format_string` target that takes a python format string as an input and produces the output by substituting the variables into it. Right now it only produces `k8s_sources`, but it can be extended in the future.  

Merge after https://github.com/pantsbuild/pants/pull/22040