### PR TITLE
Migrate docker backend to call-by-name

### DIFF
--- a/src/python/pants/backend/docker/goals/package_image.py
+++ b/src/python/pants/backend/docker/goals/package_image.py
@@ -38,14 +38,17 @@ from pants.backend.docker.util_rules.docker_binary import DockerBinary
 from pants.backend.docker.util_rules.docker_build_context import (
     DockerBuildContext,
     DockerBuildContextRequest,
+    create_docker_build_context,
 )
 from pants.backend.docker.utils import format_rename_suggestion
 from pants.core.goals.package import BuiltPackage, OutputPathField, PackageFieldSet
 from pants.engine.addresses import Address
-from pants.engine.fs import CreateDigest, Digest, FileContent
-from pants.engine.process import FallibleProcessResult, Process, ProcessExecutionFailure
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import InvalidFieldException, Target, WrappedTarget, WrappedTargetRequest
+from pants.engine.fs import CreateDigest, FileContent
+from pants.engine.internals.graph import resolve_target
+from pants.engine.intrinsics import create_digest, execute_process
+from pants.engine.process import ProcessExecutionFailure
+from pants.engine.rules import Get, collect_rules, concurrently, implicitly, rule
+from pants.engine.target import InvalidFieldException, Target, WrappedTargetRequest
 from pants.engine.unions import UnionMembership, UnionRule
 from pants.option.global_options import GlobalOptions, KeepSandboxes
 from pants.util.strutil import bullet_list, softwrap
@@ -391,22 +394,21 @@ async def build_docker_image(
     union_membership: UnionMembership,
 ) -> BuiltPackage:
     """Build a Docker image using `docker build`."""
-    context, wrapped_target = await MultiGet(
-        Get(
-            DockerBuildContext,
+    context, wrapped_target = await concurrently(
+        create_docker_build_context(
             DockerBuildContextRequest(
                 address=field_set.address,
                 build_upstream_images=True,
-            ),
+            )
         ),
-        Get(
-            WrappedTarget,
+        resolve_target(
             WrappedTargetRequest(field_set.address, description_of_origin="<infallible>"),
+            **implicitly(),
         ),
     )
 
     image_tags_requests = union_membership.get(DockerImageTagsRequest)
-    additional_image_tags = await MultiGet(
+    additional_image_tags = await concurrently(
         Get(DockerImageTags, DockerImageTagsRequest, image_tags_request_cls(wrapped_target.target))
         for image_tags_request_cls in image_tags_requests
         if image_tags_request_cls.is_applicable(wrapped_target.target)
@@ -460,7 +462,7 @@ async def build_docker_image(
             )
         ),
     )
-    result = await Get(FallibleProcessResult, Process, process)
+    result = await execute_process(process, **implicitly())
 
     if result.exit_code != 0:
         maybe_msg = format_docker_build_context_help_message(
@@ -498,7 +500,7 @@ async def build_docker_image(
 
     metadata_filename = field_set.output_path.value_or_default(file_ending="docker-info.json")
     metadata = DockerInfoV1.serialize(image_refs, image_id=image_id)
-    digest = await Get(Digest, CreateDigest([FileContent(metadata_filename, metadata)]))
+    digest = await create_digest(CreateDigest([FileContent(metadata_filename, metadata)]))
 
     return BuiltPackage(
         digest,

--- a/src/python/pants/backend/docker/goals/publish.py
+++ b/src/python/pants/backend/docker/goals/publish.py
@@ -20,9 +20,10 @@ from pants.core.goals.publish import (
     PublishProcesses,
     PublishRequest,
 )
-from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
+from pants.engine.env_vars import EnvironmentVarsRequest
+from pants.engine.internals.platform_rules import environment_vars_subset
 from pants.engine.process import InteractiveProcess, Process
-from pants.engine.rules import Get, collect_rules, rule
+from pants.engine.rules import collect_rules, implicitly, rule
 
 logger = logging.getLogger(__name__)
 
@@ -74,7 +75,9 @@ async def push_docker_images(
             ]
         )
 
-    env = await Get(EnvironmentVars, EnvironmentVarsRequest(options_env_aware.env_vars))
+    env = await environment_vars_subset(
+        EnvironmentVarsRequest(options_env_aware.env_vars), **implicitly()
+    )
     skip_push_reasons: DefaultDict[str, DefaultDict[str, set[str]]] = defaultdict(
         lambda: defaultdict(set)
     )

--- a/src/python/pants/backend/docker/goals/run_image.py
+++ b/src/python/pants/backend/docker/goals/run_image.py
@@ -16,9 +16,11 @@ from pants.backend.docker.target_types import (
 from pants.backend.docker.util_rules.docker_binary import DockerBinary
 from pants.core.goals.package import BuiltPackage, PackageFieldSet
 from pants.core.goals.run import RunFieldSet, RunInSandboxBehavior, RunRequest
-from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import WrappedTarget, WrappedTargetRequest
+from pants.engine.env_vars import EnvironmentVarsRequest
+from pants.engine.internals.graph import resolve_target
+from pants.engine.internals.platform_rules import environment_vars_subset
+from pants.engine.rules import Get, collect_rules, concurrently, implicitly, rule
+from pants.engine.target import WrappedTargetRequest
 
 
 @dataclass(frozen=True)
@@ -39,9 +41,9 @@ async def docker_image_run_request(
     options: DockerOptions,
     options_env_aware: DockerOptions.EnvironmentAware,
 ) -> RunRequest:
-    wrapped_target = await Get(
-        WrappedTarget,
+    wrapped_target = await resolve_target(
         WrappedTargetRequest(field_set.address, description_of_origin="<infallible>"),
+        **implicitly(),
     )
     build_request = DockerPackageFieldSet.create(wrapped_target.target)
     registries = options.registries()
@@ -54,8 +56,8 @@ async def docker_image_run_request(
                 registries=DockerImageRegistriesField((registry.alias,), field_set.address),
             )
             break
-    env, image = await MultiGet(
-        Get(EnvironmentVars, EnvironmentVarsRequest(options_env_aware.env_vars)),
+    env, image = await concurrently(
+        environment_vars_subset(EnvironmentVarsRequest(options_env_aware.env_vars), **implicitly()),
         Get(BuiltPackage, PackageFieldSet, build_request),
     )
 

--- a/src/python/pants/backend/docker/goals/tailor.py
+++ b/src/python/pants/backend/docker/goals/tailor.py
@@ -14,8 +14,7 @@ from pants.core.goals.tailor import (
     PutativeTargets,
     PutativeTargetsRequest,
 )
-from pants.engine.fs import PathGlobs, Paths
-from pants.engine.internals.selectors import Get
+from pants.engine.intrinsics import path_globs_to_paths
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
@@ -33,7 +32,7 @@ async def find_putative_targets(
     if not docker.tailor:
         return PutativeTargets()
 
-    all_dockerfiles = await Get(Paths, PathGlobs, req.path_globs("*Dockerfile*"))
+    all_dockerfiles = await path_globs_to_paths(req.path_globs("*Dockerfile*"))
     unowned_dockerfiles = set(all_dockerfiles.files) - set(all_owned_sources)
     pts = []
     for dockerfile in sorted(unowned_dockerfiles):

--- a/src/python/pants/backend/docker/subsystems/dockerfile_parser.py
+++ b/src/python/pants/backend/docker/subsystems/dockerfile_parser.py
@@ -12,21 +12,21 @@ from pants.backend.docker.util_rules.docker_build_args import DockerBuildArgs
 from pants.backend.python.subsystems.python_tool_base import PythonToolRequirementsBase
 from pants.backend.python.target_types import EntryPoint
 from pants.backend.python.util_rules import pex
-from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
+from pants.backend.python.util_rules.pex import (
+    VenvPex,
+    VenvPexProcess,
+    create_venv_pex,
+    setup_venv_pex_process,
+)
 from pants.base.deprecated import warn_or_error
 from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent
+from pants.engine.internals.graph import hydrate_sources, resolve_target
 from pants.engine.internals.native_engine import NativeDependenciesRequest
-from pants.engine.intrinsics import parse_dockerfile_info
+from pants.engine.intrinsics import create_digest, parse_dockerfile_info
 from pants.engine.process import Process, ProcessResult
-from pants.engine.rules import Get, collect_rules, rule
-from pants.engine.target import (
-    HydratedSources,
-    HydrateSourcesRequest,
-    SourcesField,
-    WrappedTarget,
-    WrappedTargetRequest,
-)
+from pants.engine.rules import Get, collect_rules, implicitly, rule
+from pants.engine.target import HydrateSourcesRequest, SourcesField, WrappedTargetRequest
 from pants.option.option_types import BoolOption
 from pants.util.docutil import bin_name, doc_url
 from pants.util.logging import LogLevel
@@ -87,14 +87,14 @@ async def setup_parser(dockerfile_parser: DockerfileParser) -> ParserSetup:
         content=parser_script_content,
         is_executable=True,
     )
-    parser_digest = await Get(Digest, CreateDigest([parser_content]))
+    parser_digest = await create_digest(CreateDigest([parser_content]))
 
-    parser_pex = await Get(
-        VenvPex,
-        PexRequest,
-        dockerfile_parser.to_pex_request(
-            main=EntryPoint(PurePath(parser_content.path).stem), sources=parser_digest
-        ),
+    parser_pex = await create_venv_pex(
+        **implicitly(
+            dockerfile_parser.to_pex_request(
+                main=EntryPoint(PurePath(parser_content.path).stem), sources=parser_digest
+            )
+        )
     )
     return ParserSetup(parser_pex)
 
@@ -109,8 +109,7 @@ class DockerfileParseRequest:
 async def setup_process_for_parse_dockerfile(
     request: DockerfileParseRequest, parser: ParserSetup
 ) -> Process:
-    process = await Get(
-        Process,
+    process = await setup_venv_pex_process(
         VenvPexProcess(
             parser.pex,
             argv=request.args,
@@ -118,6 +117,7 @@ async def setup_process_for_parse_dockerfile(
             input_digest=request.sources_digest,
             level=LogLevel.DEBUG,
         ),
+        **implicitly(),
     )
     return process
 
@@ -199,17 +199,17 @@ async def _legacy_parse_dockerfile(
 async def parse_dockerfile(
     request: DockerfileInfoRequest, dockerfile_parser: DockerfileParser
 ) -> DockerfileInfo:
-    wrapped_target = await Get(
-        WrappedTarget, WrappedTargetRequest(request.address, description_of_origin="<infallible>")
+    wrapped_target = await resolve_target(
+        WrappedTargetRequest(request.address, description_of_origin="<infallible>"), **implicitly()
     )
     target = wrapped_target.target
-    sources = await Get(
-        HydratedSources,
+    sources = await hydrate_sources(
         HydrateSourcesRequest(
             target.get(SourcesField),
             for_sources_types=(DockerImageSourceField,),
             enable_codegen=True,
         ),
+        **implicitly(),
     )
 
     dockerfiles = sources.snapshot.files

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -385,11 +385,6 @@ def run_test_rule(
                     input_types=(TestRequest.Batch, EnvironmentName),
                     mock=mock_debug_request,
                 ),
-                MockGet(
-                    output_type=TestDebugAdapterRequest,
-                    input_types=(TestFieldSet,),
-                    mock=mock_debug_adapter_request,
-                ),
                 # Merge XML results.
                 MockGet(
                     output_type=Digest,
@@ -413,6 +408,7 @@ def run_test_rule(
                 ),
             ],
             union_membership=union_membership,
+            warn_on_calls_satisfied_by_gets=False,  # So we don't contaminate the expected output.
         )
         assert not stdio_reader.get_stdout()
         return result.exit_code, stdio_reader.get_stderr()

--- a/src/python/pants/engine/internals/native_engine.pyi
+++ b/src/python/pants/engine/internals/native_engine.pyi
@@ -923,6 +923,7 @@ _Output = TypeVar("_Output")
 _Input = TypeVar("_Input")
 
 class PyGeneratorResponseCall:
+    rule_id: str
     output_type: type
     input_types: Sequence[type]
     inputs: Sequence[Any]

--- a/src/python/pants/engine/internals/selectors.py
+++ b/src/python/pants/engine/internals/selectors.py
@@ -53,12 +53,19 @@ class AwaitableConstraints:
     is_effect: bool
 
     def __repr__(self) -> str:
-        inputs = ", ".join(f"{t.__name__}" for t in self.input_types)
         if self.rule_id:
+            inputs = ", ".join(f"{t.__name__}" for t in self.input_types)
             return f"{self.rule_id}({inputs}) -> {self.output_type.__name__}"
         else:
             name = "Effect" if self.is_effect else "Get"
-            return f"{name}({self.output_type.__name__}, ({inputs}))"
+            if len(self.input_types) == 0:
+                inputs = ""
+            elif len(self.input_types) == 1:
+                inputs = f", {self.input_types[0].__name__}, .."
+            else:
+                input_items = ", ".join(f"{t.__name__}: .." for t in self.input_types)
+                inputs = f", {{{input_items}}}"
+            return f"{name}({self.output_type.__name__}{inputs})"
 
     def __str__(self) -> str:
         return repr(self)

--- a/src/python/pants/engine/internals/selectors.py
+++ b/src/python/pants/engine/internals/selectors.py
@@ -53,15 +53,12 @@ class AwaitableConstraints:
     is_effect: bool
 
     def __repr__(self) -> str:
-        name = "Effect" if self.is_effect else "Get"
-        if len(self.input_types) == 0:
-            inputs = ""
-        elif len(self.input_types) == 1:
-            inputs = f", {self.input_types[0].__name__}, .."
+        inputs = ", ".join(f"{t.__name__}" for t in self.input_types)
+        if self.rule_id:
+            return f"{self.rule_id}({inputs}) -> {self.output_type.__name__}"
         else:
-            input_items = ", ".join(f"{t.__name__}: .." for t in self.input_types)
-            inputs = f", {{{input_items}}}"
-        return f"{name}({self.output_type.__name__}{inputs})"
+            name = "Effect" if self.is_effect else "Get"
+            return f"{name}({self.output_type.__name__}, ({inputs}))"
 
     def __str__(self) -> str:
         return repr(self)

--- a/src/python/pants/engine/unions.py
+++ b/src/python/pants/engine/unions.py
@@ -148,7 +148,7 @@ class UnionMembership:
         members = self.union_rules.get(union_type)
         if members is None:
             raise TypeError(f"Not a registered union type: {union_type}")
-        return type(putative_member) in members
+        return putative_member in members
 
     def has_members(self, union_type: type) -> bool:
         """Check whether the union has an implementation or not."""

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -905,16 +905,15 @@ def run_rule_with_mocks(
                 for mock_get in mock_gets
                 if mock_get.output_type == res.output_type
                 and all(
-                    val in mock_get.input_types
+                    input_type in mock_get.input_types
                     or (
                         union_membership
+                        and input_type in union_membership
                         and any(
-                            input_type in union_membership
-                            and union_membership.is_member(input_type, val)
-                            for input_type in mock_get.input_types
+                            union_membership.is_member(input_type, t) for t in mock_get.input_types
                         )
                     )
-                    for val in res.input_types
+                    for input_type in res.input_types
                 )
             ),
             None,

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -736,7 +736,7 @@ def _compare_expected_mocks(
                     for input_type in mg.input_types
                 ):
                     missing_gets.remove(mg)
-                    surplus_gets.remove(sg)
+                    surplus_gets.discard(sg)
                     break
 
     errors = []
@@ -779,6 +779,7 @@ def run_rule_with_mocks(
     mock_gets: Sequence[MockGet | MockEffect] = (),
     mock_calls: Mapping[str, Callable] | None = None,
     union_membership: UnionMembership | None = None,
+    warn_on_calls_satisfied_by_gets: bool = True,
 ) -> _O:
     """A test helper that runs an @rule with a set of args and mocked underlying @rule invocations.
 
@@ -856,7 +857,7 @@ def run_rule_with_mocks(
         errors, warnings = _compare_expected_mocks(
             task_rule.awaitables, mock_calls, mock_gets, union_membership
         )
-        if warnings:
+        if warnings and warn_on_calls_satisfied_by_gets:
             logger.warning(warnings)
         if errors:
             raise ValueError(
@@ -904,7 +905,7 @@ def run_rule_with_mocks(
                 for mock_get in mock_gets
                 if mock_get.output_type == res.output_type
                 and all(
-                    type(val) in mock_get.input_types
+                    val in mock_get.input_types
                     or (
                         union_membership
                         and any(
@@ -913,7 +914,7 @@ def run_rule_with_mocks(
                             for input_type in mock_get.input_types
                         )
                     )
-                    for val in res.inputs
+                    for val in res.input_types
                 )
             ),
             None,

--- a/src/rust/engine/rule_graph/src/rules.rs
+++ b/src/rust/engine/rule_graph/src/rules.rs
@@ -38,6 +38,10 @@ impl RuleId {
     pub fn from_string(s: String) -> Self {
         Self(s)
     }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
 }
 
 impl Display for RuleId {

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -573,6 +573,14 @@ impl PyGeneratorResponseCall {
     }
 
     #[getter]
+    fn rule_id(&self, py: Python) -> PyResult<String> {
+        // TODO: Currently this is only called in test infrastructure (specifically, by
+        // rule_runner.py). But if this ends up being used in a performance sensitive
+        // code path, consider denormalizing the rule_id to avoid this copy.
+        Ok(self.borrow_inner(py)?.rule_id.as_str().to_owned())
+    }
+
+    #[getter]
     fn output_type<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyType>> {
         Ok(self.borrow_inner(py)?.output_type.as_py_type(py))
     }


### PR DESCRIPTION
More importantly, fix the rule_runner.py infrastructure to
support mocking call-by-name inside concurrently().

This required fixing a lot of preexisting brokenness in 
rule_runner.py that was unrelated to call-by-name.