### PR TITLE
Include Python prereleases from new PBS releases

### DIFF
--- a/docs/notes/2.27.x.md
+++ b/docs/notes/2.27.x.md
@@ -51,7 +51,7 @@ The Ruff tool has been upgraded from 0.11.0 to 0.11.5 by default.
 
 In [the `[ruff]` subsystem](https://www.pantsbuild.org/2.27/reference/subsystems/ruff), the deprecations have expired for these options and thus they have been removed: `install_from_resolve`, `requirements`, `interpreter_constraints`, `consnole_script`, `entry_point`. The removed options already have no effect (they're replaced by the `version` and `known_versions` options), and can be safely deleted .
 
-The Python Build Standalone backend (`pants.backend.python.providers.experimental.python_build_standalone`) has release metadata current through PBS release `20250409`.
+The Python Build Standalone backend (`pants.backend.python.providers.experimental.python_build_standalone`) has release metadata current through PBS release `20250409`. It also now includes prereleases for new releases (for instance, 3.14.0a6 in release `20250409`).
 
 The default module mappings now includes the `hdrhistogram` package (imported as `hdrh`).
 

--- a/src/python/pants/backend/python/providers/python_build_standalone/rules_integration_test.py
+++ b/src/python/pants/backend/python/providers/python_build_standalone/rules_integration_test.py
@@ -81,7 +81,7 @@ def run_run_request(
 
 
 @pytest.mark.platform_specific_behavior
-@pytest.mark.parametrize("py_version", ["3.8.*", "3.9.*", "3.9.10"])
+@pytest.mark.parametrize("py_version", ["3.8.*", "3.9.*", "3.9.10", "3.14.0a6"])
 def test_using_pbs(rule_runner, py_version):
     rule_runner.write_files(
         {

--- a/src/python/pants/backend/python/providers/python_build_standalone/scripts/generate_urls.py
+++ b/src/python/pants/backend/python/providers/python_build_standalone/scripts/generate_urls.py
@@ -113,7 +113,7 @@ def main() -> None:
 
     versions_info["scraped_releases"] = sorted(scraped_releases)
     pythons_dict = versions_info["pythons"]
-    asset_matcher = re.compile(r"^([a-zA-Z0-9]+)-([0-9.]+)\+([0-9.]+)-")
+    asset_matcher = re.compile(r"^([a-zA-Z0-9]+)-([0-9.a-z]+)\+([0-9.]+)-")
 
     for asset in asset_map.values():
         matched_versions = asset_matcher.match(asset.name)

--- a/src/python/pants/backend/python/providers/python_build_standalone/versions_info.json
+++ b/src/python/pants/backend/python/providers/python_build_standalone/versions_info.json
@@ -2172,6 +2172,30 @@
         }
       }
     },
+    "3.14.0a6": {
+      "20250409": {
+        "linux_arm64": {
+          "sha256": "498849c92f28b6f1b1c5dfe83587660eff5ac574dc7974bada9ce68634ded6f1",
+          "size": 17833018,
+          "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20250409/cpython-3.14.0a6%2B20250409-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "linux_x86_64": {
+          "sha256": "a777bbf17e251cec96d14c3ab70f67cce752930a5542b8e04ce22e892470c594",
+          "size": 21492623,
+          "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20250409/cpython-3.14.0a6%2B20250409-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        },
+        "macos_arm64": {
+          "sha256": "ee5a7b630874554bae30b5f11bee55ef7ffd093f691cb7161cae34874c00ecf0",
+          "size": 15710073,
+          "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20250409/cpython-3.14.0a6%2B20250409-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        },
+        "macos_x86_64": {
+          "sha256": "a187d2c50f43095c8f51b34babae1c291ee1a42d6777ce8d8bcd58517652f987",
+          "size": 16118156,
+          "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20250409/cpython-3.14.0a6%2B20250409-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        }
+      }
+    },
     "3.8.12": {
       "20220227": {
         "linux_x86_64": {

--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -62,6 +62,7 @@ class PythonSetup(Subsystem):
         "3.11",
         "3.12",
         "3.13",
+        "3.14",
     ]
 
     _interpreter_constraints = StrListOption(


### PR DESCRIPTION
This adjusts the PBS release scraping to include pre-release Pythons.

My thinking is that it makes it theoretically easier for us to validate things like "Pants tests works with a new Python", and similarly for users. Only rarely useful, I imagine, but also easy enough to do!

TODO: validate that this is actually functional, locally.