### PR TITLE
Sandboxer process management 

### DIFF
--- a/src/rust/engine/process_execution/children/src/lib.rs
+++ b/src/rust/engine/process_execution/children/src/lib.rs
@@ -79,7 +79,7 @@ impl ManagedChild {
     /// if the child has not yet exited. An error indicated a system error checking
     /// the result of the child process, and does not necessarily indicate that
     /// has exited or not.
-    fn check_child_has_exited(&mut self) -> Result<bool, String> {
+    pub fn check_child_has_exited(&mut self) -> Result<bool, String> {
         self.child
             .try_wait()
             .map(|o| o.is_some())

--- a/src/rust/engine/process_execution/sandboxer/src/lib.rs
+++ b/src/rust/engine/process_execution/sandboxer/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 use ::fs::{DirectoryDigest, Permissions, RelativePath};
+use children::ManagedChild;
 use hashing::Digest;
 use hyper_util::rt::TokioIo;
 use log::{debug, info, warn};
@@ -11,14 +12,19 @@ use protos::gen::pants::sandboxer::{
     sandboxer_grpc_server::{SandboxerGrpc, SandboxerGrpcServer},
 };
 use std::path::{Path, PathBuf};
+use std::process::Stdio;
+
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 use std::{collections::BTreeSet, io};
 use std::{fs, thread};
 use store::{Store, StoreCliOpt};
+use tokio::fs::OpenOptions;
 use tokio::net::{UnixListener, UnixStream};
+use tokio::sync::RwLock;
 use tokio::sync::oneshot;
+use tokio::{process::Command, sync::RwLockWriteGuard};
 use tokio_stream::wrappers::UnixListenerStream;
 use tonic::transport::{Channel, Endpoint, Server, Uri};
 use tonic::{Request, Response, Status};
@@ -82,7 +88,7 @@ pub struct SandboxerService {
 impl SandboxerService {
     // Note that since we wait one polling interval on startup, increasing
     // this constant will increase our startup time.
-    const POLLING_INTERVAL: Duration = Duration::from_millis(50);
+    pub const POLLING_INTERVAL: Duration = Duration::from_millis(50);
     const ALLOWED_IDLE_TIME: Duration = Duration::from_secs(60 * 15);
     // We count idle beats and not actual elapsed idle time, since we don't need to be very
     // precise. The two will have the same effect unless the shutdown thread is unusually starved.
@@ -101,14 +107,18 @@ impl SandboxerService {
         ensure_socket_file_removed(&self.socket_path)?;
         // Wait a beat, to let any previous sandboxer process notice this removal and exit.
         // There's no great harm in leaving a stray sandboxer process running, it will
-        // receive no requests (since the socket file was pulled out from under it) so eventually
-        // it'll shut down due to idleness. But it's nicer if we can let it go right away.
+        // receive no new connections (since the socket file was pulled out from under it)
+        // so eventually it'll shut down due to idleness. But it's nicer if we can let it
+        // go right away.
         tokio::time::sleep(SandboxerService::POLLING_INTERVAL).await;
 
         ensure_parent_dir(&self.socket_path)?;
         let listener = UnixListener::bind(&self.socket_path)?;
-        // `bind()` creates the socket file, so now we can poll it, in case the
-        // user deletes it.
+        // `bind()` creates the socket file, so now we can poll it to check if it has
+        // been deleted by the user. If it has, existing connections will continue to
+        // work (via the underlying inode) but new connections will not be possible,
+        // so we exit the process and let the caller respawn it.
+        //
         // NB: We can't easily use the notify crate to watch changes to the socket file,
         //  because on MacOS the FSEvent watches are path-based, not inode-based, and they
         //  are batched. So we may get a spurious notification for the removal above, and not
@@ -117,7 +127,8 @@ impl SandboxerService {
         let socket_path = self.socket_path.clone();
         let inactivity_counter = Arc::new(AtomicUsize::new(0));
         let inactivity_counter_ref = inactivity_counter.clone();
-        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let (graceful_shutdown_tx, graceful_shutdown_rx) = oneshot::channel();
+        let (abrupt_shutdown_tx, abrupt_shutdown_rx) = oneshot::channel();
 
         thread::spawn(move || {
             loop {
@@ -125,16 +136,24 @@ impl SandboxerService {
                 thread::sleep(SandboxerService::POLLING_INTERVAL);
                 if !fs::exists(&socket_path).unwrap_or(false) {
                     warn!("Socket file {} deleted. Exiting.", &socket_path.display());
-                    let _ = shutdown_tx.send(());
+                    let _ = graceful_shutdown_tx.send(());
                     break;
                 }
                 if inactivity_counter_ref.fetch_add(1, Ordering::Relaxed) > Self::ALLOWED_IDLE_BEATS
                 {
                     warn!("Idle time limit exceeded. Exiting.");
-                    let _ = shutdown_tx.send(());
+                    let _ = graceful_shutdown_tx.send(());
                     break;
                 }
             }
+            // The server has no graceful shutdown timeout and so can block indeterminately if a
+            // client doesn't respond to a shutdown notice. So we implement a timeout here.
+            // If the server does perform a graceful shutdown in time then the main thread will
+            // exit and this thread will not send its signal. Otherwise we'll send the signal
+            // and trigger an abrupt shutdown.
+            // See https://github.com/hyperium/tonic/issues/1820.
+            thread::sleep(SandboxerService::POLLING_INTERVAL);
+            let _ = abrupt_shutdown_tx.send(());
         });
 
         info!(
@@ -149,11 +168,16 @@ impl SandboxerService {
             store,
             inactivity_counter,
         }));
-        router
+
+        tokio::select! {
+            _ = router
             .serve_with_incoming_shutdown(UnixListenerStream::new(listener), async {
-                drop(shutdown_rx.await)
-            })
-            .await?;
+                drop(graceful_shutdown_rx.await);
+            }) => {}
+            _ = abrupt_shutdown_rx => {
+                std::process::exit(22);
+            }
+        }
         Ok(())
     }
 }
@@ -297,3 +321,173 @@ impl SandboxerClient {
             .map_err(|e| e.to_string())
     }
 }
+
+// The spawned sandboxer process and a connection to it.
+pub struct SandboxerProcess {
+    process: ManagedChild,
+    client: SandboxerClient,
+}
+
+// Manages the spawned sandboxer process and communicates with it.
+pub struct Sandboxer {
+    sandboxer_bin: PathBuf,
+    socket_path: PathBuf,
+    log_path: PathBuf,
+    store_cli_opt: StoreCliOpt,
+    process: Arc<RwLock<Option<SandboxerProcess>>>,
+}
+
+type WriteLockedSandboxerProcess<'a> = RwLockWriteGuard<'a, Option<SandboxerProcess>>;
+
+impl Sandboxer {
+    pub async fn new(
+        sandboxer_bin: PathBuf,
+        pants_workdir: PathBuf,
+        store_cli_opt: StoreCliOpt,
+    ) -> Result<Self, String> {
+        let sandboxer_workdir = pants_workdir.join("sandboxer");
+        Ok(Self {
+            sandboxer_bin,
+            socket_path: sandboxer_workdir.join("sandboxer.sock"),
+            log_path: sandboxer_workdir.join("sandboxer.log"),
+            store_cli_opt,
+            process: Arc::new(RwLock::new(None)),
+        })
+    }
+
+    pub fn socket_path(&self) -> &Path {
+        self.socket_path.as_ref()
+    }
+
+    pub async fn is_alive(&self) -> Result<bool, String> {
+        let mut locked_proc = self.process.write().await;
+        if let Some(proc) = locked_proc.as_mut() {
+            proc.process.check_child_has_exited().map(|b| !b)
+        } else {
+            Ok(false)
+        }
+    }
+
+    pub async fn spawn(&self) -> Result<(), String> {
+        let mut locked_proc = self.process.write().await;
+        self.do_spawn(&mut locked_proc).await
+    }
+
+    async fn do_spawn(
+        &self,
+        locked_proc: &mut WriteLockedSandboxerProcess<'_>,
+    ) -> Result<(), String> {
+        ensure_parent_dir(&self.log_path)?;
+        let logfile = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.log_path)
+            .await
+            .map_err(|e| e.to_string())?;
+        let mut cmd = Command::new(&self.sandboxer_bin);
+        cmd.arg("--socket-path");
+        cmd.arg(self.socket_path.as_os_str());
+        cmd.args(self.store_cli_opt.to_cli_args());
+        // Pass the calling code's max log level to the sandboxer process.
+        cmd.env("RUST_LOG", log::max_level().as_str());
+        cmd.stderr(Stdio::from(logfile.into_std().await));
+
+        debug!(
+            "Spawning sandboxer with cmd: {} {}",
+            &self.sandboxer_bin.to_string_lossy(),
+            cmd.as_std()
+                .get_args()
+                .map(|a| a.to_string_lossy())
+                .collect::<Vec<_>>()
+                .join(" ")
+        );
+
+        if locked_proc.is_none() {
+            let process = ManagedChild::spawn(&mut cmd, Some(Duration::from_millis(1000)))
+                .map_err(|e| e.to_string())?;
+            debug!("Spawned sandboxer process {:?}", process.id());
+            let client = SandboxerClient::connect_with_retries(&self.socket_path).await?;
+            let _ = locked_proc.insert(SandboxerProcess { process, client });
+        }
+        Ok(())
+    }
+
+    async fn kill(&self) {
+        let mut locked_proc = self.process.write().await;
+        self.do_kill(&mut locked_proc).await
+    }
+
+    async fn do_kill(&self, locked_proc: &mut RwLockWriteGuard<'_, Option<SandboxerProcess>>) {
+        // Note that we don't want to remove the socket file here, as it may no longer
+        // be under the control of the sandboxer process we're killing.
+        if let Some(ref mut proc) = **locked_proc {
+            // Best effort to shut down, ignoring any errors (which would
+            // typically be due to the process already being dead).
+            let _ = proc.process.attempt_shutdown_sync();
+        }
+        locked_proc.take();
+    }
+
+    async fn client(&self) -> Result<SandboxerClient, String> {
+        {
+            let proc = self.process.read().await;
+            if let Some(proc) = proc.as_ref() {
+                return Ok(proc.client.clone());
+            }
+        }
+        // We've released the read lock, so now we can acquire the write lock.
+        let mut locked_proc = self.process.write().await;
+        Ok(if let Some(proc) = locked_proc.as_mut() {
+            // Some other concurrent task spawned the process while we were
+            // waiting for the write lock, so nothing to do.
+            proc.client.clone()
+        } else {
+            self.do_spawn(&mut locked_proc).await?;
+            locked_proc.as_ref().unwrap().client.clone()
+        })
+    }
+
+    pub async fn materialize_directory(
+        &self,
+        destination: &Path,
+        destination_root: &Path,
+        dir_digest: &DirectoryDigest,
+        mutable_paths: &BTreeSet<RelativePath>,
+    ) -> Result<(), String> {
+        let mutable_paths: Vec<String> = mutable_paths
+            .iter()
+            .map(|rp| {
+                rp.to_str()
+                    .map(str::to_string)
+                    .ok_or_else(|| format!("Path is not valid string: {:?}", rp))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let ret = self
+            .client()
+            .await?
+            .materialize_directory(destination, destination_root, dir_digest, &mutable_paths)
+            .await;
+        if ret.is_err() {
+            // The server might be down for some reason (e.g., it has not been initially started
+            // yet, or the socket file was deleted by the user). If this happens, ensure the
+            // server is properly killed, and retry once.
+            self.kill().await;
+            return self
+                .client()
+                .await?
+                .materialize_directory(destination, destination_root, dir_digest, &mutable_paths)
+                .await;
+        }
+        ret
+    }
+}
+
+// Note that we do NOT want to terminate the process in a Drop implementation.
+// There would be two ways to do this:  One is to kill() the process. But that is async,
+// and so not easily callable in drop(). The other is to delete the socket file. But that
+// might pull the rug out from under another Sandboxer that has preempted the dropped one.
+// However we do set kill_on_drop for the sandboxer process on creation, so tokio will
+// attempt to kill it asynchronously for us. This may leave a zombie process, as tokio doesn't
+// guarantee timely reaping. But since we expect the Sandboxer to be dropped only when pantsd
+// (or any other controlling process) is about to exit, at which point any of its child zombies
+// will be reaped by the system, this should be fine.


### PR DESCRIPTION
- A `SandboxerProcess` struct that encapsulates a running sandboxer process and a client connection to it.
- a `Sandboxer` struct that spawns (or re-spawns) a `SandboxerProcess` as needed, and provides the public-facing sandboxer API.

Also implements abrupt shutdown in case graceful shutdown of a sandboxer process fails (which can happen in real world scenarios).