### PR TITLE
[Call-by-name] Migrate python_build_standalone provider backend

### DIFF
--- a/src/python/pants/backend/python/providers/python_build_standalone/rules.py
+++ b/src/python/pants/backend/python/providers/python_build_standalone/rules.py
@@ -561,75 +561,76 @@ async def get_python(
     copy_target = temp_dir / python_version
 
     await fallible_to_exec_result_or_raise(
-        Process(
-            [
-                sh.path,
-                "-euc",
-                # Atomically-copy the downloaded files into the named cache, in 5 steps:
-                #
-                # 1. Check if the target directory already exists, skipping all the work if it does
-                #    (the atomic creation means this will be fully created by an earlier execution,
-                #    no torn state).
-                #
-                # 2. Copy the files into a temporary directory within the persistent named cache. Copying
-                #    into a temporary directory ensures that we don't end up with partial state if this
-                #    process is interrupted. Placing the temporary directory within the persistent named
-                #    cache ensures it is on the same filesystem as the final destination, allowing for
-                #    atomic mv.
-                #
-                # 3. Actually move the temporary directory to the final destination, failing if it
-                #    already exists (which would indicate a concurrent execution), but squashing that
-                #    error. Note that this is specifically moving to the parent directory of the target,
-                #    i.e. something like:
-                #
-                #        mv .python_build_standalone/tmp/pbs-copier-.../3.10.11 .python_build_standalone
-                #
-                #    which detects `.python_build_standalone` is a directory and thus attempts to create
-                #    `.python_build_standalone/3.10.11`. This fails if that target already exists. The
-                #    alternative of explicitly passing the final target like
-                #    `mv ... .python_build_standalone/3.10.11` will (incorrectly) create nested
-                #    directory `.python_build_standalone/3.10.11/3.10.11` if the target already exists.
-                #
-                # 4. Check it worked. In particular, mv might fail for a different reason than the final
-                #    destination already existing: in those cases, we won't have put things in the right
-                #    place, and downstream code won't have the Python it needs. So, we check that the
-                #    final destination exists and fail if it doesn't, surfacing any errors to the user.
-                #
-                # 5. Clean-up the temporary files
-                f"""
-                # Step 1: check and skip
-                if {test.path} -d {persisted_destination}; then
-                    echo "{persisted_destination} already exists, fully created by earlier execution" >&2
-                    exit 0
-                fi
+        **implicitly(
+            Process(
+                [
+                    sh.path,
+                    "-euc",
+                    # Atomically-copy the downloaded files into the named cache, in 5 steps:
+                    #
+                    # 1. Check if the target directory already exists, skipping all the work if it does
+                    #    (the atomic creation means this will be fully created by an earlier execution,
+                    #    no torn state).
+                    #
+                    # 2. Copy the files into a temporary directory within the persistent named cache. Copying
+                    #    into a temporary directory ensures that we don't end up with partial state if this
+                    #    process is interrupted. Placing the temporary directory within the persistent named
+                    #    cache ensures it is on the same filesystem as the final destination, allowing for
+                    #    atomic mv.
+                    #
+                    # 3. Actually move the temporary directory to the final destination, failing if it
+                    #    already exists (which would indicate a concurrent execution), but squashing that
+                    #    error. Note that this is specifically moving to the parent directory of the target,
+                    #    i.e. something like:
+                    #
+                    #        mv .python_build_standalone/tmp/pbs-copier-.../3.10.11 .python_build_standalone
+                    #
+                    #    which detects `.python_build_standalone` is a directory and thus attempts to create
+                    #    `.python_build_standalone/3.10.11`. This fails if that target already exists. The
+                    #    alternative of explicitly passing the final target like
+                    #    `mv ... .python_build_standalone/3.10.11` will (incorrectly) create nested
+                    #    directory `.python_build_standalone/3.10.11/3.10.11` if the target already exists.
+                    #
+                    # 4. Check it worked. In particular, mv might fail for a different reason than the final
+                    #    destination already existing: in those cases, we won't have put things in the right
+                    #    place, and downstream code won't have the Python it needs. So, we check that the
+                    #    final destination exists and fail if it doesn't, surfacing any errors to the user.
+                    #
+                    # 5. Clean-up the temporary files
+                    f"""
+                    # Step 1: check and skip
+                    if {test.path} -d {persisted_destination}; then
+                        echo "{persisted_destination} already exists, fully created by earlier execution" >&2
+                        exit 0
+                    fi
 
-                # Step 2: copy from the digest into the named cache
-                {mkdir.path} -p "{temp_dir}"
-                {cp.path} -R python "{copy_target}"
+                    # Step 2: copy from the digest into the named cache
+                    {mkdir.path} -p "{temp_dir}"
+                    {cp.path} -R python "{copy_target}"
 
-                # Step 3: attempt to move, squashing the error
-                {mv.path} "{copy_target}" "{persisted_destination.parent}" || echo "mv failed: $?" >&2
+                    # Step 3: attempt to move, squashing the error
+                    {mv.path} "{copy_target}" "{persisted_destination.parent}" || echo "mv failed: $?" >&2
 
-                # Step 4: confirm and clean-up
-                if ! {test.path} -d "{persisted_destination}"; then
-                    echo "Failed to create {persisted_destination}" >&2
-                    exit 1
-                fi
+                    # Step 4: confirm and clean-up
+                    if ! {test.path} -d "{persisted_destination}"; then
+                        echo "Failed to create {persisted_destination}" >&2
+                        exit 1
+                    fi
 
-                # Step 5: remove the temporary directory
-                {rm.path} -rf "{temp_dir}"
-                """,
-            ],
-            level=LogLevel.DEBUG,
-            input_digest=downloaded_python.digest,
-            description=f"Install Python {python_version}",
-            append_only_caches=PBS_APPEND_ONLY_CACHES,
-            # Don't cache, we want this to always be run so that we can assume for the rest of the
-            # session the named_cache destination for this Python is valid, as the Python ecosystem
-            # mainly assumes absolute paths for Python interpreters.
-            cache_scope=ProcessCacheScope.PER_SESSION,
+                    # Step 5: remove the temporary directory
+                    {rm.path} -rf "{temp_dir}"
+                    """,
+                ],
+                level=LogLevel.DEBUG,
+                input_digest=downloaded_python.digest,
+                description=f"Install Python {python_version}",
+                append_only_caches=PBS_APPEND_ONLY_CACHES,
+                # Don't cache, we want this to always be run so that we can assume for the rest of the
+                # session the named_cache destination for this Python is valid, as the Python ecosystem
+                # mainly assumes absolute paths for Python interpreters.
+                cache_scope=ProcessCacheScope.PER_SESSION,
+            ),
         ),
-        **implicitly(),
     )
 
     python_path = named_caches_dir.val / PBS_NAMED_CACHE_NAME / python_version / "bin" / "python3"


### PR DESCRIPTION
Mostly automated, but required shuffling the `Process` inside the `**implicitly()` for `fallible_to_exec_result_or_raise`.

Ref #21065 