### PR TITLE
Add release notes file for 2.27

### DIFF
--- a/docs/notes/2.27.x.md
+++ b/docs/notes/2.27.x.md
@@ -1,0 +1,32 @@
+# 2.27.x Release Series
+
+Pants is a fast, scalable, user-friendly build system for codebases of all sizes.
+
+Pants is an open-source project that is not owned or controlled by any one company or organization, and does incur some expenses. These expenses are managed by Pants Build, a non-profit that was established for this purpose. This non-profit's only source of revenue is [sponsorship](https://www.pantsbuild.org/sponsorship) by individuals and companies that use Pants.
+
+We offer [formal sponsorship tiers for companies](https://www.pantsbuild.org/sponsorship), as well as individual sponsorships via [GitHub](https://github.com/sponsors/pantsbuild).
+
+Thank you to [Klaviyo](https://www.klaviyo.com/) for their Platinum tier support through throughout this release.
+
+## What's New
+
+### Highlights
+
+### Deprecations
+
+
+### General
+
+### Goals
+
+
+### Backends
+
+
+
+### Plugin API changes
+
+
+## Full Changelog
+
+For the full changelog, see the individual GitHub Releases for this series: <https://github.com/pantsbuild/pants/releases>


### PR DESCRIPTION
Branching for 2.26.x soon (https://github.com/pantsbuild/pants/pull/22115), and thus `main` will become 2.27.