### PR TITLE
Initialise terraform in the same invocation as subsequent commands

### DIFF
--- a/docs/notes/2.27.x.md
+++ b/docs/notes/2.27.x.md
@@ -86,6 +86,8 @@ The shell backend now has far less overhead when parsing shell imports on macOS:
 
 Now supports codegen for module dependencies. Dependencies may specify a target that generates a file that is consumed by the terraform module.
 
+Now `terraform init` is run in the same invocation as commands which depend on it. This should resolve an issue for users of remote caches where the Terraform provider cache is not initialised on different nodes. 
+
 ### Plugin API changes
 
 * Processes can now specify their `concurrency` requirements, influencing when Pants will execute them. Use `exclusive` to be the only running process, `exactly(n)` to require exactly `n` cpu cores, or `range(max=n, min=1)` to accept a value between `min` and `max` which is templated into the process's argv as `{pants_concurrency}`. The `concurrency` field supersedes the `concurrency_available` field, which will be deprecated in the future.

--- a/src/python/pants/backend/terraform/dependencies.py
+++ b/src/python/pants/backend/terraform/dependencies.py
@@ -129,10 +129,11 @@ class TerraformUpgradeResponse:
 
 @dataclass(frozen=True)
 class TerraformThingsNeededToRun:
-    """The things you need to run a terraform command"""
+    """The things you need to run a terraform command."""
+
     terraform_sources: SourceFiles
     dependencies_files: SourceFiles
-    cmd: TerraformDependenciesRequest
+    init_cmd: TerraformDependenciesRequest
     chdir: str
 
 
@@ -234,7 +235,7 @@ async def terraform_init(request: TerraformInitRequest) -> TerraformInitResponse
     init = await prepare_terraform_invocation(request)
 
     init_response = await Get(
-        TerraformDependenciesResponse, TerraformDependenciesRequest, init.cmd
+        TerraformDependenciesResponse, TerraformDependenciesRequest, init.init_cmd
     )
 
     all_terraform_files = await Get(
@@ -249,7 +250,9 @@ async def terraform_init(request: TerraformInitRequest) -> TerraformInitResponse
     )
 
     return TerraformInitResponse(
-        sources_and_deps=all_terraform_files, terraform_files=init.terraform_sources, chdir=init.chdir
+        sources_and_deps=all_terraform_files,
+        terraform_files=init.terraform_sources,
+        chdir=init.chdir,
     )
 
 
@@ -263,7 +266,7 @@ async def terraform_upgrade_lockfile(request: TerraformInitRequest) -> Terraform
     init = await prepare_terraform_invocation(request)
 
     init_response = await Get(
-        TerraformDependenciesResponse, TerraformDependenciesRequest, init.cmd
+        TerraformDependenciesResponse, TerraformDependenciesRequest, init.init_cmd
     )
 
     updated_lockfile, dependencies_except_lockfile = await MultiGet(

--- a/src/python/pants/backend/terraform/dependencies.py
+++ b/src/python/pants/backend/terraform/dependencies.py
@@ -110,7 +110,7 @@ class TerraformInitRequest:
 
 
 @dataclass(frozen=True)
-class TerraformThingsNeededToRun:
+class TerraformInvocationRequirements:
     """The things you need to run a terraform command."""
 
     terraform_sources: SourceFiles
@@ -120,7 +120,9 @@ class TerraformThingsNeededToRun:
 
 
 @rule
-async def prepare_terraform_invocation(request: TerraformInitRequest) -> TerraformThingsNeededToRun:
+async def prepare_terraform_invocation(
+    request: TerraformInitRequest,
+) -> TerraformInvocationRequirements:
     """Prepare a terraform module or deployment to be operated on."""
     this_targets_dependencies = await Get(
         TransitiveTargets, TransitiveTargetsRequest((request.dependencies.address,))
@@ -205,7 +207,9 @@ async def prepare_terraform_invocation(request: TerraformInitRequest) -> Terrafo
         initialise_backend=request.initialise_backend,
         upgrade=request.upgrade,
     )
-    return TerraformThingsNeededToRun(source_files, dependencies_files, terraform_init_cmd, chdir)
+    return TerraformInvocationRequirements(
+        source_files, dependencies_files, terraform_init_cmd, chdir
+    )
 
 
 def rules():

--- a/src/python/pants/backend/terraform/dependencies_test.py
+++ b/src/python/pants/backend/terraform/dependencies_test.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from pants.backend.terraform.dependencies import (
     TerraformDependenciesResponse,
     TerraformInitRequest,
-    TerraformThingsNeededToRun,
+    TerraformInvocationRequirements,
 )
 from pants.backend.terraform.goals.deploy import DeployTerraformFieldSet
 from pants.backend.terraform.testutil import (
@@ -35,7 +35,7 @@ def _do_init_terraform(
     field_set = DeployTerraformFieldSet.create(target)
 
     init = rule_runner.request(
-        TerraformThingsNeededToRun,
+        TerraformInvocationRequirements,
         [
             TerraformInitRequest(
                 field_set.root_module,

--- a/src/python/pants/backend/terraform/dependencies_test.py
+++ b/src/python/pants/backend/terraform/dependencies_test.py
@@ -7,7 +7,11 @@ import json
 import textwrap
 from pathlib import Path
 
-from pants.backend.terraform.dependencies import TerraformInitRequest, TerraformInitResponse
+from pants.backend.terraform.dependencies import (
+    TerraformDependenciesResponse,
+    TerraformInitRequest,
+    TerraformThingsNeededToRun,
+)
 from pants.backend.terraform.goals.deploy import DeployTerraformFieldSet
 from pants.backend.terraform.testutil import (
     StandardDeployment,
@@ -29,8 +33,9 @@ def _do_init_terraform(
     rule_runner.write_files(standard_deployment.files)
     target = rule_runner.get_target(standard_deployment.target)
     field_set = DeployTerraformFieldSet.create(target)
-    result = rule_runner.request(
-        TerraformInitResponse,
+
+    init = rule_runner.request(
+        TerraformThingsNeededToRun,
         [
             TerraformInitRequest(
                 field_set.root_module,
@@ -39,8 +44,13 @@ def _do_init_terraform(
             )
         ],
     )
-    initialised_files = rule_runner.request(DigestContents, [result.sources_and_deps])
-    initialised_entries = rule_runner.request(DigestEntries, [result.sources_and_deps])
+
+    result = rule_runner.request(
+        TerraformDependenciesResponse,
+        [init.init_cmd],
+    )
+    initialised_files = rule_runner.request(DigestContents, [result.digest])
+    initialised_entries = rule_runner.request(DigestEntries, [result.digest])
     assert isinstance(initialised_files, DigestContents)
     return initialised_files, initialised_entries
 

--- a/src/python/pants/backend/terraform/goals/check.py
+++ b/src/python/pants/backend/terraform/goals/check.py
@@ -1,9 +1,8 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-import asyncio
 from dataclasses import dataclass
 
-from pants.backend.terraform.dependencies import TerraformInitRequest, TerraformInitResponse, prepare_terraform_invocation
+from pants.backend.terraform.dependencies import TerraformInitRequest, prepare_terraform_invocation
 from pants.backend.terraform.target_types import (
     TerraformDeploymentFieldSet,
     TerraformDeploymentTarget,
@@ -13,7 +12,7 @@ from pants.backend.terraform.target_types import (
 )
 from pants.backend.terraform.tool import TerraformCommand, TerraformProcess
 from pants.core.goals.check import CheckRequest, CheckResult, CheckResults
-from pants.engine.internals.native_engine import MergeDigests, Digest
+from pants.engine.internals.native_engine import Digest, MergeDigests
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.process import FallibleProcessResult
 from pants.engine.rules import collect_rules, rule
@@ -93,7 +92,10 @@ async def terraform_check(
         Get(
             FallibleProcessResult,
             TerraformProcess(
-                cmds=(deployment.cmd.to_args() ,TerraformCommand(("validate",)),),
+                cmds=(
+                    deployment.init_cmd.to_args(),
+                    TerraformCommand(("validate",)),
+                ),
                 input_digest=sources_and_deps,
                 output_files=tuple(deployment.terraform_sources.files),
                 description=f"Run `terraform validate` on module {deployment.chdir} with {pluralize(len(deployment.terraform_sources.files), 'file')}.",

--- a/src/python/pants/backend/terraform/goals/check.py
+++ b/src/python/pants/backend/terraform/goals/check.py
@@ -13,7 +13,7 @@ from pants.backend.terraform.target_types import (
 from pants.backend.terraform.tool import TerraformCommand, TerraformProcess
 from pants.core.goals.check import CheckRequest, CheckResult, CheckResults
 from pants.engine.internals.native_engine import Digest, MergeDigests
-from pants.engine.internals.selectors import Get, MultiGet
+from pants.engine.internals.selectors import Get, MultiGet, concurrently
 from pants.engine.process import FallibleProcessResult
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import BoolField, Target
@@ -70,7 +70,7 @@ async def terraform_check(
     if subsystem.skip:
         return CheckResults([], checker_name=request.tool_name)
 
-    terraform_deployments = await MultiGet(
+    terraform_deployments = await concurrently(
         prepare_terraform_invocation(terraform_fieldset_to_init_request(deployment))
         for deployment in request.field_sets
     )

--- a/src/python/pants/backend/terraform/goals/check.py
+++ b/src/python/pants/backend/terraform/goals/check.py
@@ -10,7 +10,7 @@ from pants.backend.terraform.target_types import (
     TerraformModuleTarget,
     TerraformRootModuleField,
 )
-from pants.backend.terraform.tool import TerraformProcess
+from pants.backend.terraform.tool import TerraformCommand, TerraformProcess
 from pants.core.goals.check import CheckRequest, CheckResult, CheckResults
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.process import FallibleProcessResult
@@ -82,7 +82,7 @@ async def terraform_check(
         Get(
             FallibleProcessResult,
             TerraformProcess(
-                args=("validate",),
+                cmds=(TerraformCommand(("validate",)),),
                 input_digest=deployment.sources_and_deps,
                 output_files=tuple(deployment.terraform_files.files),
                 description=f"Run `terraform validate` on module {deployment.chdir} with {pluralize(len(deployment.terraform_files.files), 'file')}.",

--- a/src/python/pants/backend/terraform/goals/deploy.py
+++ b/src/python/pants/backend/terraform/goals/deploy.py
@@ -11,7 +11,7 @@ from pants.backend.terraform.dependency_inference import (
     TerraformDeploymentInvocationFilesRequest,
 )
 from pants.backend.terraform.target_types import TerraformDeploymentFieldSet
-from pants.backend.terraform.tool import TerraformProcess, TerraformTool
+from pants.backend.terraform.tool import TerraformCommand, TerraformProcess, TerraformTool
 from pants.backend.terraform.utils import terraform_arg, terraform_relpath
 from pants.core.goals.deploy import DeployFieldSet, DeployProcess, DeploySubsystem
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
@@ -81,7 +81,7 @@ async def prepare_terraform_deployment(
     process = await Get(
         Process,
         TerraformProcess(
-            args=tuple(args),
+            cmds=(TerraformCommand(tuple(args)),),
             input_digest=with_vars,
             description=f"Terraform {terraform_command}",
             chdir=initialised_terraform.chdir,

--- a/src/python/pants/backend/terraform/goals/lockfiles.py
+++ b/src/python/pants/backend/terraform/goals/lockfiles.py
@@ -114,6 +114,7 @@ async def generate_lockfile_from_sources(
             ),
             lockfile_request.target[TerraformDependenciesField],
             initialise_backend=False,
+            upgrade=True
         ),
     )
 

--- a/src/python/pants/backend/terraform/goals/lockfiles.py
+++ b/src/python/pants/backend/terraform/goals/lockfiles.py
@@ -114,7 +114,7 @@ async def generate_lockfile_from_sources(
             ),
             lockfile_request.target[TerraformDependenciesField],
             initialise_backend=False,
-            upgrade=True
+            upgrade=True,
         ),
     )
 

--- a/src/python/pants/backend/terraform/goals/lockfiles.py
+++ b/src/python/pants/backend/terraform/goals/lockfiles.py
@@ -12,7 +12,7 @@ from pants.backend.terraform.target_types import (
     TerraformModuleTarget,
     TerraformRootModuleField,
 )
-from pants.backend.terraform.tool import TerraformProcess, TerraformTool
+from pants.backend.terraform.tool import TerraformCommand, TerraformProcess, TerraformTool
 from pants.backend.terraform.utils import terraform_arg
 from pants.core.goals.generate_lockfiles import (
     GenerateLockfile,
@@ -127,7 +127,7 @@ async def generate_lockfile_from_sources(
     multiplatform_lockfile = await Get(
         FallibleProcessResult,
         TerraformProcess(
-            args=args,
+            cmds=(TerraformCommand(args),),
             input_digest=initialised_terraform.sources_and_deps,
             output_files=(".terraform.lock.hcl",),
             description=provider_lock_description,

--- a/src/python/pants/backend/terraform/goals/lockfiles.py
+++ b/src/python/pants/backend/terraform/goals/lockfiles.py
@@ -4,7 +4,7 @@ import os.path
 from dataclasses import dataclass
 from pathlib import Path
 
-from pants.backend.terraform.dependencies import TerraformInitRequest, TerraformUpgradeResponse
+from pants.backend.terraform.dependencies import TerraformInitRequest, prepare_terraform_invocation
 from pants.backend.terraform.target_types import (
     TerraformDependenciesField,
     TerraformLockfileTarget,
@@ -24,7 +24,13 @@ from pants.core.goals.generate_lockfiles import (
 )
 from pants.engine.addresses import Addresses
 from pants.engine.fs import PathGlobs
-from pants.engine.internals.native_engine import Address, AddressInput, Snapshot
+from pants.engine.internals.native_engine import (
+    Address,
+    AddressInput,
+    Digest,
+    MergeDigests,
+    Snapshot,
+)
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.internals.synthetic_targets import SyntheticAddressMaps, SyntheticTargetsRequest
 from pants.engine.internals.target_adaptor import TargetAdaptor
@@ -106,8 +112,7 @@ async def generate_lockfile_from_sources(
     keep_sandboxes: KeepSandboxes,
 ) -> GenerateLockfileResult:
     """Generate a Terraform lockfile by running `terraform providers lock` on the sources."""
-    initialised_terraform = await Get(
-        TerraformUpgradeResponse,
+    initialised_terraform = await prepare_terraform_invocation(
         TerraformInitRequest(
             TerraformRootModuleField(
                 lockfile_request.target.address.spec, lockfile_request.target.address
@@ -115,6 +120,16 @@ async def generate_lockfile_from_sources(
             lockfile_request.target[TerraformDependenciesField],
             initialise_backend=False,
             upgrade=True,
+        )
+    )
+
+    sources_and_deps = await Get(
+        Digest,
+        MergeDigests(
+            [
+                initialised_terraform.terraform_sources.snapshot.digest,
+                initialised_terraform.dependencies_files.snapshot.digest,
+            ]
         ),
     )
 
@@ -128,8 +143,11 @@ async def generate_lockfile_from_sources(
     multiplatform_lockfile = await Get(
         FallibleProcessResult,
         TerraformProcess(
-            cmds=(TerraformCommand(args),),
-            input_digest=initialised_terraform.sources_and_deps,
+            cmds=(
+                initialised_terraform.init_cmd.to_args(),
+                TerraformCommand(args),
+            ),
+            input_digest=sources_and_deps,
             output_files=(".terraform.lock.hcl",),
             description=provider_lock_description,
             chdir=initialised_terraform.chdir,

--- a/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
+++ b/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
@@ -8,7 +8,7 @@ from typing import cast
 
 from pants.backend.terraform.partition import partition_files_by_directory
 from pants.backend.terraform.target_types import TerraformFieldSet
-from pants.backend.terraform.tool import TerraformProcess
+from pants.backend.terraform.tool import TerraformCommand, TerraformProcess
 from pants.backend.terraform.tool import rules as tool_rules
 from pants.core.goals.fmt import FmtResult, FmtTargetsRequest, Partitions
 from pants.core.util_rules import external_tool
@@ -69,7 +69,14 @@ async def tffmt_fmt(request: TffmtRequest.Batch, tffmt: TfFmtSubsystem) -> FmtRe
     result = await Get(
         ProcessResult,
         TerraformProcess(
-            args=("fmt", directory),
+            cmds=(
+                TerraformCommand(
+                    (
+                        "fmt",
+                        directory,
+                    )
+                ),
+            ),
             input_digest=request.snapshot.digest,
             output_files=request.files,
             description=f"Run `terraform fmt` on {pluralize(len(request.files), 'file')}.",

--- a/src/python/pants/backend/terraform/testutil.py
+++ b/src/python/pants/backend/terraform/testutil.py
@@ -7,7 +7,12 @@ from textwrap import dedent  # noqa: PNT20
 import pytest
 
 from pants.backend.terraform import dependencies, dependency_inference, tool
-from pants.backend.terraform.dependencies import TerraformInitRequest, TerraformInitResponse
+from pants.backend.terraform.dependencies import (
+    TerraformDependenciesRequest,
+    TerraformDependenciesResponse,
+    TerraformInitRequest,
+    TerraformThingsNeededToRun,
+)
 from pants.backend.terraform.goals.deploy import DeployTerraformFieldSet
 from pants.backend.terraform.goals.deploy import rules as terraform_deploy_rules
 from pants.backend.terraform.goals.lockfiles import rules as terraform_lockfile_rules
@@ -50,8 +55,9 @@ def rule_runner_with_auto_approve() -> RuleRunner:
             *core_rules(),
             *process.rules(),
             QueryRule(DeployProcess, (DeployTerraformFieldSet,)),
-            QueryRule(TerraformInitResponse, (TerraformInitRequest,)),
             QueryRule(DigestEntries, (Digest,)),
+            QueryRule(TerraformThingsNeededToRun, (TerraformInitRequest,)),
+            QueryRule(TerraformDependenciesResponse, (TerraformDependenciesRequest,)),
         ],
         preserve_tmpdirs=True,
     )

--- a/src/python/pants/backend/terraform/testutil.py
+++ b/src/python/pants/backend/terraform/testutil.py
@@ -11,7 +11,7 @@ from pants.backend.terraform.dependencies import (
     TerraformDependenciesRequest,
     TerraformDependenciesResponse,
     TerraformInitRequest,
-    TerraformThingsNeededToRun,
+    TerraformInvocationRequirements,
 )
 from pants.backend.terraform.goals.deploy import DeployTerraformFieldSet
 from pants.backend.terraform.goals.deploy import rules as terraform_deploy_rules
@@ -56,7 +56,7 @@ def rule_runner_with_auto_approve() -> RuleRunner:
             *process.rules(),
             QueryRule(DeployProcess, (DeployTerraformFieldSet,)),
             QueryRule(DigestEntries, (Digest,)),
-            QueryRule(TerraformThingsNeededToRun, (TerraformInitRequest,)),
+            QueryRule(TerraformInvocationRequirements, (TerraformInitRequest,)),
             QueryRule(TerraformDependenciesResponse, (TerraformDependenciesRequest,)),
         ],
         preserve_tmpdirs=True,


### PR DESCRIPTION
We've uncovered problems with the interaction of the Pants named cache, Terraform's provider cache, and remote caches. This MR runs `terraform init` in the same invocation as the next Terraform commands. This will ensure that the caches are correctly initialised.

We had Terraform set up to use a named cache for its provider cache. This causes Terraform to download the providers to the named cache and create symlinks to them in the workdir. The symlinks in the workdir are the captured by Pants in a digest. The problem arises when the digest is pushed to a remote cache. Another machine does not have its named cache filled, so when it gets the digest, the symlinks point to nothing. Terraform is then disappointed.

Reviewer focus: The change pulls the arg creation for the init process into the `TerraformDependenciesRequest`, and they are not immediately invoked. They are invoked in the `TerraformProcess.cmds`. We already use a launcher script we could add the invocation to.