### PR TITLE
Disable nailgun by default

### DIFF
--- a/docs/notes/2.26.x.md
+++ b/docs/notes/2.26.x.md
@@ -25,6 +25,7 @@ New kubernetes backend! See [docs](https://www.pantsbuild.org/stable/docs/kubern
 
 - [Fixed](https://github.com/pantsbuild/pants/pull/21959) a bug where exponential backoff of file downloads could wait up to 18 days between retries under the default settings. [The `[GLOBAL].file_downloads_retry_delay ` option](https://www.pantsbuild.org/2.26/reference/global-options#file_downloads_retry_delay) is now used as a multiplier (previously it was the exponential base), and so any customisation of this option may need reconsideration for the new behaviour.
 - [Fixed](https://github.com/pantsbuild/pants/pull/22024) handling of non-absolute paths in PATH (see [#21954](https://github.com/pantsbuild/pants/issues/21954) for more info).
+- Nailgun is now disabled by default, and can be re-enabled with `--process-execution-local-enable-nailgun`.
 
 #### New call-by-name syntax for @rules
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -767,7 +767,7 @@ DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
     keep_sandboxes=KeepSandboxes.never,
     local_cache=True,
     cache_content_behavior=CacheContentBehavior.fetch,
-    process_execution_local_enable_nailgun=True,
+    process_execution_local_enable_nailgun=False,
     process_execution_graceful_shutdown_timeout=3,
     # Remote store setup.
     remote_store_address=None,


### PR DESCRIPTION
Nailgun is likely causing more harm than good, and it is likely safest to flip the default for it. Is is also deprecated and unmaintained at this point.

There's been some prior discussions:
- https://github.com/pantsbuild/pants/pull/21865
- https://github.com/pantsbuild/pants/issues/20603 (does not build JVM after 17)
- https://github.com/pantsbuild/pants/issues/21146 (may not be hermetic)
- There's also some scheduler initialization overhead that may be unnecessary

I created a PR for it so that it doesn't get lost