### PR TITLE
Support local path "replace" in go.mod (Cherry-pick of #22091)

### DIFF
--- a/src/python/pants/backend/go/util_rules/third_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/third_party_pkg.py
@@ -229,6 +229,11 @@ async def analyze_module_dependencies(request: ModuleDescriptorsRequest) -> Modu
         if "Main" in mod_json and mod_json["Main"]:
             continue
 
+        # Skip first-party modules referenced from other first-party modules.
+        # TODO Issue #22097: These cross-module references could be used for dependency inference
+        if "Replace" in mod_json and "Version" not in mod_json["Replace"]:
+            continue
+
         if "Replace" in mod_json:
             # TODO: Reject local file path replacements? Gazelle does.
             name = mod_json["Replace"]["Path"]


### PR DESCRIPTION
Issue #14996 continues to reproduce in 2.24.1: In Go, when multiple modules reference each other in a monorepo, they do so with "require" and "replace" lines in `go.mod`, e.g. if `module_a/package_a` depends on `module_b/package_b`, the `module_a/go.mod` file will contain two lines:
```
require module_b v0.0.0
replace module_b => ../module_b
```

This, however, causes pants to fail as described in issue #19463 and in issue #14996.

It is possible to work around this issue to get the pants build to pass: remove the require and replace lines and use the `dependencies` field in the `go_package` target to manage the dependency, but this unfortunately breaks the Go tools. `go mod ...`, `go test ...` etc. no longer run since they cannot resolve module_b without it being specified in `go.mod`.

This patch adds proper interpretation of a `replace` clause that lacks a Version: interpret the dependency as a first-party module within the same repository and not a third-party module that requires remote fetching. This version of the `replace` clause is described at https://go.dev/ref/mod#go-mod-file-replace
> If the path on the right side of the arrow is an absolute or relative path
> (beginning with ./ or ../), it is interpreted as the local file path to the
> replacement module root directory, which must contain a go.mod file. The
> replacement version must be omitted in this case.

This patch does not add dependency inference across these references, but merely allows the explicit dependencies to function in both pants and go.
