### PR TITLE
Refer to Python 3.11, not 3.9, in plugin docs (Cherry-pick of #22136)

### DIFF
--- a/docs/docs/contributions/development/setting-up-pants.mdx
+++ b/docs/docs/contributions/development/setting-up-pants.mdx
@@ -26,15 +26,15 @@ $ echo 'export CPPFLAGS="-I$(brew --prefix)/opt/openssl/include"' >> ~/.bashrc
 
 ## Step 2: Bootstrap the Rust engine
 
-Pants requires several dependencies to be installed: a Python 3.9 interpreter, Rust, the protobuf compiler, clang and others. There is experimental support for the Nix package manager that makes it easy to set up a dev environment. Follow the instructions on the [Nix website](https://nixos.org/download.html) to install Nix. Then `cd` into the directory where you cloned the Pants repo and type `nix-shell`. This will download all the necessary dependencies and start a shell with a suitably configured PATH variable to make them available for use.
+Pants requires several dependencies to be installed: a Python 3.11 interpreter, Rust, the protobuf compiler, clang and others. There is experimental support for the Nix package manager that makes it easy to set up a dev environment. Follow the instructions on the [Nix website](https://nixos.org/download.html) to install Nix. Then `cd` into the directory where you cloned the Pants repo and type `nix-shell`. This will download all the necessary dependencies and start a shell with a suitably configured PATH variable to make them available for use.
 
 Alternatively, you can install the dependencies manually as follows:
 
 Pants uses Rustup to install Rust. Run the command from [https://rustup.rs](https://rustup.rs) to install Rustup; ensure that `rustup` is on your `$PATH`.
 
-If your system Python is not the version Pants expects (currently Python 3.9), you'll need to provide one. Python interpreters from Linux or Mac distributions sometimes have quirks that can cause headaches with bootstrapping the dev venv. Some examples of Pythons that work well with Pants are those provided by:
+If your system Python is not the version Pants expects (currently Python 3.11), you'll need to provide one. Python interpreters from Linux or Mac distributions sometimes have quirks that can cause headaches with bootstrapping the dev venv. Some examples of Pythons that work well with Pants are those provided by:
 
-- [Fedora](https://packages.fedoraproject.org/pkgs/python3.9/python3.9/)
+- [Fedora](https://packages.fedoraproject.org/pkgs/python3.11/python3.11/)
 - [ASDF](https://github.com/asdf-community/asdf-python)
 - [PyEnv](https://github.com/pyenv/pyenv)
   Providers that sometimes cause issues include:

--- a/docs/docs/writing-plugins/overview.mdx
+++ b/docs/docs/writing-plugins/overview.mdx
@@ -165,14 +165,14 @@ pants-plugins = "pants-plugins/lock.txt"
 python-default = "3rdparty/python/default_lock.txt"
 
 [python.resolves_to_interpreter_constraints]
-# Pants runs with Python 3.9, so this lets us
+# Pants runs with Python 3.11, so this lets us
 # use different interpreter constraints when
 # generating the lockfile than the rest of our project.
 #
 # Warning: it's still necessary to set the `interpreter_constraints`
 # field on each `python_sources` and `python_tests` target in
 # our plugin! This only impacts how the lockfile is generated.
-pants-plugins = ["==3.9.*"]
+pants-plugins = ["==3.11.*"]
 ```
 
 Then, update your `pants_requirements` target generator with `resolve="pants-plugins"`, and run `pants generate-lockfiles`. You will also need to update the relevant `python_source` / `python_sources` and `python_test` / `python_tests` targets to set `resolve="pants-plugins"` (along with possibly the `interpreter_constraints` field).


### PR DESCRIPTION
In 2.25, we switched to running Pants' code using Python 3.11, not 3.9, but didn't update the docs to match. This PR does so.
