### PR TITLE
check in Rust parser whether string candidates are valid dotted names

### DIFF
--- a/src/rust/engine/dep_inference/src/python/mod.rs
+++ b/src/rust/engine/dep_inference/src/python/mod.rs
@@ -268,26 +268,27 @@ impl ImportCollector<'_> {
         };
 
         let node = parsed.root_node();
-        if node.has_error() {
+        if node.has_error() || node.kind_id() != KindID::MODULE {
             return false;
         }
 
-        // Drill down on `module` node.
-        if node.child_count() != 1 && node.child(0).unwrap().kind_id() != KindID::MODULE {
-            return false;
-        }
-        let node = node.child(0).unwrap();
-
-        // Drill down on `expression_statement` node.
+        // Drill down to the `expression_statement` node.
         if node.child_count() != 1
-            && node.child(0).unwrap().kind_id() != KindID::EXPRESSION_STATEMENT
+            || node.child(0).unwrap().kind_id() != KindID::EXPRESSION_STATEMENT
         {
             return false;
         }
         let node = node.child(0).unwrap();
 
+        // There must be a single child of the `expression_statement` node.
+        if node.child_count() != 1 {
+            return false;
+        }
+        let node = node.child(0).unwrap();
+
+        /// Helper function to traverse the remainder of the tree.
         fn is_identifier_or_attribute(node: tree_sitter::Node) -> bool {
-            // Identifiers are valid names.
+            // Identifiers are valid names and end the recursion.
             if node.kind_id() == KindID::IDENTIFIER {
                 return true;
             }

--- a/src/rust/engine/dep_inference/src/python/tests.rs
+++ b/src/rust/engine/dep_inference/src/python/tests.rs
@@ -590,12 +590,12 @@ fn contextlib_suppress_weak_imports() {
     let withitems_open = r"
     with (
         open('/dev/null') as f0,
-        open('data/subdir1/a.json') as f1,
+        open('foo.bar.txt') as f1,
     ):
         pass
     ";
     assert_imports_strong_weak(withitems_open, &[], &[]);
-    assert_strings(withitems_open, &["/dev/null", "data/subdir1/a.json"]);
+    assert_strings(withitems_open, &["foo.bar.txt"]);
     // Ensure suppress bound to variable
     assert_imports_strong_weak(
         r"
@@ -666,6 +666,7 @@ fn contextlib_suppress_weak_imports_dunder() {
     )
 }
 
+#[track_caller]
 fn assert_strings(code: &str, strings: &[&str]) {
     let mut collector = ImportCollector::new(code);
     collector.collect();
@@ -685,9 +686,9 @@ fn string_candidates() {
     assert_strings("'''a'''", &["a"]);
     assert_strings("'a.b'", &["a.b"]);
     assert_strings("'a.b.c_狗'", &["a.b.c_狗"]);
-    assert_strings("'..a.b.c.d'", &["..a.b.c.d"]);
 
     // Not candidates
+    assert_strings("'..a.b.c.d'", &[]);
     assert_strings("'I\\\\have\\\\backslashes'", &[]);
     assert_strings("'I have whitespace'", &[]);
     assert_strings("'\ttabby'", &[]);


### PR DESCRIPTION
As reported in https://github.com/pantsbuild/pants/issues/20324, the Rust dependency inference parser does not check whether string candidates (when `string_imports = true` is in effect) are valid dotted Python names.

While the Python-side of the dependency inference logic does now check (as of https://github.com/pantsbuild/pants/pull/20472), it is easy enough to support this in Rust using the tree-sitter grammar.