### PR TITLE
Mypy cache no longer shared between resolves (Cherry-pick of #22112)

### DIFF
--- a/docs/notes/2.26.x.md
+++ b/docs/notes/2.26.x.md
@@ -143,6 +143,12 @@ The Rust-based dependency inference logic now handles concatenated string litera
 
 The `pip` download log from `pex` is now materialized into the sandbox when generating lockfiles. For example: `pants --keep-sandboxes=always generate-lockfiles --resolve=foo` will create a sandbox in `/tmp/.../pants-sandbox-.../` with a file named `pex-pip-download.log`.
 
+Other changes:
+
+- Mypy cache is no longer shared between resolves to address shared cache false positives.
+New cache location is found in `~/.cache/pants/named_caches/mypy_cache/<build_root_hash>/<resolve_name>/<py_version>/cache.db`.
+
+
 #### Shell
 
 The `experiemental_test_shell_command` target type is no longer experimental and is stabilized as the `test_shell_command` target type. As part of stablilizing it, `test_shell_command` learned several new features:

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -233,6 +233,8 @@ async def mypy_typecheck_partition(
     )
     named_cache_dir = ".cache/mypy_cache"
     mypy_cache_dir = f"{named_cache_dir}/{sha256(build_root.path.encode()).hexdigest()}"
+    if partition.resolve_description:
+        mypy_cache_dir += f"/{partition.resolve_description}"
     run_cache_dir = ".tmp_cache/mypy_cache"
     argv = await _generate_argv(
         mypy,

--- a/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
@@ -3,7 +3,10 @@
 
 from __future__ import annotations
 
+import os.path
 import re
+from hashlib import sha256
+from pathlib import Path
 from textwrap import dedent
 
 import pytest
@@ -600,6 +603,49 @@ def test_protobuf_mypy(rule_runner: PythonRuleRunner) -> None:
     assert 'Argument "name" to "Person" has incompatible type "int"' in result[0].stdout
     assert 'Argument "id" to "Person" has incompatible type "str"' in result[0].stdout
     assert result[0].exit_code == 1
+
+
+def test_cache_directory_per_resolve(rule_runner: PythonRuleRunner) -> None:
+    build_multiple_resolves = dedent(
+        """\
+        python_source(
+            name='f_from_a',
+            source='f.py',
+            resolve='a',
+        )
+        python_source(
+           name='f_from_b',
+           source='f.py',
+           resolve='b',
+        )
+        """
+    )
+    rule_runner.write_files(
+        {
+            f"{PACKAGE}/f.py": GOOD_FILE,
+            f"{PACKAGE}/BUILD": build_multiple_resolves,
+            "mypy.lock": read_sibling_resource(__name__, "mypy_with_django_stubs.lock"),
+        }
+    )
+    target_a = rule_runner.get_target(Address(PACKAGE, target_name="f_from_a"))
+    target_b = rule_runner.get_target(Address(PACKAGE, target_name="f_from_b"))
+
+    runner_options = [
+        "--python-resolves={'a': 'mypy.lock', 'b': 'mypy.lock'}",
+        "--python-enable-resolves",
+    ]
+    run_mypy(rule_runner, [target_a, target_b], extra_args=runner_options)
+
+    with rule_runner.pushd():
+        Path("BUILDROOT").touch()
+        bootstrap_options = rule_runner.options_bootstrapper.bootstrap_options.for_global_scope()
+    named_cache_dir = bootstrap_options.named_caches_dir
+    mypy_cache_dir = (
+        f"{named_cache_dir}/mypy_cache/{sha256(rule_runner.build_root.encode()).hexdigest()}"
+    )
+    for resolve in ["a", "b"]:
+        expected_cache_dir = f"{mypy_cache_dir}/{resolve}"
+        assert os.path.exists(expected_cache_dir)
 
 
 @skip_unless_all_pythons_present("3.8", "3.9")


### PR DESCRIPTION
In my company's repository we have multiple resolves on the same python version with different requirements. When running `pants check` on files that are shared between the resolves sometimes (it is sporadic based on cache state) we get errors on one of the resolves with missing libraries that are not present in it, but are present in the other resolve (the file itself doesn't use this package):
```
src/python/hs_build/version_upgrade/build_macos_x86_64_wheels.py:1: error: Cannot find implementation or library stub for module named "torch.nn.functional"  [import-not-found]
src/python/hs_build/version_upgrade/build_macos_x86_64_wheels.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
```

To avoid such cache inconsistencies I propose we scope the mypy cache by resolve, so no such clashing can occur.
