### PR TITLE
Refactor the rust cli options used for creating a Store.

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -4230,6 +4230,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "bytes",
+ "clap 4.5.32",
  "concrete_time",
  "criterion",
  "deepsize",

--- a/src/rust/engine/fs/store/Cargo.toml
+++ b/src/rust/engine/fs/store/Cargo.toml
@@ -9,6 +9,7 @@ async-stream = { workspace = true }
 async-trait = { workspace = true }
 protos = { path = "../../protos" }
 bytes = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
 concrete_time = { path = "../../concrete_time" }
 async-oncecell = { workspace = true }
 deepsize = { workspace = true }

--- a/src/rust/engine/fs/store/src/cli_options.rs
+++ b/src/rust/engine/fs/store/src/cli_options.rs
@@ -91,9 +91,9 @@ impl StoreCliOpt {
 
         if let Some(cas_server) = &self.cas_server {
             let tls_config = grpc_util::tls::Config::new_from_files(
-                &self.cas_root_ca_cert_file,
-                &self.cas_client_certs_file,
-                &self.cas_client_key_file,
+                self.cas_root_ca_cert_file.as_deref(),
+                self.cas_client_certs_file.as_deref(),
+                self.cas_client_key_file.as_deref(),
             )?;
             let headers = self.get_headers(&self.cas_oauth_bearer_token_path)?;
             local_only_store

--- a/src/rust/engine/fs/store/src/cli_options.rs
+++ b/src/rust/engine/fs/store/src/cli_options.rs
@@ -1,0 +1,134 @@
+// Copyright 2025 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+use std::{collections::BTreeMap, path::PathBuf, time::Duration};
+
+use clap::Parser;
+use remote_provider::{RemoteProvider, RemoteStoreOptions};
+use task_executor::Executor;
+
+use crate::Store;
+
+#[derive(Parser)]
+pub struct StoreCliOpt {
+    ///Path to lmdb directory used for local file storage.
+    #[arg(long)]
+    local_store_path: Option<PathBuf>,
+
+    #[arg(long)]
+    pub remote_instance_name: Option<String>,
+
+    /// The host:port of the gRPC CAS server to connect to.
+    #[arg(long)]
+    pub cas_server: Option<String>,
+
+    /// Path to file containing root certificate authority certificates for the CAS server.
+    /// If not set, TLS will not be used when connecting to the CAS server.
+    #[arg(long)]
+    pub cas_root_ca_cert_file: Option<PathBuf>,
+
+    /// Path to file containing client certificates for the CAS server.
+    /// If not set, client authentication will not be used when connecting to the CAS server.
+    #[arg(long)]
+    pub cas_client_certs_file: Option<PathBuf>,
+
+    /// Path to file containing client key for the CAS server.
+    /// If not set, client authentication will not be used when connecting to the CAS server.
+    #[arg(long)]
+    pub cas_client_key_file: Option<PathBuf>,
+
+    /// Path to file containing oauth bearer token for communication with the CAS server.
+    /// If not set, no authorization will be provided to remote servers.
+    #[arg(long)]
+    pub cas_oauth_bearer_token_path: Option<PathBuf>,
+
+    /// Number of bytes to include per-chunk when uploading bytes.
+    /// grpc imposes a hard message-size limit of around 4MB.
+    #[arg(long, default_value = "3145728")]
+    pub upload_chunk_bytes: usize,
+
+    /// Number of retries per request to the store service.
+    #[arg(long, default_value = "3")]
+    pub store_rpc_retries: usize,
+
+    /// Number of concurrent requests to the store service.
+    #[arg(long, default_value = "128")]
+    pub store_rpc_concurrency: usize,
+
+    /// Total size of blobs allowed to be sent in a single API call.
+    #[arg(long, default_value = "4194304")]
+    pub store_batch_api_size_limit: usize,
+
+    /// Extra header to pass on remote execution request.
+    #[arg(long)]
+    pub header: Vec<String>,
+}
+
+impl StoreCliOpt {
+    pub fn get_headers(
+        &self,
+        oauth_bearer_token_path: &Option<PathBuf>,
+    ) -> Result<BTreeMap<String, String>, String> {
+        let mut headers: BTreeMap<String, String> = collection_from_keyvalues(self.header.iter());
+        if let Some(ref oauth_path) = oauth_bearer_token_path {
+            let token = std::fs::read_to_string(oauth_path)
+                .map_err(|e| format!("Error reading oauth bearer token file: {}", e))?;
+            headers.insert(
+                "authorization".to_owned(),
+                format!("Bearer {}", token.trim()),
+            );
+        }
+        Ok(headers)
+    }
+
+    pub async fn create_store(&self, executor: Executor) -> Result<Store, String> {
+        let local_store_path = self
+            .local_store_path
+            .clone()
+            .unwrap_or_else(Store::default_path);
+
+        let local_only_store = Store::local_only(executor.clone(), local_store_path)?;
+
+        if let Some(cas_server) = &self.cas_server {
+            let tls_config = grpc_util::tls::Config::new_from_files(
+                &self.cas_root_ca_cert_file,
+                &self.cas_client_certs_file,
+                &self.cas_client_key_file,
+            )?;
+            let headers = self.get_headers(&self.cas_oauth_bearer_token_path)?;
+            local_only_store
+                .into_with_remote(RemoteStoreOptions {
+                    provider: RemoteProvider::Reapi,
+                    store_address: cas_server.to_owned(),
+                    instance_name: self.remote_instance_name.clone(),
+                    tls_config,
+                    headers,
+                    chunk_size_bytes: self.upload_chunk_bytes,
+                    timeout: Duration::from_secs(30),
+                    retries: self.store_rpc_retries,
+                    concurrency_limit: self.store_rpc_concurrency,
+                    batch_api_size_limit: self.store_batch_api_size_limit,
+                })
+                .await
+        } else {
+            Ok(local_only_store)
+        }
+    }
+}
+
+pub fn collection_from_keyvalues<Str, It, Col>(keyvalues: It) -> Col
+where
+    Str: AsRef<str>,
+    It: Iterator<Item = Str>,
+    Col: FromIterator<(String, String)>,
+{
+    keyvalues
+        .map(|kv| {
+            let mut parts = kv.as_ref().splitn(2, '=');
+            (
+                parts.next().unwrap().to_string(),
+                parts.next().unwrap_or_default().to_string(),
+            )
+        })
+        .collect()
+}

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -56,6 +56,8 @@ const KILOBYTES: usize = 1024;
 const MEGABYTES: usize = 1024 * KILOBYTES;
 const GIGABYTES: usize = 1024 * MEGABYTES;
 
+mod cli_options;
+
 mod local;
 #[cfg(test)]
 pub mod local_tests;
@@ -66,6 +68,7 @@ mod remote_tests;
 
 // Consumers of this crate shouldn't need to worry about the exact crate structure that comes
 // together to make a store.
+pub use cli_options::StoreCliOpt;
 pub use remote_provider::{RemoteProvider, RemoteStoreOptions};
 
 pub struct LocalOptions {
@@ -336,6 +339,10 @@ impl Store {
             remote: None,
             immutable_inputs_base: Some(immutable_inputs_base.to_path_buf()),
         })
+    }
+
+    pub fn is_local_only(&self) -> bool {
+        self.remote.is_none()
     }
 
     ///

--- a/src/rust/engine/grpc_util/src/tls.rs
+++ b/src/rust/engine/grpc_util/src/tls.rs
@@ -1,8 +1,10 @@
 // Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+use std::fmt::Write;
 use std::io;
+use std::path::Path;
 use std::sync::Arc;
-use std::{fmt::Write, path::PathBuf};
 
 use rustls::{
     DigitallySignedStruct,
@@ -50,19 +52,17 @@ impl Config {
     }
 
     pub fn new_from_files(
-        root_ca_cert_file: &Option<PathBuf>,
-        client_certs_file: &Option<PathBuf>,
-        client_key_file: &Option<PathBuf>,
+        root_ca_cert_file: Option<&Path>,
+        client_certs_file: Option<&Path>,
+        client_key_file: Option<&Path>,
     ) -> Result<Self, String> {
         let root_ca_certs = root_ca_cert_file
-            .as_ref()
             .map(|path| {
                 std::fs::read(path).map_err(|e| format!("Error reading root CA certs file: {}", e))
             })
             .transpose()?;
 
         let client_certs = client_certs_file
-            .as_ref()
             .map(|path| {
                 std::fs::read(path)
                     .map_err(|e| format!("Error reading client authentication certs file: {}", e))
@@ -70,7 +70,6 @@ impl Config {
             .transpose()?;
 
         let client_key = client_key_file
-            .as_ref()
             .map(|path| {
                 std::fs::read(path)
                     .map_err(|e| format!("Error reading client authentication key file: {}", e))

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -185,9 +185,9 @@ async fn main() -> Result<(), String> {
     let runner: Box<dyn process_execution::CommandRunner> = match args.server {
         Some(address) => {
             let tls_config = grpc_util::tls::Config::new_from_files(
-                &args.execution_root_ca_cert_file,
-                &args.store_options.cas_client_certs_file,
-                &args.store_options.cas_client_key_file,
+                args.execution_root_ca_cert_file.as_deref(),
+                args.store_options.cas_client_certs_file.as_deref(),
+                args.store_options.cas_client_key_file.as_deref(),
             )?;
             let headers = args
                 .store_options

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -22,7 +22,7 @@ use protos::gen::build::bazel::remote::execution::v2::{Action, Command};
 use protos::gen::buildbarn::cas::UncachedActionResult;
 use protos::require_digest;
 use remote::remote_cache::RemoteCacheRunnerOptions;
-use store::{ImmutableInputs, RemoteProvider, RemoteStoreOptions, Store};
+use store::{ImmutableInputs, RemoteProvider, RemoteStoreOptions, Store, StoreCliOpt};
 use tokio::sync::RwLock;
 use workunit_store::{Level, WorkunitStore, in_workunit};
 
@@ -99,6 +99,9 @@ struct Opt {
     #[command(flatten)]
     action_digest: ActionDigestSpec,
 
+    #[command(flatten)]
+    store_options: StoreCliOpt,
+
     #[arg(long)]
     buildbarn_url: Option<String>,
 
@@ -113,16 +116,9 @@ struct Opt {
     #[arg(long)]
     work_dir: Option<PathBuf>,
 
-    ///Path to lmdb directory used for local file storage.
-    #[arg(long)]
-    local_store_path: Option<PathBuf>,
-
     /// Path to a directory to be used for named caches.
     #[arg(long)]
     named_cache_path: Option<PathBuf>,
-
-    #[arg(long)]
-    remote_instance_name: Option<String>,
 
     /// The host:port of the gRPC server to connect to. Forces remote execution.
     /// If unspecified, local execution will be performed.
@@ -139,47 +135,6 @@ struct Opt {
     #[arg(long)]
     execution_oauth_bearer_token_path: Option<PathBuf>,
 
-    /// The host:port of the gRPC CAS server to connect to.
-    #[arg(long)]
-    cas_server: Option<String>,
-
-    /// Path to file containing root certificate authority certificates for the CAS server.
-    /// If not set, TLS will not be used when connecting to the CAS server.
-    #[arg(long)]
-    cas_root_ca_cert_file: Option<PathBuf>,
-
-    /// Path to file containing client certificates for the CAS server.
-    /// If not set, client authentication will not be used when connecting to the CAS server.
-    #[arg(long)]
-    cas_client_certs_file: Option<PathBuf>,
-
-    /// Path to file containing client key for the CAS server.
-    /// If not set, client authentication will not be used when connecting to the CAS server.
-    #[arg(long)]
-    cas_client_key_file: Option<PathBuf>,
-
-    /// Path to file containing oauth bearer token for communication with the CAS server.
-    /// If not set, no authorization will be provided to remote servers.
-    #[arg(long)]
-    cas_oauth_bearer_token_path: Option<PathBuf>,
-
-    /// Number of bytes to include per-chunk when uploading bytes.
-    /// grpc imposes a hard message-size limit of around 4MB.
-    #[arg(long, default_value = "3145728")]
-    upload_chunk_bytes: usize,
-
-    /// Number of retries per request to the store service.
-    #[arg(long, default_value = "3")]
-    store_rpc_retries: usize,
-
-    /// Number of concurrent requests to the store service.
-    #[arg(long, default_value = "128")]
-    store_rpc_concurrency: usize,
-
-    /// Total size of blobs allowed to be sent in a single API call.
-    #[arg(long, default_value = "4194304")]
-    store_batch_api_size_limit: usize,
-
     /// Number of concurrent requests to the execution service.
     #[arg(long, default_value = "128")]
     execution_rpc_concurrency: usize,
@@ -191,10 +146,6 @@ struct Opt {
     /// Overall timeout in seconds for each request from time of submission.
     #[arg(long, default_value = "600")]
     overall_deadline_secs: u64,
-
-    /// Extra header to pass on remote execution request.
-    #[arg(long)]
-    header: Vec<String>,
 }
 
 /// A binary which takes args of format:
@@ -205,86 +156,22 @@ struct Opt {
 ///
 /// It does not perform $PATH lookup or shell expansion.
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<(), String> {
     env_logger::init();
     let workunit_store = WorkunitStore::new(false, log::Level::Debug);
     workunit_store.init_thread_state(None);
 
     let args = Opt::parse();
 
-    let mut headers: BTreeMap<String, String> = collection_from_keyvalues(args.header.iter());
-
     let executor = task_executor::Executor::new();
 
-    let local_store_path = args
-        .local_store_path
-        .clone()
-        .unwrap_or_else(Store::default_path);
+    let store = args.store_options.create_store(executor.clone()).await?;
 
-    let local_only_store =
-        Store::local_only(executor.clone(), local_store_path).expect("Error making local store");
-    let store = match (&args.server, &args.cas_server) {
-    (_, Some(cas_server)) => {
-      let root_ca_certs = args
-        .cas_root_ca_cert_file
-        .as_ref()
-        .map(|path| std::fs::read(path).expect("Error reading root CA certs file"));
-
-      let client_certs = args
-        .cas_client_certs_file
-        .as_ref()
-        .map(|path| std::fs::read(path).expect("Error reading client authentication certs file"));
-
-      let client_key = args
-        .cas_client_key_file
-        .as_ref()
-        .map(|path| std::fs::read(path).expect("Error reading client authentication key file"));
-
-      let mtls_data = match (client_certs, client_key) {
-        (Some(certs), Some(key)) => Some((certs, key)),
-        (None, None) => None,
-        _ => {
-          panic!("Must specify both --cas-client-certs-file and --cas-client-key-file or neither")
-        }
-      };
-
-      let mut headers = BTreeMap::new();
-      if let Some(ref oauth_path) = args.cas_oauth_bearer_token_path {
-        let token =
-          std::fs::read_to_string(oauth_path).expect("Error reading oauth bearer token file");
-        headers.insert(
-          "authorization".to_owned(),
-          format!("Bearer {}", token.trim()),
-        );
-      }
-
-      let tls_config = grpc_util::tls::Config::new(root_ca_certs, mtls_data)
-        .expect("failed parsing root CA certs");
-
-      local_only_store
-            .into_with_remote(RemoteStoreOptions {
-                provider: RemoteProvider::Reapi,
-          store_address: cas_server.to_owned(),
-          instance_name: args.remote_instance_name.clone(),
-          tls_config,
-          headers,
-          chunk_size_bytes: args.upload_chunk_bytes,
-          timeout: Duration::from_secs(30),
-          retries: args.store_rpc_retries,
-          concurrency_limit: args.store_rpc_concurrency,
-
-          batch_api_size_limit: args.store_batch_api_size_limit,
-        })
-        .await
+    if args.server.is_some() && store.is_local_only() {
+        return Err("Can't specify --server without --cas-server".to_string());
     }
-    (None, None) => Ok(local_only_store),
-    _ => panic!("Can't specify --server without --cas-server"),
-  }
-  .expect("Error making remote store");
 
-    let (mut request, process_metadata) = make_request(&store, &args)
-        .await
-        .expect("Failed to construct request");
+    let (mut request, process_metadata) = make_request(&store, &args).await?;
 
     if let Some(run_under) = args.run_under {
         let run_under = shlex::split(&run_under).expect("Could not shlex --run-under arg");
@@ -297,40 +184,14 @@ async fn main() {
 
     let runner: Box<dyn process_execution::CommandRunner> = match args.server {
         Some(address) => {
-            let root_ca_certs = args
-                .execution_root_ca_cert_file
-                .map(|path| std::fs::read(path).expect("Error reading root CA certs file"));
-
-            let client_certs = args
-                .cas_client_certs_file
-                .as_ref()
-                .map(|path| std::fs::read(path).expect("Error reading root client certs file"));
-
-            let client_key = args.cas_client_key_file.as_ref().map(|path| {
-                std::fs::read(path).expect("Error reading client authentication key file")
-            });
-
-            let mtls_data = match (client_certs, client_key) {
-                (Some(certs), Some(key)) => Some((certs, key)),
-                (None, None) => None,
-                _ => {
-                    panic!(
-                        "Must specify both --cas-client-certs-file and --cas-client-key-file or neither"
-                    )
-                }
-            };
-
-            let tls_config = grpc_util::tls::Config::new(root_ca_certs, mtls_data)
-                .expect("failed parsing root CA certs");
-
-            if let Some(oauth_path) = args.execution_oauth_bearer_token_path {
-                let token = std::fs::read_to_string(oauth_path)
-                    .expect("Error reading oauth bearer token file");
-                headers.insert(
-                    "authorization".to_owned(),
-                    format!("Bearer {}", token.trim()),
-                );
-            }
+            let tls_config = grpc_util::tls::Config::new_from_files(
+                &args.execution_root_ca_cert_file,
+                &args.store_options.cas_client_certs_file,
+                &args.store_options.cas_client_key_file,
+            )?;
+            let headers = args
+                .store_options
+                .get_headers(&args.execution_oauth_bearer_token_path)?;
 
             let remote_runner = remote::remote::CommandRunner::new(
                 &address,
@@ -475,7 +336,7 @@ async fn make_request(
         store,
         Digest::new(action_fingerprint, action_digest_length),
         execution_environment,
-        args.remote_instance_name.clone(),
+        args.store_options.remote_instance_name.clone(),
         args.command.cache_key_gen_version.clone(),
       ).await
     }
@@ -555,7 +416,7 @@ async fn make_request_from_flat_args(
         attempt: 0,
     };
     let metadata = ProcessMetadata {
-        instance_name: args.remote_instance_name.clone(),
+        instance_name: args.store_options.remote_instance_name.clone(),
         cache_key_gen_version: args.command.cache_key_gen_version.clone(),
     };
     Ok((process, metadata))


### PR DESCRIPTION
The process_executor binary has several options
used to create a local/remote `Store` instance.

This PR pulls those options out into a separate
options class, so they can be reused in other 
binaries. 

It also adds utility functions to create TLS config,
HTTP headers, and the Store instance itself.
