### PR TITLE
update `pants peek` docs with latest outputs (Cherry-pick of #22051)

### DIFF
--- a/docs/docs/using-pants/project-introspection.mdx
+++ b/docs/docs/using-pants/project-introspection.mdx
@@ -230,29 +230,29 @@ helloworld/greet/translations.json
 `peek` outputs JSON for each target specified.
 
 ```bash
-$ pants peek helloworld/util:tests
+$ pants peek helloworld/greet:tests
 [
   {
-    "address": "helloworld/util:tests",
+    "address": "helloworld/greet:tests",
     "target_type": "python_tests",
-    "dependencies": null,
+    "dependencies": [
+      "helloworld/greet/greeting_test.py:tests"
+    ],
     "description": null,
-    "interpreter_constraints": null,
+    "overrides": null,
     "skip_black": false,
     "skip_docformatter": false,
-    "skip_flake8": true,
+    "skip_flake8": false,
     "skip_isort": false,
     "skip_mypy": false,
     "sources": [
-      "*.py",
-      "*.pyi",
-      "!test_*.py",
-      "!*_test.py",
-      "!tests.py",
-      "!conftest.py",
-      "!test_*.pyi",
-      "!*_test.pyi",
-      "!tests.pyi"
+      "helloworld/greet/greeting_test.py"
+    ],
+    "sources_fingerprint": "2158e096d5ab63e537d88067b50a0274b83f6373143faf854d4a9adf5d01cf78",
+    "sources_raw": [
+      "test_*.py",
+      "*_test.py",
+      "tests.py"
     ],
     "tags": null
   }
@@ -262,12 +262,18 @@ $ pants peek helloworld/util:tests
 You can use `--exclude-defaults` for less verbose output:
 
 ```bash
-$ pants peek --exclude-defaults helloworld/util:tests
+$ pants peek --exclude-defaults helloworld/greet:tests
 [
   {
-    "address": "helloworld/util:tests",
+    "address": "helloworld/greet:tests",
     "target_type": "python_tests",
-    "skip_flake8": true,
+    "dependencies": [
+      "helloworld/greet/greeting_test.py:tests"
+    ],
+    "sources": [
+      "helloworld/greet/greeting_test.py"
+    ],
+    "sources_fingerprint": "2158e096d5ab63e537d88067b50a0274b83f6373143faf854d4a9adf5d01cf78"
   }
 ]
 ```
@@ -288,7 +294,7 @@ helloworld/util:lib
 Some introspection goals, such as `filter`, `dependencies` and `dependents` emit a flat list of target addresses. It's often useful to expand each of those into a full JSON structure with detailed properties of each target, by piping to `pants peek`:
 
 ```bash
-pants dependents  helloworld/main.py:lib | xargs pants peek --exclude-defaults
+$ pants dependents helloworld/main.py:lib | xargs pants peek --exclude-defaults
 [
   {
     "address": "helloworld:lib",
@@ -300,7 +306,8 @@ pants dependents  helloworld/main.py:lib | xargs pants peek --exclude-defaults
     "sources": [
       "helloworld/__init__.py",
       "helloworld/main.py"
-    ]
+    ],
+    "sources_fingerprint": "74841d8cb2060cf9a4c2aa20f77c2a1a44af4799188a5820e513776fd3fe973c"
   },
   {
     "address": "helloworld:pex_binary",
@@ -311,7 +318,11 @@ pants dependents  helloworld/main.py:lib | xargs pants peek --exclude-defaults
     "entry_point": {
       "module": "main.py",
       "function": null
-    }
+    },
+    "goals": [
+      "package",
+      "run"
+    ]
   }
 ]
 ```


### PR DESCRIPTION
Fix https://github.com/pantsbuild/pants/issues/20885 by updating the documentation for `pants peek` to reflect the current structure of the JSON output.

Closes https://github.com/pantsbuild/pants/issues/20885
