### PR TITLE
Use explicit relative path when executing __mypy_runner.sh shim script

### DIFF
--- a/docs/notes/2.27.x.md
+++ b/docs/notes/2.27.x.md
@@ -36,6 +36,10 @@ The PEX tool has been upgraded from 2.33.4 to 2.33.7 by default.
 
 In [the `[ruff]` subsystem](https://www.pantsbuild.org/2.27/reference/subsystems/ruff), the deprecations have expired for these options and thus they have been removed: `install_from_resolve`, `requirements`, `interpreter_constraints`, `consnole_script`, `entry_point`. The removed options already have no effect (they're replaced by the `version` and `known_versions` options), and can be safely deleted .
 
+Minor fixes:
+
+- If a sandbox for executing mypy is preserved, the `__run.sh` script now refers to the main script by a relative path and [can thus be successfully executed](https://github.com/pantsbuild/pants/issues/22138).
+
 ### Plugin API changes
 
 

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -367,7 +367,7 @@ async def mypy_typecheck_partition(
             append_only_caches={"mypy_cache": named_cache_dir},
         ),
     )
-    process = dataclasses.replace(process, argv=("__mypy_runner.sh",))
+    process = dataclasses.replace(process, argv=("./__mypy_runner.sh",))
     result = await Get(FallibleProcessResult, Process, process)
     report = await Get(Digest, RemovePrefix(result.output_digest, REPORT_DIR))
     return CheckResult.from_fallible_process_result(


### PR DESCRIPTION
This ensures that it ends up as a relative path in the `__run.sh` script if the sandbox is preserved, thus allowing humans to successfully run what Pants runs.

It appears that the `execvp` libc function behaves differently when `PATH` isn't set to how bash behaves (https://github.com/pantsbuild/pants/issues/22138#issuecomment-2762105083).

Fixes #22138 