### PR TITLE
Include all commits in GH release summary

### DIFF
--- a/src/python/pants_release/changelog.py
+++ b/src/python/pants_release/changelog.py
@@ -120,7 +120,7 @@ def format_notes_by_category(entries: list[Entry]) -> str:
 def format_notes(entries: list[Entry]) -> str:
     if not entries:
         return ""
-    return "\n\n".join([entry.text for entry in entries if entry.category != Category.Internal])
+    return "\n\n".join(entry.text for entry in entries)
 
 
 def main() -> None:


### PR DESCRIPTION
This removes the "internal"-category filtering from the release  notes that are auto-generated and used in the GH releases.

This is motivated by noticing that, for instance, https://github.com/pantsbuild/pants/releases/tag/release_2.25.1rc0 is missing 2 out of 3 commits, and one of those is definitely user-relevant. https://github.com/pantsbuild/pants/compare/release_2.25.0...release_2.25.1rc0:

- https://github.com/pantsbuild/pants/pull/22143
- https://github.com/pantsbuild/pants/pull/22142

Those are excluded because they're cherry-picks that get automatically labelled with `release-notes:not-required` (meaning they don't need to have changes to `docs/notes/*`), but they're still good to mention.

Prompted by this, I think it makes sense to include all changes (even internal ones) in the GH release notes, because:

- our development releases are typically quite small now (i.e. it's easy to do releases so we're doing them regularly and so most releases only have a small number of commits)
- not mentioning something that is useful to mention is worse than including some extra things

Data, looking at the releases since 2.20.0.dev0. It suggests that 77% of releases have 15 or fewer commits:

```shell
git tag -l 'release_2.2?.*' | while read -r tag; do
    previous_tag=$(git describe --abbrev=0 --tags "$tag^")
    count=$(git log --oneline "$previous_tag..$tag" | wc -l | awk '{print $1}')
    echo "$tag,$previous_tag,$count"
done | sort --numeric-sort --field-separator=',' --key=3
```

| Number of commits | Number of releases with # commits |
|---|---|
| 1-5 | 53 (44%) |
| 5-10 | 26 (22%) |
| 11-15 | 12 (10%) |
| 16-20 | 9 (8%) |
| 21-25 | 11 (9%) |
| 25+ | 7 (6%) |
| total | 118 (100%) |

(The single release with the most commits is 2.23.0a0, https://github.com/pantsbuild/pants/compare/release_2.23.0.dev6...release_2.23.0a0, with 63 commits! In this case, we fell off the "regular release" trend: there was more month between 2.23.0.dev6 (2024-08-08) and 2.23.0a0 (2024-09-12).)