### PR TITLE
skip remote cache integration test

### DIFF
--- a/tests/python/pants_test/integration/remote_cache_integration_test.py
+++ b/tests/python/pants_test/integration/remote_cache_integration_test.py
@@ -311,6 +311,7 @@ def test_eager_validation(cache_content_behavior: CacheContentBehavior) -> None:
     assert "backtrack_attempts" not in metrics3
 
 
+@pytest.mark.skip(reason="Flaky test which needs to be reevaluated.")
 def test_remote_cache_workunits() -> None:
     """Tests that remote cache operations properly emit workunits with metadata."""
     executor = PyExecutor(core_threads=2, max_threads=4)

--- a/tests/python/pants_test/integration/remote_cache_integration_test.py
+++ b/tests/python/pants_test/integration/remote_cache_integration_test.py
@@ -312,6 +312,7 @@ def test_eager_validation(cache_content_behavior: CacheContentBehavior) -> None:
 
 
 @pytest.mark.skip(reason="Flaky test which needs to be reevaluated.")
+@pytest.mark.no_error_if_skipped
 def test_remote_cache_workunits() -> None:
     """Tests that remote cache operations properly emit workunits with metadata."""
     executor = PyExecutor(core_threads=2, max_threads=4)


### PR DESCRIPTION
Skip the remote cache integration test due to flaky behavior.