### PR TITLE
Upgrade pex 2.33.4 -> 2.33.7

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -11,7 +11,7 @@ freezegun==1.2.1
 ijson==3.2.3
 libcst==1.4.0
 packaging==24.2
-pex==2.33.4
+pex==2.33.7
 psutil==5.9.8
 # This should be compatible with pytest.py, although it can be looser so that we don't
 # over-constrain pantsbuild.pants.testutil

--- a/3rdparty/python/user_reqs.lock
+++ b/3rdparty/python/user_reqs.lock
@@ -23,7 +23,7 @@
 //     "mypy-typing-asserts==0.1.1",
 //     "node-semver==0.9.0",
 //     "packaging==24.2",
-//     "pex==2.33.4",
+//     "pex==2.33.7",
 //     "psutil==5.9.8",
 //     "pydevd-pycharm==251.23536.40",
 //     "pytest<7.1.0,>=6.2.4",
@@ -1053,13 +1053,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "74adabf5dbe24b47b10b1fdca9d814338339d76e5d536e3f68c18af773f90512",
-              "url": "https://files.pythonhosted.org/packages/21/66/be866dc522514830272e128aae0fec2a0a5e995ce75baa68acf248d8eed0/pex-2.33.4-py2.py3-none-any.whl"
+              "hash": "e97d688dd3b80c1264817001cb593c0c708cc60772508a73ffcecb362d240996",
+              "url": "https://files.pythonhosted.org/packages/af/da/1d91d20d3e56a0f65d56106e2b56ae3e5a863e43a3f32ffbda1c3c7fa698/pex-2.33.7-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ed1c80e2e0f3b075a42288bae79fe22dad517f5b5de11fbc118188e968313add",
-              "url": "https://files.pythonhosted.org/packages/ca/ea/85c749a5766881aa97e7c16ed22edeaf092ed0e86c3145f8ed0372f402c8/pex-2.33.4.tar.gz"
+              "hash": "2c663d7bcd00cb0801a2df259d84b3846926141fd1244a5cde4ec71fbdfa73c3",
+              "url": "https://files.pythonhosted.org/packages/83/f1/47b1dc8f43ed8e467ca17b81e9ef2d943093b3b7630f3c1c4165a40e1bba/pex-2.33.7.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -1068,7 +1068,7 @@
             "subprocess32>=3.2.7; python_version < \"3\" and extra == \"subprocess\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.14,>=2.7",
-          "version": "2.33.4"
+          "version": "2.33.7"
         },
         {
           "artifacts": [
@@ -2344,7 +2344,7 @@
   "only_wheels": [],
   "overridden": [],
   "path_mappings": {},
-  "pex_version": "2.33.4",
+  "pex_version": "2.33.7",
   "pip_version": "25.0.1",
   "prefer_older_binary": false,
   "requirements": [
@@ -2362,7 +2362,7 @@
     "mypy-typing-asserts==0.1.1",
     "node-semver==0.9.0",
     "packaging==24.2",
-    "pex==2.33.4",
+    "pex==2.33.7",
     "psutil==5.9.8",
     "pydevd-pycharm==251.23536.40",
     "pytest<7.1.0,>=6.2.4",

--- a/docs/notes/2.27.x.md
+++ b/docs/notes/2.27.x.md
@@ -32,6 +32,8 @@ The deprecation has expired for the `[GLOBAL].allow_deprecated_macos_before_12` 
 
 #### Python
 
+The PEX tool has been upgraded from 2.33.4 to 2.33.7 by default.
+
 In [the `[ruff]` subsystem](https://www.pantsbuild.org/2.27/reference/subsystems/ruff), the deprecations have expired for these options and thus they have been removed: `install_from_resolve`, `requirements`, `interpreter_constraints`, `consnole_script`, `entry_point`. The removed options already have no effect (they're replaced by the `version` and `known_versions` options), and can be safely deleted .
 
 ### Plugin API changes

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -41,7 +41,7 @@ class PexCli(TemplatedExternalTool):
     name = "pex"
     help = "The PEX (Python EXecutable) tool (https://github.com/pex-tool/pex)."
 
-    default_version = "v2.33.4"
+    default_version = "v2.33.7"
     default_url_template = "https://github.com/pex-tool/pex/releases/download/{version}/pex"
     version_constraints = ">=2.13.0,<3.0"
 
@@ -58,6 +58,10 @@ class PexCli(TemplatedExternalTool):
     )
 
     default_known_versions = [
+        "v2.33.7|macos_x86_64|9224dd68c3b95f3c9d42818181bbbfd6e307ca828f9c1c24508a004d63984ce5|4591206",
+        "v2.33.7|macos_arm64|9224dd68c3b95f3c9d42818181bbbfd6e307ca828f9c1c24508a004d63984ce5|4591206",
+        "v2.33.7|linux_x86_64|9224dd68c3b95f3c9d42818181bbbfd6e307ca828f9c1c24508a004d63984ce5|4591206",
+        "v2.33.7|linux_arm64|9224dd68c3b95f3c9d42818181bbbfd6e307ca828f9c1c24508a004d63984ce5|4591206",
         "v2.33.4|macos_x86_64|d6a4041d52732ea0a323db2bea3e6a5995391fed3bc1f2b81d84ee0bcbc16e7c|4589638",
         "v2.33.4|macos_arm64|d6a4041d52732ea0a323db2bea3e6a5995391fed3bc1f2b81d84ee0bcbc16e7c|4589638",
         "v2.33.4|linux_x86_64|d6a4041d52732ea0a323db2bea3e6a5995391fed3bc1f2b81d84ee0bcbc16e7c|4589638",


### PR DESCRIPTION
- https://github.com/pex-tool/pex/releases/tag/v2.33.5
- https://github.com/pex-tool/pex/releases/tag/v2.33.6
- https://github.com/pex-tool/pex/releases/tag/v2.33.7