### PR TITLE
Replace deprecated importlib.resources.read_binary with (files() / …).read_bytes() (Cherry-pick of #22162)

### DIFF
--- a/src/python/pants/backend/python/util_rules/faas.py
+++ b/src/python/pants/backend/python/util_rules/faas.py
@@ -465,7 +465,7 @@ async def infer_runtime_platforms(request: RuntimePlatformsRequest) -> RuntimePl
 
     module = request.runtime.known_runtimes_complete_platforms_module()
 
-    content = importlib.resources.read_binary(module, file_name)
+    content = (importlib.resources.files(module) / file_name).read_bytes()
     snapshot = await Get(Snapshot, CreateDigest([FileContent(file_name, content)]))
 
     return RuntimePlatforms(

--- a/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
@@ -922,9 +922,9 @@ def test_lockfile_requirements_selection(
         mode_files.update({"3rdparty/python/default.lock": setuptools_poetry_lockfile})
     else:
         assert mode == ResolveMode.pex
-        lock_content = importlib.resources.read_binary(
-            "pants.backend.python.subsystems", "setuptools.lock"
-        )
+        lock_content = (
+            importlib.resources.files("pants.backend.python.subsystems") / "setuptools.lock"
+        ).read_bytes()
         mode_files.update({"3rdparty/python/default.lock": lock_content})
 
     rule_runner.write_files(mode_files)


### PR DESCRIPTION
A user packaging a FaaS artifact with Pants 2.25 can see a warning, that this PR resolves:

```
10:05:59.12 [WARN] .../venvs/2.25.1rc0/lib/python3.11/site-packages/pants/backend/python/util_rules/faas.py:476: DeprecationWarning: read_binary is deprecated. Use files() instead. Refer to https://importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy for migration advice.
  content = importlib.resources.read_binary(module, file_name)
```

I think this warning started in Pants 2.25 due to the Python 3.11 upgrade.
