### PR TITLE
Add support for pyproject.toml's [dependency-groups]

### DIFF
--- a/src/python/pants/backend/python/macros/python_requirements.py
+++ b/src/python/pants/backend/python/macros/python_requirements.py
@@ -51,7 +51,7 @@ def parse_pyproject_toml(pyproject_toml: str, *, rel_path: str) -> Iterator[PipR
     all_deps_iter = chain(
         deps_vals,
         chain.from_iterable(optional_dependencies.values()),
-        chain.from_iterable(dependency_groups.values()) # Add the new source
+        chain.from_iterable(dependency_groups.values()),  # Add the new source
     )
 
     for dep in all_deps_iter:
@@ -60,7 +60,6 @@ def parse_pyproject_toml(pyproject_toml: str, *, rel_path: str) -> Iterator[PipR
         if not dep_spec or dep_spec.startswith("-"):
             continue
         yield PipRequirement.parse(dep_spec, description_of_origin=rel_path)
-
 
 
 class PythonRequirementsSourceField(SingleSourceField):

--- a/src/python/pants/backend/python/macros/python_requirements.py
+++ b/src/python/pants/backend/python/macros/python_requirements.py
@@ -43,7 +43,7 @@ def parse_pyproject_toml(pyproject_toml: str, *, rel_path: str) -> Iterator[PipR
     if not deps_vals and not optional_dependencies and not dependency_groups:
         raise KeyError(
             softwrap(
-                "No section project.dependencies, project.optional-dependencies, "
+                "No non-empty section `project.dependencies`, `project.optional-dependencies`, "
                 f"or dependency-groups found in {rel_path}"
             )
         )

--- a/src/python/pants/backend/python/macros/python_requirements_test.py
+++ b/src/python/pants/backend/python/macros/python_requirements_test.py
@@ -113,7 +113,10 @@ def test_requirements_txt(rule_runner: RuleRunner) -> None:
                 Address("", target_name="reqs", generated_name="Django-types"),
             ),
             PythonRequirementTarget(
-                {"requirements": ["Un_Normalized_PROJECT"], "dependencies": [file_addr.spec]},
+                {
+                    "requirements": ["Un_Normalized_PROJECT"],
+                    "dependencies": [file_addr.spec],
+                },
                 Address("", target_name="reqs", generated_name="Un-Normalized-PROJECT"),
             ),
             PythonRequirementTarget(
@@ -153,11 +156,17 @@ def test_multiple_versions(rule_runner: RuleRunner) -> None:
                 Address("", target_name="reqs", generated_name="Django"),
             ),
             PythonRequirementTarget(
-                {"requirements": ["confusedmonkey==86"], "dependencies": [file_addr.spec]},
+                {
+                    "requirements": ["confusedmonkey==86"],
+                    "dependencies": [file_addr.spec],
+                },
                 Address("", target_name="reqs", generated_name="confusedmonkey"),
             ),
             PythonRequirementTarget(
-                {"requirements": ["repletewateringcan>=7"], "dependencies": [file_addr.spec]},
+                {
+                    "requirements": ["repletewateringcan>=7"],
+                    "dependencies": [file_addr.spec],
+                },
                 Address("", target_name="reqs", generated_name="repletewateringcan"),
             ),
             TargetGeneratorSourcesHelperTarget({"source": "requirements.txt"}, file_addr),
@@ -187,7 +196,10 @@ def test_source_override(rule_runner: RuleRunner) -> None:
         requirements_txt_relpath="subdir/requirements.txt",
         expected_targets={
             PythonRequirementTarget(
-                {"requirements": ["ansicolors>=1.18.0"], "dependencies": [file_addr.spec]},
+                {
+                    "requirements": ["ansicolors>=1.18.0"],
+                    "dependencies": [file_addr.spec],
+                },
                 Address("", target_name="reqs", generated_name="ansicolors"),
             ),
             TargetGeneratorSourcesHelperTarget({"source": "subdir/requirements.txt"}, file_addr),
@@ -199,7 +211,9 @@ def test_lockfile_dependency(rule_runner: RuleRunner) -> None:
     rule_runner.set_options(["--python-enable-resolves"])
     reqs_addr = Address("", target_name="reqs", relative_file_path="requirements.txt")
     lock_addr = Address(
-        "3rdparty/python", target_name="_python-default_lockfile", relative_file_path="default.lock"
+        "3rdparty/python",
+        target_name="_python-default_lockfile",
+        relative_file_path="default.lock",
     )
     assert_python_requirements(
         rule_runner,
@@ -296,7 +310,10 @@ def test_pyproject_toml(rule_runner: RuleRunner) -> None:
                 Address("", target_name="reqs", generated_name="Django-types"),
             ),
             PythonRequirementTarget(
-                {"requirements": ["Un_Normalized_PROJECT"], "dependencies": [file_addr.spec]},
+                {
+                    "requirements": ["Un_Normalized_PROJECT"],
+                    "dependencies": [file_addr.spec],
+                },
                 Address("", target_name="reqs", generated_name="Un-Normalized-PROJECT"),
             ),
             PythonRequirementTarget(
@@ -311,7 +328,7 @@ def test_pyproject_toml(rule_runner: RuleRunner) -> None:
                     "requirements": ["matplotlib>=3.0.0"],
                     "dependencies": [file_addr.spec],
                 },
-                Address("", target_name="reqs", generated_name="pytest"),
+                Address("", target_name="reqs", generated_name="matplotlib"),
             ),
             PythonRequirementTarget(
                 {

--- a/src/python/pants/backend/python/macros/python_requirements_test.py
+++ b/src/python/pants/backend/python/macros/python_requirements_test.py
@@ -257,6 +257,10 @@ def test_pyproject_toml(rule_runner: RuleRunner) -> None:
                 "Un-Normalized-PROJECT",  # Inline comment.
                 "pip@ git+https://github.com/pypa/pip.git",
             ]
+            [dependency-groups]
+            dev = [
+                "matplotlib>=3.0.0"
+            ]
             [project.optional-dependencies]
             test = [
                 "pytest>=5.7.0",
@@ -301,6 +305,13 @@ def test_pyproject_toml(rule_runner: RuleRunner) -> None:
                     "dependencies": [file_addr.spec],
                 },
                 Address("", target_name="reqs", generated_name="pip"),
+            ),
+            PythonRequirementTarget(
+                {
+                    "requirements": ["matplotlib>=3.0.0"],
+                    "dependencies": [file_addr.spec],
+                },
+                Address("", target_name="reqs", generated_name="pytest"),
             ),
             PythonRequirementTarget(
                 {


### PR DESCRIPTION
Adds support for [dependency groups](https://packaging.python.org/en/latest/specifications/dependency-groups/) in `python_requirement` target.