### PR TITLE
plugin API: add imperative "library-style" initialization support

### DIFF
--- a/src/python/pants/backend/shell/register.py
+++ b/src/python/pants/backend/shell/register.py
@@ -15,27 +15,29 @@ from pants.backend.shell.target_types import (
 )
 from pants.backend.shell.target_types import rules as target_types_rules
 from pants.backend.shell.util_rules import shell_command
+from pants.init.extension_api import ExtensionInitContextV0
 
 
-def target_types():
-    return [
-        ShellCommandTarget,
-        ShellCommandRunTarget,
-        ShellCommandTestTarget,
-        ShellSourcesGeneratorTarget,
-        Shunit2TestsGeneratorTarget,
-        ShellSourceTarget,
-        Shunit2TestTarget,
-    ]
-
-
-def rules():
-    return [
-        *dependency_inference.rules(),
-        *shell_command.rules(),
-        *shunit2.rules(),
-        *shunit2_test_runner.rules(),
-        *tailor.rules(),
-        *target_types_rules(),
-        *test.rules(),
-    ]
+def initializeV0(context: ExtensionInitContextV0) -> None:
+    context.register_target_types(
+        [
+            ShellCommandTarget,
+            ShellCommandRunTarget,
+            ShellCommandTestTarget,
+            ShellSourcesGeneratorTarget,
+            Shunit2TestsGeneratorTarget,
+            ShellSourceTarget,
+            Shunit2TestTarget,
+        ]
+    )
+    context.register_rules(
+        [
+            *dependency_inference.rules(),
+            *shell_command.rules(),
+            *shunit2.rules(),
+            *shunit2_test_runner.rules(),
+            *tailor.rules(),
+            *target_types_rules(),
+            *test.rules(),
+        ]
+    )

--- a/src/python/pants/init/extension_api.py
+++ b/src/python/pants/init/extension_api.py
@@ -1,0 +1,31 @@
+# Copyright 2025 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from typing import Any, Protocol
+
+from pants.build_graph.build_file_aliases import BuildFileAliases
+from pants.engine.rules import Rule
+from pants.engine.target import Target
+from pants.engine.unions import UnionRule
+from pants.goal.auxiliary_goal import AuxiliaryGoal
+from pants.option.subsystem import Subsystem
+
+
+class ExtensionInitContextV0(Protocol):
+    """A context object used by extension initializers to register their capabilities with the
+    engine."""
+
+    def register_aliases(self, aliases: BuildFileAliases) -> None: ...
+
+    def register_auxiliary_goals(self, goals: Iterable[type[AuxiliaryGoal]]) -> None: ...
+
+    def register_remote_auth_plugin(self, remote_auth_plugin: Callable) -> None: ...
+
+    def register_rules(self, rules: Iterable[Rule | UnionRule]) -> None: ...
+
+    def register_subsystems(self, subsystems: Iterable[type[Subsystem]]): ...
+
+    def register_target_types(self, target_types: Iterable[type[Target]] | Any) -> None: ...

--- a/src/python/pants/init/extension_loader.py
+++ b/src/python/pants/init/extension_loader.py
@@ -4,15 +4,27 @@
 import importlib
 import logging
 import traceback
+from collections.abc import Callable, Iterable
+from typing import Any
 
-from pkg_resources import Requirement, WorkingSet
+from pkg_resources import EntryPoint, Requirement, WorkingSet
 
 from pants.base.exceptions import BackendConfigurationError
 from pants.build_graph.build_configuration import BuildConfiguration
+from pants.build_graph.build_file_aliases import BuildFileAliases
+from pants.engine.rules import Rule
+from pants.engine.target import Target
+from pants.engine.unions import UnionRule
+from pants.goal.auxiliary_goal import AuxiliaryGoal
 from pants.goal.builtins import register_builtin_goals
+from pants.init.extension_api import ExtensionInitContextV0
+from pants.option.subsystem import Subsystem
 from pants.util.ordered_set import FrozenOrderedSet
 
 logger = logging.getLogger(__name__)
+
+
+_EXTENSION_INITIALIZE_METHOD_NAME = "initializeV0"
 
 
 class PluginLoadingError(Exception):
@@ -25,6 +37,30 @@ class PluginNotFound(PluginLoadingError):
 
 class PluginLoadOrderError(PluginLoadingError):
     pass
+
+
+class PluginExtensionInitContext(ExtensionInitContextV0):
+    def __init__(self, key: str, build_configuration: BuildConfiguration.Builder):
+        self._key = key
+        self._build_configuration = build_configuration
+
+    def register_aliases(self, aliases: BuildFileAliases) -> None:
+        self._build_configuration.register_aliases(aliases)
+
+    def register_auxiliary_goals(self, goals: Iterable[type[AuxiliaryGoal]]) -> None:
+        self._build_configuration.register_auxiliary_goals(self._key, goals)
+
+    def register_remote_auth_plugin(self, remote_auth_plugin: Callable) -> None:
+        self._build_configuration.register_remote_auth_plugin(remote_auth_plugin)
+
+    def register_rules(self, rules: Iterable[Rule | UnionRule]) -> None:
+        self._build_configuration.register_rules(self._key, rules)
+
+    def register_subsystems(self, subsystems: Iterable[type[Subsystem]]) -> None:
+        self._build_configuration.register_subsystems(self._key, subsystems)
+
+    def register_target_types(self, target_types: Iterable[type[Target]] | Any) -> None:
+        self._build_configuration.register_target_types(self._key, target_types)
 
 
 def load_backends_and_plugins(
@@ -45,6 +81,39 @@ def load_backends_and_plugins(
     load_plugins(bc_builder, plugins, working_set)
     register_builtin_goals(bc_builder)
     return bc_builder.create()
+
+
+def _legacy_extension_init(
+    plugin_name: str,
+    key: str,
+    entries: dict[str, EntryPoint],
+    build_configuration: BuildConfiguration.Builder,
+    loaded: dict[str, Any],
+) -> None:
+    if "load_after" in entries:
+        deps = entries["load_after"].load()()
+        for dep_name in deps:
+            dep = Requirement.parse(dep_name)
+            if dep.key not in loaded:
+                raise PluginLoadOrderError(f"Plugin {plugin_name} must be loaded after {dep}")
+    if "target_types" in entries:
+        target_types = entries["target_types"].load()()
+        build_configuration.register_target_types(key, target_types)
+    if "build_file_aliases" in entries:
+        aliases = entries["build_file_aliases"].load()()
+        build_configuration.register_aliases(aliases)
+    if "rules" in entries:
+        rules = entries["rules"].load()()
+        build_configuration.register_rules(key, rules)
+    if "remote_auth" in entries:
+        remote_auth_func = entries["remote_auth"].load()
+        logger.debug(
+            f"register remote auth function {remote_auth_func.__module__}.{remote_auth_func.__name__} from plugin: {plugin_name}"
+        )
+        build_configuration.register_remote_auth_plugin(remote_auth_func)
+    if "auxiliary_goals" in entries:
+        auxiliary_goals = entries["auxiliary_goals"].load()()
+        build_configuration.register_auxiliary_goals(key, auxiliary_goals)
 
 
 def load_plugins(
@@ -85,30 +154,23 @@ def load_plugins(
 
         entries = dist.get_entry_map().get("pantsbuild.plugin", {})
 
-        if "load_after" in entries:
-            deps = entries["load_after"].load()()
-            for dep_name in deps:
-                dep = Requirement.parse(dep_name)
-                if dep.key not in loaded:
-                    raise PluginLoadOrderError(f"Plugin {plugin} must be loaded after {dep}")
-        if "target_types" in entries:
-            target_types = entries["target_types"].load()()
-            build_configuration.register_target_types(req.key, target_types)
-        if "build_file_aliases" in entries:
-            aliases = entries["build_file_aliases"].load()()
-            build_configuration.register_aliases(aliases)
-        if "rules" in entries:
-            rules = entries["rules"].load()()
-            build_configuration.register_rules(req.key, rules)
-        if "remote_auth" in entries:
-            remote_auth_func = entries["remote_auth"].load()
-            logger.debug(
-                f"register remote auth function {remote_auth_func.__module__}.{remote_auth_func.__name__} from plugin: {plugin}"
+        if _EXTENSION_INITIALIZE_METHOD_NAME in entries:
+            initializer = entries[_EXTENSION_INITIALIZE_METHOD_NAME].load()
+            initializer_context = PluginExtensionInitContext(
+                key=req.key, build_configuration=build_configuration
             )
-            build_configuration.register_remote_auth_plugin(remote_auth_func)
-        if "auxiliary_goals" in entries:
-            auxiliary_goals = entries["auxiliary_goals"].load()()
-            build_configuration.register_auxiliary_goals(req.key, auxiliary_goals)
+            try:
+                initializer(initializer_context)
+            except Exception as e:
+                raise PluginLoadingError(f"Plugin {plugin} failed to initialize: {e!r}") from e
+        else:
+            _legacy_extension_init(
+                plugin_name=plugin,
+                key=req.key,
+                entries=entries,
+                build_configuration=build_configuration,
+                loaded=loaded,
+            )
 
         loaded[dist.as_requirement().key] = dist
 
@@ -155,21 +217,33 @@ def load_backend(build_configuration: BuildConfiguration.Builder, backend_packag
                 f"Entrypoint {name} in {backend_module} must be a zero-arg callable: {e!r}"
             )
 
-    target_types = invoke_entrypoint("target_types")
-    if target_types:
-        build_configuration.register_target_types(backend_package, target_types)
-    build_file_aliases = invoke_entrypoint("build_file_aliases")
-    if build_file_aliases:
-        build_configuration.register_aliases(build_file_aliases)
-    rules = invoke_entrypoint("rules")
-    if rules:
-        build_configuration.register_rules(backend_package, rules)
-    remote_auth_func = getattr(module, "remote_auth", None)
-    if remote_auth_func:
-        logger.debug(
-            f"register remote auth function {remote_auth_func.__module__}.{remote_auth_func.__name__} from backend: {backend_package}"
+    if hasattr(module, _EXTENSION_INITIALIZE_METHOD_NAME):
+        initializer = getattr(module, _EXTENSION_INITIALIZE_METHOD_NAME)
+        initializer_context = PluginExtensionInitContext(
+            key=backend_package, build_configuration=build_configuration
         )
-        build_configuration.register_remote_auth_plugin(remote_auth_func)
-    auxiliary_goals = invoke_entrypoint("auxiliary_goals")
-    if auxiliary_goals:
-        build_configuration.register_auxiliary_goals(backend_package, auxiliary_goals)
+        try:
+            initializer(initializer_context)
+        except Exception as e:
+            raise BackendConfigurationError(
+                f"Backend {backend_package} failed to initialize: {e!r}"
+            ) from e
+    else:
+        target_types = invoke_entrypoint("target_types")
+        if target_types:
+            build_configuration.register_target_types(backend_package, target_types)
+        build_file_aliases = invoke_entrypoint("build_file_aliases")
+        if build_file_aliases:
+            build_configuration.register_aliases(build_file_aliases)
+        rules = invoke_entrypoint("rules")
+        if rules:
+            build_configuration.register_rules(backend_package, rules)
+        remote_auth_func = getattr(module, "remote_auth", None)
+        if remote_auth_func:
+            logger.debug(
+                f"register remote auth function {remote_auth_func.__module__}.{remote_auth_func.__name__} from backend: {backend_package}"
+            )
+            build_configuration.register_remote_auth_plugin(remote_auth_func)
+        auxiliary_goals = invoke_entrypoint("auxiliary_goals")
+        if auxiliary_goals:
+            build_configuration.register_auxiliary_goals(backend_package, auxiliary_goals)


### PR DESCRIPTION
Add support for "library style" initialization of backends / plugins.  A plugin may now provide a single initializer function to be called by the engine to initialize the plugin. Rules, target types, etc. are registered with the engine via the `context` instance passed to the initializer. This is "library style" versus "framework style" initialization.

Benefits:

- Reduces the amount of "magic" in the extension API by explicitly documenting it in the `pants.init.extension_api.ExtensionInitContextV0` protocol.
- Plugins (especially out of tree plugins) can run custom logic to modify what is registered with the engine based on whatever criteria may be relevant (e.g., Pants version for plugins supporting multiple versions). This logic previously would need to be split across each of the framework-style functions.
- Backends which need to always enable another backend can now just call the other backend's initializaer function without having to know which framework methods are used by the other backend. The JVM backends are a good candidate for this use case.

The existing "legacy" extension init support is not modified.

The shell backend is ported to the new interface.