### PR TITLE
Reorder the args of the environment_vars_subset rule.

### DIFF
--- a/src/python/pants/backend/codegen/thrift/apache/rules.py
+++ b/src/python/pants/backend/codegen/thrift/apache/rules.py
@@ -131,7 +131,7 @@ async def setup_thrift_tool(
     apache_thrift_env_aware: ApacheThriftSubsystem.EnvironmentAware,
     env_target: EnvironmentTarget,
 ) -> ApacheThriftSetup:
-    env = await environment_vars_subset(**implicitly(EnvironmentVarsRequest(["PATH"])))
+    env = await environment_vars_subset(EnvironmentVarsRequest(["PATH"]), **implicitly())
     search_paths = apache_thrift_env_aware.thrift_search_paths(env)
     all_thrift_binary_paths = await find_binary(
         BinaryPathRequest(

--- a/src/python/pants/backend/javascript/subsystems/nodejs.py
+++ b/src/python/pants/backend/javascript/subsystems/nodejs.py
@@ -467,9 +467,7 @@ async def _get_nvm_root() -> str | None:
     """See https://github.com/nvm-sh/nvm#installing-and-updating."""
 
     env = await environment_vars_subset(
-        **implicitly(
-            {EnvironmentVarsRequest(("NVM_DIR", "XDG_CONFIG_HOME", "HOME")): EnvironmentVarsRequest}
-        )
+        EnvironmentVarsRequest(("NVM_DIR", "XDG_CONFIG_HOME", "HOME")), **implicitly()
     )
     nvm_dir = env.get("NVM_DIR")
     default_dir = env.get("XDG_CONFIG_HOME", env.get("HOME"))

--- a/src/python/pants/backend/rust/util_rules/toolchains.py
+++ b/src/python/pants/backend/rust/util_rules/toolchains.py
@@ -64,7 +64,7 @@ class RustToolchainProcess:
 
 @rule
 async def find_rustup(rust_subsystem: RustSubsystem) -> RustupBinary:
-    env = await environment_vars_subset(**implicitly(EnvironmentVarsRequest(["PATH"])))
+    env = await environment_vars_subset(EnvironmentVarsRequest(["PATH"]), **implicitly())
     request = BinaryPathRequest(
         binary_name="rustup",
         search_path=rust_subsystem.rustup_search_paths(env),
@@ -84,7 +84,7 @@ class RustBinaryPathRequest:
 async def rust_binary_path(
     request: RustBinaryPathRequest, rustup: RustupBinary, rust_subsystem: RustSubsystem
 ) -> BinaryPath:
-    env = await environment_vars_subset(**implicitly(EnvironmentVarsRequest(["RUSTUP_HOME"])))
+    env = await environment_vars_subset(EnvironmentVarsRequest(["RUSTUP_HOME"]), **implicitly())
     which_result = await execute_process_or_raise(
         **implicitly(
             Process(

--- a/src/python/pants/engine/internals/platform_rules.py
+++ b/src/python/pants/engine/internals/platform_rules.py
@@ -93,7 +93,8 @@ async def complete_environment_vars(
 
 @rule
 def environment_vars_subset(
-    complete_env_vars: CompleteEnvironmentVars, request: EnvironmentVarsRequest
+    request: EnvironmentVarsRequest,
+    complete_env_vars: CompleteEnvironmentVars,
 ) -> EnvironmentVars:
     return EnvironmentVars(
         complete_env_vars.get_subset(


### PR DESCRIPTION
The EnvironmentVarsRequest arg is the one commonly provided by the caller, 
with the CompleteEnvironmentVars provided implicitly.

Putting the commonly explicit arg first allows for a simpler and expected calling idiom:

`await environment_vars_subset(EnvironmentVarsRequest(..., **implicitly())`

With the explicit arg second in declaration order, this yields a long an 
incomprehensible solver error, which ends up being fixed by

`await environment_vars_subset(**implicit(EnvironmentVarsRequest(...)))`

but that is not going to be easily knowable.

This also allows the migrate-call-by-name tool to work in more cases.