### PR TITLE
migrate to call-by-name for `pants.backend.experimental.codegen.protobuf.java` backend

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -41,7 +41,6 @@ backend_packages.add = [
   "pants_explorer.server",
   "internal_plugins.releases",
   "internal_plugins.test_lockfile_fixtures",
-  "pants.backend.url_handlers.s3",
 ]
 
 # The invalidation globs cover the PYTHONPATH by default, but we exclude some files that are on the

--- a/pants.toml
+++ b/pants.toml
@@ -41,6 +41,7 @@ backend_packages.add = [
   "pants_explorer.server",
   "internal_plugins.releases",
   "internal_plugins.test_lockfile_fixtures",
+  "pants.backend.url_handlers.s3",
 ]
 
 # The invalidation globs cover the PYTHONPATH by default, but we exclude some files that are on the

--- a/pants.toml
+++ b/pants.toml
@@ -41,6 +41,9 @@ backend_packages.add = [
   "pants_explorer.server",
   "internal_plugins.releases",
   "internal_plugins.test_lockfile_fixtures",
+  "pants.backend.experimental.codegen.protobuf.go",
+  "pants.backend.experimental.codegen.protobuf.java",
+  "pants.backend.experimental.codegen.protobuf.scala",
 ]
 
 # The invalidation globs cover the PYTHONPATH by default, but we exclude some files that are on the

--- a/src/python/pants/backend/codegen/protobuf/java/dependency_inference.py
+++ b/src/python/pants/backend/codegen/protobuf/java/dependency_inference.py
@@ -9,8 +9,7 @@ from pants.backend.codegen.protobuf.target_types import (
     ProtobufGrpcToggleField,
 )
 from pants.build_graph.address import Address
-from pants.engine.internals.selectors import Get
-from pants.engine.rules import collect_rules, rule
+from pants.engine.rules import collect_rules, implicitly, rule
 from pants.engine.target import FieldSet, InferDependenciesRequest, InferredDependencies
 from pants.engine.unions import UnionRule
 from pants.jvm.dependency_inference.artifact_mapper import (
@@ -130,14 +129,14 @@ async def infer_protobuf_java_runtime_dependency(
 ) -> InferredDependencies:
     resolve = request.field_set.resolve.normalized_value(jvm)
 
-    protobuf_java_runtime_target_info = await Get(
-        ProtobufJavaRuntimeForResolve, ProtobufJavaRuntimeForResolveRequest(resolve)
+    protobuf_java_runtime_target_info = await resolve_protobuf_java_runtime_for_resolve(
+        **implicitly(ProtobufJavaRuntimeForResolveRequest(resolve))
     )
     addresses: set[Address] = set(protobuf_java_runtime_target_info.addresses)
 
     if request.field_set.grpc.value:
-        grpc_runtime_info = await Get(
-            ProtobufJavaGrpcRuntimeForResolve, ProtobufJavaGrpcRuntimeForResolveRequest(resolve)
+        grpc_runtime_info = await resolve_protobuf_java_grpc_runtime_for_resolve(
+            **implicitly(ProtobufJavaGrpcRuntimeForResolveRequest(resolve))
         )
         addresses.update(grpc_runtime_info.addresses)
 

--- a/src/python/pants/backend/codegen/protobuf/java/dependency_inference.py
+++ b/src/python/pants/backend/codegen/protobuf/java/dependency_inference.py
@@ -54,9 +54,9 @@ class ProtobufJavaRuntimeForResolve:
 
 @rule
 async def resolve_protobuf_java_runtime_for_resolve(
+    request: ProtobufJavaRuntimeForResolveRequest,
     jvm_artifact_targets: AllJvmArtifactTargets,
     jvm: JvmSubsystem,
-    request: ProtobufJavaRuntimeForResolveRequest,
 ) -> ProtobufJavaRuntimeForResolve:
     addresses = find_jvm_artifacts_or_raise(
         required_coordinates=[
@@ -86,9 +86,9 @@ class ProtobufJavaGrpcRuntimeForResolve:
 
 @rule
 async def resolve_protobuf_java_grpc_runtime_for_resolve(
+    request: ProtobufJavaGrpcRuntimeForResolveRequest,
     jvm_artifact_targets: AllJvmArtifactTargets,
     jvm: JvmSubsystem,
-    request: ProtobufJavaGrpcRuntimeForResolveRequest,
 ) -> ProtobufJavaGrpcRuntimeForResolve:
     addresses = find_jvm_artifacts_or_raise(
         required_coordinates=[
@@ -130,13 +130,13 @@ async def infer_protobuf_java_runtime_dependency(
     resolve = request.field_set.resolve.normalized_value(jvm)
 
     protobuf_java_runtime_target_info = await resolve_protobuf_java_runtime_for_resolve(
-        **implicitly(ProtobufJavaRuntimeForResolveRequest(resolve))
+        ProtobufJavaRuntimeForResolveRequest(resolve), **implicitly()
     )
     addresses: set[Address] = set(protobuf_java_runtime_target_info.addresses)
 
     if request.field_set.grpc.value:
         grpc_runtime_info = await resolve_protobuf_java_grpc_runtime_for_resolve(
-            **implicitly(ProtobufJavaGrpcRuntimeForResolveRequest(resolve))
+            ProtobufJavaGrpcRuntimeForResolveRequest(resolve), **implicitly()
         )
         addresses.update(grpc_runtime_info.addresses)
 

--- a/src/python/pants/backend/codegen/protobuf/jvm_symbol_mapper.py
+++ b/src/python/pants/backend/codegen/protobuf/jvm_symbol_mapper.py
@@ -12,7 +12,9 @@ from typing import DefaultDict
 from pants.backend.codegen.protobuf.target_types import AllProtobufTargets, ProtobufSourceField
 from pants.engine.addresses import Address
 from pants.engine.fs import Digest, DigestContents, FileContent
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.internals.graph import hydrate_sources
+from pants.engine.intrinsics import get_digest_contents
+from pants.engine.rules import Get, collect_rules, concurrently, implicitly, rule
 from pants.engine.target import HydratedSources, HydrateSourcesRequest
 from pants.jvm.dependency_inference.artifact_mapper import MutableTrieNode
 from pants.jvm.dependency_inference.symbol_mapper import SymbolMap
@@ -34,20 +36,20 @@ async def map_first_party_protobuf_jvm_targets_to_symbols(
     all_protobuf_targets: AllProtobufTargets,
     jvm: JvmSubsystem,
 ) -> SymbolMap:
-    sources = await MultiGet(
-        Get(
-            HydratedSources,
+    sources = await concurrently(
+        hydrate_sources(
             HydrateSourcesRequest(
                 tgt[ProtobufSourceField],
                 for_sources_types=(ProtobufSourceField,),
                 enable_codegen=True,
             ),
+            **implicitly(),
         )
         for tgt in all_protobuf_targets
     )
 
-    all_contents = await MultiGet(
-        Get(DigestContents, Digest, source.snapshot.digest) for source in sources
+    all_contents = await concurrently(
+        get_digest_contents(source.snapshot.digest) for source in sources
     )
 
     namespace_mapping: DefaultDict[tuple[_ResolveName, str], OrderedSet[Address]] = defaultdict(

--- a/src/python/pants/backend/url_handlers/s3/register.py
+++ b/src/python/pants/backend/url_handlers/s3/register.py
@@ -211,7 +211,6 @@ async def download_file_from_s3_scheme(request: DownloadS3SchemeURL) -> Digest:
             query=split.query,
             expected_digest=request.expected_digest,
         ),
-        **implicitly(),
     )
 
 
@@ -233,7 +232,6 @@ async def download_file_from_virtual_hosted_s3_authority(
             query=split.query,
             expected_digest=request.expected_digest,
         ),
-        **implicitly(),
     )
 
 
@@ -253,7 +251,6 @@ async def download_file_from_path_s3_authority(request: DownloadS3AuthorityPathS
             query=split.query,
             expected_digest=request.expected_digest,
         ),
-        **implicitly(),
     )
 
 

--- a/src/python/pants/backend/url_handlers/s3/register.py
+++ b/src/python/pants/backend/url_handlers/s3/register.py
@@ -56,20 +56,20 @@ async def access_aws_credentials(
         raise
 
     env_vars = await environment_vars_subset(
+        EnvironmentVarsRequest(
+            [
+                "AWS_PROFILE",
+                "AWS_REGION",
+                "AWS_ACCESS_KEY_ID",
+                "AWS_SECRET_ACCESS_KEY",
+                "AWS_SESSION_TOKEN",
+            ]
+        ),
         **implicitly(
             {
-                EnvironmentVarsRequest(
-                    [
-                        "AWS_PROFILE",
-                        "AWS_REGION",
-                        "AWS_ACCESS_KEY_ID",
-                        "AWS_SECRET_ACCESS_KEY",
-                        "AWS_SESSION_TOKEN",
-                    ]
-                ): EnvironmentVarsRequest,
                 local_environment_name.val: EnvironmentName,
             }
-        )
+        ),
     )
 
     session = boto_session.Session()


### PR DESCRIPTION
Migrate to call-by-name syntax for the `pants.backend.experimental.codegen.protobuf.java` backend. Also, `request` parameters for two rules have been reordered so that it did not need to be passed via `implicitly`.