### PR TITLE
Fix handling of non UTF-8 files in git invocations

### DIFF
--- a/docs/notes/2.27.x.md
+++ b/docs/notes/2.27.x.md
@@ -29,6 +29,8 @@ The [workunit-logger](https://www.pantsbuild.org/2.27/reference/subsystems/worku
 
 [Fixed](https://github.com/pantsbuild/pants/pull/22128) a bug where missing `docker_environment` containers (i.e. containers killed or remove by some outside process) break pantsd and requires a pantsd restart. Now pants will attempt to start a new container for the `docker_environment`.
 
+[Fixed](https://github.com/pantsbuild/pants/pull/22207) a `UnicodeDecodeError` in Git commands with non UTF-8 output. Internal Git calls now return raw bytes and callers decode when needed.
+
 ### Goals
 
 ### Backends

--- a/src/python/pants/core/util_rules/system_binaries.py
+++ b/src/python/pants/core/util_rules/system_binaries.py
@@ -549,7 +549,7 @@ class GitBinaryException(Exception):
 
 
 class GitBinary(BinaryPath):
-    def _invoke_unsandboxed(self, cmd: list[str]) -> str:
+    def _invoke_unsandboxed(self, cmd: list[str]) -> bytes:
         """Invoke the given git command, _without_ the sandboxing provided by the `Process` API.
 
         This API is for internal use only: users should prefer to consume methods of the
@@ -569,7 +569,7 @@ class GitBinary(BinaryPath):
 
         self._check_result(cmd, process.returncode, err.decode())
 
-        return out.decode().strip()
+        return out.strip()
 
     def _check_result(self, cmd: list[str], result: int, failure_msg: str | None = None) -> None:
         # git diff --exit-code exits with 1 if there were differences.

--- a/src/python/pants/vcs/git.py
+++ b/src/python/pants/vcs/git.py
@@ -64,13 +64,15 @@ class GitWorktree(EngineAwareReturnType):
 
     @property
     def commit_id(self):
-        return self._git_binary._invoke_unsandboxed(self._create_git_cmdline(["rev-parse", "HEAD"]))
+        return self._git_binary._invoke_unsandboxed(
+            self._create_git_cmdline(["rev-parse", "HEAD"])
+        ).decode()
 
     @property
     def branch_name(self) -> str | None:
         branch = self._git_binary._invoke_unsandboxed(
             self._create_git_cmdline(["rev-parse", "--abbrev-ref", "HEAD"])
-        )
+        ).decode()
         return None if branch == "HEAD" else branch
 
     def _fix_git_relative_path(self, worktree_path: str, relative_to: PurePath | str) -> str:
@@ -90,7 +92,7 @@ class GitWorktree(EngineAwareReturnType):
             )
         )
 
-        files = set(uncommitted_changes.splitlines())
+        files = set(uncommitted_changes.decode().splitlines())
         if from_commit:
             # Grab the diff from the merge-base to HEAD using ... syntax.  This ensures we have just
             # the changes that have occurred on the current branch.
@@ -102,7 +104,7 @@ class GitWorktree(EngineAwareReturnType):
             committed_changes = self._git_binary._invoke_unsandboxed(
                 self._create_git_cmdline(committed_cmd)
             )
-            files.update(committed_changes.splitlines())
+            files.update(committed_changes.decode().splitlines())
         if include_untracked:
             untracked_cmd = [
                 "ls-files",
@@ -113,7 +115,7 @@ class GitWorktree(EngineAwareReturnType):
             untracked = self._git_binary._invoke_unsandboxed(
                 self._create_git_cmdline(untracked_cmd)
             )
-            files.update(untracked.splitlines())
+            files.update(untracked.decode().splitlines())
         # git will report changed files relative to the worktree: re-relativize to relative_to
         return {self._fix_git_relative_path(f, relative_to) for f in files}
 
@@ -148,12 +150,16 @@ class GitWorktree(EngineAwareReturnType):
             # There is no git diff flag to include untracked files, so we get
             # the list of untracked files and manually create the diff by
             # comparing each file to an empty /dev/null.
-            untracked_files = self._git(
-                "ls-files",
-                "--other",
-                "--exclude-standard",
-                "--full-name",
-            ).splitlines()
+            untracked_files = (
+                self._git(
+                    "ls-files",
+                    "--other",
+                    "--exclude-standard",
+                    "--full-name",
+                )
+                .decode()
+                .splitlines()
+            )
             for file in set(untracked_files).intersection(paths):
                 untracked_diff = self._git_diff("--no-index", "/dev/null", str(relative_to / file))
                 assert len(untracked_diff) == 1
@@ -161,7 +167,7 @@ class GitWorktree(EngineAwareReturnType):
 
         return result
 
-    def _git(self, *args: str) -> str:
+    def _git(self, *args: str) -> bytes:
         """Run unsandboxed git command."""
         return self._git_binary._invoke_unsandboxed(self._create_git_cmdline(args))
 
@@ -172,7 +178,11 @@ class GitWorktree(EngineAwareReturnType):
     def changes_in(self, diffspec: str, relative_to: PurePath | str | None = None) -> set[str]:
         relative_to = PurePath(relative_to) if relative_to is not None else self.worktree
         cmd = ["diff-tree", "--no-commit-id", "--name-only", "-r", diffspec]
-        files = self._git_binary._invoke_unsandboxed(self._create_git_cmdline(cmd)).splitlines()
+        files = (
+            self._git_binary._invoke_unsandboxed(self._create_git_cmdline(cmd))
+            .decode()
+            .splitlines()
+        )
         return {self._fix_git_relative_path(f.strip(), relative_to) for f in files}
 
     def _create_git_cmdline(self, args: Iterable[str]) -> list[str]:
@@ -293,7 +303,7 @@ async def get_git_worktree(
     git_worktree = GitWorktree(
         binary=git_binary,
         gitdir=git_worktree_request.gitdir,
-        worktree=PurePath(output),
+        worktree=PurePath(output.decode()),
     )
 
     logger.debug(

--- a/src/python/pants/vcs/git_test.py
+++ b/src/python/pants/vcs/git_test.py
@@ -598,9 +598,21 @@ def test_worktree_invalidation(origin: Path) -> None:
             ),
             {"empty": (Hunk(None, TextBlock(0, 0)),)},
         ],
+        [
+            (
+                b"diff --git a/file.txt b/file.txt\n"
+                b"index e69de29..9daeafb 100644\n"
+                b"--- a/file.txt\n"
+                b"+++ b/file.txt\n"
+                b"@@ -1 +1 @@\n"
+                b"-test\n"
+                b"+test\x90\n"
+            ),
+            {"file.txt": (Hunk(TextBlock(1, 1), TextBlock(1, 1)),)},
+        ],
     ],
 )
 def test_parse_unified_diff(diff, expected):
     wt = DiffParser()
-    actual = wt.parse_unified_diff(diff.encode())
+    actual = wt.parse_unified_diff(diff.encode() if isinstance(diff, str) else diff)
     assert expected == actual

--- a/src/python/pants/vcs/git_test.py
+++ b/src/python/pants/vcs/git_test.py
@@ -602,5 +602,5 @@ def test_worktree_invalidation(origin: Path) -> None:
 )
 def test_parse_unified_diff(diff, expected):
     wt = DiffParser()
-    actual = wt.parse_unified_diff(diff)
+    actual = wt.parse_unified_diff(diff.encode())
     assert expected == actual


### PR DESCRIPTION
This modifies the git invocations to handle non utf-8 content by:
- Modified `GitBinary._invoke_unsandboxed()` to return raw bytes instead of decoded strings
- Updated methods in `GitWorktree` to decode bytes when needed
- Updated `DiffParser` to work with bytes directly instead of string diffs.

Fixes #22200