### PR TITLE
perf: immutable digest for shell dependency inference

### DIFF
--- a/docs/notes/2.27.x.md
+++ b/docs/notes/2.27.x.md
@@ -56,6 +56,10 @@ Minor fixes:
 
 - If a sandbox for executing mypy is preserved, the `__run.sh` script now refers to the main script by a relative path and [can thus be successfully executed](https://github.com/pantsbuild/pants/issues/22138).
 
+#### Shell
+
+The shell backend now has far less overhead when parsing shell imports on macOS: the shellcheck executable is now hard-linked into sandboxes, which side-steps Gatekeeper checks on macOS (when enabled, as they are by default) that made concurrent executions behave as if they were run sequentially.
+
 ### Plugin API changes
 
 * Processes can now specify their `concurrency` requirements, influencing when Pants will execute them. Use `exclusive` to be the only running process, `exactly(n)` to require exactly `n` cpu cores, or `range(max=n, min=1)` to accept a value between `min` and `max` which is templated into the process's argv as `{pants_concurrency}`. The `concurrency` field supersedes the `concurrency_available` field, which will be deprecated in the future.


### PR DESCRIPTION
Similar to https://github.com/pantsbuild/pants/pull/22113 but for shell imports 

I omitted release notes (seems kinda small?) but can add them if you'd like 