### PR TITLE
[Call-by-name] Migrate codegen backends.

### DIFF
--- a/docs/notes/2.27.x.md
+++ b/docs/notes/2.27.x.md
@@ -27,6 +27,12 @@ The deprecation has expired for the `[GLOBAL].allow_deprecated_macos_before_12` 
 
 The [workunit-logger](https://www.pantsbuild.org/2.27/reference/subsystems/workunit-logger) will now log a stub with with `"json_serializable": False` for workunit metadata that can not be serialized instead of halting the process.
 
+#### New call-by-name syntax for @rules
+Pants has a new mechanism for `@rule` invocation in backends. In this release the following backends were migrated to use this new mechanism. There should not be any user-visible effects, but please be on the lookout for any unusual bugs or error messages.
+
+- [Python Protobuf](https://www.pantsbuild.org/2.27/docs/python/integrations/protobuf-and-grpc)
+- [Python Thrift](https://www.pantsbuild.org/2.27/docs/python/integrations/thrift)
+- [Buf Linter](https://www.pantsbuild.org/prerelease/docs/go/integrations/protobuf#buf-format-and-lint-protobuf)
 
 ### Goals
 

--- a/src/python/pants/backend/codegen/export_codegen_goal.py
+++ b/src/python/pants/backend/codegen/export_codegen_goal.py
@@ -4,13 +4,14 @@
 import logging
 
 from pants.core.util_rules.distdir import DistDir
-from pants.engine.fs import Digest, MergeDigests, Workspace
+from pants.engine.fs import MergeDigests, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
-from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule
+from pants.engine.internals.graph import hydrate_sources
+from pants.engine.intrinsics import merge_digests
+from pants.engine.rules import collect_rules, concurrently, goal_rule, implicitly
 from pants.engine.target import (
     FilteredTargets,
     GenerateSourcesRequest,
-    HydratedSources,
     HydrateSourcesRequest,
     RegisteredTargetTypes,
     SourcesField,
@@ -77,21 +78,20 @@ async def export_codegen(
         )
         return ExportCodegen(exit_code=0)
 
-    all_hydrated_sources = await MultiGet(
-        Get(
-            HydratedSources,
+    all_hydrated_sources = await concurrently(
+        hydrate_sources(
             HydrateSourcesRequest(
                 sources,
                 for_sources_types=(output_type,),
                 enable_codegen=True,
             ),
+            **implicitly(),
         )
         for sources, output_type in codegen_sources_fields_with_output
     )
 
-    merged_digest = await Get(
-        Digest,
-        MergeDigests(hydrated_sources.snapshot.digest for hydrated_sources in all_hydrated_sources),
+    merged_digest = await merge_digests(
+        MergeDigests(hydrated_sources.snapshot.digest for hydrated_sources in all_hydrated_sources)
     )
 
     dest = str(dist_dir.relpath / "codegen")

--- a/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules.py
@@ -18,7 +18,7 @@ from pants.core.util_rules.system_binaries import (
 from pants.engine.fs import MergeDigests
 from pants.engine.intrinsics import merge_digests
 from pants.engine.platform import Platform
-from pants.engine.process import Process, fallible_to_exec_result_or_raise
+from pants.engine.process import Process, execute_process_or_raise
 from pants.engine.rules import collect_rules, concurrently, implicitly, rule
 from pants.engine.target import FieldSet, Target
 from pants.util.logging import LogLevel
@@ -90,7 +90,7 @@ async def run_buf_format(
         "--path",
         ",".join(request.files),
     ]
-    result = await fallible_to_exec_result_or_raise(
+    result = await execute_process_or_raise(
         **implicitly(
             Process(
                 argv=argv,

--- a/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules.py
@@ -9,12 +9,17 @@ from pants.backend.codegen.protobuf.target_types import (
     ProtobufSourceField,
 )
 from pants.core.goals.fmt import FmtResult, FmtTargetsRequest, Partitions
-from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
-from pants.core.util_rules.system_binaries import BinaryShims, BinaryShimsRequest, DiffBinary
-from pants.engine.fs import Digest, MergeDigests
+from pants.core.util_rules.external_tool import download_external_tool
+from pants.core.util_rules.system_binaries import (
+    BinaryShimsRequest,
+    DiffBinary,
+    create_binary_shims,
+)
+from pants.engine.fs import MergeDigests
+from pants.engine.intrinsics import merge_digests
 from pants.engine.platform import Platform
-from pants.engine.process import Process, ProcessResult
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.process import Process, fallible_to_exec_result_or_raise
+from pants.engine.rules import collect_rules, concurrently, implicitly, rule
 from pants.engine.target import FieldSet, Target
 from pants.util.logging import LogLevel
 from pants.util.meta import classproperty
@@ -63,20 +68,18 @@ async def partition_buf(
 async def run_buf_format(
     request: BufFormatRequest.Batch, buf: BufSubsystem, diff_binary: DiffBinary, platform: Platform
 ) -> FmtResult:
-    download_buf_get = Get(DownloadedExternalTool, ExternalToolRequest, buf.get_request(platform))
-    binary_shims_get = Get(
-        BinaryShims,
-        BinaryShimsRequest,
+    download_buf_get = download_external_tool(buf.get_request(platform))
+    binary_shims_get = create_binary_shims(
         BinaryShimsRequest.for_paths(
             diff_binary,
             rationale="run `buf format`",
         ),
+        **implicitly(),
     )
-    downloaded_buf, binary_shims = await MultiGet(download_buf_get, binary_shims_get)
+    downloaded_buf, binary_shims = await concurrently(download_buf_get, binary_shims_get)
 
-    input_digest = await Get(
-        Digest,
-        MergeDigests((request.snapshot.digest, downloaded_buf.digest)),
+    input_digest = await merge_digests(
+        MergeDigests((request.snapshot.digest, downloaded_buf.digest))
     )
 
     argv = [
@@ -87,16 +90,17 @@ async def run_buf_format(
         "--path",
         ",".join(request.files),
     ]
-    result = await Get(
-        ProcessResult,
-        Process(
-            argv=argv,
-            input_digest=input_digest,
-            output_files=request.files,
-            description=f"Run buf format on {pluralize(len(request.files), 'file')}.",
-            level=LogLevel.DEBUG,
-            env={"PATH": binary_shims.path_component},
-            immutable_input_digests=binary_shims.immutable_input_digests,
+    result = await fallible_to_exec_result_or_raise(
+        **implicitly(
+            Process(
+                argv=argv,
+                input_digest=input_digest,
+                output_files=request.files,
+                description=f"Run buf format on {pluralize(len(request.files), 'file')}.",
+                level=LogLevel.DEBUG,
+                env={"PATH": binary_shims.path_component},
+                immutable_input_digests=binary_shims.immutable_input_digests,
+            )
         ),
     )
     return await FmtResult.create(request, result)

--- a/src/python/pants/backend/codegen/protobuf/lint/buf/lint_rules.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/lint_rules.py
@@ -10,15 +10,17 @@ from pants.backend.codegen.protobuf.target_types import (
     ProtobufSourceField,
 )
 from pants.core.goals.lint import LintResult, LintTargetsRequest, Partitions
-from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
-from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
+from pants.core.util_rules.config_files import find_config_file
+from pants.core.util_rules.external_tool import download_external_tool
 from pants.core.util_rules.source_files import SourceFilesRequest
-from pants.core.util_rules.stripped_source_files import StrippedSourceFiles
-from pants.engine.fs import Digest, MergeDigests
+from pants.core.util_rules.stripped_source_files import strip_source_roots
+from pants.engine.fs import MergeDigests
+from pants.engine.internals.graph import transitive_targets as transitive_targets_get
+from pants.engine.intrinsics import execute_process, merge_digests
 from pants.engine.platform import Platform
-from pants.engine.process import FallibleProcessResult, Process
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import FieldSet, Target, TransitiveTargets, TransitiveTargetsRequest
+from pants.engine.process import Process
+from pants.engine.rules import collect_rules, concurrently, implicitly, rule
+from pants.engine.target import FieldSet, Target, TransitiveTargetsRequest
 from pants.util.logging import LogLevel
 from pants.util.meta import classproperty
 from pants.util.strutil import pluralize
@@ -60,45 +62,47 @@ async def partition_buf(
 async def run_buf(
     request: BufLintRequest.Batch[BufFieldSet, Any], buf: BufSubsystem, platform: Platform
 ) -> LintResult:
-    transitive_targets = await Get(
-        TransitiveTargets,
+    transitive_targets = await transitive_targets_get(
         TransitiveTargetsRequest(field_set.address for field_set in request.elements),
+        **implicitly(),
     )
 
-    all_stripped_sources_request = Get(
-        StrippedSourceFiles,
-        SourceFilesRequest(
-            tgt[ProtobufSourceField]
-            for tgt in transitive_targets.closure
-            if tgt.has_field(ProtobufSourceField)
-        ),
+    all_stripped_sources_request = strip_source_roots(
+        **implicitly(
+            SourceFilesRequest(
+                tgt[ProtobufSourceField]
+                for tgt in transitive_targets.closure
+                if tgt.has_field(ProtobufSourceField)
+            )
+        )
     )
-    target_stripped_sources_request = Get(
-        StrippedSourceFiles,
-        SourceFilesRequest(
-            (field_set.sources for field_set in request.elements),
-            for_sources_types=(ProtobufSourceField,),
-            enable_codegen=True,
-        ),
-    )
-
-    download_buf_get = Get(DownloadedExternalTool, ExternalToolRequest, buf.get_request(platform))
-
-    config_files_get = Get(
-        ConfigFiles,
-        ConfigFilesRequest,
-        buf.config_request,
+    target_stripped_sources_request = strip_source_roots(
+        **implicitly(
+            SourceFilesRequest(
+                (field_set.sources for field_set in request.elements),
+                for_sources_types=(ProtobufSourceField,),
+                enable_codegen=True,
+            )
+        )
     )
 
-    target_sources_stripped, all_sources_stripped, downloaded_buf, config_files = await MultiGet(
+    download_buf_get = download_external_tool(buf.get_request(platform))
+
+    config_files_get = find_config_file(buf.config_request)
+
+    (
+        target_sources_stripped,
+        all_sources_stripped,
+        downloaded_buf,
+        config_files,
+    ) = await concurrently(
         target_stripped_sources_request,
         all_stripped_sources_request,
         download_buf_get,
         config_files_get,
     )
 
-    input_digest = await Get(
-        Digest,
+    input_digest = await merge_digests(
         MergeDigests(
             (
                 target_sources_stripped.snapshot.digest,
@@ -106,13 +110,12 @@ async def run_buf(
                 downloaded_buf.digest,
                 config_files.snapshot.digest,
             )
-        ),
+        )
     )
 
     config_arg = ["--config", buf.config] if buf.config else []
 
-    process_result = await Get(
-        FallibleProcessResult,
+    process_result = await execute_process(
         Process(
             argv=[
                 downloaded_buf.exe,
@@ -126,6 +129,7 @@ async def run_buf(
             description=f"Run buf lint on {pluralize(len(request.elements), 'file')}.",
             level=LogLevel.DEBUG,
         ),
+        **implicitly(),
     )
     return LintResult.create(request, process_result)
 

--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_module_mapper.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_module_mapper.py
@@ -21,8 +21,8 @@ from pants.backend.python.dependency_inference.module_mapper import (
 )
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import PythonResolveField
-from pants.core.util_rules.stripped_source_files import StrippedFileName, StrippedFileNameRequest
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.core.util_rules.stripped_source_files import StrippedFileNameRequest, strip_file_name
+from pants.engine.rules import collect_rules, concurrently, rule
 from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
 
@@ -49,8 +49,8 @@ async def map_protobuf_to_python_modules(
     if python_protobuf_subsystem.grpclib_plugin:
         grpc_suffixes.append("_grpc")
 
-    stripped_file_per_target = await MultiGet(
-        Get(StrippedFileName, StrippedFileNameRequest(tgt[ProtobufSourceField].file_path))
+    stripped_file_per_target = await concurrently(
+        strip_file_name(StrippedFileNameRequest(tgt[ProtobufSourceField].file_path))
         for tgt in protobuf_targets
     )
 

--- a/src/python/pants/backend/codegen/protobuf/python/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/python/rules.py
@@ -16,32 +16,25 @@ from pants.backend.codegen.protobuf.python.python_protobuf_subsystem import (
 from pants.backend.codegen.protobuf.target_types import ProtobufGrpcToggleField, ProtobufSourceField
 from pants.backend.python.target_types import PythonSourceField
 from pants.backend.python.util_rules import pex
-from pants.backend.python.util_rules.pex import PexResolveInfo, VenvPex, VenvPexRequest
+from pants.backend.python.util_rules.pex import (
+    VenvPexRequest,
+    create_venv_pex,
+    determine_venv_pex_resolve_info,
+)
 from pants.backend.python.util_rules.pex_environment import PexEnvironment
 from pants.core.goals.resolves import ExportableTool
-from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
+from pants.core.util_rules.external_tool import download_external_tool
 from pants.core.util_rules.source_files import SourceFilesRequest
-from pants.core.util_rules.stripped_source_files import StrippedSourceFiles
-from pants.engine.fs import (
-    AddPrefix,
-    CreateDigest,
-    Digest,
-    Directory,
-    MergeDigests,
-    RemovePrefix,
-    Snapshot,
-)
+from pants.core.util_rules.stripped_source_files import strip_source_roots
+from pants.engine.fs import AddPrefix, CreateDigest, Directory, MergeDigests, RemovePrefix
+from pants.engine.internals.graph import transitive_targets as transitive_targets_get
+from pants.engine.intrinsics import create_digest, digest_to_snapshot, merge_digests, remove_prefix
 from pants.engine.platform import Platform
-from pants.engine.process import Process, ProcessResult
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import (
-    GeneratedSources,
-    GenerateSourcesRequest,
-    TransitiveTargets,
-    TransitiveTargetsRequest,
-)
+from pants.engine.process import Process, fallible_to_exec_result_or_raise
+from pants.engine.rules import collect_rules, concurrently, implicitly, rule
+from pants.engine.target import GeneratedSources, GenerateSourcesRequest, TransitiveTargetsRequest
 from pants.engine.unions import UnionRule
-from pants.source.source_root import SourceRoot, SourceRootRequest
+from pants.source.source_root import SourceRootRequest, get_source_root
 from pants.util.logging import LogLevel
 
 logger = logging.getLogger(__name__)
@@ -63,32 +56,31 @@ async def generate_python_from_protobuf(
     pex_environment: PexEnvironment,
     platform: Platform,
 ) -> GeneratedSources:
-    download_protoc_request = Get(
-        DownloadedExternalTool, ExternalToolRequest, protoc.get_request(platform)
-    )
+    download_protoc_request = download_external_tool(protoc.get_request(platform))
 
     output_dir = "_generated_files"
-    create_output_dir_request = Get(Digest, CreateDigest([Directory(output_dir)]))
+    create_output_dir_request = create_digest(CreateDigest([Directory(output_dir)]))
 
     # Protoc needs all transitive dependencies on `protobuf_libraries` to work properly. It won't
     # actually generate those dependencies; it only needs to look at their .proto files to work
     # with imports.
-    transitive_targets = await Get(
-        TransitiveTargets, TransitiveTargetsRequest([request.protocol_target.address])
+    transitive_targets = await transitive_targets_get(
+        TransitiveTargetsRequest([request.protocol_target.address]), **implicitly()
     )
 
     # NB: By stripping the source roots, we avoid having to set the value `--proto_path`
     # for Protobuf imports to be discoverable.
-    all_stripped_sources_request = Get(
-        StrippedSourceFiles,
-        SourceFilesRequest(
-            tgt[ProtobufSourceField]
-            for tgt in transitive_targets.closure
-            if tgt.has_field(ProtobufSourceField)
-        ),
+    all_stripped_sources_request = strip_source_roots(
+        **implicitly(
+            SourceFilesRequest(
+                tgt[ProtobufSourceField]
+                for tgt in transitive_targets.closure
+                if tgt.has_field(ProtobufSourceField)
+            )
+        )
     )
-    target_stripped_sources_request = Get(
-        StrippedSourceFiles, SourceFilesRequest([request.protocol_target[ProtobufSourceField]])
+    target_stripped_sources_request = strip_source_roots(
+        **implicitly(SourceFilesRequest([request.protocol_target[ProtobufSourceField]]))
     )
 
     (
@@ -96,7 +88,7 @@ async def generate_python_from_protobuf(
         empty_output_dir,
         all_sources_stripped,
         target_sources_stripped,
-    ) = await MultiGet(
+    ) = await concurrently(
         download_protoc_request,
         create_output_dir_request,
         all_stripped_sources_request,
@@ -120,13 +112,13 @@ async def generate_python_from_protobuf(
         protoc_gen_mypy_script = "protoc-gen-mypy"
         protoc_gen_mypy_grpc_script = "protoc-gen-mypy_grpc"
         mypy_request = python_protobuf_mypy_plugin.to_pex_request()
-        mypy_pex = await Get(
-            VenvPex,
+        mypy_pex = await create_venv_pex(
             VenvPexRequest(
                 pex_request=mypy_request,
                 complete_pex_env=complete_pex_env,
                 bin_names=[protoc_gen_mypy_script],
             ),
+            **implicitly(),
         )
         protoc_argv.extend(
             [
@@ -137,19 +129,19 @@ async def generate_python_from_protobuf(
         )
 
         if grpc_enabled and python_protobuf_subsystem.grpcio_plugin:
-            mypy_pex_info = await Get(PexResolveInfo, VenvPex, mypy_pex)
+            mypy_pex_info = await determine_venv_pex_resolve_info(mypy_pex)
 
             # In order to generate stubs for gRPC code, we need mypy-protobuf 2.0 or above.
             mypy_protobuf_info = mypy_pex_info.find("mypy-protobuf")
             if mypy_protobuf_info and mypy_protobuf_info.version.major >= 2:
                 # TODO: Use `pex_path` once VenvPex stores a Pex field.
-                mypy_pex = await Get(
-                    VenvPex,
+                mypy_pex = await create_venv_pex(
                     VenvPexRequest(
                         pex_request=mypy_request,
                         complete_pex_env=complete_pex_env,
                         bin_names=[protoc_gen_mypy_script, protoc_gen_mypy_grpc_script],
                     ),
+                    **implicitly(),
                 )
                 protoc_argv.extend(
                     [
@@ -172,10 +164,8 @@ async def generate_python_from_protobuf(
             )
 
         if python_protobuf_subsystem.grpcio_plugin:
-            downloaded_grpc_plugin = await Get(
-                DownloadedExternalTool,
-                ExternalToolRequest,
-                grpc_python_plugin.get_request(platform),
+            downloaded_grpc_plugin = await download_external_tool(
+                grpc_python_plugin.get_request(platform)
             )
             unmerged_digests.append(downloaded_grpc_plugin.digest)
             protoc_argv.extend(
@@ -185,13 +175,13 @@ async def generate_python_from_protobuf(
         if python_protobuf_subsystem.grpclib_plugin:
             protoc_gen_grpclib_script = "protoc-gen-grpclib_python"
             grpclib_request = python_protobuf_grpclib_plugin.to_pex_request()
-            grpclib_pex = await Get(
-                VenvPex,
+            grpclib_pex = await create_venv_pex(
                 VenvPexRequest(
                     pex_request=grpclib_request,
                     complete_pex_env=complete_pex_env,
                     bin_names=[protoc_gen_grpclib_script],
                 ),
+                **implicitly(),
             )
             unmerged_digests.append(grpclib_pex.digest)
             protoc_argv.extend(
@@ -202,20 +192,21 @@ async def generate_python_from_protobuf(
                 ]
             )
 
-    input_digest = await Get(Digest, MergeDigests(unmerged_digests))
+    input_digest = await merge_digests(MergeDigests(unmerged_digests))
     protoc_argv.extend(target_sources_stripped.snapshot.files)
-    result = await Get(
-        ProcessResult,
-        Process(
-            protoc_argv,
-            input_digest=input_digest,
-            immutable_input_digests={
-                protoc_relpath: downloaded_protoc_binary.digest,
-            },
-            description=f"Generating Python sources from {request.protocol_target.address}.",
-            level=LogLevel.DEBUG,
-            output_directories=(output_dir,),
-            append_only_caches=complete_pex_env.append_only_caches,
+    result = await fallible_to_exec_result_or_raise(
+        **implicitly(
+            Process(
+                protoc_argv,
+                input_digest=input_digest,
+                immutable_input_digests={
+                    protoc_relpath: downloaded_protoc_binary.digest,
+                },
+                description=f"Generating Python sources from {request.protocol_target.address}.",
+                level=LogLevel.DEBUG,
+                output_directories=(output_dir,),
+                append_only_caches=complete_pex_env.append_only_caches,
+            )
         ),
     )
 
@@ -229,15 +220,15 @@ async def generate_python_from_protobuf(
         # The target didn't specify a python source root, so use the protobuf_source's source root.
         source_root_request = SourceRootRequest.for_target(request.protocol_target)
 
-    normalized_digest, source_root = await MultiGet(
-        Get(Digest, RemovePrefix(result.output_digest, output_dir)),
-        Get(SourceRoot, SourceRootRequest, source_root_request),
+    normalized_digest, source_root = await concurrently(
+        remove_prefix(RemovePrefix(result.output_digest, output_dir)),
+        get_source_root(source_root_request),
     )
 
     source_root_restored = (
-        await Get(Snapshot, AddPrefix(normalized_digest, source_root.path))
+        await digest_to_snapshot(**implicitly(AddPrefix(normalized_digest, source_root.path)))
         if source_root.path != "."
-        else await Get(Snapshot, Digest, normalized_digest)
+        else await digest_to_snapshot(normalized_digest)
     )
     return GeneratedSources(source_root_restored)
 

--- a/src/python/pants/backend/codegen/protobuf/python/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/python/rules.py
@@ -30,7 +30,7 @@ from pants.engine.fs import AddPrefix, CreateDigest, Directory, MergeDigests, Re
 from pants.engine.internals.graph import transitive_targets as transitive_targets_get
 from pants.engine.intrinsics import create_digest, digest_to_snapshot, merge_digests, remove_prefix
 from pants.engine.platform import Platform
-from pants.engine.process import Process, fallible_to_exec_result_or_raise
+from pants.engine.process import Process, execute_process_or_raise
 from pants.engine.rules import collect_rules, concurrently, implicitly, rule
 from pants.engine.target import GeneratedSources, GenerateSourcesRequest, TransitiveTargetsRequest
 from pants.engine.unions import UnionRule
@@ -194,7 +194,7 @@ async def generate_python_from_protobuf(
 
     input_digest = await merge_digests(MergeDigests(unmerged_digests))
     protoc_argv.extend(target_sources_stripped.snapshot.files)
-    result = await fallible_to_exec_result_or_raise(
+    result = await execute_process_or_raise(
         **implicitly(
             Process(
                 protoc_argv,

--- a/src/python/pants/backend/codegen/protobuf/tailor.py
+++ b/src/python/pants/backend/codegen/protobuf/tailor.py
@@ -13,8 +13,7 @@ from pants.core.goals.tailor import (
     PutativeTargets,
     PutativeTargetsRequest,
 )
-from pants.engine.fs import PathGlobs, Paths
-from pants.engine.internals.selectors import Get
+from pants.engine.intrinsics import path_globs_to_paths
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.util.dirutil import group_by_dir
@@ -33,7 +32,7 @@ async def find_putative_targets(
     if not protoc.tailor:
         return PutativeTargets()
 
-    all_proto_files = await Get(Paths, PathGlobs, req.path_globs("*.proto"))
+    all_proto_files = await path_globs_to_paths(req.path_globs("*.proto"))
     unowned_proto_files = set(all_proto_files.files) - set(all_owned_sources)
     pts = [
         PutativeTarget.for_target_type(

--- a/src/python/pants/backend/codegen/thrift/apache/rules.py
+++ b/src/python/pants/backend/codegen/thrift/apache/rules.py
@@ -21,7 +21,7 @@ from pants.engine.internals.graph import transitive_targets as transitive_target
 from pants.engine.internals.platform_rules import environment_vars_subset
 from pants.engine.internals.selectors import concurrently
 from pants.engine.intrinsics import create_digest, digest_to_snapshot, merge_digests
-from pants.engine.process import Process, fallible_to_exec_result_or_raise
+from pants.engine.process import Process, execute_process_or_raise
 from pants.engine.rules import collect_rules, implicitly, rule
 from pants.engine.target import TransitiveTargetsRequest
 from pants.source.source_root import SourceRootsRequest, get_source_roots
@@ -107,7 +107,7 @@ async def generate_apache_thrift_sources(
         *target_sources.snapshot.files,
     ]
 
-    result = await fallible_to_exec_result_or_raise(
+    result = await execute_process_or_raise(
         **implicitly(
             Process(
                 args,
@@ -156,7 +156,7 @@ async def setup_thrift_tool(
         )
 
     version_results = await concurrently(
-        fallible_to_exec_result_or_raise(
+        execute_process_or_raise(
             **implicitly(
                 Process(
                     (binary_path.path, "-version"),

--- a/src/python/pants/backend/codegen/thrift/apache/rules.py
+++ b/src/python/pants/backend/codegen/thrift/apache/rules.py
@@ -8,20 +8,23 @@ from dataclasses import dataclass
 from pants.backend.codegen.thrift.apache.subsystem import ApacheThriftSubsystem
 from pants.backend.codegen.thrift.target_types import ThriftSourceField
 from pants.core.util_rules.environments import EnvironmentTarget
-from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
+from pants.core.util_rules.source_files import SourceFilesRequest, determine_source_files
 from pants.core.util_rules.system_binaries import (
     BinaryNotFoundError,
     BinaryPathRequest,
-    BinaryPaths,
     BinaryPathTest,
+    find_binary,
 )
-from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
-from pants.engine.fs import CreateDigest, Digest, Directory, MergeDigests, RemovePrefix, Snapshot
-from pants.engine.internals.selectors import Get, MultiGet
-from pants.engine.process import Process, ProcessResult
-from pants.engine.rules import collect_rules, rule
-from pants.engine.target import TransitiveTargets, TransitiveTargetsRequest
-from pants.source.source_root import SourceRootsRequest, SourceRootsResult
+from pants.engine.env_vars import EnvironmentVarsRequest
+from pants.engine.fs import CreateDigest, Directory, MergeDigests, RemovePrefix, Snapshot
+from pants.engine.internals.graph import transitive_targets as transitive_targets_get
+from pants.engine.internals.platform_rules import environment_vars_subset
+from pants.engine.internals.selectors import concurrently
+from pants.engine.intrinsics import create_digest, digest_to_snapshot, merge_digests
+from pants.engine.process import Process, fallible_to_exec_result_or_raise
+from pants.engine.rules import collect_rules, implicitly, rule
+from pants.engine.target import TransitiveTargetsRequest
+from pants.source.source_root import SourceRootsRequest, get_source_roots
 from pants.util.logging import LogLevel
 from pants.util.strutil import bullet_list, softwrap
 
@@ -53,39 +56,37 @@ async def generate_apache_thrift_sources(
 ) -> GeneratedThriftSources:
     output_dir = "_generated_files"
 
-    transitive_targets, empty_output_dir_digest = await MultiGet(
-        Get(TransitiveTargets, TransitiveTargetsRequest([request.thrift_source_field.address])),
-        Get(Digest, CreateDigest([Directory(output_dir)])),
+    transitive_targets, empty_output_dir_digest = await concurrently(
+        transitive_targets_get(
+            TransitiveTargetsRequest([request.thrift_source_field.address]), **implicitly()
+        ),
+        create_digest(CreateDigest([Directory(output_dir)])),
     )
 
-    transitive_sources, target_sources = await MultiGet(
-        Get(
-            SourceFiles,
+    transitive_sources, target_sources = await concurrently(
+        determine_source_files(
             SourceFilesRequest(
                 tgt[ThriftSourceField]
                 for tgt in transitive_targets.closure
                 if tgt.has_field(ThriftSourceField)
-            ),
+            )
         ),
-        Get(SourceFiles, SourceFilesRequest([request.thrift_source_field])),
+        determine_source_files(SourceFilesRequest([request.thrift_source_field])),
     )
 
-    sources_roots = await Get(
-        SourceRootsResult,
-        SourceRootsRequest,
-        SourceRootsRequest.for_files(transitive_sources.snapshot.files),
+    sources_roots = await get_source_roots(
+        SourceRootsRequest.for_files(transitive_sources.snapshot.files)
     )
     deduped_source_root_paths = sorted({sr.path for sr in sources_roots.path_to_root.values()})
 
-    input_digest = await Get(
-        Digest,
+    input_digest = await merge_digests(
         MergeDigests(
             [
                 transitive_sources.snapshot.digest,
                 target_sources.snapshot.digest,
                 empty_output_dir_digest,
             ]
-        ),
+        )
     )
 
     options_str = ""
@@ -106,18 +107,21 @@ async def generate_apache_thrift_sources(
         *target_sources.snapshot.files,
     ]
 
-    result = await Get(
-        ProcessResult,
-        Process(
-            args,
-            input_digest=input_digest,
-            output_directories=(output_dir,),
-            description=f"Generating {request.lang_name} sources from {request.thrift_source_field.address}.",
-            level=LogLevel.DEBUG,
+    result = await fallible_to_exec_result_or_raise(
+        **implicitly(
+            Process(
+                args,
+                input_digest=input_digest,
+                output_directories=(output_dir,),
+                description=f"Generating {request.lang_name} sources from {request.thrift_source_field.address}.",
+                level=LogLevel.DEBUG,
+            )
         ),
     )
 
-    output_snapshot = await Get(Snapshot, RemovePrefix(result.output_digest, output_dir))
+    output_snapshot = await digest_to_snapshot(
+        **implicitly(RemovePrefix(result.output_digest, output_dir))
+    )
     return GeneratedThriftSources(output_snapshot)
 
 
@@ -127,15 +131,15 @@ async def setup_thrift_tool(
     apache_thrift_env_aware: ApacheThriftSubsystem.EnvironmentAware,
     env_target: EnvironmentTarget,
 ) -> ApacheThriftSetup:
-    env = await Get(EnvironmentVars, EnvironmentVarsRequest(["PATH"]))
+    env = await environment_vars_subset(**implicitly(EnvironmentVarsRequest(["PATH"])))
     search_paths = apache_thrift_env_aware.thrift_search_paths(env)
-    all_thrift_binary_paths = await Get(
-        BinaryPaths,
+    all_thrift_binary_paths = await find_binary(
         BinaryPathRequest(
             search_path=search_paths,
             binary_name="thrift",
             test=BinaryPathTest(["-version"]),
         ),
+        **implicitly(),
     )
     if not all_thrift_binary_paths.paths:
         raise BinaryNotFoundError(
@@ -151,14 +155,15 @@ async def setup_thrift_tool(
             )
         )
 
-    version_results = await MultiGet(
-        Get(
-            ProcessResult,
-            Process(
-                (binary_path.path, "-version"),
-                description=f"Determine Apache Thrift version for {binary_path.path}",
-                level=LogLevel.DEBUG,
-                cache_scope=env_target.executable_search_path_cache_scope(),
+    version_results = await concurrently(
+        fallible_to_exec_result_or_raise(
+            **implicitly(
+                Process(
+                    (binary_path.path, "-version"),
+                    description=f"Determine Apache Thrift version for {binary_path.path}",
+                    level=LogLevel.DEBUG,
+                    cache_scope=env_target.executable_search_path_cache_scope(),
+                )
             ),
         )
         for binary_path in all_thrift_binary_paths.paths

--- a/src/python/pants/backend/codegen/thrift/tailor.py
+++ b/src/python/pants/backend/codegen/thrift/tailor.py
@@ -13,8 +13,7 @@ from pants.core.goals.tailor import (
     PutativeTargets,
     PutativeTargetsRequest,
 )
-from pants.engine.fs import PathGlobs, Paths
-from pants.engine.internals.selectors import Get
+from pants.engine.intrinsics import path_globs_to_paths
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.util.dirutil import group_by_dir
@@ -35,7 +34,7 @@ async def find_putative_thrift_targets(
     if not thrift_subsystem.tailor:
         return PutativeTargets()
 
-    all_thrift_files = await Get(Paths, PathGlobs, req.path_globs("*.thrift"))
+    all_thrift_files = await path_globs_to_paths(req.path_globs("*.thrift"))
     unowned_thrift_files = set(all_thrift_files.files) - set(all_owned_sources)
     pts = [
         PutativeTarget.for_target_type(

--- a/src/python/pants/backend/codegen/thrift/thrift_parser.py
+++ b/src/python/pants/backend/codegen/thrift/thrift_parser.py
@@ -9,10 +9,10 @@ from dataclasses import dataclass
 
 from pants.backend.codegen.thrift.target_types import ThriftSourceField
 from pants.engine.engine_aware import EngineAwareParameter
-from pants.engine.fs import DigestContents
-from pants.engine.internals.native_engine import Digest
-from pants.engine.rules import Get, collect_rules, rule
-from pants.engine.target import HydratedSources, HydrateSourcesRequest
+from pants.engine.internals.graph import hydrate_sources
+from pants.engine.intrinsics import get_digest_contents
+from pants.engine.rules import collect_rules, implicitly, rule
+from pants.engine.target import HydrateSourcesRequest
 from pants.util.frozendict import FrozenDict
 from pants.util.ordered_set import FrozenOrderedSet
 
@@ -45,8 +45,8 @@ class ParsedThriftRequest(EngineAwareParameter):
 
 @rule
 async def parse_thrift_file(request: ParsedThriftRequest) -> ParsedThrift:
-    sources = await Get(HydratedSources, HydrateSourcesRequest(request.sources_field))
-    digest_contents = await Get(DigestContents, Digest, sources.snapshot.digest)
+    sources = await hydrate_sources(HydrateSourcesRequest(request.sources_field), **implicitly())
+    digest_contents = await get_digest_contents(sources.snapshot.digest)
     assert len(digest_contents) == 1
 
     file_content = digest_contents[0].content.decode()


### PR DESCRIPTION
- pants.backend.codegen.protobuf.lint.buf
- pants.backend.codegen.protobuf.python
- pants.backend.codegen.thrift.apache.python