### PR TITLE
allow codegened sources for pex_binary.complete_platforms

### DIFF
--- a/docs/notes/2.26.x.md
+++ b/docs/notes/2.26.x.md
@@ -25,6 +25,7 @@ New kubernetes backend! See [docs](https://www.pantsbuild.org/stable/docs/kubern
 
 - [Fixed](https://github.com/pantsbuild/pants/pull/21959) a bug where exponential backoff of file downloads could wait up to 18 days between retries under the default settings. [The `[GLOBAL].file_downloads_retry_delay ` option](https://www.pantsbuild.org/2.26/reference/global-options#file_downloads_retry_delay) is now used as a multiplier (previously it was the exponential base), and so any customisation of this option may need reconsideration for the new behaviour.
 - [Fixed](https://github.com/pantsbuild/pants/pull/22024) handling of non-absolute paths in PATH (see [#21954](https://github.com/pantsbuild/pants/issues/21954) for more info).
+- [Fixed](https://github.com/pantsbuild/pants/pull/XXXXX) `pex_binary.complete_platforms` can now accept a codegened source, such as the result of an `shell_command`.
 
 #### New call-by-name syntax for @rules
 
@@ -100,7 +101,7 @@ The Pants repo now uses Ruff format in lieu of Black. This was not a drop-in rep
 
 `@rule` decorators have been re-typed, which should allow better call site return-type visibility (fewer `Unknown`s and `Any`s). Decorator factories of the form `@rule(desc=..., level=..., ...)` have also been strongly typed. This may cause typechecking errors for plugin authors, if the plugin is using incorrect types. However, this likely would have manifested as a runtime crash, otherwise.
 
-A bug in the Django backend has been fixed so that a repo may have no Django apps without error. 
+A bug in the Django backend has been fixed so that a repo may have no Django apps without error.
 
 [Pytype](https://www.pantsbuild.org/stable/reference/subsystems/pytype) was updated to version 2024.9.13 - which is the [last to support Python 3.8 and Python 3.9](https://github.com/google/pytype/blob/main/CHANGELOG).
 

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -143,6 +143,7 @@ async def digest_complete_platform_addresses(
                     FileSourceField,
                     ResourceSourceField,
                 ),
+                enable_codegen=True,
             ),
         )
         for tgt in original_file_targets

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -59,6 +59,7 @@ from pants.backend.python.util_rules.pex_test_utils import (
     parse_requirements,
 )
 from pants.core.goals.generate_lockfiles import GenerateLockfileResult
+from pants.core.register import wrap_as_resources
 from pants.core.target_types import FileTarget, ResourceTarget
 from pants.core.util_rules.lockfile_metadata import InvalidLockfileError
 from pants.engine.fs import (
@@ -93,6 +94,7 @@ def rule_runner() -> RuleRunner:
         rules=[
             *pex_test_utils.rules(),
             *pex_rules(),
+            *wrap_as_resources.rules,
             QueryRule(GlobalOptions, []),
             QueryRule(ProcessResult, (Process,)),
             QueryRule(PexResolveInfo, (Pex,)),
@@ -102,6 +104,7 @@ def rule_runner() -> RuleRunner:
         target_types=[
             ResourceTarget,
             FileTarget,
+            *wrap_as_resources.target_types,
         ],
     )
 
@@ -941,6 +944,34 @@ def test_digest_complete_platforms(rule_runner: RuleRunner, target_type: str) ->
     complete_platforms = rule_runner.request(
         CompletePlatforms,
         [PexCompletePlatformsField([":complete_platforms"], target.address)],
+    )
+
+    # Verify the result
+    assert len(complete_platforms) == 1
+    assert complete_platforms.digest != EMPTY_DIGEST
+
+
+def test_digest_complete_platforms_codegen(rule_runner: RuleRunner) -> None:
+    # Read the complete_platforms content using pkgutil
+    complete_platforms_content = pkgutil.get_data(__name__, "complete_platform_pex_test.json")
+    assert complete_platforms_content is not None
+
+    # Create a target with the complete platforms file
+    rule_runner.write_files(
+        {
+            "BUILD": """\
+file(name='complete_platforms', source='complete_platforms.json')
+experimental_wrap_as_resources(name="codegen", inputs=[':complete_platforms'], )
+            """,
+            "complete_platforms.json": complete_platforms_content,
+        }
+    )
+
+    # Get the CompletePlatforms object
+    target = rule_runner.get_target(Address("", target_name="codegen"))
+    complete_platforms = rule_runner.request(
+        CompletePlatforms,
+        [PexCompletePlatformsField([":codegen"], target.address)],
     )
 
     # Verify the result


### PR DESCRIPTION
For a container build, I wanted to automatically generate `complete_platforms` by launching the container we'd be deploying with. Unfortunately, while I can get the file to generate with e.g. `export-codegen` it doesn't get picked up due to the missing option. 