### PR TITLE
Fix crash when base image is referenced by digest

### DIFF
--- a/docs/notes/2.26.x.md
+++ b/docs/notes/2.26.x.md
@@ -91,6 +91,8 @@ To enable this option, add the following to your `pants.toml`
 publish_noninteractively = true
 ```
 
+[Fixed](https://github.com/pantsbuild/pants/pull/22118) a bug on package to correctly handle base images referenced by digest only.
+
 #### Javascript
 
 The Node.js runtime was upgraded from version [22.6.0](https://github.com/nodejs/node/releases/tag/v22.14.0) to version [22.14.0](https://github.com/nodejs/node/releases/tag/v22.14.0).

--- a/src/python/pants/backend/docker/util_rules/docker_build_context.py
+++ b/src/python/pants/backend/docker/util_rules/docker_build_context.py
@@ -167,7 +167,7 @@ class DockerBuildContext:
         # Go over all FROM tags and names for all stages.
         stage_names: set[str] = set()
         # tag is empty if image is referenced by digest instead
-        stage_tags = ((tag.split(maxsplit=1) + [""])[:2] for tag in dockerfile_info.version_tags)
+        stage_tags = ([*tag.split(maxsplit=1), ""][:2] for tag in dockerfile_info.version_tags)
         tags_values: dict[str, str] = {}
         for idx, (stage, tag) in enumerate(stage_tags):
             if tag.startswith("build-arg:"):

--- a/src/python/pants/backend/docker/util_rules/docker_build_context.py
+++ b/src/python/pants/backend/docker/util_rules/docker_build_context.py
@@ -166,7 +166,8 @@ class DockerBuildContext:
     ) -> tuple[set[str], dict[str, str]]:
         # Go over all FROM tags and names for all stages.
         stage_names: set[str] = set()
-        stage_tags = (tag.split(maxsplit=1) for tag in dockerfile_info.version_tags)
+        # tag is empty if image is referenced by digest instead
+        stage_tags = ((tag.split(maxsplit=1) + [""])[:2] for tag in dockerfile_info.version_tags)
         tags_values: dict[str, str] = {}
         for idx, (stage, tag) in enumerate(stage_tags):
             if tag.startswith("build-arg:"):

--- a/src/python/pants/backend/docker/util_rules/docker_build_context.py
+++ b/src/python/pants/backend/docker/util_rules/docker_build_context.py
@@ -190,10 +190,11 @@ class DockerBuildContext:
 
             if stage != f"stage{idx}":
                 stage_names.add(stage)
-            if idx == 0:
-                # Expose the first (stage0) FROM directive as the "baseimage".
-                tags_values["baseimage"] = tag
-            tags_values[stage] = tag
+            if tag:
+                if idx == 0:
+                    # Expose the first (stage0) FROM directive as the "baseimage".
+                    tags_values["baseimage"] = tag
+                tags_values[stage] = tag
 
         return stage_names, tags_values
 

--- a/src/python/pants/backend/docker/util_rules/docker_build_context_test.py
+++ b/src/python/pants/backend/docker/util_rules/docker_build_context_test.py
@@ -788,14 +788,15 @@ def test_create_docker_build_context() -> None:
             copy_source_paths=(),
             copy_build_args=DockerBuildArgs.from_strings(),
             from_image_build_args=DockerBuildArgs.from_strings(),
-            version_tags=("base latest", "stage1 1.2", "dev 2.0", "prod 2.0"),
+            # Stage without tags tests regression of #22108
+            version_tags=("base latest", "stage1 1.2", "dev 2.0", "prod 2.0", "stage0"),
         ),
     )
     assert list(context.build_args) == ["ARGNAME=value1"]
     assert dict(context.build_env.environment) == {"ENVNAME": "value2"}
     assert context.upstream_image_ids == ("abc", "def")
     assert context.dockerfile == "test/Dockerfile"
-    assert context.stages == ("base", "dev", "prod")
+    assert context.stages == ("base", "dev", "prod", "stage0")
 
 
 def test_pex_custom_output_path_issue14031(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/backend/docker/util_rules/docker_build_context_test.py
+++ b/src/python/pants/backend/docker/util_rules/docker_build_context_test.py
@@ -789,14 +789,43 @@ def test_create_docker_build_context() -> None:
             copy_build_args=DockerBuildArgs.from_strings(),
             from_image_build_args=DockerBuildArgs.from_strings(),
             # Stage without tags tests regression of #22108
-            version_tags=("base latest", "stage1 1.2", "dev 2.0", "prod 2.0", "stage0"),
+            version_tags=("base latest", "stage1 1.2", "dev 2.0", "prod 2.0", "stage4"),
         ),
     )
     assert list(context.build_args) == ["ARGNAME=value1"]
     assert dict(context.build_env.environment) == {"ENVNAME": "value2"}
     assert context.upstream_image_ids == ("abc", "def")
     assert context.dockerfile == "test/Dockerfile"
-    assert context.stages == ("base", "dev", "prod", "stage0")
+    assert context.stages == ("base", "dev", "prod")
+    assert context.interpolation_context["tags"] == {
+        "baseimage": "latest",
+        "base": "latest",
+        "stage1": "1.2",
+        "dev": "2.0",
+        "prod": "2.0",
+    }
+
+
+def test_create_docker_build_context_digest_only() -> None:
+    context = DockerBuildContext.create(
+        build_args=DockerBuildArgs.from_strings("ARGNAME=value1"),
+        snapshot=EMPTY_SNAPSHOT,
+        build_env=DockerBuildEnvironment.create({"ENVNAME": "value2"}),
+        upstream_image_ids=["def", "abc"],
+        dockerfile_info=DockerfileInfo(
+            address=Address("test"),
+            digest=EMPTY_DIGEST,
+            source="test/Dockerfile",
+            build_args=DockerBuildArgs.from_strings(),
+            copy_source_paths=(),
+            copy_build_args=DockerBuildArgs.from_strings(),
+            from_image_build_args=DockerBuildArgs.from_strings(),
+            # Stage without tags tests regression of #22108
+            version_tags=("bydigest",),
+        ),
+    )
+    assert context.stages == ("bydigest",)
+    assert context.interpolation_context["tags"] == {}
 
 
 def test_pex_custom_output_path_issue14031(rule_runner: RuleRunner) -> None:


### PR DESCRIPTION
Make sure to always unpack two values.

Fixes https://github.com/pantsbuild/pants/issues/22108