### PR TITLE
Allow extra env vars to be set on nodejs package installs

### DIFF
--- a/docs/notes/2.27.x.md
+++ b/docs/notes/2.27.x.md
@@ -52,7 +52,7 @@ Added support for formatting typescript and tsx files with Prettier.
 
 Fixed a bug where `pnpm-workspaces.yaml` could affect NPM or Yarn projects - it should be ignored.
 
-Allow extra env vars during nodejs package manager installation through [the `[nodejs].package_manager_extra_env_vars` option](https://www.pantsbuild.org/2.27/reference/subsystems/nodejs#package_manager_extra_env_vars) and/or [the `extra_env_vars` field](https://www.pantsbuild.org/2.27/reference/targets/package_json#package_manager_extra_env_vars) on `package_json` targets.
+Allow extra env vars during nodejs invocations through [the `[nodejs].extra_env_vars` option](https://www.pantsbuild.org/2.27/reference/subsystems/nodejs#extra_env_vars) and/or [the `extra_env_vars` field](https://www.pantsbuild.org/2.27/reference/targets/package_json#extra_env_vars) on `package_json` targets.
 
 #### Python
 

--- a/docs/notes/2.27.x.md
+++ b/docs/notes/2.27.x.md
@@ -52,6 +52,8 @@ Added support for formatting typescript and tsx files with Prettier.
 
 Fixed a bug where `pnpm-workspaces.yaml` could affect NPM or Yarn projects - it should be ignored.
 
+Allow extra env vars during nodejs package manager installation through `[nodejs].package_manager_extra_env_vars` option or and the `extra_env_vars` field on `package_json` targets.
+
 #### Python
 
 The Pex tool has been upgraded from 2.33.4 to [2.36.0](https://github.com/pex-tool/pex/releases/tag/v2.36.0) by default. Among other changes this includes support for Pip [25.1](https://pip.pypa.io/en/stable/news/#v25-1).

--- a/docs/notes/2.27.x.md
+++ b/docs/notes/2.27.x.md
@@ -52,7 +52,7 @@ Added support for formatting typescript and tsx files with Prettier.
 
 Fixed a bug where `pnpm-workspaces.yaml` could affect NPM or Yarn projects - it should be ignored.
 
-Allow extra env vars during nodejs package manager installation through `[nodejs].package_manager_extra_env_vars` option or and the `extra_env_vars` field on `package_json` targets.
+Allow extra env vars during nodejs package manager installation through [the `[nodejs].package_manager_extra_env_vars` option](https://www.pantsbuild.org/2.27/reference/subsystems/nodejs#package_manager_extra_env_vars) and/or [the `extra_env_vars` field](https://www.pantsbuild.org/2.27/reference/targets/package_json#package_manager_extra_env_vars) on `package_json` targets.
 
 #### Python
 

--- a/src/python/pants/backend/javascript/install_node_package.py
+++ b/src/python/pants/backend/javascript/install_node_package.py
@@ -14,7 +14,6 @@ from pants.backend.javascript.nodejs_project_environment import (
     NodeJSProjectEnvironmentRequest,
 )
 from pants.backend.javascript.package_json import (
-    NodePackageExtraEnvVarsField,
     NodePackageNameField,
     NodePackageVersionField,
     PackageJsonSourceField,
@@ -25,14 +24,12 @@ from pants.backend.javascript.target_types import JSRuntimeSourceField
 from pants.build_graph.address import Address
 from pants.core.target_types import FileSourceField, ResourceSourceField
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
-from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.internals.native_engine import AddPrefix, Digest, MergeDigests
-from pants.engine.internals.selectors import Get, MultiGet
+from pants.engine.internals.selectors import Get
 from pants.engine.process import ProcessResult
 from pants.engine.rules import Rule, collect_rules, rule
 from pants.engine.target import SourcesField, Target, TransitiveTargets, TransitiveTargetsRequest
 from pants.engine.unions import UnionMembership, UnionRule
-from pants.util.frozendict import FrozenDict
 
 
 @dataclass(frozen=True)
@@ -96,14 +93,6 @@ async def install_node_packages_for_address(
     )
     package_digest = source_files.snapshot.digest
 
-    subsystem_env_vars, target_env_vars = await MultiGet(
-        Get(EnvironmentVars, EnvironmentVarsRequest(nodejs.package_manager_extra_env_vars)),
-        Get(
-            EnvironmentVars,
-            EnvironmentVarsRequest(target.get(NodePackageExtraEnvVarsField).value or ()),
-        ),
-    )
-
     install_result = await Get(
         ProcessResult,
         NodeJsProjectEnvironmentProcess(
@@ -112,7 +101,6 @@ async def install_node_packages_for_address(
             description=f"Installing {target[NodePackageNameField].value}@{target[NodePackageVersionField].value}.",
             input_digest=package_digest,
             output_directories=tuple(project_env.node_modules_directories),
-            extra_env=FrozenDict(**subsystem_env_vars, **target_env_vars),
         ),
     )
     node_modules = await Get(Digest, AddPrefix(install_result.output_digest, project_env.root_dir))

--- a/src/python/pants/backend/javascript/install_node_package_test.py
+++ b/src/python/pants/backend/javascript/install_node_package_test.py
@@ -38,7 +38,7 @@ def test_install_node_package_with_extra_env_vars(rule_runner: RuleRunner) -> No
     # Test both subsystem and target-level environment variables
     rule_runner.set_options(
         [
-            "--nodejs-package-manager-extra-env-vars=['GLOBAL_VAR=global_value']",
+            "--nodejs-extra-env-vars=['GLOBAL_VAR=global_value', 'TARGET_VAR=will_be_overridden']",
             "--nodejs-tools=['env']",
         ],
         env_inherit={"PATH"},

--- a/src/python/pants/backend/javascript/install_node_package_test.py
+++ b/src/python/pants/backend/javascript/install_node_package_test.py
@@ -1,0 +1,90 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import json
+from textwrap import dedent
+
+import pytest
+
+from pants.backend.javascript import install_node_package, package_json
+from pants.backend.javascript.install_node_package import (
+    InstalledNodePackage,
+    InstalledNodePackageRequest,
+)
+from pants.backend.javascript.package_json import PackageJsonTarget
+from pants.backend.javascript.target_types import JSSourcesGeneratorTarget
+from pants.build_graph.address import Address
+from pants.engine.fs import DigestContents
+from pants.engine.rules import QueryRule
+from pants.testutil.rule_runner import RuleRunner
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    return RuleRunner(
+        rules=[
+            *install_node_package.rules(),
+            *package_json.rules(),
+            QueryRule(InstalledNodePackage, (InstalledNodePackageRequest,)),
+        ],
+        target_types=[PackageJsonTarget, JSSourcesGeneratorTarget],
+        objects=dict(package_json.build_file_aliases().objects),
+    )
+
+
+def test_install_node_package_with_extra_env_vars(rule_runner: RuleRunner) -> None:
+    # Test both subsystem and target-level environment variables
+    rule_runner.set_options(
+        [
+            "--nodejs-package-manager-extra-env-vars=['GLOBAL_VAR=global_value']",
+            "--nodejs-tools=['env']",
+        ],
+        env_inherit={"PATH"},
+    )
+
+    rule_runner.write_files(
+        {
+            "src/js/BUILD": dedent(
+                """
+                package_json(
+                    extra_env_vars=[
+                        "TARGET_VAR=target_value",
+                    ]
+                )
+                """
+            ),
+            "src/js/package.json": json.dumps(
+                {
+                    "name": "test-package",
+                    "version": "1.0.0",
+                    "packageManager": "yarn@1.22.22",
+                    "scripts": {
+                        "postinstall": "env > node_modules/env-vars.txt",
+                    },
+                }
+            ),
+        }
+    )
+
+    installed_package = rule_runner.request(
+        InstalledNodePackage,
+        [InstalledNodePackageRequest(Address("src/js"))],
+    )
+    digest = rule_runner.request(DigestContents, [installed_package.digest])
+    env_vars_file = next((f for f in digest if f.path == "src/js/node_modules/env-vars.txt"), None)
+    assert env_vars_file is not None
+
+    content = env_vars_file.content.decode("utf-8")
+    actual_env_vars = {}
+    for line in content.split("\n"):
+        if "=" in line:
+            key, value = line.split("=", 1)
+            actual_env_vars[key] = value
+
+    assert "TARGET_VAR" in actual_env_vars
+    assert actual_env_vars["TARGET_VAR"] == "target_value"
+
+    assert "GLOBAL_VAR" in actual_env_vars
+    assert actual_env_vars["GLOBAL_VAR"] == "global_value"

--- a/src/python/pants/backend/javascript/nodejs_project_environment.py
+++ b/src/python/pants/backend/javascript/nodejs_project_environment.py
@@ -135,7 +135,7 @@ async def setup_nodejs_project_environment_process(
     lockfile_digest, project_digest, subsystem_env_vars, env_vars = await MultiGet(
         Get(Digest, PathGlobs, req.env.resolve.get_lockfile_glob()),
         Get(Digest, MergeDigests, req.env.project.get_project_digest()),
-        Get(EnvironmentVars, EnvironmentVarsRequest(nodejs.package_manager_extra_env_vars)),
+        Get(EnvironmentVars, EnvironmentVarsRequest(nodejs.extra_env_vars)),
         Get(EnvironmentVars, EnvironmentVarsRequest(target_env_vars)),
     )
     merged = await Get(Digest, MergeDigests((req.input_digest, lockfile_digest, project_digest)))
@@ -166,10 +166,12 @@ async def setup_nodejs_project_environment_process(
             timeout_seconds=req.timeout_seconds,
             project_digest=project_digest,
             extra_env=FrozenDict(
-                **subsystem_env_vars,
-                **env_vars,
-                **req.extra_env,
-                **req.env.project.extra_env(),
+                {
+                    **subsystem_env_vars,
+                    **env_vars,
+                    **req.extra_env,
+                    **req.env.project.extra_env(),
+                }
             ),
         ),
     )

--- a/src/python/pants/backend/javascript/package/rules_test.py
+++ b/src/python/pants/backend/javascript/package/rules_test.py
@@ -244,6 +244,12 @@ def test_packages_files_as_resource_in_workspace(
 
 
 def test_extra_envs(rule_runner: RuleRunner) -> None:
+    rule_runner.set_options(
+        [
+            "--nodejs-package-manager-extra-env-vars=['FROM_SUBSYSTEM=FIZZ']",
+        ],
+        env_inherit={"PATH"},
+    )
     rule_runner.write_files(
         {
             "src/js/BUILD": dedent(
@@ -251,7 +257,8 @@ def test_extra_envs(rule_runner: RuleRunner) -> None:
                 package_json(
                     scripts=[
                         node_build_script(entry_point="build", extra_env_vars=["FOO=BAR"], output_files=["dist/index.cjs"])
-                    ]
+                    ],
+                    extra_env_vars=["FROM_PACKAGE_JSON=BUZZ"]
                 )
                 """
             ),
@@ -260,7 +267,9 @@ def test_extra_envs(rule_runner: RuleRunner) -> None:
                     "name": "ham",
                     "version": "0.0.1",
                     "browser": "lib/index.mjs",
-                    "scripts": {"build": "mkdir dist && echo $FOO >> dist/index.cjs"},
+                    "scripts": {
+                        "build": "mkdir dist && echo $FOO >> dist/index.cjs && echo $FROM_SUBSYSTEM >> dist/index.cjs && echo $FROM_PACKAGE_JSON >> dist/index.cjs"
+                    },
                 }
             ),
             "src/js/package-lock.json": json.dumps({}),
@@ -279,4 +288,4 @@ def test_extra_envs(rule_runner: RuleRunner) -> None:
     )
     rule_runner.write_digest(result.snapshot.digest)
     with open(os.path.join(rule_runner.build_root, "src/js/dist/index.cjs")) as f:
-        assert f.read() == "BAR\n"
+        assert f.read() == "BAR\nFIZZ\nBUZZ\n"

--- a/src/python/pants/backend/javascript/package/rules_test.py
+++ b/src/python/pants/backend/javascript/package/rules_test.py
@@ -246,7 +246,7 @@ def test_packages_files_as_resource_in_workspace(
 def test_extra_envs(rule_runner: RuleRunner) -> None:
     rule_runner.set_options(
         [
-            "--nodejs-package-manager-extra-env-vars=['FROM_SUBSYSTEM=FIZZ']",
+            "--nodejs-extra-env-vars=['FROM_SUBSYSTEM=FIZZ']",
         ],
         env_inherit={"PATH"},
     )

--- a/src/python/pants/backend/javascript/package_json.py
+++ b/src/python/pants/backend/javascript/package_json.py
@@ -308,6 +308,18 @@ class NodeThirdPartyPackageTarget(Target):
     )
 
 
+class NodePackageExtraEnvVarsField(StringSequenceField):
+    alias = "extra_env_vars"
+    help = help_text(
+        f"""
+        Environment variables to set when running package manager operations.
+
+        {EXTRA_ENV_VARS_USAGE_HELP}
+        """
+    )
+    required = False
+
+
 class NodePackageTarget(Target):
     alias = "node_package"
 
@@ -320,6 +332,7 @@ class NodePackageTarget(Target):
         NodePackageVersionField,
         NodePackageDependenciesField,
         NodePackageTestScriptField,
+        NodePackageExtraEnvVarsField,
     )
 
 
@@ -348,6 +361,7 @@ class PackageJsonTarget(TargetGenerator):
         *COMMON_TARGET_FIELDS,
         PackageJsonSourceField,
         NodePackageScriptsField,
+        NodePackageExtraEnvVarsField,
     )
     help = help_text(
         f"""
@@ -878,6 +892,9 @@ async def generate_node_package_targets(
             **request.template,
             NodePackageNameField.alias: pkg_json.name,
             NodePackageVersionField.alias: pkg_json.version,
+            NodePackageExtraEnvVarsField.alias: request.generator[
+                NodePackageExtraEnvVarsField
+            ].value,
             NodePackageDependenciesField.alias: [
                 file_tgt.address.spec,
                 *(tgt.address.spec for tgt in third_party_tgts),

--- a/src/python/pants/backend/javascript/run/rules_test.py
+++ b/src/python/pants/backend/javascript/run/rules_test.py
@@ -121,6 +121,12 @@ def test_creates_yarn_run_requests_package_json_scripts(rule_runner: RuleRunner)
 
 
 def test_extra_envs(rule_runner: RuleRunner) -> None:
+    rule_runner.set_options(
+        [
+            "--nodejs-package-manager-extra-env-vars=['FROM_SUBSYSTEM=FIZZ']",
+        ],
+        env_inherit={"PATH"},
+    )
     rule_runner.write_files(
         {
             "src/js/BUILD": dedent(
@@ -128,7 +134,8 @@ def test_extra_envs(rule_runner: RuleRunner) -> None:
                 package_json(
                     scripts=[
                         node_build_script(entry_point="build", extra_env_vars=["FOO=BAR"], output_files=["dist/index.cjs"])
-                    ]
+                    ],
+                    extra_env_vars=["FROM_PACKAGE_JSON=BUZZ"]
                 )
                 """
             ),
@@ -153,3 +160,5 @@ def test_extra_envs(rule_runner: RuleRunner) -> None:
 
     result = rule_runner.request(RunRequest, [RunNodeBuildScriptFieldSet.create(tgt)])
     assert result.extra_env.get("FOO") == "BAR"
+    assert result.extra_env.get("FROM_SUBSYSTEM") == "FIZZ"
+    assert result.extra_env.get("FROM_PACKAGE_JSON") == "BUZZ"

--- a/src/python/pants/backend/javascript/run/rules_test.py
+++ b/src/python/pants/backend/javascript/run/rules_test.py
@@ -123,7 +123,7 @@ def test_creates_yarn_run_requests_package_json_scripts(rule_runner: RuleRunner)
 def test_extra_envs(rule_runner: RuleRunner) -> None:
     rule_runner.set_options(
         [
-            "--nodejs-package-manager-extra-env-vars=['FROM_SUBSYSTEM=FIZZ']",
+            "--nodejs-extra-env-vars=['FROM_SUBSYSTEM=FIZZ']",
         ],
         env_inherit={"PATH"},
     )

--- a/src/python/pants/backend/javascript/subsystems/nodejs.py
+++ b/src/python/pants/backend/javascript/subsystems/nodejs.py
@@ -39,7 +39,12 @@ from pants.core.util_rules.system_binaries import (
     BinaryShims,
     BinaryShimsRequest,
 )
-from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest, PathEnvironmentVariable
+from pants.engine.env_vars import (
+    EXTRA_ENV_VARS_USAGE_HELP,
+    EnvironmentVars,
+    EnvironmentVarsRequest,
+    PathEnvironmentVariable,
+)
 from pants.engine.fs import EMPTY_DIGEST, CreateDigest, Digest, Directory, DownloadFile
 from pants.engine.internals.native_engine import FileDigest, MergeDigests
 from pants.engine.internals.platform_rules import environment_vars_subset
@@ -152,6 +157,17 @@ class NodeJS(Subsystem, TemplatedExternalToolOptionsMixin):
             the `--activate` flag.
             """
         ),
+    )
+
+    package_manager_extra_env_vars = StrListOption(
+        help=softwrap(
+            f"""
+            Environment variables to set during package manager operations.
+
+            {EXTRA_ENV_VARS_USAGE_HELP}
+            """
+        ),
+        advanced=True,
     )
 
     @property

--- a/src/python/pants/backend/javascript/subsystems/nodejs.py
+++ b/src/python/pants/backend/javascript/subsystems/nodejs.py
@@ -159,7 +159,7 @@ class NodeJS(Subsystem, TemplatedExternalToolOptionsMixin):
         ),
     )
 
-    package_manager_extra_env_vars = StrListOption(
+    extra_env_vars = StrListOption(
         help=softwrap(
             f"""
             Environment variables to set during package manager operations.


### PR DESCRIPTION
Fixes https://github.com/pantsbuild/pants/issues/20592

Allow extra env vars to be set during nodejs package installation through `[nodejs].package_manager_extra_env_vars` option or and the `extra_env_vars` field on `package_json` targets.

In our case, we have some packages that allow you to opt-out of large binary downloads by setting environment vars during installation 

[cypress](https://docs.cypress.io/app/references/advanced-installation) `CYPRESS_INSTALL_BINARY=0`
[puppeteer](https://github.com/puppeteer/puppeteer/blob/v0.10.2/docs/api.md#environment-variables) `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true`