### PR TITLE
Always install hdrhistogram dependency: --stats-logs shows metrics by default

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -8,6 +8,7 @@ ansicolors==1.1.8
 chevron==0.14.0
 fasteners==0.16.3
 freezegun==1.2.1
+hdrhistogram==0.10.3
 ijson==3.2.3
 libcst==1.4.0
 packaging==24.2

--- a/3rdparty/python/user_reqs.lock
+++ b/3rdparty/python/user_reqs.lock
@@ -18,6 +18,7 @@
 //     "fastapi==0.78.0",
 //     "fasteners==0.16.3",
 //     "freezegun==1.2.1",
+//     "hdrhistogram==0.10.3",
 //     "ijson==3.2.3",
 //     "libcst==1.4.0",
 //     "mypy-typing-asserts==0.1.1",
@@ -793,6 +794,46 @@
           "artifacts": [
             {
               "algorithm": "sha256",
+              "hash": "bfd6ad77c1f7806aaeb6b340866a6bb38a1f0fe94d8f5a5f74372c33a094913f",
+              "url": "https://files.pythonhosted.org/packages/d6/99/a26df64d5069984e38305a6d6462534722f09c7f7578e5303903192f7a6a/hdrhistogram-0.10.3-cp311-cp311-musllinux_1_1_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "d5748a22ec68a5390f9d493aca933a6871788e34df91da4cc0a6ee19e336dc6d",
+              "url": "https://files.pythonhosted.org/packages/54/58/bdd5df067445478013f7a21b378181b206cc0aaf31024366ac813e0d9a96/hdrhistogram-0.10.3-cp311-cp311-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "d814811d52e699426a8b54f2448ab5e49fee3519a200cd887fd3faaaa6f4a35d",
+              "url": "https://files.pythonhosted.org/packages/93/14/20cb3a638284a5903492eecb5b5d1303aa1ec9606b9e2296ca1753df1f0c/hdrhistogram-0.10.3-cp311-cp311-musllinux_1_1_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "f6d7e402365ced65309c3ffb060b6bcf7d1265bfba293509076f18b5d9ec260d",
+              "url": "https://files.pythonhosted.org/packages/a8/ba/37b9144c0372b1f48b9310a8e4fc77a4d4f8949190b0e56ebc2dd17c9e54/hdrhistogram-0.10.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "3f55fcbd39953b8989344cfb56cfa06094dbffc3fd4df1ff05d4b15658e1bf6d",
+              "url": "https://files.pythonhosted.org/packages/a9/22/8f1f52f3fa3291d7c1693d9266d31753be5f27b907c97ce4db495de169fa/hdrhistogram-0.10.3-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "f3890df0a6f3c582a0a8b2a49a568729cb319f1600683e4458cc98b68ca32841",
+              "url": "https://files.pythonhosted.org/packages/c2/79/674aad5279dd1a77b85efa1cbf8dcead209dc5f38f55cbbfd75bc20cc65b/hdrhistogram-0.10.3.tar.gz"
+            }
+          ],
+          "project_name": "hdrhistogram",
+          "requires_dists": [
+            "pbr>=1.4"
+          ],
+          "requires_python": null,
+          "version": "0.10.3"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
               "hash": "dacdd3d10ea1b4ca9df97a0a303cbacafc04b5cd375fa98732678151643d4988",
               "url": "https://files.pythonhosted.org/packages/3e/d2/84c9e23edbccc4a4c6f96a1b8d99dfd2350289e94f00e9ccc7aadde26fb5/httptools-0.6.4-cp311-cp311-musllinux_1_2_x86_64.whl"
             },
@@ -1048,6 +1089,26 @@
           "requires_dists": [],
           "requires_python": ">=3.8",
           "version": "24.2"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "38d4daea5d9fa63b3f626131b9d34947fd0c8be9b05a29276870580050a25a76",
+              "url": "https://files.pythonhosted.org/packages/47/ac/684d71315abc7b1214d59304e23a982472967f6bf4bde5a98f1503f648dc/pbr-6.1.1-py2.py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "93ea72ce6989eb2eed99d0f75721474f69ad88128afdef5ac377eb797c4bf76b",
+              "url": "https://files.pythonhosted.org/packages/01/d2/510cc0d218e753ba62a1bc1434651db3cd797a9716a0a66cc714cb4f0935/pbr-6.1.1.tar.gz"
+            }
+          ],
+          "project_name": "pbr",
+          "requires_dists": [
+            "setuptools"
+          ],
+          "requires_python": ">=2.6",
+          "version": "6.1.1"
         },
         {
           "artifacts": [
@@ -2357,6 +2418,7 @@
     "fastapi==0.78.0",
     "fasteners==0.16.3",
     "freezegun==1.2.1",
+    "hdrhistogram==0.10.3",
     "ijson==3.2.3",
     "libcst==1.4.0",
     "mypy-typing-asserts==0.1.1",

--- a/docs/docs/using-pants/using-pants-in-ci.mdx
+++ b/docs/docs/using-pants/using-pants-in-ci.mdx
@@ -58,7 +58,7 @@ nuke_if_too_big ~/.cache/pants/named_caches 1024
 :::
 
 :::note Tip: check cache performance with `[stats].log`
-Set the option `[stats].log = true` in `pants.ci.toml` for Pants to print metrics of your cache's performance at the end of the run, including the number of cache hits and the total time saved thanks to caching, e.g.:
+Set the option `[stats].log = true` in `pants.ci.toml` for Pants to print metrics of your cache's performance at the end of the run, including the number of cache hits, the total time saved thanks to caching, and histograms of some metrics like the size of blobs/files cached, e.g.:
 
 ```
   local_cache_requests: 204
@@ -67,7 +67,6 @@ Set the option `[stats].log = true` in `pants.ci.toml` for Pants to print metric
   local_cache_total_time_saved_ms: 307200
 ```
 
-You can also add `plugins = ["hdrhistogram"]` to the `[GLOBAL]` section of `pants.ci.toml` for Pants to print histograms of cache performance, e.g. the size of blobs cached.
 :::
 
 :::tip Remote caching

--- a/docs/notes/2.27.x.md
+++ b/docs/notes/2.27.x.md
@@ -48,6 +48,8 @@ In [the `[ruff]` subsystem](https://www.pantsbuild.org/2.27/reference/subsystems
 
 The Python Build Standalone backend (`pants.backend.python.providers.experimental.python_build_standalone`) has release metadata current through PBS release `20250317`.
 
+The default module mappings now includes the `hdrhistogram` package (imported as `hdrh`).
+
 Minor fixes:
 
 - If a sandbox for executing mypy is preserved, the `__run.sh` script now refers to the main script by a relative path and [can thus be successfully executed](https://github.com/pantsbuild/pants/issues/22138).

--- a/docs/notes/2.27.x.md
+++ b/docs/notes/2.27.x.md
@@ -19,6 +19,8 @@ Thank you to [Klaviyo](https://www.klaviyo.com/) for their Platinum tier support
 
 Changing [the `--keep-sandboxes=...` option](https://www.pantsbuild.org/2.27/reference/global-options#keep_sandboxes) no longer forces the Pantsd daemon to restart.
 
+The Pants install now includes the `hdrhistogram` dependency automatically, and thus statistics logging (as enabled by [the `[stats].log` option](https://www.pantsbuild.org/2.27/reference/subsystems/stats#log)) includes histograms of metrics by default. If this is too verbose, consider redirecting to a file by default using [the `[stats].output_file` option](https://www.pantsbuild.org/2.27/reference/subsystems/stats#output_file). This change means `hdrhistogram` does not need to be included in [the `[GLOBAL].plugins` option](https://www.pantsbuild.org/2.27/reference/global-options#plugins): this was previously required to see histograms (and recommended by docs like ["Using Pants in CI"](https://www.pantsbuild.org/2.27/docs/using-pants/using-pants-in-ci)), but is no longer necessary.
+
 The deprecation has expired for the `[GLOBAL].native_options_validation` option and it has been removed. The option already has no effect and can be safely deleted.
 
 The deprecation has expired for the `[GLOBAL].allow_deprecated_macos_before_12` option and it has been removed. The functionality has been replaced by [the `[GLOBAL].allow_deprecated_macos_versions` option](https://www.pantsbuild.org/2.27/reference/global-options#allow_deprecated_macos_versions).

--- a/pants.toml
+++ b/pants.toml
@@ -42,9 +42,6 @@ backend_packages.add = [
   "internal_plugins.releases",
   "internal_plugins.test_lockfile_fixtures",
 ]
-plugins = [
-  "hdrhistogram", # For use with `--stats-log`.
-]
 
 # The invalidation globs cover the PYTHONPATH by default, but we exclude some files that are on the
 # path but not consumed by python, and additionally add the rust code.

--- a/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
+++ b/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
@@ -164,6 +164,7 @@ DEFAULT_MODULE_MAPPING: dict[str, tuple[str, ...]] = {
     "grpcio-reflection": ("grpc_reflection",),
     "grpcio-status": ("grpc_status",),
     "grpcio-testing": ("grpc_testing",),
+    "hdrhistogram": ("hdrh",),
     "honeycomb-opentelemetry": ("honeycomb.opentelemetry",),
     "ipython": ("IPython",),
     "jack-client": ("jack",),

--- a/src/python/pants/goal/stats_aggregator.py
+++ b/src/python/pants/goal/stats_aggregator.py
@@ -13,6 +13,8 @@ from enum import Enum
 from pathlib import Path
 from typing import TypedDict
 
+from hdrh.histogram import HdrHistogram
+
 from pants.engine.internals.scheduler import Workunit
 from pants.engine.rules import collect_rules, rule
 from pants.engine.streaming_workunit_handler import (
@@ -214,8 +216,6 @@ class StatsAggregatorCallback(WorkunitsCallback):
             _log_or_write_to_file_plain(self.output_file, output_lines)
             return
 
-        from hdrh.histogram import HdrHistogram  # pants: no-infer-dep
-
         histograms = context.get_observation_histograms()["histograms"]
         if not histograms:
             output_lines.append("No observation histogram were recorded.")
@@ -293,8 +293,6 @@ class StatsAggregatorCallback(WorkunitsCallback):
         if not self.log:
             _log_or_write_to_file_json(self.output_file, stats_object)
             return
-
-        from hdrh.histogram import HdrHistogram  # pants: no-infer-dep
 
         histograms = context.get_observation_histograms()["histograms"]
         if not histograms:

--- a/src/python/pants/goal/stats_aggregator_integration_test.py
+++ b/src/python/pants/goal/stats_aggregator_integration_test.py
@@ -17,7 +17,6 @@ def test_counters_and_histograms() -> None:
     ) as tmpdir:
         argv = [
             "--backend-packages=['pants.backend.python', 'pants.backend.python.lint.black']",
-            "--plugins=hdrhistogram",
             "--stats-log",
             "lint",
             f"{tmpdir}::",
@@ -40,14 +39,6 @@ def test_memory_summary() -> None:
     result.assert_success()
     assert "Memory summary" in result.stderr
     assert "pants.engine.unions.UnionMembership" in result.stderr
-
-
-def test_warn_if_no_histograms() -> None:
-    result = run_pants(["--stats-log", "roots"])
-    result.assert_success()
-    assert "Counters:" in result.stderr
-    assert "Please run with `--plugins=hdrhistogram`" in result.stderr
-    assert "Observation histogram summaries:" not in result.stderr
 
 
 def test_writing_to_output_file_plain_text() -> None:
@@ -84,7 +75,6 @@ def test_writing_to_output_file_json() -> None:
     with setup_tmpdir({"src/py/app.py": "print(0)\n", "src/py/BUILD": "python_sources()"}):
         argv1 = [
             "--backend-packages=['pants.backend.python']",
-            "--plugins=hdrhistogram",
             "--stats-log",
             "--stats-memory-summary",
             "--stats-format=jsonlines",
@@ -94,7 +84,6 @@ def test_writing_to_output_file_json() -> None:
         run_pants(argv1).assert_success()
         argv2 = [
             "--backend-packages=['pants.backend.python']",
-            "--plugins=hdrhistogram",
             "--stats-log",
             "--stats-memory-summary",
             "--stats-format=jsonlines",


### PR DESCRIPTION
This turns the `hdrhistogram` Python dependency of the main Pants code from an (implicit) optional dependency (only used if installed into the Pants venv via `[GLOBAL].plugins`), into a normal required one, included in the main Pants PEXes, and thus always available.

This has a user-facing change: if the `[stats].log` option is set, then the logging now always/automatically includes the histograms of some metrics. Previously, they were only visible if `hdrhistogram` was installed via `[GLOBAL].plugins` (and if it wasn't installed, a warning was printed unconditionally).

This causes the PEX to include 2 extra dependencies: `hdrhistogram` and its transitive dependency `pbr`:

```
==                      Added dependencies                      ==

  hdrhistogram                   0.10.3
  pbr                            6.1.1
```

Sizes of the artifacts:

| which | before (MiB) | after (MiB) | change |
|---|---|---|---|
| compressed (size of `pants-per.pex`) | 22.03 | 22.18 | +151 KiB (+0.67%) |
| uncompressed | 69.04 | 69.49 | +475 KiB (+0.66%) | 

Note: in practice, I imagine many installs of Pants would've included these (at least, in CI, if not locally), given the "TIP: CHECK CACHE PERFORMANCE WITH [stats].log" section in the https://www.pantsbuild.org/2.26/docs/using-pants/using-pants-in-ci docs. Thus, this change doesn't seem like it should be treated as adding extra dependencies: it's more ensuring our explicit dependency list reflects the implicit reality.

As a side benefit, this may make initialising Pants a little faster (especially relevant to CI). For instance, in my work CI, we only have `hdrhistogram` as an additional plugin, and starting pants seems to spend several seconds installing `hdrhistogram` (as implied by the `Starting: Resolving plugins: hdrhistogram` to `Completed: Resolving plugins: hdrhistogram` log lines).

Fixes #22189 