### PR TITLE
Include a summary of which initialization options changed in Pantsd daemon restart logs

### DIFF
--- a/docs/notes/2.27.x.md
+++ b/docs/notes/2.27.x.md
@@ -18,6 +18,8 @@ Thank you to [Klaviyo](https://www.klaviyo.com/) for their Platinum tier support
 
 Changing [the `--keep-sandboxes=...` option](https://www.pantsbuild.org/2.27/reference/global-options#keep_sandboxes) no longer forces the Pantsd daemon to restart.
 
+Include a [summary](https://github.com/pantsbuild/pants/pull/22232) of which initialization options changed in Pantsd daemon restart logs.
+
 The Pants install now includes the `hdrhistogram` dependency automatically, and thus statistics logging (as enabled by [the `[stats].log` option](https://www.pantsbuild.org/2.27/reference/subsystems/stats#log)) includes histograms of metrics by default. If this is too verbose, consider redirecting to a file by default using [the `[stats].output_file` option](https://www.pantsbuild.org/2.27/reference/subsystems/stats#output_file). This change means `hdrhistogram` does not need to be included in [the `[GLOBAL].plugins` option](https://www.pantsbuild.org/2.27/reference/global-options#plugins): this was previously required to see histograms (and recommended by docs like ["Using Pants in CI"](https://www.pantsbuild.org/2.27/docs/using-pants/using-pants-in-ci)), but is no longer necessary.
 
 The deprecation has expired for the `[GLOBAL].native_options_validation` option and it has been removed. The option already has no effect and can be safely deleted.

--- a/src/python/pants/option/BUILD
+++ b/src/python/pants/option/BUILD
@@ -13,7 +13,10 @@ python_tests(
         ): {
             "dependencies": ["//BUILD_ROOT:files", "//pants.toml:files"],
         },
-        "global_options_test.py": {
+        (
+            "global_options_test.py",
+            "options_diff_test.py",
+        ): {
             "dependencies": [
                 "//BUILD_ROOT:files",
                 "//pants.toml:files",

--- a/src/python/pants/option/options_diff.py
+++ b/src/python/pants/option/options_diff.py
@@ -1,0 +1,22 @@
+# Copyright 2025 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from typing import Any
+
+
+def summarize_options_map_diff(old: dict[str, Any], new: dict[str, Any]) -> str:
+    """Compare two options map (as produced by `OptionsFingerprinter.options_map_for_scope`), and
+    return a one-liner like:
+
+    `key1: 'old' -> "new'; list_key: ['x', 'y'] -> ['x']`
+    """
+    diffs = []
+    for key in sorted({*old, *new}):
+        o = old.get(key)
+        n = new.get(key)
+
+        if o == n:
+            continue
+
+        diffs.append(f"{key}: {o!r} -> {n!r}")
+
+    return "; ".join(diffs)

--- a/src/python/pants/option/options_diff.py
+++ b/src/python/pants/option/options_diff.py
@@ -1,11 +1,16 @@
 # Copyright 2025 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from dataclasses import fields
+from enum import Enum
 from typing import Any
+
+from pants.option.global_options import DynamicRemoteOptions
 
 
 def summarize_options_map_diff(old: dict[str, Any], new: dict[str, Any]) -> str:
     """Compare two options map (as produced by `OptionsFingerprinter.options_map_for_scope`), and
-    return a one-liner like:
+    return a one-liner summarizing all differences, e.g.:
 
     `key1: 'old' -> "new'; list_key: ['x', 'y'] -> ['x']`
     """
@@ -16,6 +21,28 @@ def summarize_options_map_diff(old: dict[str, Any], new: dict[str, Any]) -> str:
 
         if o == n:
             continue
+
+        diffs.append(f"{key}: {o!r} -> {n!r}")
+
+    return "; ".join(diffs)
+
+
+def summarize_dynamic_options_diff(old: DynamicRemoteOptions, new: DynamicRemoteOptions) -> str:
+    """Compare two `DynamicRemoteOptions` and return a one-liner summarizing all differences, e.g.:
+
+    `provider: 'reapi' -> 'experimental-file'; cache_read: False -> True`
+    """
+    diffs = []
+    for field in fields(DynamicRemoteOptions):
+        key = field.name
+        o = getattr(old, key)
+        n = getattr(new, key)
+
+        if o == n:
+            continue
+
+        o = o.value if isinstance(o, Enum) else o
+        n = n.value if isinstance(n, Enum) else n
 
         diffs.append(f"{key}: {o!r} -> {n!r}")
 

--- a/src/python/pants/option/options_diff_test.py
+++ b/src/python/pants/option/options_diff_test.py
@@ -1,10 +1,13 @@
 # Copyright 2025 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+from dataclasses import replace
 from typing import Any
 
 import pytest
 
-from pants.option.options_diff import summarize_options_map_diff
+from pants.option.global_options import DynamicRemoteOptions, RemoteProvider
+from pants.option.options_diff import summarize_dynamic_options_diff, summarize_options_map_diff
+from pants.testutil.option_util import create_dynamic_remote_options
 
 
 @pytest.mark.parametrize(
@@ -41,4 +44,50 @@ def test_summarize_options_map_diff(
     old: dict[str, Any], new: dict[str, Any], expected_diff: str
 ) -> None:
     diff = summarize_options_map_diff(old, new)
+    assert diff == expected_diff
+
+
+@pytest.mark.parametrize(
+    "old, new, expected_diff",
+    [
+        [
+            create_dynamic_remote_options(),
+            create_dynamic_remote_options(),
+            "",
+        ],
+        [
+            create_dynamic_remote_options(),
+            replace(create_dynamic_remote_options(), execution=True),
+            "execution: False -> True",
+        ],
+        [
+            create_dynamic_remote_options(),
+            replace(create_dynamic_remote_options(), provider=RemoteProvider.experimental_file),
+            "provider: 'reapi' -> 'experimental-file'",
+        ],
+        [
+            create_dynamic_remote_options(),
+            replace(create_dynamic_remote_options(), store_headers={"auth": "token"}),
+            "store_headers: {} -> {'auth': 'token'}",
+        ],
+        [
+            replace(create_dynamic_remote_options(), execution=True, execution_headers={"x": "1"}),
+            replace(create_dynamic_remote_options(), execution=False, execution_headers={}),
+            "execution: True -> False; execution_headers: {'x': '1'} -> {}",
+        ],
+        [
+            create_dynamic_remote_options(),
+            replace(
+                create_dynamic_remote_options(),
+                instance_name="test",
+                parallelism=32,
+            ),
+            "instance_name: 'main' -> 'test'; parallelism: 128 -> 32",
+        ],
+    ],
+)
+def test_summarize_dynamic_options_diff(
+    old: DynamicRemoteOptions, new: DynamicRemoteOptions, expected_diff: str
+) -> None:
+    diff = summarize_dynamic_options_diff(old, new)
     assert diff == expected_diff

--- a/src/python/pants/option/options_diff_test.py
+++ b/src/python/pants/option/options_diff_test.py
@@ -1,0 +1,44 @@
+# Copyright 2025 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from typing import Any
+
+import pytest
+
+from pants.option.options_diff import summarize_options_map_diff
+
+
+@pytest.mark.parametrize(
+    "old, new, expected_diff",
+    [
+        [
+            {"a": 1, "b": ["x", "y"], "c": True},
+            {"a": 1, "b": ["x", "y"], "c": True},
+            "",
+        ],
+        [
+            {"l": ["x", "y"]},
+            {"l": ["x", "y", "z"]},
+            "l: ['x', 'y'] -> ['x', 'y', 'z']",
+        ],
+        [
+            {"flag": True, "a": 30},
+            {"flag": False, "a": 30},
+            "flag: True -> False",
+        ],
+        [
+            {},
+            {"foo": "bar"},
+            "foo: None -> 'bar'",
+        ],
+        [
+            {"x": "a", "y": ["b", "c"], "z": True},
+            {"x": "d", "y": ["e", "f", "g"], "z": False},
+            "x: 'a' -> 'd'; y: ['b', 'c'] -> ['e', 'f', 'g']; z: True -> False",
+        ],
+    ],
+)
+def test_summarize_options_map_diff(
+    old: dict[str, Any], new: dict[str, Any], expected_diff: str
+) -> None:
+    diff = summarize_options_map_diff(old, new)
+    assert diff == expected_diff

--- a/src/python/pants/option/options_fingerprinter.py
+++ b/src/python/pants/option/options_fingerprinter.py
@@ -41,29 +41,6 @@ class OptionsFingerprinter:
     :API: public
     """
 
-    @classmethod
-    def combined_options_fingerprint_for_scope(cls, scope, options, daemon_only=False) -> str:
-        """Given options and a scope, compute a combined fingerprint for the scope.
-
-        :param string scope: The scope to fingerprint.
-        :param Options options: The `Options` object to fingerprint.
-        :param daemon_only: Whether to fingerprint only daemon=True options.
-        :return: Hexadecimal string representing the fingerprint for all `options`
-                 values in `scope`.
-        """
-        fingerprinter = cls()
-        hasher = sha1()
-        option_items = options.get_fingerprintable_for_scope(scope, daemon_only)
-        for _, option_type, option_value in option_items:
-            fingerprint = fingerprinter.fingerprint(option_type, option_value)
-            if fingerprint is None:
-                # This isn't necessarily a good value to be using here, but it preserves behavior from
-                # before the commit which added it. I suspect that using the empty string would be
-                # reasonable too, but haven't done any archaeology to check.
-                fingerprint = "None"
-            hasher.update(fingerprint.encode())
-        return hasher.hexdigest()
-
     @staticmethod
     def options_map_for_scope(scope: str, options: Options) -> dict[str, Any]:
         """Given options and a scope, create a JSON-serializable map of all fingerprintable options

--- a/src/python/pants/option/options_integration_test.py
+++ b/src/python/pants/option/options_integration_test.py
@@ -153,5 +153,7 @@ def test_fromfile_invalidation(tmp_path: Path) -> None:
     )
     # Same pantsd process, new scheduler.
     assert_same_daemon()
-    assert "Initialization options changed: reinitializing scheduler..." in pants_run.stderr
+    assert "Initialization options changed" in pants_run.stderr
+    assert "pants_distdir" in pants_run.stderr
+    assert "Reinitializing scheduler" in pants_run.stderr
     assert "Scheduler initialized." in pants_run.stderr

--- a/src/python/pants/pantsd/pants_daemon_core.py
+++ b/src/python/pants/pantsd/pants_daemon_core.py
@@ -7,7 +7,7 @@ import logging
 import threading
 from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import Protocol
+from typing import Any, Protocol
 
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.engine.env_vars import CompleteEnvironmentVars
@@ -18,6 +18,7 @@ from pants.init.options_initializer import OptionsInitializer
 from pants.option.global_options import AuthPluginResult, DynamicRemoteOptions
 from pants.option.option_value_container import OptionValueContainer
 from pants.option.options_bootstrapper import OptionsBootstrapper
+from pants.option.options_diff import summarize_dynamic_options_diff, summarize_options_map_diff
 from pants.option.options_fingerprinter import OptionsFingerprinter
 from pants.option.scope import GLOBAL_SCOPE
 from pants.pantsd.service.pants_service import PantsServices
@@ -56,8 +57,8 @@ class PantsDaemonCore:
 
         self._scheduler: GraphScheduler | None = None
         self._services: PantsServices | None = None
-        self._fingerprint: str | None = None
 
+        self._prior_options_map: dict[str, Any] | None = None
         self._prior_dynamic_remote_options: DynamicRemoteOptions | None = None
         self._prior_auth_plugin_result: AuthPluginResult | None = None
 
@@ -86,7 +87,6 @@ class PantsDaemonCore:
 
     def _initialize(
         self,
-        options_fingerprint: str,
         bootstrap_options: OptionValueContainer,
         build_config: BuildConfiguration,
         dynamic_remote_options: DynamicRemoteOptions,
@@ -98,7 +98,7 @@ class PantsDaemonCore:
         """
         try:
             logger.info(
-                f"{scheduler_restart_explanation}: reinitializing scheduler..."
+                f"{scheduler_restart_explanation}. Reinitializing scheduler..."
                 if scheduler_restart_explanation
                 else "Initializing scheduler..."
             )
@@ -109,7 +109,6 @@ class PantsDaemonCore:
             )
 
             self._services = self._services_constructor(bootstrap_options, self._scheduler)
-            self._fingerprint = options_fingerprint
             logger.info("Scheduler initialized.")
         except Exception as e:
             self._kill_switch.set()
@@ -142,43 +141,37 @@ class PantsDaemonCore:
             self._prior_auth_plugin_result,
             remote_auth_plugin_func=build_config.remote_auth_plugin_func,
         )
-        remote_options_changed = (
-            self._prior_dynamic_remote_options is not None
-            and dynamic_remote_options != self._prior_dynamic_remote_options
-        )
-        if remote_options_changed:
-            scheduler_restart_explanation = "Remote cache/execution options updated"
+        remote_options_changed = dynamic_remote_options != self._prior_dynamic_remote_options
+        if self._prior_dynamic_remote_options is not None and remote_options_changed:
+            diff = summarize_dynamic_options_diff(
+                self._prior_dynamic_remote_options, dynamic_remote_options
+            )
+            scheduler_restart_explanation = f"Remote cache/execution options updated: {diff}"
 
-        # Compute the fingerprint of the bootstrap options. Note that unlike
-        # PantsDaemonProcessManager (which fingerprints only `daemon=True` options), this
-        # fingerprints all fingerprintable options in the bootstrap options, which are
-        # all used to construct a Scheduler.
-        options_fingerprint = OptionsFingerprinter.combined_options_fingerprint_for_scope(
+        options_map = OptionsFingerprinter.options_map_for_scope(
             GLOBAL_SCOPE,
             options_bootstrapper.bootstrap_options,
         )
-        bootstrap_options_changed = (
-            self._fingerprint is not None and options_fingerprint != self._fingerprint
-        )
-        if bootstrap_options_changed:
-            scheduler_restart_explanation = "Initialization options changed"
+        bootstrap_options_changed = options_map != self._prior_options_map
+        if self._prior_options_map is not None and bootstrap_options_changed:
+            diff = summarize_options_map_diff(self._prior_options_map, options_map)
+            scheduler_restart_explanation = f"Initialization options changed: {diff}"
 
         with self._lifecycle_lock:
             if self._scheduler is None or scheduler_restart_explanation:
-                # The fingerprint mismatches, either because this is the first run (and there is no
-                # fingerprint) or because relevant options have changed. Create a new scheduler
-                # and services.
+                # No existing options to compare (first run) or options have changed. Create a new
+                # scheduler and services.
                 bootstrap_options = options_bootstrapper.bootstrap_options.for_global_scope()
                 assert bootstrap_options is not None
                 with self._handle_exceptions():
                     self._initialize(
-                        options_fingerprint,
                         bootstrap_options,
                         build_config,
                         dynamic_remote_options,
                         scheduler_restart_explanation,
                     )
 
+            self._prior_options_map = options_map
             self._prior_dynamic_remote_options = dynamic_remote_options
             self._prior_auth_plugin_result = auth_plugin_result
 


### PR DESCRIPTION
With this change, the pantsd scheduler logs will now include a summary of which options changed during restart:

- Instead of fingerprinting bootstrap options directly, build a map of each fingerprintable options to its current value and track it across restarts.
- Generate a one-line diff comparing the old and new set of bootstrap and remote options
- Those diffs are then logged whenever the scheduler restarts

Closes #22224