### PR TITLE
update 2.25.x release notes for PBS cherry pick

### DIFF
--- a/docs/notes/2.25.x.md
+++ b/docs/notes/2.25.x.md
@@ -150,7 +150,7 @@ Several improvements to the Python Build Standalone backend (`pants.backend.pyth
 
 - The [`--python-build-standalone-provider-known-python-versions`](https://www.pantsbuild.org/2.25/reference/subsystems/python-build-standalone-python-provider#known_python_versions) option now accepts a three-field format where each value is `SHA256|FILE_SIZE|URL`. All of the PBS release metadata will be parsed from the URL (which must use the naming convention used by the PBS project). (The existing five-field format is still accepted and will now allow the version and platform fields to be blank if that data can be inferred from the URL.)
 
-- Metadata on PBS releases is current to PBS release 20250212.
+- Metadata on PBS releases is current to PBS release `20250311`.
 
 - Changed references to Python Build Standalone to refer to the new [GitHub organization](https://github.com/astral-sh/python-build-standalone) as described in [Transferring Python Build Standalone Stewardship to Astral](https://gregoryszorc.com/blog/2024/12/03/transferring-python-build-standalone-stewardship-to-astral/).
 


### PR DESCRIPTION
Update the 2.25.x release notes to reflect the cherry pick of latest PBS release.