### PR TITLE
Initial code for the sandboxer service

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -3832,7 +3832,7 @@ version = "0.0.1"
 dependencies = [
  "bytes",
  "children",
- "clap 4.5.32",
+ "clap 4.5.36",
  "env_logger",
  "fs",
  "hashing",
@@ -3845,7 +3845,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic",
- "tower",
+ "tower 0.4.13",
 ]
 
 [[package]]

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1251,6 +1251,7 @@ dependencies = [
  "remote",
  "reqwest",
  "rule_graph",
+ "sandboxer",
  "serde",
  "serde_json",
  "smallvec",
@@ -3893,6 +3894,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "sandboxer"
+version = "0.0.1"
+dependencies = [
+ "bytes",
+ "children",
+ "clap 4.5.32",
+ "env_logger",
+ "fs",
+ "hashing",
+ "hyper-util",
+ "log",
+ "protos",
+ "store",
+ "task_executor",
+ "tempfile",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tower",
 ]
 
 [[package]]

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -74,6 +74,7 @@ rand = { workspace = true }
 regex = { workspace = true }
 reqwest = { version = "0.12", default-features = false, features = ["stream", "rustls-tls"] }
 rule_graph = { path = "rule_graph" }
+sandboxer = { path = "process_execution/sandboxer" }
 smallvec = { version = "1", features = ["union"] }
 stdio = { path = "stdio" }
 store = { path = "fs/store" }

--- a/src/rust/engine/fs/store/src/cli_options.rs
+++ b/src/rust/engine/fs/store/src/cli_options.rs
@@ -9,7 +9,7 @@ use task_executor::Executor;
 
 use crate::Store;
 
-#[derive(Parser)]
+#[derive(Debug, Parser)]
 pub struct StoreCliOpt {
     ///Path to lmdb directory used for local file storage.
     #[arg(long)]

--- a/src/rust/engine/process_execution/sandboxer/Cargo.toml
+++ b/src/rust/engine/process_execution/sandboxer/Cargo.toml
@@ -14,7 +14,7 @@ fs = { path = "../../fs" }
 hashing = { path = "../../hashing" }
 hyper-util = { workspace = true }
 log = { workspace = true }
-protos = { path = "../../protos" }  # TODO: Split up protos and only depend on ours.
+protos = { path = "../../protos" }                                # TODO: Split up protos and only depend on ours.
 store = { path = "../../fs/store" }
 task_executor = { path = "../../task_executor" }
 tempfile = { workspace = true }

--- a/src/rust/engine/process_execution/sandboxer/Cargo.toml
+++ b/src/rust/engine/process_execution/sandboxer/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+version = "0.0.1"
+edition = "2021"
+name = "sandboxer"
+authors = ["Pants Build <pantsbuild@gmail.com>"]
+publish = false
+
+[dependencies]
+bytes = { workspace = true }
+children = { path = "../children" }
+clap = { workspace = true, features = ["derive"] }
+env_logger = { workspace = true }
+fs = { path = "../../fs" }
+hashing = { path = "../../hashing" }
+hyper-util = { workspace = true }
+log = { workspace = true }
+protos = { path = "../../protos" }  # TODO: Split up protos and only depend on ours.
+store = { path = "../../fs/store" }
+task_executor = { path = "../../task_executor" }
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["process"] }
+tokio-stream = { workspace = true }
+tonic = { workspace = true, features = ["transport", "codegen"] }
+tower = { workspace = true }
+
+[lints]
+workspace = true

--- a/src/rust/engine/process_execution/sandboxer/src/lib.rs
+++ b/src/rust/engine/process_execution/sandboxer/src/lib.rs
@@ -1,0 +1,226 @@
+// Copyright 2025 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+use ::fs::{DirectoryDigest, Permissions, RelativePath};
+use hashing::Digest;
+use log::{debug, info, warn};
+use protos::gen::pants::sandboxer::{
+    MaterializeDirectoryRequest, MaterializeDirectoryResponse,
+    sandboxer_grpc_server::{SandboxerGrpc, SandboxerGrpcServer},
+};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+use std::{collections::BTreeSet, io};
+use std::{fs, process, thread};
+use store::{Store, StoreCliOpt};
+use tokio::net::UnixListener;
+use tokio_stream::wrappers::UnixListenerStream;
+use tonic::transport::Server;
+use tonic::{Request, Response, Status};
+
+#[cfg(test)]
+mod tests;
+
+// The Sandboxer is a solution to the following problem:
+//
+// For isolation, Pants executes subprocesses in "sandbox directories". Just before executing a
+// subprocess Pants creates a sandbox directory for it, and materializes its input files from the
+// store into the sandbox.
+// In some cases an executable run by the subprocess is also materialized into the sandbox.
+// This can lead to an ETXTBSY error in the subprocess:
+//
+// - While the main process is writing the executable exeA for subprocess A, we fork some other
+//   subprocess B.
+// - Subprocess B inherits the open file handles of the main process, which in this case
+//   includes a write file handle to exeA (subprocess B will close the inherited handles when it
+//   execs, but that hasn't happened yet).
+// - Subprocess A forks, and tries to exec exeA. This fails with ETXTBSY because subprocess B holds
+//   an open write file handle to exeA.
+//
+// See: https://github.com/golang/go/issues/22315 for an excellent description of this generic
+// Unix problem.
+//
+// The Sandboxer solves the problem via a separate, dedicated process that writes executables into
+// sandboxes, and never itself spawns any subprocesses.
+//
+// The Sandboxer implementation consists of the following units:
+// - A server, running in a standalone process, that receives and satisifes file writing requests.
+// - A client that sends file writing requests to that server via a Unix domain socket.
+// - The SandboxerProcess struct, which encapsulates a server process and a client connection to it.
+// - The Sandboxer struct, which manages a SandboxerProcess, respawning it as needed.
+//
+// We use a Unix domain socket primarily because it's easy to pick a unique socket path per repo.
+
+fn ensure_socket_file_removed(socket_path: &Path) -> Result<(), String> {
+    let mut ret = fs::remove_file(socket_path);
+    if let Err(ref err) = ret {
+        if err.kind() == io::ErrorKind::NotFound {
+            ret = Ok(());
+        }
+    } else {
+        debug!("Removed existing socket file {}", &socket_path.display());
+    }
+    ret.map_err(|e| e.to_string())
+}
+
+fn ensure_parent_dir(path: &Path) -> Result<(), String> {
+    std::fs::create_dir_all(path.parent().unwrap()).map_err(|e| e.to_string())
+}
+
+// The service that the spawned sandboxer process runs.
+// The process exits if anything goes wrong, since it's easy and cheap to respawn it.
+// It also exits if it's been idle for a while, so that orphaned processes don't pile up.
+#[derive(Debug)]
+pub struct SandboxerService {
+    socket_path: PathBuf,
+    store_cli_opt: StoreCliOpt,
+}
+
+impl SandboxerService {
+    // Note that since we wait one polling interval on startup, increasing
+    // this constant will increase our startup time.
+    const POLLING_INTERVAL: Duration = Duration::from_millis(50);
+    const ALLOWED_IDLE_TIME: Duration = Duration::from_secs(60 * 15);
+    // We count idle beats and not actual elapsed idle time, since we don't need to be very
+    // precise. The two will have the same effect unless the shutdown thread is unusually starved.
+    const ALLOWED_IDLE_BEATS: usize =
+        Self::ALLOWED_IDLE_TIME.div_duration_f32(Self::POLLING_INTERVAL) as usize;
+
+    pub fn new(socket_path: PathBuf, store_cli_opt: StoreCliOpt) -> Self {
+        Self {
+            socket_path,
+            store_cli_opt,
+        }
+    }
+
+    pub async fn serve(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        self.do_serve(true).await
+    }
+
+    // Used only in tests, in which case we don't want to run the shutdown thread
+    // since it'll exit the test process itself.
+    pub async fn serve_in_process(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        self.do_serve(false).await
+    }
+
+    pub async fn do_serve(
+        &mut self,
+        with_shutdown_thread: bool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        // `bind()` expects the socket file not to exist, so we ensure that.
+        ensure_socket_file_removed(&self.socket_path)?;
+        // Wait a beat, to let any previous sandboxer process notice this removal and exit.
+        // There's no great harm in leaving a stray sandboxer process running, it will
+        // receive no requests (since the socket file was pulled out from under it) so eventually
+        // it'll shut down due to idleness. But it's nicer if we can let it go right away.
+        tokio::time::sleep(SandboxerService::POLLING_INTERVAL).await;
+
+        ensure_parent_dir(&self.socket_path)?;
+        let listener = UnixListener::bind(&self.socket_path)?;
+        // `bind()` creates the socket file, so now we can poll it, in case the
+        // user deletes it.
+        // NB: We can't easily use the notify crate to watch changes to the socket file,
+        //  because on MacOS the FSEvent watches are path-based, not inode-based, and they
+        //  are batched. So we may get a spurious notification for the removal above, and not
+        //  know if we should act on it. We could use notify's PollWatcher, but it's easier to
+        // implement simple polling ourselves, without the overkill of the notify crate.
+        let socket_path = self.socket_path.clone();
+        let inactivity_counter = Arc::new(AtomicUsize::new(0));
+        let inactivity_counter_ref = inactivity_counter.clone();
+        if with_shutdown_thread {
+            thread::spawn(move || {
+                loop {
+                    // Note: just a regular thread::sleep() since this is not an async context.
+                    thread::sleep(SandboxerService::POLLING_INTERVAL);
+                    if !fs::exists(&socket_path).unwrap_or(false) {
+                        warn!("Socket file {} deleted. Exiting.", &socket_path.display());
+                        process::exit(22);
+                    }
+                    if inactivity_counter_ref.fetch_add(1, Ordering::Relaxed)
+                        > Self::ALLOWED_IDLE_BEATS
+                    {
+                        warn!("Idle time limit exceeded. Exiting.");
+                        process::exit(23);
+                    }
+                }
+            });
+        }
+
+        info!(
+            "Sandboxer server started on socket path {}",
+            self.socket_path.display()
+        );
+        let store = self
+            .store_cli_opt
+            .create_store(task_executor::Executor::new())
+            .await?;
+        let router = Server::builder().add_service(SandboxerGrpcServer::new(SandboxerGrpcImpl {
+            store,
+            inactivity_counter,
+        }));
+        router
+            .serve_with_incoming(UnixListenerStream::new(listener))
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub struct SandboxerGrpcImpl {
+    store: Store,
+
+    // We increment this at every poll interval, and reset it on every gRPC call.
+    inactivity_counter: Arc<AtomicUsize>,
+}
+
+impl SandboxerGrpcImpl {
+    async fn do_materialize_directory(
+        &self,
+        request: Request<MaterializeDirectoryRequest>,
+    ) -> Result<Response<MaterializeDirectoryResponse>, String> {
+        let r = request.into_inner();
+        debug!("Received materialize_directory() request: {:#?}", &r);
+        let destination_root: PathBuf = r.destination_root.into();
+        let digest: Digest = r.digest.ok_or("No digest provided")?.try_into()?;
+        let dir_digest = DirectoryDigest::from_persisted_digest(digest);
+        let mutable_paths = BTreeSet::<RelativePath>::from_iter(
+            r.mutable_paths
+                .iter()
+                .map(RelativePath::new)
+                .collect::<Result<Vec<_>, _>>()?
+                .into_iter(),
+        );
+        self.store
+            .materialize_directory(
+                r.destination.into(),
+                &destination_root,
+                dir_digest,
+                false,
+                &mutable_paths,
+                Permissions::Writable,
+            )
+            .await
+            .map_err(|e| e.to_string())?;
+        Ok(Response::new(MaterializeDirectoryResponse {
+            confirmation: { "OK".to_string() },
+        }))
+    }
+}
+
+#[tonic::async_trait]
+impl SandboxerGrpc for SandboxerGrpcImpl {
+    async fn materialize_directory(
+        &self,
+        request: Request<MaterializeDirectoryRequest>,
+    ) -> Result<Response<MaterializeDirectoryResponse>, Status> {
+        self.inactivity_counter.store(0, Ordering::Relaxed);
+        let ret = self
+            .do_materialize_directory(request)
+            .await
+            .map_err(Status::failed_precondition);
+        debug!("materialize_directory() result: {:#?}", ret);
+        ret
+    }
+}

--- a/src/rust/engine/process_execution/sandboxer/src/lib.rs
+++ b/src/rust/engine/process_execution/sandboxer/src/lib.rs
@@ -20,9 +20,6 @@ use tokio_stream::wrappers::UnixListenerStream;
 use tonic::transport::Server;
 use tonic::{Request, Response, Status};
 
-#[cfg(test)]
-mod tests;
-
 // The Sandboxer is a solution to the following problem:
 //
 // For isolation, Pants executes subprocesses in "sandbox directories". Just before executing a

--- a/src/rust/engine/protos/build.rs
+++ b/src/rust/engine/protos/build.rs
@@ -29,6 +29,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "protos/googleapis/google/rpc/status.proto",
         "protos/googleapis/google/longrunning/operations.proto",
         "protos/pants/cache.proto",
+        "protos/pants/sandboxer.proto",
         "protos/standard/google/protobuf/empty.proto",
       ],
       &[

--- a/src/rust/engine/protos/protos/pants/sandboxer.proto
+++ b/src/rust/engine/protos/protos/pants/sandboxer.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+package pants.sandboxer;
+
+import "build/bazel/remote/execution/v2/remote_execution.proto";
+
+service SandboxerGrpc {
+  rpc MaterializeDirectory (MaterializeDirectoryRequest) returns (MaterializeDirectoryResponse);
+}
+
+message MaterializeDirectoryRequest {
+  string destination = 1;
+  string destination_root = 2;
+  build.bazel.remote.execution.v2.Digest digest = 3;
+  repeated string mutable_paths = 4;
+}
+
+message MaterializeDirectoryResponse {
+  string confirmation = 1;
+}

--- a/src/rust/engine/protos/protos/pants/sandboxer.proto
+++ b/src/rust/engine/protos/protos/pants/sandboxer.proto
@@ -9,12 +9,22 @@ service SandboxerGrpc {
 }
 
 message MaterializeDirectoryRequest {
+  // Materialize into this directory.
   string destination = 1;
+
+  // A common root under which destination directories are created. Must be an ancestor of
+  // (or identical to) destination.
+  // Used to determine whether files can be hardlinked from the store into destination.
+  // Determining this is slightly expensive, so instead of doing so for each destination
+  // we determine hardlinkability on (and therefore under) this root dir and cache that knowledge.
   string destination_root = 2;
+
+  // The digest to materialize. Must represent a directory.
   build.bazel.remote.execution.v2.Digest digest = 3;
+
+  // Paths listed here will not be hardlinked.
   repeated string mutable_paths = 4;
 }
 
 message MaterializeDirectoryResponse {
-  string confirmation = 1;
 }

--- a/src/rust/engine/protos/src/lib.rs
+++ b/src/rust/engine/protos/src/lib.rs
@@ -61,6 +61,9 @@ pub mod gen {
         pub mod cache {
             tonic::include_proto!("pants.cache");
         }
+        pub mod sandboxer {
+            tonic::include_proto!("pants.sandboxer");
+        }
     }
 }
 


### PR DESCRIPTION
- A new crate
- A .proto defining the sandboxer API
- Code implementing that API

This code is not currently wired up to anything. It is broken
out of a larger change for ease of code review.

Future commits will introduce:
- Client code
- Code for managing a sandboxer process
- Tests
- Wiring this up to the process executor