### PR TITLE
[Call-by-name] migrate Terraform backends

### DIFF
--- a/src/python/pants/backend/terraform/goals/deploy.py
+++ b/src/python/pants/backend/terraform/goals/deploy.py
@@ -11,15 +11,20 @@ from pants.backend.terraform.dependency_inference import (
     get_terraform_backend_and_vars,
 )
 from pants.backend.terraform.target_types import TerraformDeploymentFieldSet
-from pants.backend.terraform.tool import TerraformCommand, TerraformProcess, TerraformTool
+from pants.backend.terraform.tool import (
+    TerraformCommand,
+    TerraformProcess,
+    TerraformTool,
+    setup_terraform_process,
+)
 from pants.backend.terraform.utils import terraform_arg, terraform_relpath
 from pants.core.goals.deploy import DeployFieldSet, DeployProcess, DeploySubsystem
-from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
+from pants.core.util_rules.source_files import SourceFilesRequest, determine_source_files
 from pants.engine.engine_aware import EngineAwareParameter
-from pants.engine.internals.native_engine import Digest, MergeDigests
-from pants.engine.internals.selectors import Get
-from pants.engine.process import InteractiveProcess, Process
-from pants.engine.rules import collect_rules, rule
+from pants.engine.internals.native_engine import MergeDigests
+from pants.engine.intrinsics import merge_digests
+from pants.engine.process import InteractiveProcess
+from pants.engine.rules import collect_rules, implicitly, rule
 from pants.engine.target import SourcesField
 from pants.engine.unions import UnionRule
 from pants.option.global_options import KeepSandboxes
@@ -61,28 +66,26 @@ async def prepare_terraform_deployment(
             request.field_set.dependencies.address, request.field_set.dependencies
         )
     )
-    var_files = await Get(
-        SourceFiles, SourceFilesRequest(e.get(SourcesField) for e in invocation_files.vars_files)
+    var_files = await determine_source_files(
+        SourceFilesRequest(e.get(SourcesField) for e in invocation_files.vars_files)
     )
     for var_file in var_files.files:
         args.append(terraform_arg("-var-file", terraform_relpath(deployment.chdir, var_file)))
 
-    with_vars = await Get(
-        Digest,
+    with_vars = await merge_digests(
         MergeDigests(
             [
                 var_files.snapshot.digest,
                 deployment.terraform_sources.snapshot.digest,
                 deployment.dependencies_files.snapshot.digest,
             ]
-        ),
+        )
     )
 
     if terraform_subsystem.args:
         args.extend(terraform_subsystem.args)
 
-    process = await Get(
-        Process,
+    process = await setup_terraform_process(
         TerraformProcess(
             cmds=(
                 deployment.init_cmd.to_args(),
@@ -92,14 +95,15 @@ async def prepare_terraform_deployment(
             description=f"Terraform {terraform_command}",
             chdir=deployment.chdir,
         ),
+        **implicitly(),
     )
     return InteractiveProcess.from_process(process, keep_sandboxes=keep_sandboxes)
 
 
 @rule(desc="Run Terraform deploy process", level=LogLevel.DEBUG)
 async def run_terraform_deploy(field_set: DeployTerraformFieldSet) -> DeployProcess:
-    interactive_process = await Get(
-        InteractiveProcess, TerraformDeploymentRequest(field_set=field_set)
+    interactive_process = await prepare_terraform_deployment(
+        TerraformDeploymentRequest(field_set=field_set), **implicitly()
     )
 
     return DeployProcess(

--- a/src/python/pants/backend/terraform/goals/tailor.py
+++ b/src/python/pants/backend/terraform/goals/tailor.py
@@ -18,8 +18,7 @@ from pants.core.goals.tailor import (
     PutativeTargets,
     PutativeTargetsRequest,
 )
-from pants.engine.fs import PathGlobs, Paths
-from pants.engine.internals.selectors import Get
+from pants.engine.intrinsics import path_globs_to_paths
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.util.dirutil import group_by_dir
@@ -41,7 +40,7 @@ async def find_putative_terraform_module_targets(
         return PutativeTargets()
     putative_targets: list[PutativeTarget] = []
 
-    all_terraform_files = await Get(Paths, PathGlobs, request.path_globs("*.tf"))
+    all_terraform_files = await path_globs_to_paths(request.path_globs("*.tf"))
     unowned_terraform_files = set(all_terraform_files.files) - set(all_owned_sources)
 
     putative_targets.extend(
@@ -54,7 +53,7 @@ async def find_putative_terraform_module_targets(
         for dirname, filenames in group_by_dir(unowned_terraform_files).items()
     )
 
-    all_backend_files = await Get(Paths, PathGlobs, request.path_globs("*.tfbackend"))
+    all_backend_files = await path_globs_to_paths(request.path_globs("*.tfbackend"))
     unowned_backend_files = set(all_backend_files.files) - set(all_owned_sources)
     for backend_file in unowned_backend_files:
         dirname, filename = os.path.split(backend_file)
@@ -70,7 +69,7 @@ async def find_putative_terraform_module_targets(
 
     # We generate separate targets for each var file,
     # to not make assumptions that they're all together.
-    all_var_files = await Get(Paths, PathGlobs, request.path_globs("*.tfvars"))
+    all_var_files = await path_globs_to_paths(request.path_globs("*.tfvars"))
     unowned_var_files = set(all_var_files.files) - set(all_owned_sources)
     for var_file in unowned_var_files:
         dirname, filename = os.path.split(var_file)

--- a/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
+++ b/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
@@ -13,10 +13,9 @@ from pants.backend.terraform.tool import rules as tool_rules
 from pants.core.goals.fmt import FmtResult, FmtTargetsRequest, Partitions
 from pants.core.util_rules import external_tool
 from pants.core.util_rules.partitions import Partition
-from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
-from pants.engine.internals.selectors import Get
-from pants.engine.process import ProcessResult
-from pants.engine.rules import collect_rules, rule
+from pants.core.util_rules.source_files import SourceFilesRequest, determine_source_files
+from pants.engine.process import fallible_to_exec_result_or_raise
+from pants.engine.rules import collect_rules, implicitly, rule
 from pants.option.option_types import SkipOption
 from pants.option.subsystem import Subsystem
 from pants.util.strutil import pluralize
@@ -53,8 +52,8 @@ async def partition_tffmt(
     if tffmt.skip:
         return Partitions()
 
-    source_files = await Get(
-        SourceFiles, SourceFilesRequest([field_set.sources for field_set in request.field_sets])
+    source_files = await determine_source_files(
+        SourceFilesRequest([field_set.sources for field_set in request.field_sets])
     )
 
     return Partitions(
@@ -66,21 +65,22 @@ async def partition_tffmt(
 @rule(desc="Format with `terraform fmt`")
 async def tffmt_fmt(request: TffmtRequest.Batch, tffmt: TfFmtSubsystem) -> FmtResult:
     directory = cast(PartitionMetadata, request.partition_metadata).directory
-    result = await Get(
-        ProcessResult,
-        TerraformProcess(
-            cmds=(
-                TerraformCommand(
-                    (
-                        "fmt",
-                        directory,
-                    )
+    result = await fallible_to_exec_result_or_raise(
+        **implicitly(
+            TerraformProcess(
+                cmds=(
+                    TerraformCommand(
+                        (
+                            "fmt",
+                            directory,
+                        )
+                    ),
                 ),
-            ),
-            input_digest=request.snapshot.digest,
-            output_files=request.files,
-            description=f"Run `terraform fmt` on {pluralize(len(request.files), 'file')}.",
-        ),
+                input_digest=request.snapshot.digest,
+                output_files=request.files,
+                description=f"Run `terraform fmt` on {pluralize(len(request.files), 'file')}.",
+            )
+        )
     )
 
     return await FmtResult.create(request, result)


### PR DESCRIPTION
Migrate the Terraform backends `pants.backend.experimental.terraform`, `pants.backend.experimental.terraform.lint.tfsec`, and `pants.backend.experimental.terraform.lint.trivy` to call-by-name syntax.