### PR TITLE
[Call-by-name] migrate `pants.backend.experimental.kotlin` backend

### DIFF
--- a/src/python/pants/backend/kotlin/compile/kotlinc_plugins.py
+++ b/src/python/pants/backend/kotlin/compile/kotlinc_plugins.py
@@ -136,7 +136,8 @@ async def resolve_kotlinc_plugins_for_target(
         plugin[KotlincPluginArtifactField].to_address_input() for plugin in candidate_plugins
     ]
     artifact_addresses = await concurrently(
-        resolve_address(**implicitly(address_input)) for address_input in address_inputs
+        resolve_address(**implicitly({address_input: AddressInput}))
+        for address_input in address_inputs
     )
     candidate_artifacts = await resolve_targets(**implicitly(Addresses(artifact_addresses)))
 

--- a/src/python/pants/backend/kotlin/compile/kotlinc_plugins.py
+++ b/src/python/pants/backend/kotlin/compile/kotlinc_plugins.py
@@ -13,14 +13,17 @@ from pants.backend.kotlin.target_types import (
     KotlincPluginArtifactField,
     KotlincPluginIdField,
 )
-from pants.build_graph.address import Address, AddressInput
 from pants.engine.addresses import Addresses
-from pants.engine.internals.native_engine import Digest, MergeDigests
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import AllTargets, CoarsenedTargets, Target, Targets
+from pants.engine.internals.build_files import maybe_resolve_address, resolve_address
+from pants.engine.internals.graph import coarsened_targets as coarsened_targets_get
+from pants.engine.internals.graph import resolve_targets
+from pants.engine.internals.native_engine import MergeDigests
+from pants.engine.intrinsics import merge_digests
+from pants.engine.rules import collect_rules, concurrently, implicitly, rule
+from pants.engine.target import AllTargets, Target, Targets
 from pants.jvm.compile import ClasspathEntry, FallibleClasspathEntry
 from pants.jvm.goals import lockfile
-from pants.jvm.resolve.coursier_fetch import CoursierFetchRequest
+from pants.jvm.resolve.coursier_fetch import CoursierFetchRequest, fetch_with_coursier
 from pants.jvm.resolve.jvm_tool import rules as jvm_tool_rules
 from pants.jvm.resolve.key import CoursierResolveKey
 from pants.jvm.subsystems import JvmSubsystem
@@ -129,10 +132,11 @@ async def resolve_kotlinc_plugins_for_target(
             continue
         candidate_plugins.append(plugin)
         artifact_field = plugin[KotlincPluginArtifactField]
-        artifact_address_gets.append(Get(Address, AddressInput, artifact_field.to_address_input()))
+        address_input = await maybe_resolve_address(artifact_field.to_address_input())
+        artifact_address_gets.append(resolve_address(address_input))
 
-    artifact_addresses = await MultiGet(artifact_address_gets)
-    candidate_artifacts = await Get(Targets, Addresses(artifact_addresses))
+    artifact_addresses = await concurrently(artifact_address_gets)
+    candidate_artifacts = await resolve_targets(**implicitly(Addresses(artifact_addresses)))
 
     plugins: dict[str, tuple[Target, Target]] = {}  # Maps plugin ID to relevant JVM artifact
     for plugin, artifact in zip(candidate_plugins, candidate_artifacts):
@@ -162,14 +166,11 @@ def _plugin_id(target: Target) -> str:
 @rule
 async def fetch_kotlinc_plugins(request: KotlincPluginsRequest) -> KotlincPlugins:
     # Fetch all the artifacts
-    coarsened_targets = await Get(
-        CoarsenedTargets, Addresses(target.address for target in request.artifacts)
+    coarsened_targets = await coarsened_targets_get(
+        **implicitly(Addresses(target.address for target in request.artifacts))
     )
-    fallible_artifacts = await MultiGet(
-        Get(
-            FallibleClasspathEntry,
-            CoursierFetchRequest(ct, resolve=request.resolve),
-        )
+    fallible_artifacts = await concurrently(
+        fetch_with_coursier(CoursierFetchRequest(ct, resolve=request.resolve))
         for ct in coarsened_targets
     )
 
@@ -179,7 +180,7 @@ async def fetch_kotlinc_plugins(request: KotlincPluginsRequest) -> KotlincPlugin
         raise Exception(f"Fetching local kotlinc plugins failed: {failed}")
 
     entries = list(ClasspathEntry.closure(artifacts))
-    merged_classpath_digest = await Get(Digest, MergeDigests(entry.digest for entry in entries))
+    merged_classpath_digest = await merge_digests(MergeDigests(entry.digest for entry in entries))
     merged = ClasspathEntry.merge(merged_classpath_digest, entries)
 
     ids = tuple(_plugin_id(target) for target in request.plugins)

--- a/src/python/pants/backend/kotlin/dependency_inference/symbol_mapper.py
+++ b/src/python/pants/backend/kotlin/dependency_inference/symbol_mapper.py
@@ -4,11 +4,13 @@
 from collections import defaultdict
 from collections.abc import Mapping
 
-from pants.backend.kotlin.dependency_inference.kotlin_parser import KotlinSourceDependencyAnalysis
+from pants.backend.kotlin.dependency_inference.kotlin_parser import (
+    resolve_fallible_result_to_analysis,
+)
 from pants.backend.kotlin.target_types import KotlinSourceField
 from pants.core.util_rules.source_files import SourceFilesRequest
-from pants.engine.internals.selectors import Get, MultiGet
-from pants.engine.rules import collect_rules, rule
+from pants.engine.internals.selectors import concurrently
+from pants.engine.rules import collect_rules, implicitly, rule
 from pants.engine.target import AllTargets, Targets
 from pants.engine.unions import UnionRule
 from pants.jvm.dependency_inference.artifact_mapper import MutableTrieNode
@@ -39,8 +41,10 @@ async def map_first_party_kotlin_targets_to_symbols(
     kotlin_targets: AllKotlinTargets,
     jvm: JvmSubsystem,
 ) -> SymbolMap:
-    source_analysis = await MultiGet(
-        Get(KotlinSourceDependencyAnalysis, SourceFilesRequest([target[KotlinSourceField]]))
+    source_analysis = await concurrently(
+        resolve_fallible_result_to_analysis(
+            **implicitly(SourceFilesRequest([target[KotlinSourceField]]))
+        )
         for target in kotlin_targets
     )
     address_and_analysis = zip(

--- a/src/python/pants/backend/kotlin/goals/check.py
+++ b/src/python/pants/backend/kotlin/goals/check.py
@@ -8,7 +8,8 @@ import logging
 from pants.backend.kotlin.target_types import KotlinFieldSet
 from pants.core.goals.check import CheckRequest, CheckResult, CheckResults
 from pants.engine.addresses import Addresses
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.internals.graph import coarsened_targets as coarsened_targets_get
+from pants.engine.rules import Get, collect_rules, concurrently, implicitly, rule
 from pants.engine.target import CoarsenedTargets
 from pants.engine.unions import UnionRule
 from pants.jvm.compile import (
@@ -16,7 +17,7 @@ from pants.jvm.compile import (
     ClasspathEntryRequestFactory,
     FallibleClasspathEntry,
 )
-from pants.jvm.resolve.key import CoursierResolveKey
+from pants.jvm.resolve.coursier_fetch import select_coursier_resolve_for_targets
 from pants.util.logging import LogLevel
 
 logger = logging.getLogger(__name__)
@@ -32,17 +33,18 @@ async def kotlinc_check(
     request: KotlincCheckRequest,
     classpath_entry_request: ClasspathEntryRequestFactory,
 ) -> CheckResults:
-    coarsened_targets = await Get(
-        CoarsenedTargets, Addresses(field_set.address for field_set in request.field_sets)
+    coarsened_targets = await coarsened_targets_get(
+        **implicitly(Addresses(field_set.address for field_set in request.field_sets))
     )
 
     # NB: Each root can have an independent resolve, because there is no inherent relation
     # between them other than that they were on the commandline together.
-    resolves = await MultiGet(
-        Get(CoursierResolveKey, CoarsenedTargets([t])) for t in coarsened_targets
+    resolves = await concurrently(
+        select_coursier_resolve_for_targets(CoarsenedTargets([t]), **implicitly())
+        for t in coarsened_targets
     )
 
-    results = await MultiGet(
+    results = await concurrently(
         Get(
             FallibleClasspathEntry,
             ClasspathEntryRequest,

--- a/src/python/pants/backend/kotlin/goals/tailor.py
+++ b/src/python/pants/backend/kotlin/goals/tailor.py
@@ -19,8 +19,7 @@ from pants.core.goals.tailor import (
     PutativeTargets,
     PutativeTargetsRequest,
 )
-from pants.engine.fs import PathGlobs, Paths
-from pants.engine.internals.selectors import Get
+from pants.engine.intrinsics import path_globs_to_paths
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import Target
 from pants.engine.unions import UnionRule
@@ -60,7 +59,7 @@ async def find_putative_targets(
 
     if kotlin_subsystem.tailor_source_targets:
         all_kotlin_files_globs = req.path_globs("*.kt")
-        all_kotlin_files = await Get(Paths, PathGlobs, all_kotlin_files_globs)
+        all_kotlin_files = await path_globs_to_paths(all_kotlin_files_globs)
         unowned_kotlin_files = set(all_kotlin_files.files) - set(all_owned_sources)
         classified_unowned_kotlin_files = classify_source_files(unowned_kotlin_files)
 

--- a/src/python/pants/backend/kotlin/test/junit.py
+++ b/src/python/pants/backend/kotlin/test/junit.py
@@ -7,8 +7,7 @@ from dataclasses import dataclass
 from pants.backend.kotlin.subsystems.kotlin import KotlinSubsystem
 from pants.backend.kotlin.target_types import KotlinJunitTestDependenciesField
 from pants.build_graph.address import Address
-from pants.engine.internals.selectors import Get
-from pants.engine.rules import collect_rules, rule
+from pants.engine.rules import collect_rules, implicitly, rule
 from pants.engine.target import FieldSet, InferDependenciesRequest, InferredDependencies
 from pants.engine.unions import UnionRule
 from pants.jvm.dependency_inference.artifact_mapper import (
@@ -75,8 +74,8 @@ async def infer_kotlin_junit_dependency(
 ) -> InferredDependencies:
     resolve = request.field_set.resolve.normalized_value(jvm)
 
-    kotlin_junit_libraries = await Get(
-        KotlinJunitLibrariesForResolve, KotlinJunitLibrariesForResolveRequest(resolve)
+    kotlin_junit_libraries = await resolve_kotlin_junit_libraries_for_resolve(
+        KotlinJunitLibrariesForResolveRequest(resolve), **implicitly()
     )
     return InferredDependencies(kotlin_junit_libraries.addresses)
 


### PR DESCRIPTION
Migrate to call-by-name syntax for the `pants.backend.experimental.kotlin` backend.