### PR TITLE
[Call-by-name] migrate `src/python/pants/jvm/resolve`

### DIFF
--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -533,6 +533,15 @@ async def coursier_resolve_lockfile(
     return CoursierResolvedLockfile(entries=tuple(new_entries))
 
 
+@rule
+async def get_coursier_lockfile_for_resolve(
+    coursier_resolve: CoursierResolveKey,
+) -> CoursierResolvedLockfile:
+    lockfile_digest_contents = await get_digest_contents(coursier_resolve.digest)
+    lockfile_contents = lockfile_digest_contents[0].content
+    return CoursierResolvedLockfile.from_serialized(lockfile_contents)
+
+
 @rule(desc="Fetch with coursier")
 async def fetch_with_coursier(request: CoursierFetchRequest) -> FallibleClasspathEntry:
     # TODO: Loading this per JvmArtifact.
@@ -718,15 +727,6 @@ async def select_coursier_resolve_for_targets(
     )
     resolve_digest = await path_globs_to_digest(lockfile_source)
     return CoursierResolveKey(resolve, resolve_path, resolve_digest)
-
-
-@rule
-async def get_coursier_lockfile_for_resolve(
-    coursier_resolve: CoursierResolveKey,
-) -> CoursierResolvedLockfile:
-    lockfile_digest_contents = await get_digest_contents(coursier_resolve.digest)
-    lockfile_contents = lockfile_digest_contents[0].content
-    return CoursierResolvedLockfile.from_serialized(lockfile_contents)
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/jvm/resolve/coursier_setup.py
+++ b/src/python/pants/jvm/resolve/coursier_setup.py
@@ -16,14 +16,15 @@ from pants.core.util_rules import external_tool
 from pants.core.util_rules.adhoc_binaries import PythonBuildStandaloneBinary
 from pants.core.util_rules.external_tool import (
     DownloadedExternalTool,
-    ExternalToolRequest,
     TemplatedExternalTool,
+    download_external_tool,
 )
 from pants.core.util_rules.system_binaries import BashBinary, MkdirBinary
 from pants.engine.fs import CreateDigest, Digest, FileContent, MergeDigests
+from pants.engine.intrinsics import create_digest, merge_digests
 from pants.engine.platform import Platform
 from pants.engine.process import Process
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.rules import collect_rules, concurrently, rule
 from pants.engine.unions import UnionRule
 from pants.option.option_types import StrListOption, StrOption
 from pants.util.frozendict import FrozenDict
@@ -289,13 +290,8 @@ async def setup_coursier(
 
     post_process_stderr = POST_PROCESS_COURSIER_STDERR_SCRIPT.format(python_path=python.path)
 
-    downloaded_coursier_get = Get(
-        DownloadedExternalTool,
-        ExternalToolRequest,
-        coursier_subsystem.get_request(platform),
-    )
-    wrapper_scripts_digest_get = Get(
-        Digest,
+    downloaded_coursier_get = download_external_tool(coursier_subsystem.get_request(platform))
+    wrapper_scripts_digest_get = create_digest(
         CreateDigest(
             [
                 FileContent(
@@ -314,23 +310,22 @@ async def setup_coursier(
                     is_executable=True,
                 ),
             ]
-        ),
+        )
     )
 
-    downloaded_coursier, wrapper_scripts_digest = await MultiGet(
+    downloaded_coursier, wrapper_scripts_digest = await concurrently(
         downloaded_coursier_get, wrapper_scripts_digest_get
     )
 
     return Coursier(
         coursier=downloaded_coursier,
-        _digest=await Get(
-            Digest,
+        _digest=await merge_digests(
             MergeDigests(
                 [
                     downloaded_coursier.digest,
                     wrapper_scripts_digest,
                 ]
-            ),
+            )
         ),
         repos=FrozenOrderedSet(coursier_subsystem.repos),
         jvm_index=coursier_subsystem.jvm_index,

--- a/src/python/pants/jvm/resolve/jvm_tool.py
+++ b/src/python/pants/jvm/resolve/jvm_tool.py
@@ -6,13 +6,14 @@ import os
 from dataclasses import dataclass
 from typing import ClassVar
 
-from pants.build_graph.address import Address, AddressInput
+from pants.build_graph.address import AddressInput
 from pants.core.goals.generate_lockfiles import DEFAULT_TOOL_LOCKFILE
 from pants.core.goals.resolves import ExportableTool
 from pants.engine.addresses import Addresses
-from pants.engine.internals.selectors import Get, MultiGet
-from pants.engine.rules import collect_rules, rule
-from pants.engine.target import Targets
+from pants.engine.internals.build_files import resolve_address
+from pants.engine.internals.graph import resolve_targets
+from pants.engine.internals.selectors import concurrently
+from pants.engine.rules import collect_rules, implicitly, rule
 from pants.jvm.resolve.common import (
     ArtifactRequirement,
     ArtifactRequirements,
@@ -161,8 +162,10 @@ async def gather_coordinates_for_jvm_lockfile(
         )
 
     # Gather coordinates from the provided addresses.
-    addresses = await MultiGet(Get(Address, AddressInput, ai) for ai in candidate_address_inputs)
-    all_supplied_targets = await Get(Targets, Addresses(addresses))
+    addresses = await concurrently(
+        resolve_address(**implicitly({ai: AddressInput})) for ai in candidate_address_inputs
+    )
+    all_supplied_targets = await resolve_targets(**implicitly(Addresses(addresses)))
     other_targets = []
     for tgt in all_supplied_targets:
         if JvmArtifactFieldSet.is_applicable(tgt):


### PR DESCRIPTION
Migrate the `jvm/resolve` part of the JVM support logic.