### PR TITLE
fix CI "build wheels" step for rustup no longer installing default toolchain (Cherry-pick of #22037)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,7 +40,7 @@ jobs:
       run: '# Set the default toolchain. Installs the toolchain if it is not already
         installed.
 
-        rustup default 1.85.0
+        rustup default 1.82.0
 
         cargo version
 
@@ -130,7 +130,7 @@ jobs:
       run: '# Set the default toolchain. Installs the toolchain if it is not already
         installed.
 
-        rustup default 1.85.0
+        rustup default 1.82.0
 
         cargo version
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,6 +36,15 @@ jobs:
         echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
 
         '
+    - name: Install Rust toolchain
+      run: '# Set the default toolchain. Installs the toolchain if it is not already
+        installed.
+
+        rustup default 1.85.0
+
+        cargo version
+
+        '
     - name: Expose Pythons
       run: 'echo "/opt/python/cp37-cp37m/bin" >> $GITHUB_PATH
 
@@ -115,6 +124,15 @@ jobs:
         -v -y --default-toolchain none
 
         echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
+
+        '
+    - name: Install Rust toolchain
+      run: '# Set the default toolchain. Installs the toolchain if it is not already
+        installed.
+
+        rustup default 1.85.0
+
+        cargo version
 
         '
     - name: Expose Pythons

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -358,7 +358,7 @@ jobs:
     - name: Install Rust toolchain
       run: '# Set the default toolchain. Installs the toolchain if it is not already installed.
 
-        rustup default 1.85.0
+        rustup default 1.82.0
 
         cargo version
 
@@ -430,7 +430,7 @@ jobs:
     - name: Install Rust toolchain
       run: '# Set the default toolchain. Installs the toolchain if it is not already installed.
 
-        rustup default 1.85.0
+        rustup default 1.82.0
 
         cargo version
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -355,6 +355,14 @@ jobs:
         echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
 
         '
+    - name: Install Rust toolchain
+      run: '# Set the default toolchain. Installs the toolchain if it is not already installed.
+
+        rustup default 1.85.0
+
+        cargo version
+
+        '
     - name: Expose Pythons
       run: 'echo "/opt/python/cp37-cp37m/bin" >> $GITHUB_PATH
 
@@ -417,6 +425,14 @@ jobs:
       run: 'curl --proto ''=https'' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -v -y --default-toolchain none
 
         echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
+
+        '
+    - name: Install Rust toolchain
+      run: '# Set the default toolchain. Installs the toolchain if it is not already installed.
+
+        rustup default 1.85.0
+
+        cargo version
 
         '
     - name: Expose Pythons


### PR DESCRIPTION
Fix the "Build wheels" step for a breaking change in [Rustup v1.28.0](https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html) which no longer installs a default toolchain any more.

Use `rustup default` to install the applicable toolchain because it is idempotent and will install the toolchain if it is not already installed. `rustup toolchain install` by design will try to install even if the toolchain is already installed. See https://github.com/rust-lang/rustup/issues/710 for discussion of this distinction.

Closes https://github.com/pantsbuild/pants/issues/22036
