### PR TITLE
fix CI "build wheels" step for rustup no longer installing default toolchain (Cherry-pick of #22037)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,6 +40,15 @@ jobs:
         echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
 
         '
+    - name: Install Rust toolchain
+      run: '# Set the default toolchain. Installs the toolchain if it is not already
+        installed.
+
+        rustup default 1.85.0
+
+        cargo version
+
+        '
     - name: Expose Pythons
       run: 'echo "/opt/python/cp37-cp37m/bin" >> $GITHUB_PATH
 
@@ -147,6 +156,15 @@ jobs:
         -v -y --default-toolchain none
 
         echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
+
+        '
+    - name: Install Rust toolchain
+      run: '# Set the default toolchain. Installs the toolchain if it is not already
+        installed.
+
+        rustup default 1.85.0
+
+        cargo version
 
         '
     - name: Expose Pythons

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,7 +44,7 @@ jobs:
       run: '# Set the default toolchain. Installs the toolchain if it is not already
         installed.
 
-        rustup default 1.85.0
+        rustup default 1.84.1
 
         cargo version
 
@@ -162,7 +162,7 @@ jobs:
       run: '# Set the default toolchain. Installs the toolchain if it is not already
         installed.
 
-        rustup default 1.85.0
+        rustup default 1.84.1
 
         cargo version
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -359,6 +359,14 @@ jobs:
         echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
 
         '
+    - name: Install Rust toolchain
+      run: '# Set the default toolchain. Installs the toolchain if it is not already installed.
+
+        rustup default 1.85.0
+
+        cargo version
+
+        '
     - name: Expose Pythons
       run: 'echo "/opt/python/cp37-cp37m/bin" >> $GITHUB_PATH
 
@@ -427,6 +435,14 @@ jobs:
       run: 'curl --proto ''=https'' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -v -y --default-toolchain none
 
         echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
+
+        '
+    - name: Install Rust toolchain
+      run: '# Set the default toolchain. Installs the toolchain if it is not already installed.
+
+        rustup default 1.85.0
+
+        cargo version
 
         '
     - name: Expose Pythons

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -362,7 +362,7 @@ jobs:
     - name: Install Rust toolchain
       run: '# Set the default toolchain. Installs the toolchain if it is not already installed.
 
-        rustup default 1.85.0
+        rustup default 1.84.1
 
         cargo version
 
@@ -440,7 +440,7 @@ jobs:
     - name: Install Rust toolchain
       run: '# Set the default toolchain. Installs the toolchain if it is not already installed.
 
-        rustup default 1.85.0
+        rustup default 1.84.1
 
         cargo version
 

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -317,16 +317,28 @@ def rust_channel() -> str:
     return cast(str, rust_toolchain["toolchain"]["channel"])
 
 
-def install_rustup() -> Step:
-    return {
-        "name": "Install rustup",
-        "run": dedent(
-            """\
+def install_rustup() -> list[Step]:
+    return [
+        {
+            "name": "Install rustup",
+            "run": dedent(
+                """\
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -v -y --default-toolchain none
             echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
             """
-        ),
-    }
+            ),
+        },
+        {
+            "name": "Install Rust toolchain",
+            "run": dedent(
+                f"""\
+            # Set the default toolchain. Installs the toolchain if it is not already installed.
+            rustup default {rust_channel()}
+            cargo version
+            """
+            ),
+        },
+    ]
 
 
 def install_pythons(versions: list[str]) -> Step:
@@ -846,7 +858,7 @@ def build_wheels_job(
     if container:
         initial_steps = [
             *checkout(containerized=True, ref=for_deploy_ref),
-            install_rustup(),
+            *install_rustup(),
             {
                 "name": "Expose Pythons",
                 "run": dedent(


### PR DESCRIPTION
Fix the "Build wheels" step for a breaking change in [Rustup v1.28.0](https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html) which no longer installs a default toolchain any more.

Use `rustup default` to install the applicable toolchain because it is idempotent and will install the toolchain if it is not already installed. `rustup toolchain install` by design will try to install even if the toolchain is already installed. See https://github.com/rust-lang/rustup/issues/710 for discussion of this distinction.

Closes https://github.com/pantsbuild/pants/issues/22036
