### PR TITLE
Add logging to rule-graph construction for basic performance tracing

### DIFF
--- a/src/rust/engine/rule_graph/src/builder.rs
+++ b/src/rust/engine/rule_graph/src/builder.rs
@@ -304,6 +304,7 @@ impl<R: Rule> Builder<R> {
     /// Validate that all rules have unique RuleIds.
     ///
     fn validate_rule_ids(&self) -> Result<(), String> {
+        log::debug!("Rule graph: validating rule IDs...");
         let mut invalid_rule_ids: Vec<&RuleId> = self
             .rules
             .values()
@@ -331,6 +332,7 @@ impl<R: Rule> Builder<R> {
     /// and each node in this phase represents all of those possibilities.
     ///
     fn initial_polymorphic(&self) -> OutLabeledGraph<R> {
+        log::debug!("Rule graph: building initial polymorphic graph...");
         let mut graph: Graph<R> = DiGraph::new();
 
         // Initialize the graph with nodes for Queries, Params, and Reentries.
@@ -603,6 +605,7 @@ impl<R: Rule> Builder<R> {
     /// This represents ambiguity that must be handled (likely by erroring) in later phases.
     ///
     fn monomorphize(graph: LabeledGraph<R>) -> MonomorphizedGraph<R> {
+        log::debug!("Rule graph: monomophizing graph...");
         // The monomorphized graph contains nodes and edges that have been marked deleted, because:
         //   1. we expose which nodes and edges were deleted to allow for improved error messages
         //   2. it is slow to delete nodes/edges with petgraph: marking them is much cheaper.
@@ -1008,6 +1011,7 @@ impl<R: Rule> Builder<R> {
     /// See https://en.wikipedia.org/wiki/Live_variable_analysis
     ///
     fn live_param_labeled_graph(&self, graph: OutLabeledGraph<R>) -> LabeledGraph<R> {
+        log::debug!("Rule graph: labelling live variables...");
         // Add in_sets for each node, with all sets empty initially.
         let mut graph: LabeledGraph<R> = graph.map(
             |_node_id, node| {
@@ -1066,6 +1070,7 @@ impl<R: Rule> Builder<R> {
     /// most specific error possible.
     ///
     fn prune_edges(&self, mut graph: MonomorphizedGraph<R>) -> Result<InLabeledGraph<R>, String> {
+        log::debug!("Rule graph: pruning edges...");
         // Walk from roots, choosing one source for each DependencyKey of each node.
         let mut visited = graph.visit_map();
         let mut errored = HashMap::default();
@@ -1386,6 +1391,7 @@ impl<R: Rule> Builder<R> {
     /// this point are errors.
     ///
     fn finalize(self, graph: InLabeledGraph<R>) -> Result<RuleGraph<R>, String> {
+        log::debug!("Rule graph: finalizing...");
         let entry_for = |node_id| -> Entry<R> {
             let (node, in_set): &(Node<R>, ParamTypes<_>) = &graph[node_id];
             match node {

--- a/src/rust/engine/rule_graph/src/lib.rs
+++ b/src/rust/engine/rule_graph/src/lib.rs
@@ -241,7 +241,14 @@ impl<R: Rule> RuleGraph<R> {
         rules: IndexSet<R>,
         queries: IndexSet<Query<R::TypeId>>,
     ) -> Result<RuleGraph<R>, String> {
-        Builder::new(rules, queries).graph()
+        log::debug!("Rule graph: building...");
+        let start = std::time::Instant::now();
+
+        let graph = Builder::new(rules, queries).graph();
+
+        log::debug!("Rule graph: built in {:.3}s", start.elapsed().as_secs_f64());
+
+        graph
     }
 
     pub fn find_root_edges<I: IntoIterator<Item = R::TypeId>>(


### PR DESCRIPTION
This gives is designed to provide some lightweight additional insight into what's happening while the scheduler is initialising, because rule graph construction seems to be the single largest time sink.

There's logging around the whole `RuleGraph::new()` call, plus logging at the start of each step of the `.graph()` builder:

https://github.com/pantsbuild/pants/blob/85c61c397f689416fe5c2abdf70a03bbd310d5d9/src/rust/engine/rule_graph/src/builder.rs#L283-L301

Example of output on the Pants repo `MODE=debug pants --level=debug version` (trimmed):

```
...
08:18:40.00 [INFO] Initializing scheduler...
...
08:18:40.20 [DEBUG] Rule graph: building...
08:18:40.20 [DEBUG] Rule graph: validating rule IDs...
08:18:40.20 [DEBUG] Rule graph: building initial polymorphic graph...
08:18:42.34 [DEBUG] Rule graph: labelling live variables...
08:18:42.84 [DEBUG] Rule graph: monomophizing graph...
08:18:58.41 [DEBUG] Rule graph: pruning edges...
08:18:58.65 [DEBUG] Rule graph: finalizing...
08:18:58.67 [DEBUG] Rule graph: built in 18.473s
...
08:18:58.68 [INFO] Scheduler initialized.
...
2.26.0.dev7
```

Diffing the timestamps:

| phase | part | time (s) |
|---|---|---|
| Scheduler init  | before rule graph | 0.2 |
| Rule graph | labelling live variables | 0.5 |
|  |  monomophizing graph | 16.57 | 
|  |  pruning edges | 0.24 |
|  | **total** | **18.47** |
| Scheduler init | after rule graph | 0.01 |
|  | **total** | **18.68** |

