### PR TITLE
upgrade to Rust  v1.86.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,7 +44,7 @@ jobs:
       run: '# Set the default toolchain. Installs the toolchain if it is not already
         installed.
 
-        rustup default 1.85.0
+        rustup default 1.86.0
 
         cargo version
 
@@ -162,7 +162,7 @@ jobs:
       run: '# Set the default toolchain. Installs the toolchain if it is not already
         installed.
 
-        rustup default 1.85.0
+        rustup default 1.86.0
 
         cargo version
 
@@ -309,7 +309,7 @@ jobs:
       with:
         key: macOS13-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain')
           }}-v2
-        path: '~/.rustup/toolchains/1.85.0-*
+        path: '~/.rustup/toolchains/1.86.0-*
 
           ~/.rustup/update-hashes
 
@@ -434,7 +434,7 @@ jobs:
       with:
         key: macOS14-ARM64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain')
           }}-v2
-        path: '~/.rustup/toolchains/1.85.0-*
+        path: '~/.rustup/toolchains/1.86.0-*
 
           ~/.rustup/update-hashes
 
@@ -560,7 +560,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.85.0-*
+        path: '~/.rustup/toolchains/1.86.0-*
 
           ~/.rustup/update-hashes
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,7 +40,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: Linux-ARM64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.85.0-*
+        path: '~/.rustup/toolchains/1.86.0-*
 
           ~/.rustup/update-hashes
 
@@ -145,7 +145,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.85.0-*
+        path: '~/.rustup/toolchains/1.86.0-*
 
           ~/.rustup/update-hashes
 
@@ -260,7 +260,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: macOS13-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.85.0-*
+        path: '~/.rustup/toolchains/1.86.0-*
 
           ~/.rustup/update-hashes
 
@@ -362,7 +362,7 @@ jobs:
     - name: Install Rust toolchain
       run: '# Set the default toolchain. Installs the toolchain if it is not already installed.
 
-        rustup default 1.85.0
+        rustup default 1.86.0
 
         cargo version
 
@@ -440,7 +440,7 @@ jobs:
     - name: Install Rust toolchain
       run: '# Set the default toolchain. Installs the toolchain if it is not already installed.
 
-        rustup default 1.85.0
+        rustup default 1.86.0
 
         cargo version
 
@@ -536,7 +536,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: macOS13-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.85.0-*
+        path: '~/.rustup/toolchains/1.86.0-*
 
           ~/.rustup/update-hashes
 
@@ -622,7 +622,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: macOS14-ARM64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.85.0-*
+        path: '~/.rustup/toolchains/1.86.0-*
 
           ~/.rustup/update-hashes
 

--- a/src/rust/engine/fs/src/directory.rs
+++ b/src/rust/engine/fs/src/directory.rs
@@ -736,12 +736,10 @@ impl DigestTrie {
                     Ordering::Less => {
                         add_ours(our_entry, result);
                         ours = our_iter.next();
-                        continue;
                     }
                     Ordering::Greater => {
                         add_theirs(their_entry, result);
                         theirs = their_iter.next();
-                        continue;
                     }
                     Ordering::Equal => match (our_entry, their_entry) {
                         (Entry::File(our_file), Entry::File(their_file)) => {

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -86,7 +86,7 @@ impl RelativePath {
                 Component::RootDir => {
                     return Err(format!("Absolute paths are not allowed: {candidate:?}"));
                 }
-                Component::CurDir => continue,
+                Component::CurDir => (),
                 Component::ParentDir => {
                     if !relative_path.pop() {
                         return Err(format!(

--- a/src/rust/engine/graph/src/entry.rs
+++ b/src/rust/engine/graph/src/entry.rs
@@ -412,10 +412,9 @@ impl<N: Node> Entry<N> {
                     // The dependencies requested by the Node so far have changed: return to cancel
                     // the work so that it can be retried from the beginning.
                     return;
-                  } else {
-                    // No dependencies have actually changed: continue waiting.
-                    continue;
                   }
+
+                  // No dependencies have actually changed: Fall through and continue waiting.
               }
               None => {
                   // We were aborted via drop: exit.

--- a/src/rust/engine/graph/src/lib.rs
+++ b/src/rust/engine/graph/src/lib.rs
@@ -479,7 +479,7 @@ impl<N: Node> Graph<N> {
                         node, self.invalidation_delay
                     );
                     sleep(self.invalidation_delay).await;
-                    continue;
+                    // fall through and retry
                 }
                 res => break res,
             }

--- a/src/rust/engine/process_execution/pe_nailgun/src/nailgun_pool.rs
+++ b/src/rust/engine/process_execution/pe_nailgun/src/nailgun_pool.rs
@@ -178,7 +178,7 @@ impl NailgunPool {
             match Self::try_use(pool_entry)? {
                 TryUse::Usable(process) => return Ok(Some((idx, process))),
                 TryUse::Dead => dead_processes.push(idx),
-                TryUse::Busy => continue,
+                TryUse::Busy => (),
             }
         }
         // NB: We'll only prune dead processes if we don't find a live match, but that's fine.

--- a/src/rust/engine/process_execution/remote/src/remote.rs
+++ b/src/rust/engine/process_execution/remote/src/remote.rs
@@ -343,7 +343,6 @@ impl CommandRunner {
                 OperationStreamItem::Running(_) => {
                     // The operation has not reached an ExecutionStage that we recognize as
                     // "executing" (likely: it is queued, doing a cache lookup, etc): keep waiting.
-                    continue;
                 }
                 OperationStreamItem::Outcome(outcome) => return outcome,
             }
@@ -378,7 +377,6 @@ impl CommandRunner {
                         }
                         OperationStreamItem::Running(_) => {
                             // The operation is still running.
-                            continue;
                         }
                         OperationStreamItem::Outcome(outcome) => break outcome,
                     }

--- a/src/rust/engine/process_execution/src/bounded.rs
+++ b/src/rust/engine/process_execution/src/bounded.rs
@@ -196,7 +196,6 @@ impl crate::CommandRunner for CommandRunner {
                   concurrency_available,
                   permit.concurrency(),
                 );
-                continue;
               },
               res = running_process => {
                 // The process completed.

--- a/src/rust/engine/process_execution/src/fork_exec.rs
+++ b/src/rust/engine/process_execution/src/fork_exec.rs
@@ -53,7 +53,6 @@ pub async fn spawn_process(
                         tokio::time::sleep(std::time::Duration::from_millis(sleep_millis)).await;
                         retries += 1;
                         sleep_millis *= 2;
-                        continue;
                     } else if retries > 0 {
                         break Err(format!(
                             "Error launching process after {} {} for ETXTBSY. Final error was: {:?}",

--- a/src/rust/engine/rust-toolchain
+++ b/src/rust/engine/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.85.0"
+channel = "1.86.0"
 # NB: We don't list the components (namely `clippy` and `rustfmt`) and instead rely on either the
 #  the profile being "default" (by-and-large the default profile) or the nice error message from
 #  `cargo fmt` and `cargo clippy` if the required component isn't installed

--- a/src/rust/engine/sharded_lmdb/src/lib.rs
+++ b/src/rust/engine/sharded_lmdb/src/lib.rs
@@ -604,7 +604,6 @@ impl ShardedLmdb {
                                     return Err(msg);
                                 } else {
                                     attempts += 1;
-                                    continue;
                                 }
                             }
                             Err(StoreError::Lmdb(lmdb::Error::KeyExist)) => return Ok(()),

--- a/src/rust/engine/testutil/mock/src/execution_server.rs
+++ b/src/rust/engine/testutil/mock/src/execution_server.rs
@@ -90,9 +90,9 @@ impl MockExecution {
     ///
     /// # Arguments:
     ///  * `name` - The name of the operation. It is assumed that all operation_responses use this
-    ///             name.
+    ///    name.
     ///  * `expected_api_calls` - Vec of ExpectedAPICall instances representing the API calls
-    ///                            to expect from the client. Will be returned in order.
+    ///    to expect from the client. Will be returned in order.
     ///
     pub fn new(expected_api_calls: Vec<ExpectedAPICall>) -> MockExecution {
         MockExecution {
@@ -115,13 +115,13 @@ impl TestServer {
     ///
     /// # Arguments
     /// * `mock_execution` - The canned responses to issue. Returns the MockExecution's
-    ///                      operation_responses in order to any ExecuteRequest or GetOperation
-    ///                      requests.
-    ///                      If an ExecuteRequest request is received which is not equal to this
-    ///                      MockExecution's execute_request, an error will be returned.
-    ///                      If a GetOperation request is received whose name is not equal to this
-    ///                      MockExecution's name, or more requests are received than stub responses
-    ///                      are available for, an error will be returned.
+    ///   operation_responses in order to any ExecuteRequest or GetOperation
+    ///   requests.
+    ///   If an ExecuteRequest request is received which is not equal to this
+    ///   MockExecution's execute_request, an error will be returned.
+    ///   If a GetOperation request is received whose name is not equal to this
+    ///   MockExecution's name, or more requests are received than stub responses
+    ///   are available for, an error will be returned.
     pub async fn new(mock_execution: MockExecution, port: Option<u16>) -> TestServer {
         let mock_responder = MockResponder::new(mock_execution);
         let mock_responder2 = mock_responder.clone();

--- a/src/rust/engine/ui/src/instance/prodash.rs
+++ b/src/rust/engine/ui/src/instance/prodash.rs
@@ -130,7 +130,7 @@ impl ProdashInstance {
                     } else {
                         desc.chars()
                             .take(max_len - 3)
-                            .chain(std::iter::repeat('.').take(3))
+                            .chain(std::iter::repeat_n('.', 3))
                             .collect()
                     };
                     let mut item = self.tree.add_child(description);

--- a/src/rust/engine/watch/src/lib.rs
+++ b/src/rust/engine/watch/src/lib.rs
@@ -146,12 +146,11 @@ impl InvalidationWatcher {
                         Ok(Err(err)) => {
                             if let notify::ErrorKind::PathNotFound = err.kind {
                                 warn!("Path(s) did not exist: {:?}", err.paths);
-                                continue;
                             } else {
                                 break format!("Watch error: {err}");
                             }
                         }
-                        Err(RecvTimeoutError::Timeout) => continue,
+                        Err(RecvTimeoutError::Timeout) => (),
                         Err(RecvTimeoutError::Disconnected) => {
                             break "The watch provider exited.".to_owned();
                         }


### PR DESCRIPTION
Upgrade to Rust v1.86.0.

[Release notes blog](https://blog.rust-lang.org/2025/04/03/Rust-1.86.0.html)