### PR TITLE
[Call-by-name] migrate BSP backends

### DIFF
--- a/src/python/pants/backend/scala/bsp/rules.py
+++ b/src/python/pants/backend/scala/bsp/rules.py
@@ -23,7 +23,7 @@ from pants.backend.scala.compile.scalac_plugins import (
     ScalaPlugins,
     ScalaPluginsForTargetRequest,
     ScalaPluginsRequest,
-    ScalaPluginTargetsForTarget,
+    resolve_scala_plugins_for_target,
 )
 from pants.backend.scala.subsystems.scala import ScalaSubsystem
 from pants.backend.scala.subsystems.scalac import Scalac
@@ -48,15 +48,18 @@ from pants.bsp.util_rules.targets import (
     BSPDependencyModulesResult,
     BSPResourcesRequest,
     BSPResourcesResult,
+    resolve_bsp_build_target_addresses,
 )
 from pants.core.util_rules.system_binaries import BashBinary, ReadlinkBinary
 from pants.engine.addresses import Addresses
 from pants.engine.fs import AddPrefix, CreateDigest, Digest, FileContent, MergeDigests, Workspace
+from pants.engine.internals.graph import coarsened_targets as coarsened_targets_get
 from pants.engine.internals.native_engine import Snapshot
-from pants.engine.internals.selectors import Get, MultiGet
-from pants.engine.process import Process, ProcessResult
-from pants.engine.rules import _uncacheable_rule, collect_rules, rule
-from pants.engine.target import CoarsenedTarget, CoarsenedTargets, FieldSet, Targets
+from pants.engine.internals.selectors import Get, concurrently
+from pants.engine.intrinsics import add_prefix, create_digest, merge_digests
+from pants.engine.process import Process, execute_process_or_raise
+from pants.engine.rules import _uncacheable_rule, collect_rules, implicitly, rule
+from pants.engine.target import CoarsenedTarget, FieldSet
 from pants.engine.unions import UnionRule
 from pants.jvm.bsp.compile import _jvm_bsp_compile, jvm_classes_directory
 from pants.jvm.bsp.compile import rules as jvm_compile_rules
@@ -64,7 +67,7 @@ from pants.jvm.bsp.resources import _jvm_bsp_resources
 from pants.jvm.bsp.resources import rules as jvm_resources_rules
 from pants.jvm.bsp.spec import JvmBuildTarget, MavenDependencyModule, MavenDependencyModuleArtifact
 from pants.jvm.compile import ClasspathEntry, ClasspathEntryRequest, ClasspathEntryRequestFactory
-from pants.jvm.jdk_rules import DefaultJdk, JdkEnvironment, JdkRequest
+from pants.jvm.jdk_rules import DefaultJdk, JdkRequest, prepare_jdk_environment
 from pants.jvm.resolve.common import ArtifactRequirement, ArtifactRequirements
 from pants.jvm.resolve.coordinate import Coordinate
 from pants.jvm.resolve.coursier_fetch import (
@@ -72,6 +75,8 @@ from pants.jvm.resolve.coursier_fetch import (
     CoursierResolvedLockfile,
     ToolClasspath,
     ToolClasspathRequest,
+    get_coursier_lockfile_for_resolve,
+    select_coursier_resolve_for_targets,
 )
 from pants.jvm.resolve.key import CoursierResolveKey
 from pants.jvm.subsystems import JvmSubsystem
@@ -124,9 +129,9 @@ async def collect_thirdparty_modules(
     request: ThirdpartyModulesRequest,
     classpath_entry_request: ClasspathEntryRequestFactory,
 ) -> ThirdpartyModules:
-    coarsened_targets = await Get(CoarsenedTargets, Addresses, request.addresses)
-    resolve = await Get(CoursierResolveKey, CoarsenedTargets, coarsened_targets)
-    lockfile = await Get(CoursierResolvedLockfile, CoursierResolveKey, resolve)
+    coarsened_targets = await coarsened_targets_get(**implicitly(request.addresses))
+    resolve = await select_coursier_resolve_for_targets(coarsened_targets, **implicitly())
+    lockfile = await get_coursier_lockfile_for_resolve(resolve)
 
     applicable_lockfile_entries: dict[CoursierLockfileEntry, CoarsenedTarget] = {}
     for ct in coarsened_targets.coarsened_closure():
@@ -143,7 +148,7 @@ async def collect_thirdparty_modules(
                 continue
             applicable_lockfile_entries[entry] = ct
 
-    classpath_entries = await MultiGet(
+    classpath_entries = await concurrently(
         Get(
             ClasspathEntry,
             ClasspathEntryRequest,
@@ -152,7 +157,7 @@ async def collect_thirdparty_modules(
         for target in applicable_lockfile_entries.values()
     )
 
-    resolve_digest = await Get(Digest, MergeDigests(cpe.digest for cpe in classpath_entries))
+    resolve_digest = await merge_digests(MergeDigests(cpe.digest for cpe in classpath_entries))
 
     return ThirdpartyModules(
         resolve,
@@ -220,10 +225,10 @@ async def bsp_resolve_scala_metadata(
     # The maximum JDK version will be compatible with all the specified targets
     jdk_requests = [JdkRequest.from_field(version) for version in jdk_versions]
     jdk_request = max(jdk_requests, key=_jdk_request_sort_key(jvm))
-    jdk = await Get(JdkEnvironment, JdkRequest, jdk_request)
+    jdk = await prepare_jdk_environment(**implicitly({jdk_request: JdkRequest}))
 
     if any(i.version == DefaultJdk.SYSTEM for i in jdk_requests):
-        system_jdk = await Get(JdkEnvironment, JdkRequest, JdkRequest.SYSTEM)
+        system_jdk = await prepare_jdk_environment(**implicitly({JdkRequest.SYSTEM: JdkRequest}))
         if system_jdk.jre_major_version > jdk.jre_major_version:
             jdk = system_jdk
 
@@ -236,8 +241,7 @@ async def bsp_resolve_scala_metadata(
         {jdk.java_home_command}
         """
     )
-    leak_sandbox_path_digest = await Get(
-        Digest,
+    leak_sandbox_path_digest = await create_digest(
         CreateDigest(
             [
                 FileContent(
@@ -246,24 +250,25 @@ async def bsp_resolve_scala_metadata(
                     is_executable=True,
                 ),
             ]
-        ),
+        )
     )
 
-    leaked_paths = await Get(
-        ProcessResult,
-        Process(
-            [
-                bash.path,
-                cmd,
-            ],
-            input_digest=leak_sandbox_path_digest,
-            immutable_input_digests=jdk.immutable_input_digests,
-            env=jdk.env,
-            use_nailgun=(),
-            description="Report JDK cache paths for BSP",
-            append_only_caches=jdk.append_only_caches,
-            level=LogLevel.TRACE,
-        ),
+    leaked_paths = await execute_process_or_raise(
+        **implicitly(
+            Process(
+                [
+                    bash.path,
+                    cmd,
+                ],
+                input_digest=leak_sandbox_path_digest,
+                immutable_input_digests=jdk.immutable_input_digests,
+                env=jdk.env,
+                use_nailgun=(),
+                description="Report JDK cache paths for BSP",
+                append_only_caches=jdk.append_only_caches,
+                level=LogLevel.TRACE,
+            )
+        )
     )
 
     cache_dir, jdk_home = leaked_paths.stdout.decode().strip().split("\n")
@@ -345,14 +350,16 @@ class HandleScalacOptionsResult:
 async def handle_bsp_scalac_options_request(
     request: HandleScalacOptionsRequest, build_root: BuildRoot, workspace: Workspace, scalac: Scalac
 ) -> HandleScalacOptionsResult:
-    targets = await Get(Targets, BuildTargetIdentifier, request.bsp_target_id)
-    thirdparty_modules = await Get(
-        ThirdpartyModules, ThirdpartyModulesRequest(Addresses(tgt.address for tgt in targets))
+    targets = await resolve_bsp_build_target_addresses(**implicitly(request.bsp_target_id))
+    thirdparty_modules = await collect_thirdparty_modules(
+        ThirdpartyModulesRequest(Addresses(tgt.address for tgt in targets)), **implicitly()
     )
     resolve = thirdparty_modules.resolve
 
-    scalac_plugin_targets = await MultiGet(
-        Get(ScalaPluginTargetsForTarget, ScalaPluginsForTargetRequest(tgt, resolve.name))
+    scalac_plugin_targets = await concurrently(
+        resolve_scala_plugins_for_target(
+            ScalaPluginsForTargetRequest(tgt, resolve.name), **implicitly()
+        )
         for tgt in targets
     )
 
@@ -362,13 +369,13 @@ async def handle_bsp_scalac_options_request(
     )
 
     thirdparty_modules_prefix = f"jvm/resolves/{resolve.name}/lib"
-    thirdparty_modules_digest, local_plugins_digest = await MultiGet(
-        Get(Digest, AddPrefix(thirdparty_modules.merged_digest, thirdparty_modules_prefix)),
-        Get(Digest, AddPrefix(local_plugins.classpath.digest, local_plugins_prefix)),
+    thirdparty_modules_digest, local_plugins_digest = await concurrently(
+        add_prefix(AddPrefix(thirdparty_modules.merged_digest, thirdparty_modules_prefix)),
+        add_prefix(AddPrefix(local_plugins.classpath.digest, local_plugins_prefix)),
     )
 
-    resolve_digest = await Get(
-        Digest, MergeDigests([thirdparty_modules_digest, local_plugins_digest])
+    resolve_digest = await merge_digests(
+        MergeDigests([thirdparty_modules_digest, local_plugins_digest])
     )
     workspace.write_digest(resolve_digest, path_prefix=".pants.d/bsp")
 
@@ -394,8 +401,9 @@ async def handle_bsp_scalac_options_request(
 
 @rule
 async def bsp_scalac_options_request(request: ScalacOptionsParams) -> ScalacOptionsResult:
-    results = await MultiGet(
-        Get(HandleScalacOptionsResult, HandleScalacOptionsRequest(btgt)) for btgt in request.targets
+    results = await concurrently(
+        handle_bsp_scalac_options_request(HandleScalacOptionsRequest(btgt), **implicitly())
+        for btgt in request.targets
     )
     return ScalacOptionsResult(items=tuple(result.item for result in results))
 
@@ -466,14 +474,13 @@ async def scala_bsp_dependency_modules(
     request: ScalaBSPDependencyModulesRequest,
     build_root: BuildRoot,
 ) -> BSPDependencyModulesResult:
-    thirdparty_modules = await Get(
-        ThirdpartyModules,
-        ThirdpartyModulesRequest(Addresses(fs.address for fs in request.field_sets)),
+    thirdparty_modules = await collect_thirdparty_modules(
+        ThirdpartyModulesRequest(Addresses(fs.address for fs in request.field_sets)), **implicitly()
     )
     resolve = thirdparty_modules.resolve
 
-    resolve_digest = await Get(
-        Digest, AddPrefix(thirdparty_modules.merged_digest, f"jvm/resolves/{resolve.name}/lib")
+    resolve_digest = await add_prefix(
+        AddPrefix(thirdparty_modules.merged_digest, f"jvm/resolves/{resolve.name}/lib")
     )
 
     modules = [

--- a/src/python/pants/bsp/util_rules/compile.py
+++ b/src/python/pants/bsp/util_rules/compile.py
@@ -11,15 +11,22 @@ from typing import TypeVar
 
 from pants.bsp.context import BSPContext
 from pants.bsp.protocol import BSPHandlerMapping
-from pants.bsp.spec.base import BuildTargetIdentifier, StatusCode, TaskId
+from pants.bsp.spec.base import StatusCode, TaskId
 from pants.bsp.spec.compile import CompileParams, CompileReport, CompileResult, CompileTask
 from pants.bsp.spec.task import TaskFinishParams, TaskStartParams
-from pants.bsp.util_rules.targets import BSPBuildTargetInternal, BSPCompileRequest, BSPCompileResult
+from pants.bsp.util_rules.targets import (
+    BSPBuildTargetInternal,
+    BSPCompileRequest,
+    BSPCompileResult,
+    resolve_bsp_build_target_addresses,
+    resolve_bsp_build_target_identifier,
+)
 from pants.engine.fs import Workspace
-from pants.engine.internals.native_engine import EMPTY_DIGEST, Digest, MergeDigests
-from pants.engine.internals.selectors import Get, MultiGet
-from pants.engine.rules import _uncacheable_rule, collect_rules, rule
-from pants.engine.target import FieldSet, Targets
+from pants.engine.internals.native_engine import EMPTY_DIGEST, MergeDigests
+from pants.engine.internals.selectors import Get, concurrently
+from pants.engine.intrinsics import merge_digests
+from pants.engine.rules import _uncacheable_rule, collect_rules, implicitly, rule
+from pants.engine.target import FieldSet
 from pants.engine.unions import UnionMembership, UnionRule
 from pants.util.ordered_set import FrozenOrderedSet
 
@@ -52,7 +59,7 @@ async def compile_bsp_target(
     bsp_context: BSPContext,
     union_membership: UnionMembership,
 ) -> BSPCompileResult:
-    targets = await Get(Targets, BSPBuildTargetInternal, request.bsp_target)
+    targets = await resolve_bsp_build_target_addresses(request.bsp_target, **implicitly())
     compile_request_types: FrozenOrderedSet[type[BSPCompileRequest]] = union_membership.get(
         BSPCompileRequest
     )
@@ -78,7 +85,7 @@ async def compile_bsp_target(
         )
     )
 
-    compile_results = await MultiGet(
+    compile_results = await concurrently(
         Get(
             BSPCompileResult,
             BSPCompileRequest,
@@ -108,7 +115,7 @@ async def compile_bsp_target(
         )
     )
 
-    output_digest = await Get(Digest, MergeDigests([r.output_digest for r in compile_results]))
+    output_digest = await merge_digests(MergeDigests([r.output_digest for r in compile_results]))
 
     return BSPCompileResult(
         status=status,
@@ -121,24 +128,24 @@ async def bsp_compile_request(
     request: CompileParams,
     workspace: Workspace,
 ) -> CompileResult:
-    bsp_targets = await MultiGet(
-        Get(BSPBuildTargetInternal, BuildTargetIdentifier, bsp_target_id)
+    bsp_targets = await concurrently(
+        resolve_bsp_build_target_identifier(bsp_target_id, **implicitly())
         for bsp_target_id in request.targets
     )
 
-    compile_results = await MultiGet(
-        Get(
-            BSPCompileResult,
+    compile_results = await concurrently(
+        compile_bsp_target(
             CompileOneBSPTargetRequest(
                 bsp_target=bsp_target,
                 origin_id=request.origin_id,
                 arguments=request.arguments,
             ),
+            **implicitly(),
         )
         for bsp_target in bsp_targets
     )
 
-    output_digest = await Get(Digest, MergeDigests([r.output_digest for r in compile_results]))
+    output_digest = await merge_digests(MergeDigests([r.output_digest for r in compile_results]))
     if output_digest != EMPTY_DIGEST:
         workspace.write_digest(output_digest, path_prefix=".pants.d/bsp")
 

--- a/src/python/pants/bsp/util_rules/targets.py
+++ b/src/python/pants/bsp/util_rules/targets.py
@@ -44,21 +44,22 @@ from pants.bsp.spec.targets import (
     WorkspaceBuildTargetsResult,
 )
 from pants.engine.environment import EnvironmentName
-from pants.engine.fs import DigestContents, PathGlobs, Workspace
+from pants.engine.fs import PathGlobs, Workspace
+from pants.engine.internals.graph import resolve_source_paths, resolve_targets
 from pants.engine.internals.native_engine import EMPTY_DIGEST, Digest, MergeDigests
-from pants.engine.internals.selectors import Get, MultiGet
-from pants.engine.rules import _uncacheable_rule, collect_rules, rule
+from pants.engine.internals.selectors import Get, concurrently
+from pants.engine.intrinsics import get_digest_contents, merge_digests
+from pants.engine.rules import _uncacheable_rule, collect_rules, implicitly, rule
 from pants.engine.target import (
     Field,
     FieldDefaults,
     FieldSet,
     SourcesField,
-    SourcesPaths,
     SourcesPathsRequest,
     Targets,
 )
 from pants.engine.unions import UnionMembership, UnionRule, union
-from pants.source.source_root import SourceRootsRequest, SourceRootsResult
+from pants.source.source_root import SourceRootsRequest, get_source_roots
 from pants.util.frozendict import FrozenDict
 from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
 from pants.util.strutil import bullet_list
@@ -148,13 +149,14 @@ async def parse_one_bsp_mapping(request: _ParseOneBSPMappingRequest) -> BSPBuild
 async def materialize_bsp_build_targets(bsp_goal: BSPGoal) -> BSPBuildTargets:
     definitions: dict[str, BSPTargetDefinition] = {}
     for config_file in bsp_goal.groups_config_files:
-        config_contents = await Get(  # noqa: PNT30: requires triage
-            DigestContents,
-            PathGlobs(
-                [config_file],
-                glob_match_error_behavior=GlobMatchErrorBehavior.error,
-                description_of_origin=f"BSP config file `{config_file}`",
-            ),
+        config_contents = await get_digest_contents(
+            **implicitly(
+                PathGlobs(
+                    [config_file],
+                    glob_match_error_behavior=GlobMatchErrorBehavior.error,
+                    description_of_origin=f"BSP config file `{config_file}`",
+                )
+            )
         )
         if len(config_contents) == 0:
             raise ValueError(f"BSP targets config file `{config_file}` does not exist.")
@@ -202,8 +204,8 @@ async def materialize_bsp_build_targets(bsp_goal: BSPGoal) -> BSPBuildTargets:
                 resolve_filter=resolve_filter,
             )
 
-    bsp_internal_targets = await MultiGet(
-        Get(BSPBuildTargetInternal, _ParseOneBSPMappingRequest(name, definition))
+    bsp_internal_targets = await concurrently(
+        parse_one_bsp_mapping(_ParseOneBSPMappingRequest(name, definition))
         for name, definition in definitions.items()
     )
     target_mapping = dict(zip(definitions.keys(), bsp_internal_targets))
@@ -232,10 +234,8 @@ async def resolve_bsp_build_target_addresses(
     field_defaults: FieldDefaults,
 ) -> Targets:
     # NB: Using `RawSpecs` directly rather than `RawSpecsWithoutFileOwners` results in a rule graph cycle.
-    targets = await Get(
-        Targets,
-        RawSpecsWithoutFileOwners,
-        RawSpecsWithoutFileOwners.from_raw_specs(bsp_target.specs),
+    targets = await resolve_targets(
+        **implicitly(RawSpecsWithoutFileOwners.from_raw_specs(bsp_target.specs))
     )
     if bsp_target.definition.resolve_filter is None:
         return targets
@@ -268,17 +268,16 @@ async def resolve_bsp_build_target_addresses(
 async def resolve_bsp_build_target_source_roots(
     bsp_target: BSPBuildTargetInternal,
 ) -> BSPBuildTargetSourcesInfo:
-    targets = await Get(Targets, BSPBuildTargetInternal, bsp_target)
+    targets = await resolve_bsp_build_target_addresses(bsp_target, **implicitly())
     targets_with_sources = [tgt for tgt in targets if tgt.has_field(SourcesField)]
-    sources_paths = await MultiGet(
-        Get(SourcesPaths, SourcesPathsRequest(tgt[SourcesField])) for tgt in targets_with_sources
+    sources_paths = await concurrently(
+        resolve_source_paths(SourcesPathsRequest(tgt[SourcesField]), **implicitly())
+        for tgt in targets_with_sources
     )
     merged_source_files: set[str] = set()
     for sp in sources_paths:
         merged_source_files.update(sp.files)
-    source_roots_result = await Get(
-        SourceRootsResult, SourceRootsRequest, SourceRootsRequest.for_files(merged_source_files)
-    )
+    source_roots_result = await get_source_roots(SourceRootsRequest.for_files(merged_source_files))
     source_root_paths = {x.path for x in source_roots_result.path_to_root.values()}
     return BSPBuildTargetSourcesInfo(
         source_files=frozenset(merged_source_files),
@@ -346,7 +345,7 @@ async def generate_one_bsp_build_target_request(
     build_root: BuildRoot,
 ) -> GenerateOneBSPBuildTargetResult:
     # Find all Pants targets that are part of this BSP build target.
-    targets = await Get(Targets, BSPBuildTargetInternal, request.bsp_target)
+    targets = await resolve_bsp_build_target_addresses(request.bsp_target, **implicitly())
 
     # Determine whether the targets are compilable.
     can_compile = any(
@@ -381,7 +380,7 @@ async def generate_one_bsp_build_target_request(
                 field_sets_by_request_type[metadata_request_type].add(field_set_type.create(tgt))
 
     # Request each language backend to provide metadata for the BuildTarget, and then merge it.
-    metadata_results = await MultiGet(
+    metadata_results = await concurrently(
         Get(
             BSPBuildTargetsMetadataResult,
             BSPBuildTargetsMetadataRequest,
@@ -391,13 +390,13 @@ async def generate_one_bsp_build_target_request(
     )
     metadata = merge_metadata(list(zip(field_sets_by_request_type.keys(), metadata_results)))
 
-    digest = await Get(Digest, MergeDigests([r.digest for r in metadata_results]))
+    digest = await merge_digests(MergeDigests([r.digest for r in metadata_results]))
 
     # Determine "base directory" for this build target using source roots.
     # TODO: This actually has nothing to do with source roots. It should probably be computed as an ancestor
     # directory or else be configurable by the user. It is used as a hint in IntelliJ for where to place the
     # corresponding IntelliJ module.
-    source_info = await Get(BSPBuildTargetSourcesInfo, BSPBuildTargetInternal, request.bsp_target)
+    source_info = await resolve_bsp_build_target_source_roots(request.bsp_target)
     if source_info.source_roots:
         roots = [build_root.pathlib_path.joinpath(p) for p in source_info.source_roots]
     else:
@@ -438,11 +437,13 @@ async def bsp_workspace_build_targets(
     bsp_build_targets: BSPBuildTargets,
     workspace: Workspace,
 ) -> WorkspaceBuildTargetsResult:
-    bsp_target_results = await MultiGet(
-        Get(GenerateOneBSPBuildTargetResult, GenerateOneBSPBuildTargetRequest(target_internal))
+    bsp_target_results = await concurrently(
+        generate_one_bsp_build_target_request(
+            GenerateOneBSPBuildTargetRequest(target_internal), **implicitly()
+        )
         for target_internal in bsp_build_targets.targets_mapping.values()
     )
-    digest = await Get(Digest, MergeDigests([r.digest for r in bsp_target_results]))
+    digest = await merge_digests(MergeDigests([r.digest for r in bsp_target_results]))
     if digest != EMPTY_DIGEST:
         workspace.write_digest(digest, path_prefix=".pants.d/bsp")
 
@@ -478,8 +479,8 @@ async def materialize_bsp_build_target_sources(
     request: MaterializeBuildTargetSourcesRequest,
     build_root: BuildRoot,
 ) -> MaterializeBuildTargetSourcesResult:
-    bsp_target = await Get(BSPBuildTargetInternal, BuildTargetIdentifier, request.bsp_target_id)
-    source_info = await Get(BSPBuildTargetSourcesInfo, BSPBuildTargetInternal, bsp_target)
+    bsp_target = await resolve_bsp_build_target_identifier(request.bsp_target_id, **implicitly())
+    source_info = await resolve_bsp_build_target_source_roots(bsp_target)
 
     if source_info.source_roots:
         roots = [build_root.pathlib_path.joinpath(p) for p in source_info.source_roots]
@@ -504,8 +505,10 @@ async def materialize_bsp_build_target_sources(
 
 @rule
 async def bsp_build_target_sources(request: SourcesParams) -> SourcesResult:
-    sources_items = await MultiGet(
-        Get(MaterializeBuildTargetSourcesResult, MaterializeBuildTargetSourcesRequest(btgt))
+    sources_items = await concurrently(
+        materialize_bsp_build_target_sources(
+            MaterializeBuildTargetSourcesRequest(btgt), **implicitly()
+        )
         for btgt in request.targets
     )
     return SourcesResult(items=tuple(si.sources_item for si in sources_items))
@@ -576,7 +579,7 @@ async def resolve_one_dependency_module(
     request: ResolveOneDependencyModuleRequest,
     union_membership: UnionMembership,
 ) -> ResolveOneDependencyModuleResult:
-    targets = await Get(Targets, BuildTargetIdentifier, request.bsp_target_id)
+    targets = await resolve_bsp_build_target_addresses(**implicitly(request.bsp_target_id))
 
     field_sets_by_request_type: dict[type[BSPDependencyModulesRequest], list[FieldSet]] = (
         defaultdict(list)
@@ -594,7 +597,7 @@ async def resolve_one_dependency_module(
     if not field_sets_by_request_type:
         return ResolveOneDependencyModuleResult(bsp_target_id=request.bsp_target_id)
 
-    responses = await MultiGet(
+    responses = await concurrently(
         Get(
             BSPDependencyModulesResult,
             BSPDependencyModulesRequest,
@@ -604,7 +607,7 @@ async def resolve_one_dependency_module(
     )
 
     modules = set(itertools.chain.from_iterable([r.modules for r in responses]))
-    digest = await Get(Digest, MergeDigests([r.digest for r in responses]))
+    digest = await merge_digests(MergeDigests([r.digest for r in responses]))
 
     return ResolveOneDependencyModuleResult(
         bsp_target_id=request.bsp_target_id,
@@ -618,11 +621,11 @@ async def resolve_one_dependency_module(
 async def bsp_dependency_modules(
     request: DependencyModulesParams, workspace: Workspace
 ) -> DependencyModulesResult:
-    responses = await MultiGet(
-        Get(ResolveOneDependencyModuleResult, ResolveOneDependencyModuleRequest(btgt))
+    responses = await concurrently(
+        resolve_one_dependency_module(ResolveOneDependencyModuleRequest(btgt), **implicitly())
         for btgt in request.targets
     )
-    output_digest = await Get(Digest, MergeDigests([r.digest for r in responses]))
+    output_digest = await merge_digests(MergeDigests([r.digest for r in responses]))
     workspace.write_digest(output_digest, path_prefix=".pants.d/bsp")
     return DependencyModulesResult(
         tuple(DependencyModulesItem(target=r.bsp_target_id, modules=r.modules) for r in responses)


### PR DESCRIPTION
Migrate the BSP backends to call-by-name syntax:

- `pants.backend.experimental.bsp`
- `pants.backend.experimental.java.bsp`
- `pants.backend.experimental.scala.bsp`