### PR TITLE
Allow for absolute paths to DistDir outside of BuildRoot

### DIFF
--- a/src/python/pants/core/util_rules/distdir.py
+++ b/src/python/pants/core/util_rules/distdir.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from pants.base.build_root import BuildRoot
 from pants.engine.rules import collect_rules, rule
 from pants.option.global_options import GlobalOptions
-from pants.util.strutil import softwrap
 
 
 def is_child_of(path: Path, directory: Path) -> bool:

--- a/src/python/pants/core/util_rules/distdir.py
+++ b/src/python/pants/core/util_rules/distdir.py
@@ -16,20 +16,13 @@ def is_child_of(path: Path, directory: Path) -> bool:
 
 
 # for backward compatibility -- to prevent extensive patching across the codebase
-# we we preserve the old relpath attribute and alias path to it in normalize_distdir()
+# we we preserve the old relpath attribute, but note that the Path held inside
+# is always absolute now; see normalize_distdir()
 @dataclass(frozen=True)
 class DistDir:
     """The directory to which we write distributable files."""
 
-    path: Path
-    """
-    The absolutized path for the dist dir
-    """
-
     relpath: Path
-    """
-    Deprecated property from when DistDir was forced to be a relative path; use path instead
-    """
 
 
 @rule
@@ -42,7 +35,7 @@ def normalize_distdir(distdir: Path, buildroot: Path) -> DistDir:
         path = distdir
     else:
         path = buildroot / distdir
-    return DistDir(path=path, relpath=path)
+    return DistDir(relpath=path)
 
 
 def rules():

--- a/src/python/pants/core/util_rules/distdir_test.py
+++ b/src/python/pants/core/util_rules/distdir_test.py
@@ -3,15 +3,15 @@
 
 from pathlib import Path
 
-import pytest
-
 from pants.core.util_rules.distdir import DistDir, is_child_of, normalize_distdir
 
 
 def test_distdir() -> None:
     buildroot = Path("/buildroot")
     assert DistDir(relpath=Path("/buildroot/dist")) == normalize_distdir(Path("dist"), buildroot)
-    assert DistDir(relpath=Path("/buildroot/dist")) == normalize_distdir(Path("/buildroot/dist"), buildroot)
+    assert DistDir(relpath=Path("/buildroot/dist")) == normalize_distdir(
+        Path("/buildroot/dist"), buildroot
+    )
     assert DistDir(relpath=Path("/other/dist")) == normalize_distdir(Path("/other/dist"), buildroot)
 
 

--- a/src/python/pants/core/util_rules/distdir_test.py
+++ b/src/python/pants/core/util_rules/distdir_test.py
@@ -5,15 +5,14 @@ from pathlib import Path
 
 import pytest
 
-from pants.core.util_rules.distdir import DistDir, InvalidDistDir, is_child_of, validate_distdir
+from pants.core.util_rules.distdir import DistDir, is_child_of, normalize_distdir
 
 
 def test_distdir() -> None:
     buildroot = Path("/buildroot")
-    assert DistDir(relpath=Path("dist")) == validate_distdir(Path("dist"), buildroot)
-    assert DistDir(relpath=Path("dist")) == validate_distdir(Path("/buildroot/dist"), buildroot)
-    with pytest.raises(InvalidDistDir):
-        validate_distdir(Path("/other/dist"), buildroot)
+    assert DistDir(path=Path("/buildroot/dist")) == normalize_distdir(Path("dist"), buildroot)
+    assert DistDir(path=Path("/buildroot/dist")) == normalize_distdir(Path("/buildroot/dist"), buildroot)
+    assert DistDir(path=Path("/other/dist")) == normalize_distdir(Path("/other/dist"), buildroot)
 
 
 def test_is_child_of() -> None:

--- a/src/python/pants/core/util_rules/distdir_test.py
+++ b/src/python/pants/core/util_rules/distdir_test.py
@@ -10,9 +10,9 @@ from pants.core.util_rules.distdir import DistDir, is_child_of, normalize_distdi
 
 def test_distdir() -> None:
     buildroot = Path("/buildroot")
-    assert DistDir(path=Path("/buildroot/dist")) == normalize_distdir(Path("dist"), buildroot)
-    assert DistDir(path=Path("/buildroot/dist")) == normalize_distdir(Path("/buildroot/dist"), buildroot)
-    assert DistDir(path=Path("/other/dist")) == normalize_distdir(Path("/other/dist"), buildroot)
+    assert DistDir(relpath=Path("/buildroot/dist")) == normalize_distdir(Path("dist"), buildroot)
+    assert DistDir(relpath=Path("/buildroot/dist")) == normalize_distdir(Path("/buildroot/dist"), buildroot)
+    assert DistDir(relpath=Path("/other/dist")) == normalize_distdir(Path("/other/dist"), buildroot)
 
 
 def test_is_child_of() -> None:


### PR DESCRIPTION
Removed InvalidDistDir check. This is to allow users to locate dist outside of their local source directories if they are affected by [docker/for-mac#6812](https://github.com/docker/for-mac/issues/6812); in that scenario, the local source directory is mounted inside Docker, and the cited issue causes flakiness in I/O. Since there's no compelling reason to force dist to be inside the source directory, relax the constraint.

#21771 