### PR TITLE
[Call-by-name] migrate Thrift codegen backends

### DIFF
--- a/src/python/pants/backend/codegen/thrift/scrooge/java/rules.py
+++ b/src/python/pants/backend/codegen/thrift/scrooge/java/rules.py
@@ -6,8 +6,8 @@ from dataclasses import dataclass
 
 from pants.backend.codegen.thrift.scrooge.java import symbol_mapper
 from pants.backend.codegen.thrift.scrooge.rules import (
-    GeneratedScroogeThriftSources,
     GenerateScroogeThriftSourcesRequest,
+    generate_scrooge_thrift_sources,
 )
 from pants.backend.codegen.thrift.target_types import (
     ThriftDependenciesField,
@@ -18,9 +18,9 @@ from pants.backend.codegen.thrift.target_types import (
 from pants.backend.java.target_types import JavaSourceField
 from pants.backend.scala.subsystems.scala import ScalaSubsystem
 from pants.build_graph.address import Address
-from pants.engine.fs import AddPrefix, Digest, Snapshot
-from pants.engine.internals.selectors import Get
-from pants.engine.rules import collect_rules, rule
+from pants.engine.fs import AddPrefix
+from pants.engine.intrinsics import digest_to_snapshot
+from pants.engine.rules import collect_rules, implicitly, rule
 from pants.engine.target import (
     FieldSet,
     GeneratedSources,
@@ -37,7 +37,7 @@ from pants.jvm.dependency_inference.artifact_mapper import (
 )
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmResolveField, PrefixedJvmJdkField, PrefixedJvmResolveField
-from pants.source.source_root import SourceRoot, SourceRootRequest
+from pants.source.source_root import SourceRootRequest, get_source_root
 from pants.util.logging import LogLevel
 
 
@@ -65,23 +65,21 @@ class InferScroogeThriftJavaDependencies(InferDependenciesRequest):
 async def generate_java_from_thrift_with_scrooge(
     request: GenerateJavaFromThriftRequest,
 ) -> GeneratedSources:
-    result = await Get(
-        GeneratedScroogeThriftSources,
+    result = await generate_scrooge_thrift_sources(
         GenerateScroogeThriftSourcesRequest(
             thrift_source_field=request.protocol_target[ThriftSourceField],
             lang_id="java",
             lang_name="Java",
         ),
+        **implicitly(),
     )
 
-    source_root = await Get(
-        SourceRoot, SourceRootRequest, SourceRootRequest.for_target(request.protocol_target)
-    )
+    source_root = await get_source_root(SourceRootRequest.for_target(request.protocol_target))
 
     source_root_restored = (
-        await Get(Snapshot, AddPrefix(result.snapshot.digest, source_root.path))
+        await digest_to_snapshot(**implicitly(AddPrefix(result.snapshot.digest, source_root.path)))
         if source_root.path != "."
-        else await Get(Snapshot, Digest, result.snapshot.digest)
+        else await digest_to_snapshot(result.snapshot.digest)
     )
     return GeneratedSources(source_root_restored)
 
@@ -130,8 +128,8 @@ async def inject_scrooge_thrift_java_dependencies(
     request: InferScroogeThriftJavaDependencies, jvm: JvmSubsystem
 ) -> InferredDependencies:
     resolve = request.field_set.resolve.normalized_value(jvm)
-    dependencies_info = await Get(
-        ScroogeThriftJavaRuntimeForResolve, ScroogeThriftJavaRuntimeForResolveRequest(resolve)
+    dependencies_info = await resolve_scrooge_thrift_java_runtime_for_resolve(
+        ScroogeThriftJavaRuntimeForResolveRequest(resolve), **implicitly()
     )
     return InferredDependencies(dependencies_info.addresses)
 


### PR DESCRIPTION
Migrate the Thrift codegen backends to call-by-name syntax.