### PR TITLE
fix CI "build wheels" step for rustup no longer installing default toolchain

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,6 +37,12 @@ jobs:
       run: 'curl --proto ''=https'' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s --
         -v -y --default-toolchain none
 
+        rustup show active-toolchain || rustup toolchain install
+
+        rustup toolchain install 1.85.0
+
+        cargo version
+
         echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
 
         '
@@ -145,6 +151,12 @@ jobs:
     - name: Install rustup
       run: 'curl --proto ''=https'' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s --
         -v -y --default-toolchain none
+
+        rustup show active-toolchain || rustup toolchain install
+
+        rustup toolchain install 1.85.0
+
+        cargo version
 
         echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,10 @@ jobs:
 
         '
     - name: Install Rust toolchain
-      run: 'rustup toolchain install 1.85.0
+      run: '# Set the default toolchain. Installs the toolchain if it is not already
+        installed.
+
+        rustup default 1.85.0
 
         cargo version
 
@@ -156,7 +159,10 @@ jobs:
 
         '
     - name: Install Rust toolchain
-      run: 'rustup toolchain install 1.85.0
+      run: '# Set the default toolchain. Installs the toolchain if it is not already
+        installed.
+
+        rustup default 1.85.0
 
         cargo version
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,13 +37,13 @@ jobs:
       run: 'curl --proto ''=https'' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s --
         -v -y --default-toolchain none
 
-        rustup show active-toolchain || rustup toolchain install
+        echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
 
-        rustup toolchain install 1.85.0
+        '
+    - name: Install Rust toolchain
+      run: 'rustup toolchain install 1.85.0
 
         cargo version
-
-        echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
 
         '
     - name: Expose Pythons
@@ -152,13 +152,13 @@ jobs:
       run: 'curl --proto ''=https'' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s --
         -v -y --default-toolchain none
 
-        rustup show active-toolchain || rustup toolchain install
+        echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
 
-        rustup toolchain install 1.85.0
+        '
+    - name: Install Rust toolchain
+      run: 'rustup toolchain install 1.85.0
 
         cargo version
-
-        echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
 
         '
     - name: Expose Pythons

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -360,7 +360,9 @@ jobs:
 
         '
     - name: Install Rust toolchain
-      run: 'rustup toolchain install 1.85.0
+      run: '# Set the default toolchain. Installs the toolchain if it is not already installed.
+
+        rustup default 1.85.0
 
         cargo version
 
@@ -436,7 +438,9 @@ jobs:
 
         '
     - name: Install Rust toolchain
-      run: 'rustup toolchain install 1.85.0
+      run: '# Set the default toolchain. Installs the toolchain if it is not already installed.
+
+        rustup default 1.85.0
 
         cargo version
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -356,6 +356,12 @@ jobs:
     - name: Install rustup
       run: 'curl --proto ''=https'' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -v -y --default-toolchain none
 
+        rustup show active-toolchain || rustup toolchain install
+
+        rustup toolchain install 1.85.0
+
+        cargo version
+
         echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
 
         '
@@ -425,6 +431,12 @@ jobs:
       run: git config --global safe.directory "$GITHUB_WORKSPACE"
     - name: Install rustup
       run: 'curl --proto ''=https'' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -v -y --default-toolchain none
+
+        rustup show active-toolchain || rustup toolchain install
+
+        rustup toolchain install 1.85.0
+
+        cargo version
 
         echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -356,13 +356,13 @@ jobs:
     - name: Install rustup
       run: 'curl --proto ''=https'' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -v -y --default-toolchain none
 
-        rustup show active-toolchain || rustup toolchain install
+        echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
 
-        rustup toolchain install 1.85.0
+        '
+    - name: Install Rust toolchain
+      run: 'rustup toolchain install 1.85.0
 
         cargo version
-
-        echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
 
         '
     - name: Expose Pythons
@@ -432,13 +432,13 @@ jobs:
     - name: Install rustup
       run: 'curl --proto ''=https'' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -v -y --default-toolchain none
 
-        rustup show active-toolchain || rustup toolchain install
+        echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
 
-        rustup toolchain install 1.85.0
+        '
+    - name: Install Rust toolchain
+      run: 'rustup toolchain install 1.85.0
 
         cargo version
-
-        echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
 
         '
     - name: Expose Pythons

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -333,7 +333,8 @@ def install_rustup() -> list[Step]:
             "name": "Install Rust toolchain",
             "run": dedent(
                 f"""\
-            rustup toolchain install {rust_channel()}
+            # Set the default toolchain. Installs the toolchain if it is not already installed.
+            rustup default {rust_channel()}
             cargo version
             """
             ),

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -322,9 +322,12 @@ def install_rustup() -> Step:
     return {
         "name": "Install rustup",
         "run": dedent(
-            """\
+            f"""\
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -v -y --default-toolchain none
-            echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
+            rustup show active-toolchain || rustup toolchain install
+            rustup toolchain install {rust_channel()}
+            cargo version
+            echo "${{HOME}}/.cargo/bin" >> $GITHUB_PATH
             """
         ),
     }


### PR DESCRIPTION
Fix the "Build wheels" step for a breaking change in [Rustup v1.28.0](https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html) which no longer installs a default toolchain any more.

Use `rustup default` to install the applicable toolchain because it is idempotent and will install the toolchain if it is not already installed. `rustup toolchain install` by design will try to install even if the toolchain is already installed. See https://github.com/rust-lang/rustup/issues/710 for discussion of this distinction.

Closes https://github.com/pantsbuild/pants/issues/22036