### PR TITLE
Support local path "replace" in go.mod

### DIFF
--- a/docs/notes/2.26.x.md
+++ b/docs/notes/2.26.x.md
@@ -104,7 +104,7 @@ The Pants repo now uses Ruff format in lieu of Black. This was not a drop-in rep
 
 `@rule` decorators have been re-typed, which should allow better call site return-type visibility (fewer `Unknown`s and `Any`s). Decorator factories of the form `@rule(desc=..., level=..., ...)` have also been strongly typed. This may cause typechecking errors for plugin authors, if the plugin is using incorrect types. However, this likely would have manifested as a runtime crash, otherwise.
 
-A bug in the Django backend has been fixed so that a repo may have no Django apps without error. 
+A bug in the Django backend has been fixed so that a repo may have no Django apps without error.
 
 [Pytype](https://www.pantsbuild.org/stable/reference/subsystems/pytype) was updated to version 2024.9.13 - which is the [last to support Python 3.8 and Python 3.9](https://github.com/google/pytype/blob/main/CHANGELOG).
 
@@ -137,6 +137,11 @@ Fixed a bug on dependency inference to correctly handle imports with file suffix
 #### S3
 
 The S3 backend now creates new AWS credentials when the `AWS_` environment variables change. This allows credentials to be updated without restarting the Pants daemon.
+
+#### Go
+
+- [Fixed](https://github.com/pantsbuild/pants/pull/22091) handling local-path replace lines in go.mod (see [#14996](https://github.com/pantsbuild/pants/issues/14996) for more info).
+
 
 ### Plugin API changes
 

--- a/src/python/pants/backend/go/util_rules/third_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/third_party_pkg.py
@@ -229,6 +229,10 @@ async def analyze_module_dependencies(request: ModuleDescriptorsRequest) -> Modu
         if "Main" in mod_json and mod_json["Main"]:
             continue
 
+        # Skip first-party modules referenced from other first-party modules.
+        if "Replace" in mod_json and "Version" not in mod_json["Replace"]:
+            continue
+
         if "Replace" in mod_json:
             # TODO: Reject local file path replacements? Gazelle does.
             name = mod_json["Replace"]["Path"]

--- a/src/python/pants/backend/go/util_rules/third_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/third_party_pkg.py
@@ -230,6 +230,7 @@ async def analyze_module_dependencies(request: ModuleDescriptorsRequest) -> Modu
             continue
 
         # Skip first-party modules referenced from other first-party modules.
+        # TODO These cross-module references could be used for dependency inference
         if "Replace" in mod_json and "Version" not in mod_json["Replace"]:
             continue
 

--- a/src/python/pants/backend/go/util_rules/third_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/third_party_pkg.py
@@ -230,7 +230,7 @@ async def analyze_module_dependencies(request: ModuleDescriptorsRequest) -> Modu
             continue
 
         # Skip first-party modules referenced from other first-party modules.
-        # TODO These cross-module references could be used for dependency inference
+        # TODO Issue #22097: These cross-module references could be used for dependency inference
         if "Replace" in mod_json and "Version" not in mod_json["Replace"]:
             continue
 


### PR DESCRIPTION
Issue #14996 continues to reproduce in 2.24.1: In Go, when multiple modules reference each other in a monorepo, they do so with "require" and "replace" lines in `go.mod`, e.g. if `module_a/package_a` depends on `module_b/package_b`, the `module_a/go.mod` file will contain two lines:
```
require module_b v0.0.0
replace module_b => ../module_b
```

This, however, causes pants to fail as described in issue #19463 and in issue #14996.

It is possible to work around this issue to get the pants build to pass: remove the require and replace lines and use the `dependencies` field in the `go_package` target to manage the dependency, but this unfortunately breaks the Go tools. `go mod ...`, `go test ...` etc. no longer run since they cannot resolve module_b without it being specified in `go.mod`.

This patch adds proper interpretation of a `replace` clause that lacks a Version: interpret the dependency as a first-party module within the same repository and not a third-party module that requires remote fetching. This version of the `replace` clause is described at https://go.dev/ref/mod#go-mod-file-replace
> If the path on the right side of the arrow is an absolute or relative path
> (beginning with ./ or ../), it is interpreted as the local file path to the
> replacement module root directory, which must contain a go.mod file. The
> replacement version must be omitted in this case.

This patch does not add dependency inference across these references, but merely allows the explicit dependencies to function in both pants and go.