### PR TITLE
Use absolute path/{chroot} for PEX_ROOT

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex_environment.py
+++ b/src/python/pants/backend/python/util_rules/pex_environment.py
@@ -237,7 +237,7 @@ class CompletePexEnvironment:
         d = dict(
             PATH=path,
             PEX_IGNORE_RCFILES="true",
-            PEX_ROOT=f"{chroot}/{self.pex_root}",
+            PEX_ROOT=f"{{chroot}}/{self.pex_root}",
             **subprocess_env_dict,
         )
         if python:

--- a/src/python/pants/backend/python/util_rules/pex_environment.py
+++ b/src/python/pants/backend/python/util_rules/pex_environment.py
@@ -237,11 +237,7 @@ class CompletePexEnvironment:
         d = dict(
             PATH=path,
             PEX_IGNORE_RCFILES="true",
-            PEX_ROOT=(
-                os.path.relpath(self.pex_root, self._working_directory)
-                if self._working_directory
-                else str(self.pex_root)
-            ),
+            PEX_ROOT=f"{chroot}/{self.pex_root}",
             **subprocess_env_dict,
         )
         if python:


### PR DESCRIPTION
Experiment. Goals:

- simplify code that has to juggle relative PEX_ROOT paths
- unblock using immutable inputs to execute pexes