### PR TITLE
Refactor children out into a separate crate.

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -582,6 +582,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "children"
+version = "0.0.1"
+dependencies = [
+ "log",
+ "nix",
+ "tokio",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1129,6 +1138,7 @@ dependencies = [
  "axum-server",
  "bytes",
  "cache",
+ "children",
  "concrete_time",
  "crossbeam-channel",
  "deepsize",
@@ -3062,6 +3072,7 @@ dependencies = [
  "bincode",
  "bytes",
  "cache",
+ "children",
  "concrete_time",
  "deepsize",
  "derivative",

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -46,6 +46,7 @@ deepsize = { workspace = true, features = ["internment", "smallvec"] }
 dep_inference = { path = "dep_inference" }
 derivative = { workspace = true }
 async-oncecell = { workspace = true }
+children = { path = "process_execution/children" }
 docker = { path = "process_execution/docker" }
 fnv = { workspace = true }
 fs = { path = "fs" }

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -13,6 +13,7 @@ async-oncecell = { workspace = true }
 walkdir = { workspace = true }
 protos = { path = "../protos" }
 bytes = { workspace = true }
+children = { path = "./children" }
 cache = { path = "../cache" }
 derivative = { workspace = true }
 deepsize = { workspace = true, features = ["log"] }

--- a/src/rust/engine/process_execution/children/Cargo.toml
+++ b/src/rust/engine/process_execution/children/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+version = "0.0.1"
+edition = "2021"
+name = "children"
+authors = ["Pants Build <pantsbuild@gmail.com>"]
+publish = false
+
+[dependencies]
+log = { workspace = true }
+nix = { workspace = true }
+tokio = { workspace = true, features = ["process"] }
+
+[lints]
+workspace = true

--- a/src/rust/engine/process_execution/children/src/lib.rs
+++ b/src/rust/engine/process_execution/children/src/lib.rs
@@ -1,5 +1,6 @@
 // Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 use std::ops::{Deref, DerefMut};
 use std::{thread, time};
 

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -49,8 +49,6 @@ mod cache_tests;
 
 pub mod switched;
 
-pub mod children;
-
 pub mod local;
 #[cfg(test)]
 pub mod local_tests;
@@ -67,8 +65,8 @@ pub mod workspace_tests;
 
 extern crate uname;
 
-pub use crate::children::ManagedChild;
 pub use crate::named_caches::{CacheName, NamedCaches};
+pub use children::ManagedChild;
 
 // Environment variable which is exclusively used for cache key invalidation.
 // This may be not specified in an Process, and may be populated only by the


### PR DESCRIPTION
So it can be easily reused without introducing
possibly circular deps on process_execution.