### PR TITLE
[Call-by-name] migrate `pants.backend.experimental.codegen.avro.java` backend

### DIFF
--- a/src/python/pants/backend/codegen/avro/tailor.py
+++ b/src/python/pants/backend/codegen/avro/tailor.py
@@ -13,8 +13,7 @@ from pants.core.goals.tailor import (
     PutativeTargets,
     PutativeTargetsRequest,
 )
-from pants.engine.fs import PathGlobs, Paths
-from pants.engine.internals.selectors import Get
+from pants.engine.intrinsics import path_globs_to_paths
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.util.dirutil import group_by_dir
@@ -35,7 +34,7 @@ async def find_putative_targets(
     if not avro_subsystem.tailor:
         return PutativeTargets()
 
-    all_avro_files = await Get(Paths, PathGlobs, req.path_globs("*.avsc", "*.avpr", "*.avdl"))
+    all_avro_files = await path_globs_to_paths(req.path_globs("*.avsc", "*.avpr", "*.avdl"))
     unowned_avro_files = set(all_avro_files.files) - set(all_owned_sources)
     pts = [
         PutativeTarget.for_target_type(


### PR DESCRIPTION
Migrate to call-by-name syntax for the `pants.backend.experimental.codegen.avro.java` backend.