### PR TITLE
fix: js/ts dependency inference with file suffix

### DIFF
--- a/docs/notes/2.26.x.md
+++ b/docs/notes/2.26.x.md
@@ -83,6 +83,8 @@ yarn: 1.22.22
 
 [Prettier](https://www.pantsbuild.org/stable/reference/subsystems/prettier) default version was upgraded from [2.6.2](https://github.com/prettier/prettier/releases/tag/2.6.2) to [3.5.2](https://github.com/prettier/prettier/releases/tag/3.5.2).
 
+Fixed a bug on dependency inference to correctly handle imports with file suffixes (e.g., `.generated.js`).
+
 #### Python
 
 Some deprecations have expired and been removed:
@@ -119,6 +121,10 @@ The `experiemental_test_shell_command` target type is no longer experimental and
 #### Terraform
 
 For the `tfsec` linter, the deprecation of support for leading `v`s in the `version` and `known_versions` field has expired and been removed. Write `1.28.13` instead of `v1.28.13`.
+
+#### TypeScript
+
+Fixed a bug on dependency inference to correctly handle imports with file suffixes (e.g., `.generated.ts`).
 
 #### S3
 

--- a/src/python/pants/backend/javascript/dependency_inference/rules.py
+++ b/src/python/pants/backend/javascript/dependency_inference/rules.py
@@ -161,12 +161,13 @@ async def _prepare_inference_metadata(address: Address, file_path: str) -> Infer
 
 def _add_extensions(file_imports: frozenset[str], file_extensions: tuple[str, ...]) -> PathGlobs:
     extensions = file_extensions + tuple(f"/index{ext}" for ext in file_extensions)
+    file_extensions = set(file_extensions)
     return PathGlobs(
         string
         for file_import in file_imports
         for string in (
             [file_import]
-            if PurePath(file_import).suffix in set(file_extensions)
+            if PurePath(file_import).suffix in file_extensions
             else [f"{file_import}{ext}" for ext in extensions]
         )
     )

--- a/src/python/pants/backend/javascript/dependency_inference/rules.py
+++ b/src/python/pants/backend/javascript/dependency_inference/rules.py
@@ -161,13 +161,13 @@ async def _prepare_inference_metadata(address: Address, file_path: str) -> Infer
 
 def _add_extensions(file_imports: frozenset[str], file_extensions: tuple[str, ...]) -> PathGlobs:
     extensions = file_extensions + tuple(f"/index{ext}" for ext in file_extensions)
-    file_extensions = set(file_extensions)
+    valid_file_extensions = set(file_extensions)
     return PathGlobs(
         string
         for file_import in file_imports
         for string in (
             [file_import]
-            if PurePath(file_import).suffix in file_extensions
+            if PurePath(file_import).suffix in valid_file_extensions
             else [f"{file_import}{ext}" for ext in extensions]
         )
     )

--- a/src/python/pants/backend/javascript/dependency_inference/rules.py
+++ b/src/python/pants/backend/javascript/dependency_inference/rules.py
@@ -166,7 +166,7 @@ def _add_extensions(file_imports: frozenset[str], file_extensions: tuple[str, ..
         for file_import in file_imports
         for string in (
             [file_import]
-            if PurePath(file_import).suffix and PurePath(file_import).suffix in file_extensions
+            if PurePath(file_import).suffix in set(file_extensions)
             else [f"{file_import}{ext}" for ext in extensions]
         )
     )

--- a/src/python/pants/backend/javascript/dependency_inference/rules.py
+++ b/src/python/pants/backend/javascript/dependency_inference/rules.py
@@ -166,7 +166,7 @@ def _add_extensions(file_imports: frozenset[str], file_extensions: tuple[str, ..
         for file_import in file_imports
         for string in (
             [file_import]
-            if PurePath(file_import).suffix
+            if PurePath(file_import).suffix and PurePath(file_import).suffix in file_extensions
             else [f"{file_import}{ext}" for ext in extensions]
         )
     )


### PR DESCRIPTION
# Description

Its possible that we have a file like `foo.<suffix>.js`, but when importing that file on another .js file, dependency inference wasn't working.