### PR TITLE
wip: batch load from remote

### DIFF
--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -195,6 +195,7 @@ class Scheduler:
             store_rpc_concurrency=execution_options.remote_store_rpc_concurrency,
             store_rpc_timeout_millis=execution_options.remote_store_rpc_timeout_millis,
             store_batch_api_size_limit=execution_options.remote_store_batch_api_size_limit,
+            store_batch_load_enabled=execution_options.remote_store_batch_load_enabled,
             cache_warnings_behavior=execution_options.remote_cache_warnings.value,
             cache_content_behavior=execution_options.cache_content_behavior.value,
             cache_rpc_concurrency=execution_options.remote_cache_rpc_concurrency,

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -319,6 +319,7 @@ class DynamicRemoteOptions:
     execution_headers: dict[str, str]
     parallelism: int
     store_rpc_concurrency: int
+    store_batch_load_enabled: bool
     cache_rpc_concurrency: int
     execution_rpc_concurrency: int
 
@@ -384,6 +385,7 @@ class DynamicRemoteOptions:
             execution_headers={},
             parallelism=DEFAULT_EXECUTION_OPTIONS.process_execution_remote_parallelism,
             store_rpc_concurrency=DEFAULT_EXECUTION_OPTIONS.remote_store_rpc_concurrency,
+            store_batch_load_enabled=DEFAULT_EXECUTION_OPTIONS.remote_store_batch_load_enabled,
             cache_rpc_concurrency=DEFAULT_EXECUTION_OPTIONS.remote_cache_rpc_concurrency,
             execution_rpc_concurrency=DEFAULT_EXECUTION_OPTIONS.remote_execution_rpc_concurrency,
         )
@@ -409,6 +411,7 @@ class DynamicRemoteOptions:
         store_headers = cast("dict[str, str]", bootstrap_options.remote_store_headers)
         parallelism = cast(int, bootstrap_options.process_execution_remote_parallelism)
         store_rpc_concurrency = cast(int, bootstrap_options.remote_store_rpc_concurrency)
+        store_batch_load_enabled = cast(bool, bootstrap_options.remote_store_batch_load_enabled)
         cache_rpc_concurrency = cast(int, bootstrap_options.remote_cache_rpc_concurrency)
         execution_rpc_concurrency = cast(int, bootstrap_options.remote_execution_rpc_concurrency)
         execution_headers.update(token_header)
@@ -425,6 +428,7 @@ class DynamicRemoteOptions:
             execution_headers=execution_headers,
             parallelism=parallelism,
             store_rpc_concurrency=store_rpc_concurrency,
+            store_batch_load_enabled=store_batch_load_enabled,
             cache_rpc_concurrency=cache_rpc_concurrency,
             execution_rpc_concurrency=execution_rpc_concurrency,
         )
@@ -484,6 +488,7 @@ class DynamicRemoteOptions:
         store_headers = cast("dict[str, str]", bootstrap_options.remote_store_headers)
         parallelism = cast(int, bootstrap_options.process_execution_remote_parallelism)
         store_rpc_concurrency = cast(int, bootstrap_options.remote_store_rpc_concurrency)
+        store_batch_load_enabled = cast(bool, bootstrap_options.remote_store_batch_load_enabled)
         cache_rpc_concurrency = cast(int, bootstrap_options.remote_cache_rpc_concurrency)
         execution_rpc_concurrency = cast(int, bootstrap_options.remote_execution_rpc_concurrency)
         return cls(
@@ -498,6 +503,7 @@ class DynamicRemoteOptions:
             execution_headers=execution_headers,
             parallelism=parallelism,
             store_rpc_concurrency=store_rpc_concurrency,
+            store_batch_load_enabled=store_batch_load_enabled,
             cache_rpc_concurrency=cache_rpc_concurrency,
             execution_rpc_concurrency=execution_rpc_concurrency,
         )
@@ -522,6 +528,7 @@ class DynamicRemoteOptions:
         store_headers = cast("dict[str, str]", bootstrap_options.remote_store_headers)
         parallelism = cast(int, bootstrap_options.process_execution_remote_parallelism)
         store_rpc_concurrency = cast(int, bootstrap_options.remote_store_rpc_concurrency)
+        store_batch_load_enabled = cast(bool, bootstrap_options.remote_store_batch_load_enabled)
         cache_rpc_concurrency = cast(int, bootstrap_options.remote_cache_rpc_concurrency)
         execution_rpc_concurrency = cast(int, bootstrap_options.remote_execution_rpc_concurrency)
         auth_plugin_result = cast(
@@ -583,6 +590,7 @@ class DynamicRemoteOptions:
             execution_headers=execution_headers,
             parallelism=parallelism,
             store_rpc_concurrency=store_rpc_concurrency,
+            store_batch_load_enabled=store_batch_load_enabled,
             cache_rpc_concurrency=cache_rpc_concurrency,
             execution_rpc_concurrency=execution_rpc_concurrency,
         )
@@ -633,6 +641,7 @@ class ExecutionOptions:
     remote_store_rpc_retries: int
     remote_store_rpc_concurrency: int
     remote_store_batch_api_size_limit: int
+    remote_store_batch_load_enabled: bool
     remote_store_rpc_timeout_millis: int
 
     remote_cache_warnings: RemoteCacheWarningsBehavior
@@ -680,6 +689,7 @@ class ExecutionOptions:
             remote_store_rpc_retries=bootstrap_options.remote_store_rpc_retries,
             remote_store_rpc_concurrency=dynamic_remote_options.store_rpc_concurrency,
             remote_store_batch_api_size_limit=bootstrap_options.remote_store_batch_api_size_limit,
+            remote_store_batch_load_enabled=bootstrap_options.remote_store_batch_load_enabled,
             remote_store_rpc_timeout_millis=bootstrap_options.remote_store_rpc_timeout_millis,
             # Remote cache setup.
             remote_cache_warnings=bootstrap_options.remote_cache_warnings,
@@ -774,6 +784,7 @@ DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
     remote_store_rpc_concurrency=128,
     remote_store_batch_api_size_limit=4194304,
     remote_store_rpc_timeout_millis=30000,
+    remote_store_batch_load_enabled=False,
     # Remote cache setup.
     remote_cache_warnings=RemoteCacheWarningsBehavior.backoff,
     remote_cache_rpc_concurrency=128,
@@ -1613,6 +1624,11 @@ class BootstrapOptions:
         advanced=True,
         default=DEFAULT_EXECUTION_OPTIONS.remote_store_batch_api_size_limit,
         help="The maximum total size of blobs allowed to be sent in a single batch API call to the remote store.",
+    )
+    remote_store_batch_load_enabled = BoolOption(
+        default=DEFAULT_EXECUTION_OPTIONS.remote_store_batch_load_enabled,
+        advanced=True,
+        help="Whether to enable batch load requests to the remote store.",
     )
     remote_cache_warnings = EnumOption(
         default=DEFAULT_EXECUTION_OPTIONS.remote_cache_warnings,

--- a/src/python/pants/option/global_options_test.py
+++ b/src/python/pants/option/global_options_test.py
@@ -294,6 +294,7 @@ def test_remote_provider_matches_rust_enum(
         store_rpc_concurrency=0,
         store_rpc_timeout_millis=0,
         store_batch_api_size_limit=0,
+        store_batch_load_enabled=False,
         cache_warnings_behavior="ignore",
         cache_content_behavior="validate",
         cache_rpc_concurrency=0,

--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -780,6 +780,7 @@ async fn main() {
                 retries: 1,
                 concurrency_limit: *args.get_one("rpc-concurrency-limit").unwrap(),
                 batch_api_size_limit: *args.get_one("batch-api-size-limit").unwrap(),
+                batch_load_enabled: false,
             })
             .await
             .expect("Error making remote store"),

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -430,6 +430,7 @@ async fn execute(top_match: &clap::ArgMatches) -> Result<(), ExitError> {
                             batch_api_size_limit: *top_match
                                 .get_one("batch-api-size-limit")
                                 .unwrap(),
+                            batch_load_enabled: false,
                         })
                         .await,
                     true,

--- a/src/rust/engine/fs/store/src/cli_options.rs
+++ b/src/rust/engine/fs/store/src/cli_options.rs
@@ -197,6 +197,7 @@ impl StoreCliOpt {
                     retries: self.store_rpc_retries,
                     concurrency_limit: self.store_rpc_concurrency,
                     batch_api_size_limit: self.store_batch_api_size_limit,
+                    batch_load_enabled: false,
                 })
                 .await
         } else {

--- a/src/rust/engine/fs/store/src/tests.rs
+++ b/src/rust/engine/fs/store/src/tests.rs
@@ -75,6 +75,7 @@ fn remote_options(
         retries: 1,
         concurrency_limit: 256,
         batch_api_size_limit: STORE_BATCH_API_SIZE_LIMIT,
+        batch_load_enabled: false,
     }
 }
 ///

--- a/src/rust/engine/process_execution/remote/src/remote_cache_tests.rs
+++ b/src/rust/engine/process_execution/remote/src/remote_cache_tests.rs
@@ -117,6 +117,7 @@ impl StoreSetup {
                 retries: 1,
                 concurrency_limit: 256,
                 batch_api_size_limit: 4 * 1024 * 1024,
+                batch_load_enabled: false,
             })
             .await
             .unwrap();
@@ -172,6 +173,7 @@ async fn create_cached_runner(
                 retries: 0,
                 batch_api_size_limit: 0,
                 chunk_size_bytes: 0,
+                batch_load_enabled: false,
             },
         )
         .await
@@ -781,6 +783,7 @@ async fn make_action_result_basic() {
             timeout: CACHE_READ_TIMEOUT,
             retries: 0,
             batch_api_size_limit: 0,
+            batch_load_enabled: false,
             chunk_size_bytes: 0,
         },
     )

--- a/src/rust/engine/process_execution/remote/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/remote/src/remote_tests.rs
@@ -1296,6 +1296,7 @@ fn remote_options_for_cas(cas: &mock::StubCAS) -> RemoteStoreOptions {
         retries: 1,
         concurrency_limit: STORE_CONCURRENCY_LIMIT,
         batch_api_size_limit: STORE_BATCH_API_SIZE_LIMIT,
+        batch_load_enabled: false,
     }
 }
 

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -243,6 +243,7 @@ async fn main() -> Result<(), String> {
                             retries: 0,
                             batch_api_size_limit: 0,
                             chunk_size_bytes: 0,
+                            batch_load_enabled: false,
                         },
                     )
                     .await

--- a/src/rust/engine/remote_provider/remote_provider_opendal/src/action_cache_tests.rs
+++ b/src/rust/engine/remote_provider/remote_provider_opendal/src/action_cache_tests.rs
@@ -39,6 +39,7 @@ fn remote_options() -> RemoteStoreOptions {
         retries: 1,
         concurrency_limit: 256,
         batch_api_size_limit: 10000,
+        batch_load_enabled: false,
     }
 }
 

--- a/src/rust/engine/remote_provider/remote_provider_opendal/src/byte_store_tests.rs
+++ b/src/rust/engine/remote_provider/remote_provider_opendal/src/byte_store_tests.rs
@@ -36,6 +36,7 @@ fn remote_options() -> RemoteStoreOptions {
         retries: 1,
         concurrency_limit: 256,
         batch_api_size_limit: 10000,
+        batch_load_enabled: false,
     }
 }
 

--- a/src/rust/engine/remote_provider/remote_provider_opendal/src/lib.rs
+++ b/src/rust/engine/remote_provider/remote_provider_opendal/src/lib.rs
@@ -294,6 +294,14 @@ impl ByteStoreProvider for Provider {
 
         Ok(existences.into_iter().flatten().collect())
     }
+
+    fn batch_load_supported(&self) -> bool {
+        false
+    }
+
+    async fn load_batch(&self, _digests: Vec<Digest>) -> Result<Vec<Bytes>, String> {
+        Err("load_batch not implemented for remote opendal provider".to_string())
+    }
 }
 
 #[async_trait]

--- a/src/rust/engine/remote_provider/remote_provider_reapi/src/action_cache_tests.rs
+++ b/src/rust/engine/remote_provider/remote_provider_reapi/src/action_cache_tests.rs
@@ -21,6 +21,7 @@ async fn new_provider(cas: &StubCAS) -> Provider {
         retries: 0,
         batch_api_size_limit: 0,
         chunk_size_bytes: 0,
+        batch_load_enabled: false,
     })
     .await
     .unwrap()

--- a/src/rust/engine/remote_provider/remote_provider_reapi/src/byte_store_tests.rs
+++ b/src/rust/engine/remote_provider/remote_provider_reapi/src/byte_store_tests.rs
@@ -35,6 +35,7 @@ fn remote_options(
         retries: 1,
         concurrency_limit: 256,
         batch_api_size_limit,
+        batch_load_enabled: false,
     }
 }
 

--- a/src/rust/engine/remote_provider/remote_provider_traits/src/lib.rs
+++ b/src/rust/engine/remote_provider/remote_provider_traits/src/lib.rs
@@ -37,6 +37,7 @@ pub struct RemoteStoreOptions {
     pub retries: usize,
     pub concurrency_limit: usize,
     pub batch_api_size_limit: usize,
+    pub batch_load_enabled: bool,
 }
 
 #[async_trait]
@@ -62,6 +63,10 @@ pub trait ByteStoreProvider: Sync + Send + 'static {
         digest: Digest,
         destination: &mut dyn LoadDestination,
     ) -> Result<bool, String>;
+
+    async fn load_batch(&self, digests: Vec<Digest>) -> Result<Vec<Bytes>, String>;
+
+    fn batch_load_supported(&self) -> bool;
 
     /// Return any digests from `digests` that are not (currently) available in the remote store.
     ///

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -98,6 +98,7 @@ pub struct RemotingOptions {
     pub store_rpc_concurrency: usize,
     pub store_rpc_timeout: Duration,
     pub store_batch_api_size_limit: usize,
+    pub store_batch_load_enabled: bool,
     pub cache_warnings_behavior: RemoteCacheWarningsBehavior,
     pub cache_content_behavior: CacheContentBehavior,
     pub cache_rpc_concurrency: usize,
@@ -130,6 +131,7 @@ impl RemotingOptions {
             retries: self.store_rpc_retries,
             concurrency_limit: self.store_rpc_concurrency,
             batch_api_size_limit: self.store_batch_api_size_limit,
+            batch_load_enabled: self.store_batch_load_enabled,
         })
     }
 }

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -333,6 +333,7 @@ impl PyRemotingOptions {
         store_rpc_concurrency,
         store_rpc_timeout_millis,
         store_batch_api_size_limit,
+        store_batch_load_enabled,
         cache_warnings_behavior,
         cache_content_behavior,
         cache_rpc_concurrency,
@@ -358,6 +359,7 @@ impl PyRemotingOptions {
         store_rpc_concurrency: usize,
         store_rpc_timeout_millis: u64,
         store_batch_api_size_limit: usize,
+        store_batch_load_enabled: bool,
         cache_warnings_behavior: String,
         cache_content_behavior: String,
         cache_rpc_concurrency: usize,
@@ -390,6 +392,7 @@ impl PyRemotingOptions {
             store_rpc_concurrency,
             store_rpc_timeout: Duration::from_millis(store_rpc_timeout_millis),
             store_batch_api_size_limit,
+            store_batch_load_enabled,
             cache_warnings_behavior: RemoteCacheWarningsBehavior::from_str(
                 &cache_warnings_behavior,
             )


### PR DESCRIPTION
Introduces batched loads for small digests for REAPI remotes. 

For large trees, this materially reduces the amount of time it takes to fetch them from the remote. 

I've been testing this against a node_modules directory of ~300k files.

Testing manually on my local machine against bazel-remote running locally and remotely (wiping `~/.cache/pants/lmdb_store/` between tests)

| Environment         | Individual | Batched |
|---------------------|--------|-------|
| localhost           | 10s    | 5s    |
| over internet to aws    | 2m     | 58s   |


Early draft for feedback on the approach

Things I'd like feedback on
- I added a global option to enable this feature, mostly to de-risk the new codepath, so it can be flagged off in the event it breaks someone 
- What should the default be? (True?) 
- The place I put this in (`ensure_downloaded`) fixes my immediate problem, but should it go somewhere else? 
- How should I benchmark this change beyond manual testing?  