### PR TITLE
2.25.x: add note about updating pantsbuild/actions/init-pants for py3.11 support (Cherry-pick of #22054)

### DIFF
--- a/docs/notes/2.25.x.md
+++ b/docs/notes/2.25.x.md
@@ -51,6 +51,8 @@ The version of Python used by Pants itself has been updated to [3.11](https://do
 
 Note: Pants uses its own separately-installed Python installation to run itself. This installation is managed by the Pants Launcher Binary. The Pants choice of Python 3.11 for its own code does not limit the versions of Python that you can use to test and build your own code.
 
+For GitHub Actions users that use the [pantsbuild/actions/init-pants](https://github.com/pantsbuild/actions/tree/main/init-pants) action with `setup-python-for-plugins=true`, you will need to update your GHA workflows to use [v10](https://github.com/pantsbuild/actions/releases/tag/v10) or newer to get the correct version of Python.
+
 ### Backends
 
 #### Docker


### PR DESCRIPTION
v10 of the action is required
