### PR TITLE
Remove deprecated options that expire in 2.27.0.dev0

### DIFF
--- a/docs/notes/2.27.x.md
+++ b/docs/notes/2.27.x.md
@@ -19,6 +19,8 @@ Thank you to [Klaviyo](https://www.klaviyo.com/) for their Platinum tier support
 
 The deprecation has expired for the `[GLOBAL].native_options_validation` option and it has been removed. The option already has no effect and can be safely deleted.
 
+The deprecation has expired for the `[GLOBAL].allow_deprecated_macos_before_12` option and it has been removed. The functionality has been replaced by [the `[GLOBAL].allow_deprecated_macos_versions` option](https://www.pantsbuild.org/2.27/reference/global-options#allow_deprecated_macos_versions).
+
 ### Goals
 
 

--- a/docs/notes/2.27.x.md
+++ b/docs/notes/2.27.x.md
@@ -17,6 +17,8 @@ Thank you to [Klaviyo](https://www.klaviyo.com/) for their Platinum tier support
 
 ### General
 
+The deprecation has expired for the `[GLOBAL].native_options_validation` option and it has been removed. The option already has no effect and can be safely deleted.
+
 ### Goals
 
 

--- a/docs/notes/2.27.x.md
+++ b/docs/notes/2.27.x.md
@@ -26,6 +26,10 @@ Thank you to [Klaviyo](https://www.klaviyo.com/) for their Platinum tier support
 
 [The `[dockerfile-parser].use_rust_parser` option](https://www.pantsbuild.org/2.27/reference/subsystems/dockerfile-parser) now defaults to true, meaning, by default, Dockerfiles are now parsed using the native Rust-based parser, which is faster and requires no external dependencies. The old parser is deprecated and will be removed in a future version of Pants.
 
+#### Python
+
+In [the `[ruff]` subsystem](https://www.pantsbuild.org/2.27/reference/subsystems/ruff), the deprecations have expired for these options and thus they have been removed: `install_from_resolve`, `requirements`, `interpreter_constraints`, `consnole_script`, `entry_point`. The removed options already have no effect (they're replaced by the `version` and `known_versions` options), and can be safely deleted .
+
 ### Plugin API changes
 
 

--- a/src/python/pants/backend/python/lint/ruff/subsystem.py
+++ b/src/python/pants/backend/python/lint/ruff/subsystem.py
@@ -16,15 +16,7 @@ from pants.core.util_rules.external_tool import TemplatedExternalTool
 from pants.engine.platform import Platform
 from pants.engine.rules import collect_rules
 from pants.engine.unions import UnionRule
-from pants.option.option_types import (
-    ArgsListOption,
-    BoolOption,
-    FileOption,
-    SkipOption,
-    StrListOption,
-    StrOption,
-)
-from pants.util.docutil import doc_url
+from pants.option.option_types import ArgsListOption, BoolOption, FileOption, SkipOption
 from pants.util.strutil import softwrap
 
 
@@ -164,47 +156,6 @@ class Ruff(TemplatedExternalTool):
             check_existence=[os.path.join(d, "ruff.toml") for d in all_dirs],
             check_content={os.path.join(d, "pyproject.toml"): b"[tool.ruff" for d in all_dirs},
         )
-
-    _removal_hint = f"NOW IGNORED: use `version` and `known_versions` options to customise the version of ruff, replacing this option; consider deleting the resolve and `python_requirement` if no longer used. See {doc_url('reference/subsystems/ruff')}"
-
-    # Options that only exist to ease the upgrade from Ruff as a Python tool to Ruff as an external
-    # downloaded one
-    install_from_resolve = StrOption(
-        advanced=True,
-        default=None,
-        removal_version="2.27.0.dev0",
-        removal_hint=_removal_hint,
-        help="Formerly used to customise the version of Ruff to install.",
-    )
-
-    requirements = StrListOption(
-        advanced=True,
-        default=None,
-        removal_version="2.27.0.dev0",
-        removal_hint=_removal_hint,
-        help="Formerly used to customise the version of Ruff to install.",
-    )
-    interpreter_constraints = StrListOption(
-        advanced=True,
-        default=None,
-        removal_version="2.27.0.dev0",
-        removal_hint=_removal_hint,
-        help="Formerly used to customise the version of Ruff to install.",
-    )
-    console_script = StrOption(
-        advanced=True,
-        default=None,
-        removal_version="2.27.0.dev0",
-        removal_hint=_removal_hint,
-        help="Formerly used to customise the version of Ruff to install.",
-    )
-    entry_point = StrOption(
-        advanced=True,
-        default=None,
-        removal_version="2.27.0.dev0",
-        removal_hint=_removal_hint,
-        help="Formerly used to customise the version of Ruff to install.",
-    )
 
 
 def rules():

--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -20,7 +20,7 @@ from pants.init.util import init_workdir
 from pants.option.option_value_container import OptionValueContainer
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.util.docutil import doc_url
-from pants.util.osutil import get_normalized_arch_name, is_macos_before_12, macos_major_version
+from pants.util.osutil import get_normalized_arch_name, macos_major_version
 from pants.util.strutil import softwrap
 
 logger = logging.getLogger(__name__)
@@ -182,11 +182,6 @@ def _validate_macos_version(global_bootstrap_options: OptionValueContainer) -> N
     macos_version = macos_major_version()
     if macos_version is None:
         # Not macOS, no validation/deprecations required!
-        return
-
-    if global_bootstrap_options.allow_deprecated_macos_before_12 and is_macos_before_12():
-        # If someone has set this (deprecated) option, and the system is older than macOS 12,
-        # they'll don't want messages, so just skip.
         return
 
     arch_versions = _MACOS_VERSION_BECOMES_UNSUPPORTED_IN[get_normalized_arch_name()]

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1769,22 +1769,6 @@ class BootstrapOptions:
             )
         return value
 
-    allow_deprecated_macos_before_12 = BoolOption(
-        default=False,
-        advanced=True,
-        help=softwrap(
-            f"""
-            Silence warnings about running Pants on macOS 10.15 - 11. In future versions, Pants will
-            only be supported on macOS 12 and newer.
-
-            If you have questions or concerns about this, please reach out to us at
-            {doc_url("community/getting-help")}.
-            """
-        ),
-        removal_version="2.27.0.dev0",
-        removal_hint='Upgrade your operating system or write `allow_deprecated_macos_versions = ["10", "11"]` instead.',
-    )
-
     allow_deprecated_macos_versions = StrListOption(
         default=[],
         advanced=True,

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -43,7 +43,7 @@ from pants.option.option_types import (
     collect_options_info,
 )
 from pants.option.option_value_container import OptionValueContainer
-from pants.option.options import NativeOptionsValidation, Options
+from pants.option.options import Options
 from pants.option.scope import GLOBAL_SCOPE
 from pants.option.subsystem import Subsystem
 from pants.util.dirutil import fast_relpath_optional
@@ -978,33 +978,6 @@ class BootstrapOptions:
             Paths to Pants config files. This may only be set through the environment variable
             `PANTS_CONFIG_FILES` and the command line argument `--pants-config-files`; it will
             be ignored if in a config file like `pants.toml`.
-            """
-        ),
-    )
-    native_options_validation = EnumOption(
-        default=NativeOptionsValidation.warning,
-        removal_version="2.27.0.dev0",
-        removal_hint="The legacy parser has been removed so this option has no effect.",
-        help=softwrap(
-            """
-            Pants is switching its option parsing system from a legacy parser written in Python
-            to a new one written in Rust.
-
-            The results of parsing a given option by each system should be identical. However
-            during a transition period we will run both parsers and compare their results.
-            This option controls how to report discrepancies that arise.
-
-            - `error`: Discrepancies will cause Pants to exit.
-
-            - `warning`: Discrepancies will be logged but Pants will continue.
-
-            - `ignore`: A last resort to turn off this check entirely.
-
-            If you encounter discrepancies that are not easily resolvable, please reach out to
-            us on Slack or file an issue: https://www.pantsbuild.org/community/getting-help.
-
-            The native parser will become the default in 2.23.x, and the legacy parser will be removed in 2.24.x.
-            So it is imperative that we find out about any discrepancies during this transition period.
             """
         ),
     )

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -7,7 +7,6 @@ import dataclasses
 import logging
 from collections import defaultdict
 from collections.abc import Iterable, Mapping, Sequence
-from enum import Enum
 from typing import Any
 
 from pants.base.deprecated import warn_or_error
@@ -29,12 +28,6 @@ from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
 from pants.util.strutil import softwrap
 
 logger = logging.getLogger(__name__)
-
-
-class NativeOptionsValidation(Enum):
-    ignore = "ignore"
-    warning = "warning"
-    error = "error"
 
 
 class Options:

--- a/src/python/pants/util/osutil.py
+++ b/src/python/pants/util/osutil.py
@@ -111,12 +111,6 @@ def is_macos_big_sur() -> bool:
     return macos_major_version() == 11
 
 
-def is_macos_before_12() -> bool:
-    """MacOS 11 support ended Sep 2023."""
-    version = macos_major_version()
-    return version is not None and version < 12
-
-
 def getuser() -> str:
     try:
         return getpass.getuser()


### PR DESCRIPTION
This resolves the 3 of the 4 deprecations that expire in 2.27.0.dev0 now that we've branched for 2.26 (#22115), all removing some options:

- old options on `[ruff]` (deprecated in 2.24, in #21237 and then postponed in #21926)
- `[GLOBAL].native_options_validation` (deprecated in 2.25, in #21577 and then postponed #21926)
- `[GLOBAL].allow_deprecated_macos_before_12` (deprecated in 2.24, in #21569 and then postponed in #21926)

The last 2.27.0.dev0 deprecation is resolved in #22124.