### PR TITLE
[Call-by-name] migrate `pants.backend.url_handlers.s3` backend

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -41,7 +41,6 @@ backend_packages.add = [
   "pants_explorer.server",
   "internal_plugins.releases",
   "internal_plugins.test_lockfile_fixtures",
-  "pants.backend.url_handlers.s3",
 ]
 
 # The invalidation globs cover the PYTHONPATH by default, but we exclude some files that are on the

--- a/pants.toml
+++ b/pants.toml
@@ -41,6 +41,7 @@ backend_packages.add = [
   "pants_explorer.server",
   "internal_plugins.releases",
   "internal_plugins.test_lockfile_fixtures",
+  "pants.backend.url_handlers.s3",
 ]
 
 # The invalidation globs cover the PYTHONPATH by default, but we exclude some files that are on the

--- a/src/python/pants/backend/url_handlers/s3/register.py
+++ b/src/python/pants/backend/url_handlers/s3/register.py
@@ -211,7 +211,6 @@ async def download_file_from_s3_scheme(request: DownloadS3SchemeURL) -> Digest:
             query=split.query,
             expected_digest=request.expected_digest,
         ),
-        **implicitly(),
     )
 
 
@@ -233,7 +232,6 @@ async def download_file_from_virtual_hosted_s3_authority(
             query=split.query,
             expected_digest=request.expected_digest,
         ),
-        **implicitly(),
     )
 
 
@@ -253,7 +251,6 @@ async def download_file_from_path_s3_authority(request: DownloadS3AuthorityPathS
             query=split.query,
             expected_digest=request.expected_digest,
         ),
-        **implicitly(),
     )
 
 

--- a/src/python/pants/backend/url_handlers/s3/register.py
+++ b/src/python/pants/backend/url_handlers/s3/register.py
@@ -211,6 +211,7 @@ async def download_file_from_s3_scheme(request: DownloadS3SchemeURL) -> Digest:
             query=split.query,
             expected_digest=request.expected_digest,
         ),
+        **implicitly(),
     )
 
 
@@ -232,6 +233,7 @@ async def download_file_from_virtual_hosted_s3_authority(
             query=split.query,
             expected_digest=request.expected_digest,
         ),
+        **implicitly(),
     )
 
 
@@ -251,6 +253,7 @@ async def download_file_from_path_s3_authority(request: DownloadS3AuthorityPathS
             query=split.query,
             expected_digest=request.expected_digest,
         ),
+        **implicitly(),
     )
 
 

--- a/src/python/pants/backend/url_handlers/s3/register.py
+++ b/src/python/pants/backend/url_handlers/s3/register.py
@@ -56,20 +56,20 @@ async def access_aws_credentials(
         raise
 
     env_vars = await environment_vars_subset(
+        EnvironmentVarsRequest(
+            [
+                "AWS_PROFILE",
+                "AWS_REGION",
+                "AWS_ACCESS_KEY_ID",
+                "AWS_SECRET_ACCESS_KEY",
+                "AWS_SESSION_TOKEN",
+            ]
+        ),
         **implicitly(
             {
-                EnvironmentVarsRequest(
-                    [
-                        "AWS_PROFILE",
-                        "AWS_REGION",
-                        "AWS_ACCESS_KEY_ID",
-                        "AWS_SECRET_ACCESS_KEY",
-                        "AWS_SESSION_TOKEN",
-                    ]
-                ): EnvironmentVarsRequest,
                 local_environment_name.val: EnvironmentName,
             }
-        )
+        ),
     )
 
     session = boto_session.Session()


### PR DESCRIPTION
Migrate to call-by-name syntax in the `pants.backend.url_handlers.s3` backend.