### PR TITLE
Don't run a full CI on devcontainer changes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
-    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only != 'true')
+    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.no_code != 'true')
     name: Bootstrap Pants, test Rust (Linux-ARM64)
     needs:
     - classify_changes
@@ -107,7 +107,7 @@ jobs:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
-    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only != 'true')
+    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.no_code != 'true')
     name: Bootstrap Pants, test and lint Rust (Linux-x86_64)
     needs:
     - classify_changes
@@ -222,7 +222,7 @@ jobs:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
-    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only != 'true')
+    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.no_code != 'true')
     name: Bootstrap Pants, test Rust (macOS13-x86_64)
     needs:
     - classify_changes
@@ -332,7 +332,7 @@ jobs:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
     if: ((github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.release == 'true' || needs.classify_changes.outputs.ci_config
-      == 'true')) && (needs.classify_changes.outputs.docs_only != 'true')
+      == 'true')) && (needs.classify_changes.outputs.no_code != 'true')
     name: Build wheels (Linux-ARM64)
     needs:
     - classify_changes
@@ -414,7 +414,7 @@ jobs:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
     if: ((github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.release == 'true' || needs.classify_changes.outputs.ci_config
-      == 'true')) && (needs.classify_changes.outputs.docs_only != 'true')
+      == 'true')) && (needs.classify_changes.outputs.no_code != 'true')
     name: Build wheels (Linux-x86_64)
     needs:
     - classify_changes
@@ -494,7 +494,7 @@ jobs:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
     if: ((github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.release == 'true' || needs.classify_changes.outputs.ci_config
-      == 'true')) && (needs.classify_changes.outputs.docs_only != 'true')
+      == 'true')) && (needs.classify_changes.outputs.no_code != 'true')
     name: Build wheels (macOS13-x86_64)
     needs:
     - classify_changes
@@ -584,7 +584,7 @@ jobs:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
     if: ((github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.release == 'true' || needs.classify_changes.outputs.ci_config
-      == 'true')) && (needs.classify_changes.outputs.docs_only != 'true')
+      == 'true')) && (needs.classify_changes.outputs.no_code != 'true')
     name: Build wheels (macOS14-ARM64)
     needs:
     - classify_changes
@@ -689,8 +689,9 @@ jobs:
     name: Classify changes
     outputs:
       ci_config: ${{ steps.classify.outputs.ci_config }}
+      dev_utils: ${{ steps.classify.outputs.dev_utils }}
       docs: ${{ steps.classify.outputs.docs }}
-      docs_only: ${{ steps.classify.outputs.docs_only }}
+      no_code: ${{ steps.classify.outputs.no_code }}
       notes: ${{ steps.classify.outputs.notes }}
       other: ${{ steps.classify.outputs.other }}
       release: ${{ steps.classify.outputs.release }}
@@ -707,12 +708,11 @@ jobs:
       run: "if [[ -z $GITHUB_EVENT_PULL_REQUEST_BASE_SHA ]]; then\n  # push: compare to the immediate parent, which should\
         \ already be fetched\n  # (checkout's fetch_depth defaults to 10)\n  comparison_sha=$(git rev-parse HEAD^)\nelse\n\
         \  # pull request: compare to the base branch, ensuring that commit exists\n  git fetch --depth=1 \"$GITHUB_EVENT_PULL_REQUEST_BASE_SHA\"\
-        \n  comparison_sha=\"$GITHUB_EVENT_PULL_REQUEST_BASE_SHA\"\nfi\necho \"comparison_sha=$comparison_sha\"\n\naffected=$(git\
-        \ diff --name-only \"$comparison_sha\" HEAD | python build-support/bin/classify_changed_files.py)\necho \"Affected:\"\
-        \nif [[ \"${affected}\" == \"docs\" || \"${affected}\" == \"docs notes\" ]]; then\n  echo \"docs_only=true\" | tee\
-        \ -a $GITHUB_OUTPUT\nfi\nfor i in ${affected}; do\n  echo \"${i}=true\" | tee -a $GITHUB_OUTPUT\ndone\n"
+        \n  comparison_sha=\"$GITHUB_EVENT_PULL_REQUEST_BASE_SHA\"\nfi\necho \"comparison_sha=$comparison_sha\"\n\nchange_labels=$(git\
+        \ diff --name-only \"$comparison_sha\" HEAD | python build-support/bin/classify_changed_files.py)\necho \"Change Labels:\"\
+        \nfor i in ${change_labels}; do\n  echo \"${i}=true\" | tee -a $GITHUB_OUTPUT\ndone\n"
   lint_python:
-    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only != 'true')
+    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.no_code != 'true')
     name: Lint Python and Shell
     needs:
     - bootstrap_pants_linux_x86_64
@@ -825,7 +825,7 @@ jobs:
       run: echo 'merge_ok=true' >> ${GITHUB_OUTPUT}
   test_python_linux_arm64:
     env: {}
-    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only != 'true')
+    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.no_code != 'true')
     name: Test Python (Linux-ARM64)
     needs:
     - bootstrap_pants_linux_arm64
@@ -886,7 +886,7 @@ jobs:
   test_python_linux_x86_64_0:
     env:
       PANTS_PROCESS_EXECUTION_LOCAL_PARALLELISM: '1'
-    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only != 'true')
+    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.no_code != 'true')
     name: Test Python (Linux-x86_64) Shard 0/10
     needs:
     - bootstrap_pants_linux_x86_64
@@ -988,7 +988,7 @@ jobs:
   test_python_linux_x86_64_1:
     env:
       PANTS_PROCESS_EXECUTION_LOCAL_PARALLELISM: '1'
-    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only != 'true')
+    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.no_code != 'true')
     name: Test Python (Linux-x86_64) Shard 1/10
     needs:
     - bootstrap_pants_linux_x86_64
@@ -1090,7 +1090,7 @@ jobs:
   test_python_linux_x86_64_2:
     env:
       PANTS_PROCESS_EXECUTION_LOCAL_PARALLELISM: '1'
-    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only != 'true')
+    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.no_code != 'true')
     name: Test Python (Linux-x86_64) Shard 2/10
     needs:
     - bootstrap_pants_linux_x86_64
@@ -1192,7 +1192,7 @@ jobs:
   test_python_linux_x86_64_3:
     env:
       PANTS_PROCESS_EXECUTION_LOCAL_PARALLELISM: '1'
-    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only != 'true')
+    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.no_code != 'true')
     name: Test Python (Linux-x86_64) Shard 3/10
     needs:
     - bootstrap_pants_linux_x86_64
@@ -1294,7 +1294,7 @@ jobs:
   test_python_linux_x86_64_4:
     env:
       PANTS_PROCESS_EXECUTION_LOCAL_PARALLELISM: '1'
-    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only != 'true')
+    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.no_code != 'true')
     name: Test Python (Linux-x86_64) Shard 4/10
     needs:
     - bootstrap_pants_linux_x86_64
@@ -1396,7 +1396,7 @@ jobs:
   test_python_linux_x86_64_5:
     env:
       PANTS_PROCESS_EXECUTION_LOCAL_PARALLELISM: '1'
-    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only != 'true')
+    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.no_code != 'true')
     name: Test Python (Linux-x86_64) Shard 5/10
     needs:
     - bootstrap_pants_linux_x86_64
@@ -1498,7 +1498,7 @@ jobs:
   test_python_linux_x86_64_6:
     env:
       PANTS_PROCESS_EXECUTION_LOCAL_PARALLELISM: '1'
-    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only != 'true')
+    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.no_code != 'true')
     name: Test Python (Linux-x86_64) Shard 6/10
     needs:
     - bootstrap_pants_linux_x86_64
@@ -1600,7 +1600,7 @@ jobs:
   test_python_linux_x86_64_7:
     env:
       PANTS_PROCESS_EXECUTION_LOCAL_PARALLELISM: '1'
-    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only != 'true')
+    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.no_code != 'true')
     name: Test Python (Linux-x86_64) Shard 7/10
     needs:
     - bootstrap_pants_linux_x86_64
@@ -1702,7 +1702,7 @@ jobs:
   test_python_linux_x86_64_8:
     env:
       PANTS_PROCESS_EXECUTION_LOCAL_PARALLELISM: '1'
-    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only != 'true')
+    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.no_code != 'true')
     name: Test Python (Linux-x86_64) Shard 8/10
     needs:
     - bootstrap_pants_linux_x86_64
@@ -1804,7 +1804,7 @@ jobs:
   test_python_linux_x86_64_9:
     env:
       PANTS_PROCESS_EXECUTION_LOCAL_PARALLELISM: '1'
-    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only != 'true')
+    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.no_code != 'true')
     name: Test Python (Linux-x86_64) Shard 9/10
     needs:
     - bootstrap_pants_linux_x86_64
@@ -1907,7 +1907,7 @@ jobs:
     env:
       ARCHFLAGS: -arch x86_64
       _PYTHON_HOST_PLATFORM: macosx-13.0-x86_64
-    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only != 'true')
+    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.no_code != 'true')
     name: Test Python (macOS13-x86_64)
     needs:
     - bootstrap_pants_macos13_x86_64

--- a/build-support/bin/classify_changed_files.py
+++ b/build-support/bin/classify_changed_files.py
@@ -12,14 +12,20 @@ from collections import defaultdict
 # and runnable without `./pants run`.
 
 
-class Affected(enum.Enum):
+class ChangeLabel(enum.Enum):
+    dev_utils = "dev_utils"
     docs = "docs"
     rust = "rust"
     release = "release"
     ci_config = "ci_config"
     notes = "notes"
     other = "other"
+    no_code = "no_code"
 
+
+_dev_utils_globs = [
+    ".devcontainer/*",
+]
 
 _docs_globs = [
     "*.md",
@@ -47,22 +53,25 @@ _notes_globs = [
 
 
 _affected_to_globs = {
-    Affected.docs: _docs_globs,
-    Affected.rust: _rust_globs,
-    Affected.release: _release_globs,
-    Affected.ci_config: _ci_config_globs,
-    Affected.notes: _notes_globs,
+    ChangeLabel.dev_utils: _dev_utils_globs,
+    ChangeLabel.docs: _docs_globs,
+    ChangeLabel.rust: _rust_globs,
+    ChangeLabel.release: _release_globs,
+    ChangeLabel.ci_config: _ci_config_globs,
+    ChangeLabel.notes: _notes_globs,
 }
 
 
-def classify(changed_files: list[str]) -> set[Affected]:
-    classified: dict[Affected, set[str]] = defaultdict(set)
+def classify(changed_files: list[str]) -> set[ChangeLabel]:
+    classified: dict[ChangeLabel, set[str]] = defaultdict(set)
     for affected, globs in _affected_to_globs.items():
         for pattern in globs:
             classified[affected].update(fnmatch.filter(changed_files, pattern))
     ret = {k for k, v in classified.items() if v}
     if set(changed_files) - set().union(*classified.values()):
-        ret.add(Affected.other)
+        ret.add(ChangeLabel.other)
+    if len(ret - {ChangeLabel.dev_utils, ChangeLabel.docs, ChangeLabel.notes}) == 0:
+        ret.add(ChangeLabel.no_code)
     return ret
 
 

--- a/build-support/bin/classify_changed_files_test.py
+++ b/build-support/bin/classify_changed_files_test.py
@@ -2,28 +2,31 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import pytest
-from classify_changed_files import Affected, classify
+from classify_changed_files import ChangeLabel, classify
 
 
 @pytest.mark.parametrize(
     ["changed_files", "expected"],
     (
-        [["docs/path/to/some/doc", "docs/path/to/some/other/doc"], {Affected.docs}],
+        [
+            ["docs/path/to/some/doc", "docs/path/to/some/other/doc"],
+            {ChangeLabel.docs, ChangeLabel.no_code},
+        ],
         [
             ["README.md", "path/to/some/dir/README.md"],
-            {Affected.docs},
+            {ChangeLabel.docs, ChangeLabel.no_code},
         ],
         [
             ["docs/notes/2.16.x.md"],
-            {Affected.docs, Affected.notes},
+            {ChangeLabel.docs, ChangeLabel.notes, ChangeLabel.no_code},
         ],
-        [["src/rust/engine/path/to/file.rs"], {Affected.rust}],
-        [["src/python/pants/VERSION"], {Affected.release}],
-        [["src/python/pants_release/generate_github_workflows.py"], {Affected.ci_config}],
-        [["src/python/pants/whatever.py"], {Affected.other}],
+        [["src/rust/engine/path/to/file.rs"], {ChangeLabel.rust}],
+        [["src/python/pants/VERSION"], {ChangeLabel.release}],
+        [["src/python/pants_release/generate_github_workflows.py"], {ChangeLabel.ci_config}],
+        [["src/python/pants/whatever.py"], {ChangeLabel.other}],
         [
             ["docs/path/to/some/doc", "src/rust/engine/rust-toolchain"],
-            {Affected.docs, Affected.rust},
+            {ChangeLabel.docs, ChangeLabel.rust},
         ],
         [
             [
@@ -31,7 +34,14 @@ from classify_changed_files import Affected, classify
                 "src/rust/engine/rust-toolchain",
                 "src/python/pants/whatever.py",
             ],
-            {Affected.docs, Affected.rust, Affected.other},
+            {ChangeLabel.docs, ChangeLabel.rust, ChangeLabel.other},
+        ],
+        [
+            [
+                ".devcontainer/Dockerfile",
+                "docs/path/to/some/doc",
+            ],
+            {ChangeLabel.dev_utils, ChangeLabel.docs, ChangeLabel.no_code},
         ],
     ),
 )


### PR DESCRIPTION
The devcontainer is strictly for local development, so running 
tests/packaging is unnecessary when it changes.

To facilitate this change:
- Change the terminology "Affected" to the more general "ChangeLabel".
- Move the logic to determine whether full CI needs to run or not into
  the classifier script itself, via a "no code" label. This replaces the "docs only"
  concept that was previously implemented in the CI script. Now that more
  labels are in play, it is easier to implement this in Python than in shell.