### PR TITLE
Use an immutable input for ruff executable, cut macOS overhead

### DIFF
--- a/docs/notes/2.26.x.md
+++ b/docs/notes/2.26.x.md
@@ -115,7 +115,10 @@ Some deprecations have expired and been removed:
 
 The default version of the [Pex](https://docs.pex-tool.org/) tool has been updated from 2.32.0 to [2.33.2](https://github.com/pex-tool/pex/releases/tag/v2.33.2).  Among many improvements and bug fixes, this unlocks support for pip [25.0.1](https://pip.pypa.io/en/stable/news/#v25-0-1).
 
-The default version of the [Ruff](https://docs.astral.sh/ruff/) tool has been updated from [0.7.2](https://github.com/astral-sh/ruff/releases/tag/0.7.2) to [0.9.6](https://github.com/astral-sh/ruff/releases/tag/0.9.6).
+The Ruff backends (`pants.backend.experimental.python.lint.ruff.check`, `pants.backend.experimental.python.lint.ruff.format`) have had several improvements:
+
+- Far less overhead for concurrent executions on macOS: the executable is now hard-linked into sandboxes, which side-steps Gatekeeper checks on macOS (when enabled, as they are by default) that made concurrent executions behave as if they were run sequentially.
+- The default version of the [Ruff](https://docs.astral.sh/ruff/) tool has been updated from [0.7.2](https://github.com/astral-sh/ruff/releases/tag/0.7.2) to [0.11.0](https://github.com/astral-sh/ruff/releases/tag/0.11.0).
 
 The Pants repo now uses Ruff format in lieu of Black. This was not a drop-in replacement, with over 160 files modified (and about 5 MyPy errors introduced by Ruff's formatting).
 


### PR DESCRIPTION
This uses an immutable input to load the ruff executable into a sandbox, making the highly-concurrent execution _much_ faster on macOS (when Gatekeeper is enabled) by making them actually-parallel instead of taking each invocation taking an additional ~0.4s compared to the previous one.

As identified by @chris-smith-zocdoc in https://github.com/pantsbuild/pants/issues/22111#issuecomment-2744978600, it seems the Gatekeeper security checks of new executables on macOS:

1. consider a copy (but not hardlink) of an existing executable as a "new" one
2. run sequentially
3. take a non-trivial fraction of a second (in the range of 0.4s)

These interact particularly poorly with Pants' sandboxing: the "default" way of providing an executable by merging it into the main digest results in copying an executable, and thus each execution of ruff results in a new Gatekeeper checks (1). For pants' concurrent invocations, all of these checks happen sequentially/serially (2), and, because the checks take so long (3) but ruff runs so fast, the total execution time is completely dominated by the Gatekeeper overhead.

Notes:

- I believe this optimisation will only work when `[GLOBAL].local_execution_root_dir` and `[GLOBAL].local_store_dir` support hard-links between them (or else materialising the immutable inputs will still have to copy executables, and thus still suffer from 1). I believe this is supported by default.
- I suspect there are other backends that suffer from this problem too, I'll have a think about how to help them... but I suspect Ruff is one of the most egregious given it runs so fast (i.e. the overhead ratio is very large).

Fixes #22111 

## Performance

Using a modified version of the reproducer in #22111, with 16 concurrent Ruff processes, this clearly makes a big difference. (There's still a fair amount of overhead compared to running outside of Pants, but we've at least solved the worst problem here.)

| pants version | Local process total time (s) | Wall time (s) |
|---|---|---|
| 2.26.0.dev8 (latest release at time of writing) | 60 | 7.31 |
| this PR | 7.5 | 0.89 |

Wall time = time to from the "scheduler initialized" log-line to the last log message, i.e. real-time required to run the Ruff processes themselves ignoring .

```shell
cd $(mktemp -d)

cat > pants.toml <<EOF
[GLOBAL]
pants_version = "2.26.0.dev8"

backend_packages = [
  "pants.backend.python",
  "pants.backend.experimental.python.lint.ruff.check",
]

process_execution_local_parallelism = 100
local_cache = false

[stats]
log = true

[python]
interpreter_constraints = ["CPython==3.10.*"]

[lint]
batch_size = 1
EOF

echo "python_sources(name='src')" > BUILD

for i in $(seq 1 16); do
    touch src$i.py
done

time pants lint ::
```

(Changes from #22111: removing the `pants version` scheduler initialisation, removing the "Manual" comparisons, setting `[stats].log = true`, setting `process_execution_local_parallelism = 100` to get full-parallelism)