### PR TITLE
Provide selected python interpreter to non-internal pex packaging via --python-path

### DIFF
--- a/docs/notes/2.27.x.md
+++ b/docs/notes/2.27.x.md
@@ -50,6 +50,8 @@ In [the `[ruff]` subsystem](https://www.pantsbuild.org/2.27/reference/subsystems
 
 The Python Build Standalone backend (`pants.backend.python.providers.experimental.python_build_standalone`) has release metadata current through PBS release `20250317`.
 
+Packaging a `pex_binary` target for a local interpreter (that is, without `complete_platforms`) now works when using a Python provider like `pants.backend.python.providers.experimental.python_build_standalone` or `pants.backend.python.providers.experimental.pyenv`.
+
 The default module mappings now includes the `hdrhistogram` package (imported as `hdrh`).
 
 Minor fixes:

--- a/src/python/pants/backend/python/goals/package_pex_binary_integration_test.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary_integration_test.py
@@ -480,7 +480,8 @@ def test_package_with_python_provider() -> None:
             [
                 "--backend-packages=pants.backend.python",
                 "--backend-packages=pants.backend.python.providers.experimental.python_build_standalone",
-                # a "random" old version of Python, that seems unlikely to be installed on most systems, by default
+                # a random (https://xkcd.com/221/) old version of Python, that seems unlikely to be
+                # installed on most systems, by default
                 "--python-interpreter-constraints=CPython==3.10.2",
                 "package",
                 f"{tmpdir}:target",

--- a/src/python/pants/backend/python/goals/package_pex_binary_integration_test.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary_integration_test.py
@@ -495,7 +495,10 @@ def test_package_with_python_provider() -> None:
     field_set = PexBinaryFieldSet.create(tgt)
 
     # a random (https://xkcd.com/221/) old version of Python, that seems unlikely to be installed on
-    # most systems, by default
+    # most systems, by default... but also, we don't propagate PATH (etc.) for this rule_runner, so
+    # the test shouldn't be able to find system interpreters anyway.
+    #
+    # (Thus we have two layers of "assurance" the test is doing what is intended.)
     rule_runner.set_options(["--python-interpreter-constraints=CPython==3.10.2"])
 
     result = rule_runner.request(BuiltPackage, [field_set])

--- a/src/python/pants/backend/python/goals/package_pex_binary_integration_test.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary_integration_test.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import json
-import os
 import os.path
 import pkgutil
 import subprocess

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -464,7 +464,7 @@ async def _determine_pex_python_and_platforms(request: PexRequest) -> _BuildPexP
             [
                 *request.interpreter_constraints.generate_pex_arg_list(),
                 "--python-path",
-                os.path.dirname(python.path),
+                python.path,
             ],
         )
 

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -456,7 +456,17 @@ async def _determine_pex_python_and_platforms(request: PexRequest) -> _BuildPexP
     else:
         # `--interpreter-constraint` options are mutually exclusive with the `--python` option,
         # so we only specify them if we have not already located a concrete Python.
-        return _BuildPexPythonSetup(None, request.interpreter_constraints.generate_pex_arg_list())
+        python = await Get(
+            PythonExecutable, InterpreterConstraints, request.interpreter_constraints
+        )
+        return _BuildPexPythonSetup(
+            python,
+            [
+                *request.interpreter_constraints.generate_pex_arg_list(),
+                "--python-path",
+                os.path.dirname(python.path),
+            ],
+        )
 
     return _BuildPexPythonSetup(python, ["--python", python.path])
 

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -446,19 +446,24 @@ async def _determine_pex_python_and_platforms(request: PexRequest) -> _BuildPexP
 
     if request.python:
         python = request.python
-    elif request.internal_only:
-        # NB: If it's an internal_only PEX, we do our own lookup of the interpreter based on the
-        # interpreter constraints, and then will run the PEX with that specific interpreter. We
-        # will have already validated that there were no platforms.
-        python = await Get(
-            PythonExecutable, InterpreterConstraints, request.interpreter_constraints
-        )
     else:
-        # `--interpreter-constraint` options are mutually exclusive with the `--python` option,
-        # so we only specify them if we have not already located a concrete Python.
         python = await Get(
             PythonExecutable, InterpreterConstraints, request.interpreter_constraints
         )
+
+    if request.python or request.internal_only:
+        # Sometimes we want to build and run with a specific interpreter (either because request
+        # demanded it, or because it's an internal-only PEX). We will have already validated that
+        # there were no platforms.
+        return _BuildPexPythonSetup(python, ["--python", python.path])
+
+    else:
+        # Otherwise, we don't want to force compatibility with a particular interpreter (as in, the
+        # resulting PEX should follow the ICs), but we _do_ want to tell PEX about at least one
+        # interpreter that is compatible, to ensure that an interpreter installed/managed by
+        # provider backends are visible (in the extreme case, a machine may have no Python
+        # interpreters installed at all, and just rely on Pants' provider backends to install them,
+        # and thus pex searching $PATH will find nothing).
         return _BuildPexPythonSetup(
             python,
             [
@@ -467,8 +472,6 @@ async def _determine_pex_python_and_platforms(request: PexRequest) -> _BuildPexP
                 python.path,
             ],
         )
-
-    return _BuildPexPythonSetup(python, ["--python", python.path])
 
 
 @dataclass

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -656,10 +656,15 @@ def test_determine_pex_python_and_platforms() -> None:
         )
         assert result == expected
 
-    assert_setup(expected=_BuildPexPythonSetup(None, []))
+    assert_setup(
+        expected=_BuildPexPythonSetup(discovered_python, ["--python-path", discovered_python.path])
+    )
     assert_setup(
         interpreter_constraints=ics,
-        expected=_BuildPexPythonSetup(None, ["--interpreter-constraint", "CPython==3.8"]),
+        expected=_BuildPexPythonSetup(
+            discovered_python,
+            ["--interpreter-constraint", "CPython==3.8", "--python-path", discovered_python.path],
+        ),
     )
     assert_setup(
         internal_only=True,


### PR DESCRIPTION
This propagates Pants' interpreter selection into the PEX build when building local-compatible `pex_binary` target, rather than have the building process do a full-system-wide search for compatible interpreters.

In particular, when building a pex in the "default" mode/for the local system, without an explicit `complete_platforms` and not for internal-use only, we now do Pants-side interpreter selection and provide a `--python-path` argument to that chosen interpreter, to tell Pex where to find the relevant interpreter, rather than letting Pex do the search again.

A Pex-based search of `PATH` (and other paths) may not be able to find an interpreter if the user is using a Python provider backend, which will have Pants install and manage Python interpreters without being externally installed.

Fixes #21048 

Closes #21948 (replaced by this work)

Co-authored-by: Tom Solberg <me@sbg.dev>