### PR TITLE
handle Python concatenated strings in Rust dependency inference parser

### DIFF
--- a/docs/notes/2.26.x.md
+++ b/docs/notes/2.26.x.md
@@ -110,6 +110,8 @@ The Python backend uses the PyPI `packaging` distribution to parse Python versio
 
 The Python Build Standalone backend (`pants.backend.python.providers.experimental.python_build_standalone`) has release metadata current through PBS release `20250212`.
 
+The Rust-based dependency inference logic now handles concatenated string literals properly and so imports such as `__import__("foo" ".bar")` will be properly handled.
+
 #### Shell
 
 The `experiemental_test_shell_command` target type is no longer experimental and is stabilized as the `test_shell_command` target type. As part of stablilizing it, `test_shell_command` learned several new features:

--- a/src/rust/engine/dep_inference/src/python/mod.rs
+++ b/src/rust/engine/dep_inference/src/python/mod.rs
@@ -125,6 +125,7 @@ impl ImportCollector<'_> {
             KindID::CONCATENATED_STRING => {
                 let substrings: Vec<Option<String>> = node
                     .children(&mut node.walk())
+                    .filter(|n| n.kind_id() != KindID::COMMENT)
                     .map(|n| self.string_literal_from_node(n))
                     .collect();
                 if substrings.iter().any(|s| s.is_none()) {

--- a/src/rust/engine/dep_inference/src/python/mod.rs
+++ b/src/rust/engine/dep_inference/src/python/mod.rs
@@ -130,7 +130,7 @@ impl ImportCollector<'_> {
                 if substrings.iter().any(|s| s.is_none()) {
                     return None;
                 }
-                let substrings: Vec<String> = substrings.into_iter().map(|s| s.unwrap()).collect();
+                let substrings: Vec<String> = substrings.into_iter().flatten().collect();
                 Some(substrings.join(""))
             }
             _ => None,

--- a/src/rust/engine/dep_inference/src/python/mod.rs
+++ b/src/rust/engine/dep_inference/src/python/mod.rs
@@ -108,12 +108,12 @@ impl ImportCollector<'_> {
             KindID::STRING => {
                 let content_node = node.child(1)?;
                 if content_node.kind_id() != KindID::STRING_CONTENT {
-                    // String literals are expected to be have STRING_START STRING_CONTENT STRING_END children.
+                    // String literals are expected to have children: STRING_START STRING_CONTENT STRING_END
                     return None;
                 }
 
                 if content_node
-                    .named_children(&mut content_node.walk())
+                    .children(&mut content_node.walk())
                     .any(|n| n.kind_id() == KindID::ESCAPE_SEQUENCE)
                 {
                     // A string with an escape sequence is probably not referring to an importable name.
@@ -124,7 +124,7 @@ impl ImportCollector<'_> {
             }
             KindID::CONCATENATED_STRING => {
                 let substrings: Vec<Option<String>> = node
-                    .named_children(&mut node.walk())
+                    .children(&mut node.walk())
                     .map(|n| self.string_literal_from_node(n))
                     .collect();
                 if substrings.iter().any(|s| s.is_none()) {

--- a/src/rust/engine/dep_inference/src/python/mod.rs
+++ b/src/rust/engine/dep_inference/src/python/mod.rs
@@ -110,7 +110,7 @@ impl ImportCollector<'_> {
     }
 
     /// Extract an optional "import name" string from a string-related `tree_sitter::Node`. The string is
-    /// expected to analyze statically as an import name and so `extract_string` ignore any strings
+    /// expected to analyze statically as an import name and so `extract_string` ignores any strings
     /// containing escape sequences as well as any use of f-strings with interpolations.
     fn extract_string(&self, node: tree_sitter::Node) -> Option<String> {
         match node.kind_id() {
@@ -127,7 +127,8 @@ impl ImportCollector<'_> {
                     || content_node.child_count() > 0
                 {
                     // The `string_content` node is expected to have no children if the string is a simple string literal.
-                    // If there are children, then it means that the string contains escape sequences and is not an import name.
+                    // If there are children, then it means that the string contains escape sequences and is not an import name
+                    // (either an `escape_sequence` or `escape_interpolation` node).
                     return None;
                 }
 

--- a/src/rust/engine/dep_inference/src/python/tests.rs
+++ b/src/rust/engine/dep_inference/src/python/tests.rs
@@ -279,6 +279,17 @@ fn dunder_import() {
     )  # pants: no-infer-dep",
         &[],
     );
+    assert_imports(
+        "
+    __import__(
+          'foo'   # Intervening comment will be ignored.
+          \".bar\"
+          \"\"\".xyzzy\"\"\"
+          '''.funky'''
+        )
+    ",
+        &["foo.bar.xyzzy.funky"],
+    );
 }
 
 fn assert_imports_strong_weak(code: &str, strong: &[&str], weak: &[&str]) {

--- a/src/rust/engine/dep_inference/src/python/tests.rs
+++ b/src/rust/engine/dep_inference/src/python/tests.rs
@@ -722,7 +722,10 @@ fn python2() {
       __import__(b'treat.as.a.regular.import.not.a.string.import')
       __import__(u'{}'.format('interpolation'))
 
-        __import__('foo' '.bar')
+        __import__(
+          'foo'   # Intervening comment will be ignored.
+          '.bar'
+        )
 
         importlib.import_module(b'dep.from.bytes')
         importlib.import_module(u'dep.from.str')
@@ -739,16 +742,16 @@ fn python2() {
             ("project.demo.Demo", (5, false)),
             ("pkg_resources", (7, false)),
             ("treat.as.a.regular.import.not.a.string.import", (8, false)),
-            ("weak1", (19, true)),
-            ("strong1", (20, false)),
-            ("strong2", (21, false)),
-            ("strong3", (22, false)),
-            ("foo.bar", (11, false)),
+            ("weak1", (22, true)),
+            ("strong1", (23, false)),
+            ("strong2", (24, false)),
+            ("strong3", (25, false)),
+            ("foo.bar", (12, false)),
         ]),
         HashMap::from([
-            ("dep.from.bytes", 13),
-            ("dep.from.str", 14),
-            ("dep.from.str_狗", 15),
+            ("dep.from.bytes", 16),
+            ("dep.from.str", 17),
+            ("dep.from.str_狗", 18),
         ]),
     );
 }

--- a/src/rust/engine/dep_inference/src/python/tests.rs
+++ b/src/rust/engine/dep_inference/src/python/tests.rs
@@ -722,6 +722,8 @@ fn python2() {
       __import__(b'treat.as.a.regular.import.not.a.string.import')
       __import__(u'{}'.format('interpolation'))
 
+        __import__('foo' '.bar')
+
         importlib.import_module(b'dep.from.bytes')
         importlib.import_module(u'dep.from.str')
         importlib.import_module(u'dep.from.str_狗')
@@ -737,15 +739,16 @@ fn python2() {
             ("project.demo.Demo", (5, false)),
             ("pkg_resources", (7, false)),
             ("treat.as.a.regular.import.not.a.string.import", (8, false)),
-            ("weak1", (17, true)),
-            ("strong1", (18, false)),
-            ("strong2", (19, false)),
-            ("strong3", (20, false)),
+            ("weak1", (19, true)),
+            ("strong1", (20, false)),
+            ("strong2", (21, false)),
+            ("strong3", (22, false)),
+            ("foo.bar", (11, false)),
         ]),
         HashMap::from([
-            ("dep.from.bytes", 11),
-            ("dep.from.str", 12),
-            ("dep.from.str_狗", 13),
+            ("dep.from.bytes", 13),
+            ("dep.from.str", 14),
+            ("dep.from.str_狗", 15),
         ]),
     );
 }

--- a/src/rust/engine/dep_inference/src/python/tests.rs
+++ b/src/rust/engine/dep_inference/src/python/tests.rs
@@ -279,6 +279,8 @@ fn dunder_import() {
     )  # pants: no-infer-dep",
         &[],
     );
+
+    // Concatenated strings are accepted.
     assert_imports(
         "
     __import__(
@@ -290,6 +292,11 @@ fn dunder_import() {
     ",
         &["foo.bar.xyzzy.funky"],
     );
+
+    // f-strings with interpolations are ignored
+    assert_imports("__import__(f'foo.{name}')", &[]);
+    assert_imports("__import__(f'foo.{{name}}')", &[]);
+    assert_imports("__import__(f'foo.bar\n')", &[]);
 }
 
 fn assert_imports_strong_weak(code: &str, strong: &[&str], weak: &[&str]) {

--- a/src/rust/engine/dep_inference/src/python/tests.rs
+++ b/src/rust/engine/dep_inference/src/python/tests.rs
@@ -689,6 +689,10 @@ fn string_candidates() {
     assert_strings("'''\na'''", &[]);
     assert_strings("'''a\n'''", &[]);
 
+    // Concatenated strings
+    assert_strings("'foo' \".bar\"", &["foo.bar"]);
+    assert_strings("'''foo''' \"\"\".bar\"\"\"", &["foo.bar"]);
+
     // Technically the value of the string doesn't contain whitespace, but the parser isn't that
     // sophisticated yet.
     assert_strings("'''\\\na'''", &[]);
@@ -718,6 +722,8 @@ fn string_candidates() {
     ",
         &[],
     );
+    assert_strings("'foo' \".bar\" # pants: no-infer-dep", &[]);
+    assert_strings("'''foo''' \"\"\".bar\"\"\" # pants: no-infer-dep", &[]);
 }
 
 #[test]


### PR DESCRIPTION
As reported in https://github.com/pantsbuild/pants/issues/20324, the Rust-based Python import parser does not handle certain valid source patterns including concatenated strings.

Fix the Rust-based parser to handle concatenated strings correctly. Strings are parsed out of `Node`s via the new `extract_string` helper. The `insert_import` function is refactored to avoid double parsing of strings.

Added some tests as well for concatenated strings.