### PR TITLE
[Call-by-name] migrate src/python/pants/backend/go/util_rules

### DIFF
--- a/src/python/pants/backend/go/util_rules/cgo_binaries.py
+++ b/src/python/pants/backend/go/util_rules/cgo_binaries.py
@@ -8,12 +8,11 @@ from pants.backend.go.subsystems.golang import GolangSubsystem
 from pants.core.util_rules.system_binaries import (
     BinaryPath,
     BinaryPathRequest,
-    BinaryPaths,
     BinaryPathTest,
+    find_binary,
 )
 from pants.engine.engine_aware import EngineAwareParameter
-from pants.engine.internals.selectors import Get
-from pants.engine.rules import collect_rules, rule
+from pants.engine.rules import collect_rules, implicitly, rule
 
 
 @dataclass(frozen=True)
@@ -34,7 +33,7 @@ async def find_cgo_binary_path(
         search_path=golang_env_aware.cgo_tool_search_paths,
         test=request.binary_path_test,
     )
-    paths = await Get(BinaryPaths, BinaryPathRequest, path_request)
+    paths = await find_binary(path_request, **implicitly())
     first_path = paths.first_path_or_raise(
         path_request, rationale=f"find the `{request.binary_name}` tool required by CGo"
     )


### PR DESCRIPTION
This migrates a few files from `src/python/pants/backend/go/util_rules`. There are a lot of files in go backend, so breaking this up to make the review easier. 

Most of this was non-eventful, there were 2 functions I needed to move up to so the rules were visible, eg this error

```
... was not detected in your @rule body at rule compile time.
```