### PR TITLE
Use pex's native --sh-boot for low-overhead VenvPexes

### DIFF
--- a/docs/notes/2.27.x.md
+++ b/docs/notes/2.27.x.md
@@ -36,6 +36,10 @@ The PEX tool has been upgraded from 2.33.4 to 2.33.7 by default.
 
 In [the `[ruff]` subsystem](https://www.pantsbuild.org/2.27/reference/subsystems/ruff), the deprecations have expired for these options and thus they have been removed: `install_from_resolve`, `requirements`, `interpreter_constraints`, `consnole_script`, `entry_point`. The removed options already have no effect (they're replaced by the `version` and `known_versions` options), and can be safely deleted .
 
+Minor fixes:
+
+- If a sandbox for executing mypy is preserved, the `__run.sh` script now refers to the main script by a relative path and [can thus be successfully executed](https://github.com/pantsbuild/pants/issues/22138).
+
 ### Plugin API changes
 
 

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -367,7 +367,7 @@ async def mypy_typecheck_partition(
             append_only_caches={"mypy_cache": named_cache_dir},
         ),
     )
-    process = dataclasses.replace(process, argv=("__mypy_runner.sh",))
+    process = dataclasses.replace(process, argv=("./__mypy_runner.sh",))
     result = await Get(FallibleProcessResult, Process, process)
     report = await Get(Digest, RemovePrefix(result.output_digest, REPORT_DIR))
     return CheckResult.from_fallible_process_result(

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -43,7 +43,7 @@ class PexCli(TemplatedExternalTool):
 
     default_version = "v2.33.7"
     default_url_template = "https://github.com/pex-tool/pex/releases/download/{version}/pex"
-    version_constraints = ">=2.13.0,<3.0"
+    version_constraints = ">=2.33.7,<3.0"
 
     # extra args to be passed to the pex tool; note that they
     # are going to apply to all invocations of the pex tool.


### PR DESCRIPTION
Still a work-in-progress, opening to run all tests and see what's broken.

TODO:

- updating comments 
- updating docs
- updating release notes etc.
- considering if this needs explicit tests