### PR TITLE
delete some namespace package declarations

### DIFF
--- a/testprojects/pants-plugins/src/python/test_pants_plugin/__init__.py
+++ b/testprojects/pants-plugins/src/python/test_pants_plugin/__init__.py
@@ -1,1 +1,0 @@
-__import__("pkg_resources").declare_namespace(__name__)

--- a/testprojects/pants-plugins/src/python/workunit_logger/__init__.py
+++ b/testprojects/pants-plugins/src/python/workunit_logger/__init__.py
@@ -1,1 +1,0 @@
-__import__("pkg_resources").declare_namespace(__name__)


### PR DESCRIPTION
Delete some namespace package declarations made via the deprecated `pkg_resources` module in code under `testprojects/`. It seems unnecessary to declare these as namespace packages since there doesn't appear to be a common directory that would be the single namespace in any event.