### PR TITLE
[Call-by-name] migrate `pants.backend.experimental.codegen.python_format_string.k8s` backend

### DIFF
--- a/src/python/pants/backend/codegen/python_format_string/k8s/rules.py
+++ b/src/python/pants/backend/codegen/python_format_string/k8s/rules.py
@@ -12,11 +12,7 @@ from pants.engine.fs import CreateDigest, FileContent
 from pants.engine.internals.graph import hydrate_sources
 from pants.engine.intrinsics import digest_to_snapshot, get_digest_contents
 from pants.engine.rules import collect_rules, implicitly, rule
-from pants.engine.target import (
-    GeneratedSources,
-    GenerateSourcesRequest,
-    HydrateSourcesRequest,
-)
+from pants.engine.target import GeneratedSources, GenerateSourcesRequest, HydrateSourcesRequest
 from pants.engine.unions import UnionRule
 
 

--- a/src/python/pants/backend/codegen/python_format_string/k8s/rules.py
+++ b/src/python/pants/backend/codegen/python_format_string/k8s/rules.py
@@ -8,12 +8,13 @@ from pants.backend.codegen.python_format_string.target_types import (
     PythonFormatStringValuesField,
 )
 from pants.backend.k8s.target_types import K8sSourceField
-from pants.engine.fs import CreateDigest, Digest, DigestContents, FileContent, Snapshot
-from pants.engine.rules import Get, collect_rules, rule
+from pants.engine.fs import CreateDigest, FileContent
+from pants.engine.internals.graph import hydrate_sources
+from pants.engine.intrinsics import digest_to_snapshot, get_digest_contents
+from pants.engine.rules import collect_rules, implicitly, rule
 from pants.engine.target import (
     GeneratedSources,
     GenerateSourcesRequest,
-    HydratedSources,
     HydrateSourcesRequest,
 )
 from pants.engine.unions import UnionRule
@@ -29,8 +30,8 @@ async def generate_k8s_source(
     request: GenerateK8sSourceFromPythonFormatStringRequest,
 ) -> GeneratedSources:
     format_string_target = request.protocol_target
-    hydrated_sources = await Get(
-        HydratedSources, HydrateSourcesRequest(format_string_target[PythonFormatStringSourceField])
+    hydrated_sources = await hydrate_sources(
+        HydrateSourcesRequest(format_string_target[PythonFormatStringSourceField]), **implicitly()
     )
 
     if len(hydrated_sources.snapshot.files) != 1:
@@ -40,7 +41,7 @@ async def generate_k8s_source(
     if values is None:
         raise ValueError(f"`{PythonFormatStringValuesField.alias}` is required")
 
-    contents = await Get(DigestContents, Digest, hydrated_sources.snapshot.digest)
+    contents = await get_digest_contents(hydrated_sources.snapshot.digest)
     content = contents[0].content.decode("utf-8")
     try:
         rendered = content.format(**values)
@@ -54,9 +55,8 @@ async def generate_k8s_source(
     path = format_string_target[PythonFormatStringOutputPathField].value_or_default(
         file_ending="rendered"
     )
-    snapshot = await Get(
-        Snapshot,
-        CreateDigest([FileContent(path=path, content=rendered.encode("utf-8"))]),
+    snapshot = await digest_to_snapshot(
+        **implicitly(CreateDigest([FileContent(path=path, content=rendered.encode("utf-8"))]))
     )
     return GeneratedSources(snapshot)
 


### PR DESCRIPTION
Migrate the `pants.backend.experimental.codegen.python_format_string.k8s` backend to call-by-name syntax.