### PR TITLE
docs: fix note about explicit kubectl contexts in k8s backend

### DIFF
--- a/docs/docs/kubernetes/index.mdx
+++ b/docs/docs/kubernetes/index.mdx
@@ -24,7 +24,6 @@ First, activate the relevant backend in `pants.toml`:
 backend_packages = [
   ...
   "pants.backend.experimental.k8s",
-  ...
 ]
 ```
 
@@ -104,10 +103,13 @@ pants experimental-deploy src/k8s:webpages
 ✓ src/k8s:webpages deployed to context kind-kind
 ```
 
-note::: To prevent accidentally deploying kubernetes manifests to the wrong
-cluster, the context field is required on `k8s_bundle` for deployment. For
-deploying the same `k8s_bundle` to multiple contexts, consider using
-`parametrize` like `k8s_bundle(..., context=parametrize("stage", "prod"))`. For
-CI agents which will only have access to a single context, set the
+:::note Explicitly set kubectl contexts
+To prevent accidentally deploying kubernetes manifests to the wrong cluster,
+the context field is required on `k8s_bundle` for deployment. For deploying the
+same `k8s_bundle` to multiple contexts, consider using [`parametrize`
+builtin](../using-pants/key-concepts/targets-and-build-files.mdx#parametrizing-targets)
+like `k8s_bundle(..., context=parametrize("stage", "prod"))`. For CI agents
+which will only have access to a single context, set the
 `[kubectl].pass_context` to false in `pants.toml` to have them use their
 default context.
+:::


### PR DESCRIPTION
Formatting is off:
![image](https://github.com/user-attachments/assets/9c6e1c9d-0d2c-4224-a2f3-5d1b8f7d38df)

This pr fixes it:
![image](https://github.com/user-attachments/assets/d0c0bba8-0c7d-4e14-80c4-e87345d38490)
