### PR TITLE
fix: expose the npm_distribution target

### DIFF
--- a/docs/notes/2.26.x.md
+++ b/docs/notes/2.26.x.md
@@ -87,6 +87,8 @@ Fixed a bug on dependency inference to correctly handle imports with file suffix
 
 Fixed a bug where typescript source files (`.ts` and `.tsx`) were not being added to the sandbox during JavaScript test execution.
 
+Exposed the `npm_distribution` target type that can be used to create publishable npm registry distributions.
+
 #### Python
 
 Some deprecations have expired and been removed:

--- a/src/python/pants/backend/javascript/package_json.py
+++ b/src/python/pants/backend/javascript/package_json.py
@@ -929,7 +929,12 @@ async def generate_node_package_targets(
 
 
 def target_types() -> Iterable[type[Target]]:
-    return [PackageJsonTarget, NodePackageTarget, NodeThirdPartyPackageTarget]
+    return [
+        PackageJsonTarget,
+        NodePackageTarget,
+        NodeThirdPartyPackageTarget,
+        NPMDistributionTarget,
+    ]
 
 
 def rules() -> Iterable[Rule | UnionRule]:


### PR DESCRIPTION
# Description

The `npm_distribution` target was added via https://github.com/pantsbuild/pants/pull/18925 but wasn't exposed when registering the `javascript` backend, so there is currently no way to use this target.