### PR TITLE
update to Pex 2.26.0

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -12,7 +12,7 @@ hdrhistogram==0.10.3
 ijson==3.2.3
 libcst==1.4.0
 packaging==24.2
-pex==2.33.9
+pex==2.36.0
 psutil==5.9.8
 # This should be compatible with pytest.py, although it can be looser so that we don't
 # over-constrain pantsbuild.pants.testutil

--- a/3rdparty/python/user_reqs.lock
+++ b/3rdparty/python/user_reqs.lock
@@ -24,7 +24,7 @@
 //     "mypy-typing-asserts==0.1.1",
 //     "node-semver==0.9.0",
 //     "packaging==24.2",
-//     "pex==2.33.9",
+//     "pex==2.36.0",
 //     "psutil==5.9.8",
 //     "pydevd-pycharm==251.23536.40",
 //     "pytest<7.1.0,>=6.2.4",
@@ -247,19 +247,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe",
-              "url": "https://files.pythonhosted.org/packages/38/fc/bce832fd4fd99766c04d1ee0eead6b0ec6486fb100ae5e74c1d91292b982/certifi-2025.1.31-py3-none-any.whl"
+              "hash": "30350364dfe371162649852c63336a15c70c6510c2ad5015b21c2345311805f3",
+              "url": "https://files.pythonhosted.org/packages/4a/7e/3db2bd1b1f9e95f7cddca6d6e75e2f2bd9f51b1246e546d88addca0106bd/certifi-2025.4.26-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651",
-              "url": "https://files.pythonhosted.org/packages/1c/ab/c9f1e32b7b1bf505bf26f0ef697775960db7932abeb7b516de930ba2705f/certifi-2025.1.31.tar.gz"
+              "hash": "0a816057ea3cdefcef70270d2c515e4506bbc954f417fa5ade2021213bb8f0c6",
+              "url": "https://files.pythonhosted.org/packages/e8/9e/c05b3920a3b7d20d3d3310465f50348e5b3694f4f88c6daf736eef3024c4/certifi-2025.4.26.tar.gz"
             }
           ],
           "project_name": "certifi",
           "requires_dists": [],
           "requires_python": ">=3.6",
-          "version": "2025.1.31"
+          "version": "2025.4.26"
         },
         {
           "artifacts": [
@@ -447,23 +447,8 @@
             },
             {
               "algorithm": "sha256",
-              "hash": "81276f0ea79a208d961c433a947029e1a15948966658cf6710bbabb60fcc2639",
-              "url": "https://files.pythonhosted.org/packages/06/88/638865be7198a84a7713950b1db7343391c6066a20e614f8fa286eb178ed/cryptography-44.0.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "d1c3572526997b36f245a96a2b1713bf79ce99b271bbcf084beb6b9b075f29ea",
-              "url": "https://files.pythonhosted.org/packages/16/32/051f7ce79ad5a6ef5e26a92b37f172ee2d6e1cce09931646eef8de1e9827/cryptography-44.0.2-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl"
-            },
-            {
-              "algorithm": "sha256",
               "hash": "3c00b6b757b32ce0f62c574b78b939afab9eecaf597c4d624caca4f9e71e7843",
               "url": "https://files.pythonhosted.org/packages/26/e4/ba680f0b35ed4a07d87f9e98f3ebccb05091f3bf6b5a478b943253b3bbd5/cryptography-44.0.2-cp37-abi3-manylinux_2_28_aarch64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "bc821e161ae88bfe8088d11bb39caf2916562e0a2dc7b6d56714a48b784ef0bb",
-              "url": "https://files.pythonhosted.org/packages/27/61/72e3afdb3c5ac510330feba4fc1faa0fe62e070592d6ad00c40bb69165e5/cryptography-44.0.2-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
@@ -474,11 +459,6 @@
               "algorithm": "sha256",
               "hash": "4e389622b6927d8133f314949a9812972711a111d577a5d1f4bee5e58736b80a",
               "url": "https://files.pythonhosted.org/packages/2a/07/79554a9c40eb11345e1861f46f845fa71c9e25bf66d132e123d9feb8e7f9/cryptography-44.0.2-cp37-abi3-manylinux_2_34_aarch64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "29ecec49f3ba3f3849362854b7253a9f59799e3763b0c9d0826259a88efa02f1",
-              "url": "https://files.pythonhosted.org/packages/30/ec/7ea7c1e4c8fc8329506b46c6c4a52e2f20318425d48e0fe597977c71dbce/cryptography-44.0.2-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
@@ -517,11 +497,6 @@
             },
             {
               "algorithm": "sha256",
-              "hash": "7bdcd82189759aba3816d1f729ce42ffded1ac304c151d0a8e89b9996ab863d5",
-              "url": "https://files.pythonhosted.org/packages/9c/e8/44ae3e68c8b6d1cbc59040288056df2ad7f7f03bbcaca6b503c737ab8e73/cryptography-44.0.2-cp37-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl"
-            },
-            {
-              "algorithm": "sha256",
               "hash": "8e0ddd63e6bf1161800592c71ac794d3fb8001f2caebe0966e77c5234fa9efc3",
               "url": "https://files.pythonhosted.org/packages/9e/be/7a26142e6d0f7683d8a382dd963745e65db895a79a280a30525ec92be890/cryptography-44.0.2-cp39-abi3-macosx_10_9_universal2.whl"
             },
@@ -549,11 +524,6 @@
               "algorithm": "sha256",
               "hash": "909c97ab43a9c0c0b0ada7a1281430e4e5ec0458e6d9244c0e821bbf152f061d",
               "url": "https://files.pythonhosted.org/packages/d6/d7/f30e75a6aa7d0f65031886fa4a1485c2fbfe25a1896953920f6a9cfe2d3b/cryptography-44.0.2-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "9a1e657c0f4ea2a23304ee3f964db058c9e9e635cc7019c4aa21c330755ef6fd",
-              "url": "https://files.pythonhosted.org/packages/d7/fc/99fe639bcdf58561dfad1faa8a7369d1dc13f20acd78371bb97a01613585/cryptography-44.0.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
@@ -774,21 +744,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761",
-              "url": "https://files.pythonhosted.org/packages/95/04/ff642e65ad6b90db43e668d70ffb6736436c7ce41fcc549f4e9472234127/h11-0.14.0-py3-none-any.whl"
+              "hash": "63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86",
+              "url": "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d",
-              "url": "https://files.pythonhosted.org/packages/f5/38/3af3d3633a34a3316095b39c8e8fb4853a28a536e55d347bd8d8e9a14b03/h11-0.14.0.tar.gz"
+              "hash": "4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1",
+              "url": "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz"
             }
           ],
           "project_name": "h11",
-          "requires_dists": [
-            "typing-extensions; python_version < \"3.8\""
-          ],
-          "requires_python": ">=3.7",
-          "version": "0.14.0"
+          "requires_dists": [],
+          "requires_python": ">=3.8",
+          "version": "0.16.0"
         },
         {
           "artifacts": [
@@ -1114,13 +1082,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "169ba5720a2b792d800d846cd0e182b7c34076cfb39bde5d3ca8d5c08ec5b645",
-              "url": "https://files.pythonhosted.org/packages/c0/8c/3a113e5d617a92d77fac71b4dda992a79562cf037aba1c3aa23b9297ac01/pex-2.33.9-py2.py3-none-any.whl"
+              "hash": "ff94ac7e2a85f458c681c4aad7f97f51b3659ebfe682af5b9a75d67a6282b1c2",
+              "url": "https://files.pythonhosted.org/packages/0d/de/73cea02b9f78e57f72585ab5cabc945047edfabdec7f1093bdd822408b09/pex-2.36.0-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f718fbc81528f55ffc58670fd25ac7656574a3043fdc99ebbc7478d6619e8548",
-              "url": "https://files.pythonhosted.org/packages/09/cd/c132ad9f08efdabfac31112ec30daa4f2c54134349bf30b1cb6915b36da6/pex-2.33.9.tar.gz"
+              "hash": "2e38c0751a09f74dd921ce6e2c55c5f87029e90e6bf543692c5dfac3193de670",
+              "url": "https://files.pythonhosted.org/packages/fd/3d/13a0cc943c38bf4f84246e25b11948c55cb22a0fcc1ba10262054f2fe4b5/pex-2.36.0.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -1129,7 +1097,7 @@
             "subprocess32>=3.2.7; python_version < \"3\" and extra == \"subprocess\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.14,>=2.7",
-          "version": "2.33.9"
+          "version": "2.36.0"
         },
         {
           "artifacts": [
@@ -1165,16 +1133,6 @@
               "algorithm": "sha256",
               "hash": "6be126e3225486dff286a8fb9a06246a5253f4c7c53b475ea5f5ac934e64194c",
               "url": "https://files.pythonhosted.org/packages/90/c7/6dc0a455d111f68ee43f27793971cf03fe29b6ef972042549db29eec39a2/psutil-5.9.8.tar.gz"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "8cb6403ce6d8e047495a701dc7c5bd788add903f8986d523e3e20b98b733e421",
-              "url": "https://files.pythonhosted.org/packages/b3/bd/28c5f553667116b2598b9cc55908ec435cb7f77a34f2bff3e3ca765b0f78/psutil-5.9.8-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "d06016f7f8625a1825ba3732081d77c94589dca78b7a3fc072194851e88461a4",
-              "url": "https://files.pythonhosted.org/packages/c5/4f/0e22aaa246f96d6ac87fe5ebb9c5a693fbe8877f537a1022527c47ca43c5/psutil-5.9.8-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
@@ -1233,43 +1191,43 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "db70c920cba9d05c69ad4a9e7f8e9e83011abb2c6490e561de9ae24aee44925c",
-              "url": "https://files.pythonhosted.org/packages/2d/a8/3e34e7127203ac002e1a5eb45108ef523d9196f75468fde5fdbec7544201/pydantic-1.10.21-py3-none-any.whl"
+              "hash": "343037d608bcbd34df937ac259708bfc83664dadf88afe8516c4f282d7d471a9",
+              "url": "https://files.pythonhosted.org/packages/e9/e0/1ed151a56869be1588ad2d8cda9f8c1d95b16f74f09a7cea879ca9b63a8b/pydantic-1.10.22-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c1ba253eb5af8d89864073e6ce8e6c8dec5f49920cff61f38f5c3383e38b1c9f",
-              "url": "https://files.pythonhosted.org/packages/04/80/d7b6655e3fa2ef838ede8646d7474baa27e05f49902b61b1638d5b89ec4f/pydantic-1.10.21-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "eccb58767f13c6963dcf96d02cb8723ebb98b16692030803ac075d2439c07b0f",
+              "url": "https://files.pythonhosted.org/packages/14/67/4979c19e8cfd092085a292485e0b42d74e4eeefbb8cd726aa8ba38d06294/pydantic-1.10.22-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "57f0101e6c97b411f287a0b7cf5ebc4e5d3b18254bf926f45a11615d29475793",
-              "url": "https://files.pythonhosted.org/packages/1f/16/df08e4ce8c7eaa52903a7dd5e80cdcc8d7369f9732415cfa413fc0389a09/pydantic-1.10.21-cp311-cp311-musllinux_1_2_i686.whl"
+              "hash": "7778e6200ff8ed5f7052c1516617423d22517ad36cc7a3aedd51428168e3e5e8",
+              "url": "https://files.pythonhosted.org/packages/1a/04/32339ce43e97519d19e7759902515c750edbf4832a13063a4ab157f83f42/pydantic-1.10.22-cp311-cp311-musllinux_1_2_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "935b19fdcde236f4fbf691959fa5c3e2b6951fff132964e869e57c70f2ad1ba3",
-              "url": "https://files.pythonhosted.org/packages/37/82/74d99737fb2b8694681c72f44558bed14d546bbe14e3ff29b93285749de8/pydantic-1.10.21-cp311-cp311-macosx_11_0_arm64.whl"
+              "hash": "8e530a8da353f791ad89e701c35787418605d35085f4bdda51b416946070e938",
+              "url": "https://files.pythonhosted.org/packages/42/03/e435ed85a9abda29e3fbdb49c572fe4131a68c6daf3855a01eebda9e1b27/pydantic-1.10.22-cp311-cp311-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "90e85834f0370d737c77a386ce505c21b06bfe7086c1c568b70e15a568d9670d",
-              "url": "https://files.pythonhosted.org/packages/c1/0f/f47794035ffca6d115666c02818f1d905e55dca3e3e470717416a9a6f07d/pydantic-1.10.21-cp311-cp311-musllinux_1_2_x86_64.whl"
+              "hash": "654322b85642e9439d7de4c83cb4084ddd513df7ff8706005dada43b34544946",
+              "url": "https://files.pythonhosted.org/packages/72/ea/4a625035672f6c06d3f1c7e33aa0af6bf1929991e27017e98b9c2064ae0b/pydantic-1.10.22-cp311-cp311-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "64b48e2b609a6c22178a56c408ee1215a7206077ecb8a193e2fda31858b2362a",
-              "url": "https://files.pythonhosted.org/packages/c3/e9/d99a2c4f8f6d7c711f39f6ecf485b7f3bba66189bbbad505d24eb0106922/pydantic-1.10.21.tar.gz"
+              "hash": "bffe02767d27c39af9ca7dc7cd479c00dda6346bb62ffc89e306f665108317a2",
+              "url": "https://files.pythonhosted.org/packages/92/35/dffc1b29cb7198aadab68d75447191e59bdbc1f1d2d51826c9a4460d372f/pydantic-1.10.22-cp311-cp311-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2b6a04efdcd25486b27f24c1648d5adc1633ad8b4506d0e96e5367f075ed2e0b",
-              "url": "https://files.pythonhosted.org/packages/c4/af/754cf630677fa5fcc438a67da8276f615e4c98046bb0095c95b1879151f3/pydantic-1.10.21-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "ee1006cebd43a8e7158fb7190bb8f4e2da9649719bff65d0c287282ec38dec6d",
+              "url": "https://files.pythonhosted.org/packages/9a/57/5996c63f0deec09e9e901a2b838247c97c6844999562eac4e435bcb83938/pydantic-1.10.22.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "8b6350b68566bb6b164fb06a3772e878887f3c857c46c0c534788081cb48adf4",
-              "url": "https://files.pythonhosted.org/packages/f0/4f/b41e38ff64b6796d17add34c8346f7c63bae5caea3b0cb0f82f39f31de6f/pydantic-1.10.21-cp311-cp311-macosx_10_9_x86_64.whl"
+              "hash": "a8bece75bd1b9fc1c32b57a32831517943b1159ba18b4ba32c0d431d76a120ae",
+              "url": "https://files.pythonhosted.org/packages/a4/f0/424ad837746e69e9f061ba9be68c2a97aef7376d1911692904d8efbcd322/pydantic-1.10.22-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             }
           ],
           "project_name": "pydantic",
@@ -1279,7 +1237,7 @@
             "typing-extensions>=4.2.0"
           ],
           "requires_python": ">=3.7",
-          "version": "1.10.21"
+          "version": "1.10.22"
         },
         {
           "artifacts": [
@@ -1385,21 +1343,6 @@
             },
             {
               "algorithm": "sha256",
-              "hash": "52cb72a79269189d4e0dc537556f4740f7f0a9ec41c1322598799b0bdad4ef92",
-              "url": "https://files.pythonhosted.org/packages/59/bb/fddf10acd09637327a97ef89d2a9d621328850a72f1fdc8c08bdf72e385f/PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "a36d4a9dda1f19ce6e03c9a784a2921a4b726b02e1c736600ca9c22029474394",
-              "url": "https://files.pythonhosted.org/packages/5d/70/87a065c37cca41a75f2ce113a5a2c2aa7533be648b184ade58971b5f7ccc/PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "06b8f6fa7f5de8d5d2f7573fe8c863c051225a27b61e6860fd047b1775807858",
-              "url": "https://files.pythonhosted.org/packages/66/28/ca86676b69bf9f90e710571b67450508484388bfce09acf8a46f0b8c785f/PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
               "hash": "8ac7448f09ab85811607bdd21ec2464495ac8b7c66d146bf545b0f08fb9220ba",
               "url": "https://files.pythonhosted.org/packages/a7/22/27582568be639dfe22ddb3902225f91f2f17ceff88ce80e4db396c8986da/PyNaCl-1.5.0.tar.gz"
             },
@@ -1407,11 +1350,6 @@
               "algorithm": "sha256",
               "hash": "401002a4aaa07c9414132aaed7f6836ff98f59277a234704ff66878c2ee4a0d1",
               "url": "https://files.pythonhosted.org/packages/ce/75/0b8ede18506041c0bf23ac4d8e2971b4161cd6ce630b177d0a08eb0d8857/PyNaCl-1.5.0-cp36-abi3-macosx_10_10_universal2.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "0c84947a22519e013607c9be43706dd42513f9e6ae5d39d3613ca1e142fba44d",
-              "url": "https://files.pythonhosted.org/packages/ee/87/f1bb6a595f14a327e8285b9eb54d41fef76c585a0edef0a45f6fc95de125/PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl"
             }
           ],
           "project_name": "pynacl",
@@ -1800,19 +1738,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "e72c4ff06e4fb6e4b5a9f0f55fe6e81514581fca1515028625d0f299c602ccc9",
-              "url": "https://files.pythonhosted.org/packages/d1/c2/fe97d779f3ef3b15f05c94a2f1e3d21732574ed441687474db9d342a7315/soupsieve-2.6-py3-none-any.whl"
+              "hash": "6e60cc5c1ffaf1cebcc12e8188320b72071e922c2e897f737cadce79ad5d30c4",
+              "url": "https://files.pythonhosted.org/packages/e7/9c/0e6afc12c269578be5c0c1c9f4b49a8d32770a080260c333ac04cc1c832d/soupsieve-2.7-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e2e68417777af359ec65daac1057404a3c8a5455bb8abc36f1a9866ab1a51abb",
-              "url": "https://files.pythonhosted.org/packages/d7/ce/fbaeed4f9fb8b2daa961f90591662df6a86c1abf25c548329a86920aedfb/soupsieve-2.6.tar.gz"
+              "hash": "ad282f9b6926286d2ead4750552c8a6142bc4c783fd66b0293547c8fe6ae126a",
+              "url": "https://files.pythonhosted.org/packages/3f/f4/4a80cd6ef364b2e8b65b15816a843c0980f7a5a2b4dc701fc574952aa19f/soupsieve-2.7.tar.gz"
             }
           ],
           "project_name": "soupsieve",
           "requires_dists": [],
           "requires_python": ">=3.8",
-          "version": "2.6"
+          "version": "2.7"
         },
         {
           "artifacts": [
@@ -2405,8 +2343,8 @@
   "only_wheels": [],
   "overridden": [],
   "path_mappings": {},
-  "pex_version": "2.33.9",
-  "pip_version": "25.0.1",
+  "pex_version": "2.36.0",
+  "pip_version": "25.1",
   "prefer_older_binary": false,
   "requirements": [
     "PyGithub==2.4.0",
@@ -2424,7 +2362,7 @@
     "mypy-typing-asserts==0.1.1",
     "node-semver==0.9.0",
     "packaging==24.2",
-    "pex==2.33.9",
+    "pex==2.36.0",
     "psutil==5.9.8",
     "pydevd-pycharm==251.23536.40",
     "pytest<7.1.0,>=6.2.4",

--- a/docs/notes/2.27.x.md
+++ b/docs/notes/2.27.x.md
@@ -54,7 +54,7 @@ Fixed a bug where `pnpm-workspaces.yaml` could affect NPM or Yarn projects - it 
 
 #### Python
 
-The PEX tool has been upgraded from 2.33.4 to 2.33.9 by default.
+The Pex tool has been upgraded from 2.33.4 to [2.36.0](https://github.com/pex-tool/pex/releases/tag/v2.36.0) by default. Among other changes this includes support for Pip [25.1](https://pip.pypa.io/en/stable/news/#v25-1).
 
 The Ruff tool has been upgraded from 0.11.0 to 0.11.5 by default.
 

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -41,7 +41,7 @@ class PexCli(TemplatedExternalTool):
     name = "pex"
     help = "The PEX (Python EXecutable) tool (https://github.com/pex-tool/pex)."
 
-    default_version = "v2.33.9"
+    default_version = "v2.36.0"
     default_url_template = "https://github.com/pex-tool/pex/releases/download/{version}/pex"
     version_constraints = ">=2.13.0,<3.0"
 
@@ -58,10 +58,10 @@ class PexCli(TemplatedExternalTool):
     )
 
     default_known_versions = [
-        "v2.33.9|macos_x86_64|cfd9eb9bed9ac3c33d7da632a38973b42d2d77afe9fdef65dd43b53d0eeb4a98|4678343",
-        "v2.33.9|macos_arm64|cfd9eb9bed9ac3c33d7da632a38973b42d2d77afe9fdef65dd43b53d0eeb4a98|4678343",
-        "v2.33.9|linux_x86_64|cfd9eb9bed9ac3c33d7da632a38973b42d2d77afe9fdef65dd43b53d0eeb4a98|4678343",
-        "v2.33.9|linux_arm64|cfd9eb9bed9ac3c33d7da632a38973b42d2d77afe9fdef65dd43b53d0eeb4a98|4678343",
+        "v2.36.0|macos_x86_64|a08968717dd7bf24d0e7f2800cf44f5308555f727b1d371546815904c8f6d453|4812034",
+        "v2.36.0|macos_arm64|a08968717dd7bf24d0e7f2800cf44f5308555f727b1d371546815904c8f6d453|4812034",
+        "v2.36.0|linux_x86_64|a08968717dd7bf24d0e7f2800cf44f5308555f727b1d371546815904c8f6d453|4812034",
+        "v2.36.0|linux_arm64|a08968717dd7bf24d0e7f2800cf44f5308555f727b1d371546815904c8f6d453|4812034",
     ]
 
 


### PR DESCRIPTION
Changelogs:
 * https://github.com/pex-tool/pex/releases/tag/v2.33.10
 * https://github.com/pex-tool/pex/releases/tag/v2.34.0
 * https://github.com/pex-tool/pex/releases/tag/v2.35.0
 * https://github.com/pex-tool/pex/releases/tag/v2.36.0

```
Lockfile diff: 3rdparty/python/user_reqs.lock [python-default]

==                    Upgraded dependencies                     ==

  certifi                        2025.1.31    -->   2025.4.26
  h11                            0.14.0       -->   0.16.0
  pex                            2.33.9       -->   2.36.0
  pydantic                       1.10.21      -->   1.10.22
  soupsieve                      2.6          -->   2.7
```

ref #21223