### PR TITLE
[Call-by-name] migrate Scala backends

### DIFF
--- a/src/python/pants/backend/scala/compile/scalac.py
+++ b/src/python/pants/backend/scala/compile/scalac.py
@@ -9,10 +9,10 @@ from itertools import chain
 
 from pants.backend.java.target_types import JavaFieldSet, JavaGeneratorFieldSet, JavaSourceField
 from pants.backend.scala.compile.scalac_plugins import (
-    ScalaPlugins,
     ScalaPluginsForTargetRequest,
     ScalaPluginsRequest,
-    ScalaPluginTargetsForTarget,
+    fetch_plugins,
+    resolve_scala_plugins_for_target,
 )
 from pants.backend.scala.compile.scalac_plugins import rules as scalac_plugins_rules
 from pants.backend.scala.resolve.artifact import rules as scala_artifact_rules
@@ -24,13 +24,15 @@ from pants.backend.scala.util_rules.versions import (
     ScalaArtifactsForVersionRequest,
     ScalaArtifactsForVersionResult,
     ScalaVersion,
+    resolve_scala_artifacts_for_version,
 )
 from pants.core.util_rules.source_files import SourceFilesRequest
-from pants.core.util_rules.stripped_source_files import StrippedSourceFiles
+from pants.core.util_rules.stripped_source_files import strip_source_roots
 from pants.core.util_rules.system_binaries import BashBinary, ZipBinary
-from pants.engine.fs import EMPTY_DIGEST, CreateDigest, Digest, Directory, MergeDigests
-from pants.engine.process import FallibleProcessResult, Process, ProcessCacheScope, ProcessResult
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.fs import EMPTY_DIGEST, CreateDigest, Directory, MergeDigests
+from pants.engine.intrinsics import create_digest, execute_process, merge_digests
+from pants.engine.process import Process, ProcessCacheScope, execute_process_or_raise
+from pants.engine.rules import Get, collect_rules, concurrently, implicitly, rule
 from pants.engine.target import CoarsenedTarget, SourcesField
 from pants.engine.unions import UnionRule
 from pants.jvm.classpath import Classpath
@@ -39,15 +41,20 @@ from pants.jvm.compile import (
     ClasspathEntry,
     ClasspathEntryRequest,
     CompileResult,
-    FallibleClasspathEntries,
     FallibleClasspathEntry,
+    compile_classpath_entries,
 )
 from pants.jvm.compile import rules as jvm_compile_rules
-from pants.jvm.jdk_rules import JdkEnvironment, JdkRequest, JvmProcess
+from pants.jvm.jdk_rules import JdkRequest, JvmProcess, prepare_jdk_environment
 from pants.jvm.resolve.common import ArtifactRequirements
-from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
+from pants.jvm.resolve.coursier_fetch import (
+    ToolClasspath,
+    ToolClasspathRequest,
+    materialize_classpath_for_tool,
+)
 from pants.jvm.strip_jar import strip_jar
 from pants.jvm.strip_jar.strip_jar import StripJarRequest
+from pants.jvm.strip_jar.strip_jar import strip_jar as strip_jar_get
 from pants.jvm.subsystems import JvmSubsystem
 from pants.util.logging import LogLevel
 
@@ -79,7 +86,9 @@ async def compile_scala_source(
     request: CompileScalaSourceRequest,
 ) -> FallibleClasspathEntry:
     # Request classpath entries for our direct dependencies.
-    dependency_cpers = await Get(FallibleClasspathEntries, ClasspathDependenciesRequest(request))
+    dependency_cpers = await compile_classpath_entries(
+        **implicitly(ClasspathDependenciesRequest(request))
+    )
     direct_dependency_classpath_entries = dependency_cpers.if_all_succeeded()
 
     if direct_dependency_classpath_entries is None:
@@ -91,8 +100,8 @@ async def compile_scala_source(
         )
 
     scala_version = scala.version_for_resolve(request.resolve.name)
-    scala_artifacts = await Get(
-        ScalaArtifactsForVersionResult, ScalaArtifactsForVersionRequest(scala_version)
+    scala_artifacts = await resolve_scala_artifacts_for_version(
+        ScalaArtifactsForVersionRequest(scala_version)
     )
 
     component_members_with_sources = tuple(
@@ -100,30 +109,28 @@ async def compile_scala_source(
     )
     component_members_and_source_files = zip(
         component_members_with_sources,
-        await MultiGet(
-            Get(
-                # Some Scalac plugins (i.e. SemanticDB) require us to use stripped source files so the plugin
-                # would emit compilation output that correlates with the appropiate paths in the input files.
-                StrippedSourceFiles,
-                SourceFilesRequest(
-                    (t.get(SourcesField),),
-                    for_sources_types=(ScalaSourceField, JavaSourceField),
-                    enable_codegen=True,
-                ),
+        await concurrently(
+            strip_source_roots(
+                **implicitly(
+                    SourceFilesRequest(
+                        (t.get(SourcesField),),
+                        for_sources_types=(ScalaSourceField, JavaSourceField),
+                        enable_codegen=True,
+                    )
+                )
             )
             for t in component_members_with_sources
         ),
     )
 
-    plugins_ = await MultiGet(
-        Get(
-            ScalaPluginTargetsForTarget,
-            ScalaPluginsForTargetRequest(target, request.resolve.name),
+    plugins_ = await concurrently(
+        resolve_scala_plugins_for_target(
+            ScalaPluginsForTargetRequest(target, request.resolve.name), **implicitly()
         )
         for target in request.component.members
     )
     plugins_request = ScalaPluginsRequest.from_target_plugins(plugins_, request.resolve)
-    local_plugins = await Get(ScalaPlugins, ScalaPluginsRequest, plugins_request)
+    local_plugins = await fetch_plugins(plugins_request)
 
     component_members_and_scala_source_files = [
         (target, sources)
@@ -133,8 +140,8 @@ async def compile_scala_source(
 
     if not component_members_and_scala_source_files:
         # Is a generator, and so exports all of its direct deps.
-        exported_digest = await Get(
-            Digest, MergeDigests(cpe.digest for cpe in direct_dependency_classpath_entries)
+        exported_digest = await merge_digests(
+            MergeDigests(cpe.digest for cpe in direct_dependency_classpath_entries)
         )
         classpath_entry = ClasspathEntry.merge(exported_digest, direct_dependency_classpath_entries)
         return FallibleClasspathEntry(
@@ -150,9 +157,8 @@ async def compile_scala_source(
 
     user_classpath = Classpath(direct_dependency_classpath_entries, request.resolve)
 
-    tool_classpath, sources_digest, jdk = await MultiGet(
-        Get(
-            ToolClasspath,
+    tool_classpath, sources_digest, jdk = await concurrently(
+        materialize_classpath_for_tool(
             ToolClasspathRequest(
                 artifact_requirements=ArtifactRequirements.from_coordinates(
                     [
@@ -160,15 +166,14 @@ async def compile_scala_source(
                         scala_artifacts.library_coordinate,
                     ]
                 ),
-            ),
+            )
         ),
-        Get(
-            Digest,
+        merge_digests(
             MergeDigests(
                 (sources.snapshot.digest for _, sources in component_members_and_scala_source_files)
-            ),
+            )
         ),
-        Get(JdkEnvironment, JdkRequest, JdkRequest.from_target(request.component)),
+        prepare_jdk_environment(**implicitly(JdkRequest.from_target(request.component))),
     )
 
     extra_immutable_input_digests = {
@@ -182,72 +187,74 @@ async def compile_scala_source(
 
     output_file = compute_output_jar_filename(request.component)
     compilation_output_dir = "__out"
-    compilation_empty_dir = await Get(Digest, CreateDigest([Directory(compilation_output_dir)]))
-    merged_digest = await Get(Digest, MergeDigests([sources_digest, compilation_empty_dir]))
+    compilation_empty_dir = await create_digest(CreateDigest([Directory(compilation_output_dir)]))
+    merged_digest = await merge_digests(MergeDigests([sources_digest, compilation_empty_dir]))
 
-    compile_result = await Get(
-        FallibleProcessResult,
-        JvmProcess(
-            jdk=jdk,
-            classpath_entries=tool_classpath.classpath_entries(toolcp_relpath),
-            argv=[
-                scala_artifacts.compiler_main,
-                "-bootclasspath",
-                ":".join(tool_classpath.classpath_entries(toolcp_relpath)),
-                *local_plugins.args(local_scalac_plugins_relpath),
-                *(("-classpath", classpath_arg) if classpath_arg else ()),
-                *scalac.args,
-                "-d",
-                compilation_output_dir,
-                *sorted(
-                    chain.from_iterable(
-                        sources.snapshot.files
-                        for _, sources in component_members_and_scala_source_files
-                    )
-                ),
-            ],
-            input_digest=merged_digest,
-            extra_immutable_input_digests=extra_immutable_input_digests,
-            extra_nailgun_keys=extra_nailgun_keys,
-            output_directories=(compilation_output_dir,),
-            description=f"Compile {request.component} with scalac",
-            level=LogLevel.DEBUG,
-        ),
+    compile_result = await execute_process(
+        **implicitly(
+            JvmProcess(
+                jdk=jdk,
+                classpath_entries=tool_classpath.classpath_entries(toolcp_relpath),
+                argv=[
+                    scala_artifacts.compiler_main,
+                    "-bootclasspath",
+                    ":".join(tool_classpath.classpath_entries(toolcp_relpath)),
+                    *local_plugins.args(local_scalac_plugins_relpath),
+                    *(("-classpath", classpath_arg) if classpath_arg else ()),
+                    *scalac.args,
+                    "-d",
+                    compilation_output_dir,
+                    *sorted(
+                        chain.from_iterable(
+                            sources.snapshot.files
+                            for _, sources in component_members_and_scala_source_files
+                        )
+                    ),
+                ],
+                input_digest=merged_digest,
+                extra_immutable_input_digests=extra_immutable_input_digests,
+                extra_nailgun_keys=extra_nailgun_keys,
+                output_directories=(compilation_output_dir,),
+                description=f"Compile {request.component} with scalac",
+                level=LogLevel.DEBUG,
+            )
+        )
     )
     output: ClasspathEntry | None = None
     if compile_result.exit_code == 0:
         # We package the outputs into a JAR file in a similar way as how it's
         # done in the `javac.py` implementation
-        jar_result = await Get(
-            ProcessResult,
-            Process(
-                argv=[
-                    bash.path,
-                    "-c",
-                    " ".join(
-                        [
-                            "cd",
-                            compilation_output_dir,
-                            ";",
-                            zip_binary.path,
-                            "-r",
-                            f"../{output_file}",
-                            ".",
-                        ]
-                    ),
-                ],
-                input_digest=compile_result.output_digest,
-                output_files=(output_file,),
-                description=f"Capture outputs of {request.component} for scalac",
-                level=LogLevel.TRACE,
-                cache_scope=ProcessCacheScope.LOCAL_SUCCESSFUL,
-            ),
+        jar_result = await execute_process_or_raise(
+            **implicitly(
+                Process(
+                    argv=[
+                        bash.path,
+                        "-c",
+                        " ".join(
+                            [
+                                "cd",
+                                compilation_output_dir,
+                                ";",
+                                zip_binary.path,
+                                "-r",
+                                f"../{output_file}",
+                                ".",
+                            ]
+                        ),
+                    ],
+                    input_digest=compile_result.output_digest,
+                    output_files=(output_file,),
+                    description=f"Capture outputs of {request.component} for scalac",
+                    level=LogLevel.TRACE,
+                    cache_scope=ProcessCacheScope.LOCAL_SUCCESSFUL,
+                )
+            )
         )
         output_digest = jar_result.output_digest
 
         if jvm.reproducible_jars:
-            output_digest = await Get(
-                Digest, StripJarRequest(digest=output_digest, filenames=(output_file,))
+            output_digest = await strip_jar_get(
+                **implicitly(StripJarRequest(digest=output_digest, filenames=(output_file,)))
             )
 
         output = ClasspathEntry(output_digest, (output_file,), direct_dependency_classpath_entries)

--- a/src/python/pants/backend/scala/compile/scalac.py
+++ b/src/python/pants/backend/scala/compile/scalac.py
@@ -105,6 +105,8 @@ async def compile_scala_source(
     component_members_and_source_files = zip(
         component_members_with_sources,
         await concurrently(
+            # Some Scalac plugins (i.e. SemanticDB) require us to use stripped source files so the plugin
+            # would emit compilation output that correlates with the appropiate paths in the input files.
             strip_source_roots(
                 **implicitly(
                     SourceFilesRequest(

--- a/src/python/pants/backend/scala/compile/scalac_plugins.py
+++ b/src/python/pants/backend/scala/compile/scalac_plugins.py
@@ -15,15 +15,16 @@ from pants.backend.scala.target_types import (
 from pants.build_graph.address import Address, AddressInput
 from pants.engine.addresses import Addresses
 from pants.engine.environment import ChosenLocalEnvironmentName, EnvironmentName
-from pants.engine.internals.native_engine import Digest, MergeDigests
+from pants.engine.internals.graph import coarsened_targets as coarsened_targets_get
+from pants.engine.internals.native_engine import MergeDigests
 from pants.engine.internals.parametrize import (
     _TargetParametrizations,
     _TargetParametrizationsRequest,
 )
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.intrinsics import merge_digests
+from pants.engine.rules import Get, collect_rules, concurrently, implicitly, rule
 from pants.engine.target import (
     AllTargets,
-    CoarsenedTargets,
     FieldDefaults,
     Target,
     Targets,
@@ -32,7 +33,7 @@ from pants.engine.target import (
 )
 from pants.jvm.compile import ClasspathEntry, FallibleClasspathEntry
 from pants.jvm.goals import lockfile
-from pants.jvm.resolve.coursier_fetch import CoursierFetchRequest
+from pants.jvm.resolve.coursier_fetch import CoursierFetchRequest, fetch_with_coursier
 from pants.jvm.resolve.jvm_tool import rules as jvm_tool_rules
 from pants.jvm.resolve.key import CoursierResolveKey
 from pants.jvm.subsystems import JvmSubsystem
@@ -225,14 +226,11 @@ def _plugin_name(target: Target) -> str:
 @rule
 async def fetch_plugins(request: ScalaPluginsRequest) -> ScalaPlugins:
     # Fetch all the artifacts
-    coarsened_targets = await Get(
-        CoarsenedTargets, Addresses(target.address for target in request.artifacts)
+    coarsened_targets = await coarsened_targets_get(
+        **implicitly(Addresses(target.address for target in request.artifacts))
     )
-    fallible_artifacts = await MultiGet(
-        Get(
-            FallibleClasspathEntry,
-            CoursierFetchRequest(ct, resolve=request.resolve),
-        )
+    fallible_artifacts = await concurrently(
+        fetch_with_coursier(CoursierFetchRequest(ct, resolve=request.resolve))
         for ct in coarsened_targets
     )
 
@@ -241,7 +239,7 @@ async def fetch_plugins(request: ScalaPluginsRequest) -> ScalaPlugins:
         failed = [i for i in fallible_artifacts if i.exit_code != 0]
         raise Exception(f"Fetching local scala plugins failed: {failed}")
 
-    merged_classpath_digest = await Get(Digest, MergeDigests(i.digest for i in artifacts))
+    merged_classpath_digest = await merge_digests(MergeDigests(i.digest for i in artifacts))
     merged = ClasspathEntry.merge(merged_classpath_digest, artifacts)
 
     names = tuple(_plugin_name(target) for target in request.plugins)

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser.py
@@ -13,32 +13,48 @@ from pants.backend.scala.subsystems.scala import ScalaSubsystem
 from pants.backend.scala.subsystems.scalac import Scalac
 from pants.backend.scala.util_rules.versions import (
     ScalaArtifactsForVersionRequest,
-    ScalaArtifactsForVersionResult,
     ScalaVersion,
     _resolve_scala_artifacts_for_version,
+    resolve_scala_artifacts_for_version,
 )
 from pants.core.goals.resolves import ExportableTool
-from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
+from pants.core.util_rules.source_files import (
+    SourceFiles,
+    SourceFilesRequest,
+    determine_source_files,
+)
 from pants.engine.fs import (
     AddPrefix,
     CreateDigest,
-    Digest,
-    DigestContents,
     Directory,
     FileContent,
     MergeDigests,
     RemovePrefix,
 )
-from pants.engine.internals.selectors import Get, MultiGet
-from pants.engine.process import FallibleProcessResult, ProcessResult, ProductDescription
-from pants.engine.rules import collect_rules, rule
-from pants.engine.target import WrappedTarget, WrappedTargetRequest
+from pants.engine.internals.graph import resolve_target
+from pants.engine.internals.selectors import concurrently
+from pants.engine.intrinsics import (
+    add_prefix,
+    create_digest,
+    execute_process,
+    get_digest_contents,
+    merge_digests,
+    remove_prefix,
+)
+from pants.engine.process import (
+    FallibleProcessResult,
+    ProductDescription,
+    execute_process_or_raise,
+    fallible_to_exec_result_or_raise,
+)
+from pants.engine.rules import collect_rules, implicitly, rule
+from pants.engine.target import WrappedTargetRequest
 from pants.engine.unions import UnionRule
 from pants.jvm.compile import ClasspathEntry
 from pants.jvm.jdk_rules import InternalJdk, JvmProcess
 from pants.jvm.jdk_rules import rules as jdk_rules
 from pants.jvm.resolve.common import ArtifactRequirements
-from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
+from pants.jvm.resolve.coursier_fetch import ToolClasspathRequest, materialize_classpath_for_tool
 from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool, JvmToolBase
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmResolveField
@@ -262,14 +278,14 @@ async def create_analyze_scala_source_request(
 ) -> AnalyzeScalaSourceRequest:
     address = request.sources_fields[0].address
 
-    wrapped_tgt, source_files = await MultiGet(
-        Get(
-            WrappedTarget,
+    wrapped_tgt, source_files = await concurrently(
+        resolve_target(
             WrappedTargetRequest(
                 address, description_of_origin="<the Scala analyze request setup rule>"
             ),
+            **implicitly(),
         ),
-        Get(SourceFiles, SourceFilesRequest, request),
+        determine_source_files(request),
     )
 
     tgt = wrapped_tgt.target
@@ -302,12 +318,11 @@ async def analyze_scala_source_dependencies(
     processorcp_relpath = "__processorcp"
     toolcp_relpath = "__toolcp"
 
-    tool_classpath, prefixed_source_files_digest = await MultiGet(
-        Get(
-            ToolClasspath,
-            ToolClasspathRequest(lockfile=GenerateJvmLockfileFromTool.create(tool)),
+    tool_classpath, prefixed_source_files_digest = await concurrently(
+        materialize_classpath_for_tool(
+            ToolClasspathRequest(lockfile=GenerateJvmLockfileFromTool.create(tool))
         ),
-        Get(Digest, AddPrefix(source_files.snapshot.digest, source_prefix)),
+        add_prefix(AddPrefix(source_files.snapshot.digest, source_prefix)),
     )
 
     extra_immutable_input_digests = {
@@ -317,28 +332,29 @@ async def analyze_scala_source_dependencies(
 
     analysis_output_path = "__source_analysis.json"
 
-    process_result = await Get(
-        FallibleProcessResult,
-        JvmProcess(
-            jdk=jdk,
-            classpath_entries=[
-                *tool_classpath.classpath_entries(toolcp_relpath),
-                processorcp_relpath,
-            ],
-            argv=[
-                "org.pantsbuild.backend.scala.dependency_inference.ScalaParser",
-                analysis_output_path,
-                source_path,
-                str(request.scala_version),
-                str(request.source3),
-            ],
-            input_digest=prefixed_source_files_digest,
-            extra_immutable_input_digests=extra_immutable_input_digests,
-            output_files=(analysis_output_path,),
-            extra_nailgun_keys=extra_immutable_input_digests,
-            description=f"Analyzing {source_files.files[0]}",
-            level=LogLevel.DEBUG,
-        ),
+    process_result = await execute_process(
+        **implicitly(
+            JvmProcess(
+                jdk=jdk,
+                classpath_entries=[
+                    *tool_classpath.classpath_entries(toolcp_relpath),
+                    processorcp_relpath,
+                ],
+                argv=[
+                    "org.pantsbuild.backend.scala.dependency_inference.ScalaParser",
+                    analysis_output_path,
+                    source_path,
+                    str(request.scala_version),
+                    str(request.source3),
+                ],
+                input_digest=prefixed_source_files_digest,
+                extra_immutable_input_digests=extra_immutable_input_digests,
+                output_files=(analysis_output_path,),
+                extra_nailgun_keys=extra_immutable_input_digests,
+                description=f"Analyzing {source_files.files[0]}",
+                level=LogLevel.DEBUG,
+            )
+        )
     )
 
     return FallibleScalaSourceDependencyAnalysisResult(process_result=process_result)
@@ -349,14 +365,15 @@ async def resolve_fallible_result_to_analysis(
     fallible_result: FallibleScalaSourceDependencyAnalysisResult,
 ) -> ScalaSourceDependencyAnalysis:
     description = ProductDescription("Scala source dependency analysis failed.")
-    result = await Get(
-        ProcessResult,
-        {
-            fallible_result.process_result: FallibleProcessResult,
-            description: ProductDescription,
-        },
+    result = await fallible_to_exec_result_or_raise(
+        **implicitly(
+            {
+                fallible_result.process_result: FallibleProcessResult,
+                description: ProductDescription,
+            }
+        )
     )
-    analysis_contents = await Get(DigestContents, Digest, result.output_digest)
+    analysis_contents = await get_digest_contents(result.output_digest)
     analysis = json.loads(analysis_contents[0].content)
     return ScalaSourceDependencyAnalysis.from_json_dict(analysis)
 
@@ -376,65 +393,63 @@ async def setup_scala_parser_classfiles(
 
     parser_source = FileContent("ScalaParser.scala", parser_source_content)
 
-    scala_artifacts = await Get(
-        ScalaArtifactsForVersionResult, ScalaArtifactsForVersionRequest(_PARSER_SCALA_VERSION)
+    scala_artifacts = await resolve_scala_artifacts_for_version(
+        ScalaArtifactsForVersionRequest(_PARSER_SCALA_VERSION)
     )
 
-    tool_classpath, parser_classpath, source_digest = await MultiGet(
-        Get(
-            ToolClasspath,
+    tool_classpath, parser_classpath, source_digest = await concurrently(
+        materialize_classpath_for_tool(
             ToolClasspathRequest(
                 prefix="__toolcp",
                 artifact_requirements=ArtifactRequirements.from_coordinates(
                     scala_artifacts.all_coordinates
                 ),
-            ),
+            )
         ),
-        Get(
-            ToolClasspath,
+        materialize_classpath_for_tool(
             ToolClasspathRequest(
                 prefix="__parsercp", lockfile=(GenerateJvmLockfileFromTool.create(tool))
-            ),
+            )
         ),
-        Get(Digest, CreateDigest([parser_source, Directory(dest_dir)])),
+        create_digest(CreateDigest([parser_source, Directory(dest_dir)])),
     )
 
-    merged_digest = await Get(
-        Digest,
+    merged_digest = await merge_digests(
         MergeDigests(
             (
                 tool_classpath.digest,
                 parser_classpath.digest,
                 source_digest,
             )
-        ),
+        )
     )
 
-    process_result = await Get(
-        ProcessResult,
-        JvmProcess(
-            jdk=jdk,
-            classpath_entries=tool_classpath.classpath_entries(),
-            argv=[
-                "scala.tools.nsc.Main",
-                "-bootclasspath",
-                ":".join(tool_classpath.classpath_entries()),
-                "-classpath",
-                ":".join(parser_classpath.classpath_entries()),
-                "-d",
-                dest_dir,
-                parser_source.path,
-            ],
-            input_digest=merged_digest,
-            output_directories=(dest_dir,),
-            description="Compile Scala parser for dependency inference with scalac",
-            level=LogLevel.DEBUG,
-            # NB: We do not use nailgun for this process, since it is launched exactly once.
-            use_nailgun=False,
-        ),
+    process_result = await execute_process_or_raise(
+        **implicitly(
+            JvmProcess(
+                jdk=jdk,
+                classpath_entries=tool_classpath.classpath_entries(),
+                argv=[
+                    "scala.tools.nsc.Main",
+                    "-bootclasspath",
+                    ":".join(tool_classpath.classpath_entries()),
+                    "-classpath",
+                    ":".join(parser_classpath.classpath_entries()),
+                    "-d",
+                    dest_dir,
+                    parser_source.path,
+                ],
+                input_digest=merged_digest,
+                output_directories=(dest_dir,),
+                description="Compile Scala parser for dependency inference with scalac",
+                level=LogLevel.DEBUG,
+                # NB: We do not use nailgun for this process, since it is launched exactly once.
+                use_nailgun=False,
+            )
+        )
     )
-    stripped_classfiles_digest = await Get(
-        Digest, RemovePrefix(process_result.output_digest, dest_dir)
+    stripped_classfiles_digest = await remove_prefix(
+        RemovePrefix(process_result.output_digest, dest_dir)
     )
     return ScalaParserCompiledClassfiles(digest=stripped_classfiles_digest)
 

--- a/src/python/pants/backend/scala/dependency_inference/symbol_mapper.py
+++ b/src/python/pants/backend/scala/dependency_inference/symbol_mapper.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Mapping
 
-from pants.backend.scala.dependency_inference.scala_parser import ScalaSourceDependencyAnalysis
+from pants.backend.scala.dependency_inference.scala_parser import (
+    resolve_fallible_result_to_analysis,
+)
 from pants.backend.scala.target_types import ScalaSourceField
 from pants.core.util_rules.source_files import SourceFilesRequest
 from pants.engine.addresses import Address
-from pants.engine.internals.selectors import Get, MultiGet
-from pants.engine.rules import collect_rules, rule
+from pants.engine.internals.selectors import concurrently
+from pants.engine.rules import collect_rules, implicitly, rule
 from pants.engine.target import AllTargets, Targets
 from pants.engine.unions import UnionRule
 from pants.jvm.dependency_inference import symbol_mapper
@@ -60,8 +62,10 @@ async def map_first_party_scala_targets_to_symbols(
     scala_targets: AllScalaTargets,
     jvm: JvmSubsystem,
 ) -> SymbolMap:
-    source_analysis = await MultiGet(
-        Get(ScalaSourceDependencyAnalysis, SourceFilesRequest([target[ScalaSourceField]]))
+    source_analysis = await concurrently(
+        resolve_fallible_result_to_analysis(
+            **implicitly(SourceFilesRequest([target[ScalaSourceField]]))
+        )
         for target in scala_targets
     )
     address_and_analysis = zip(

--- a/src/python/pants/backend/scala/goals/check.py
+++ b/src/python/pants/backend/scala/goals/check.py
@@ -9,7 +9,8 @@ from pants.backend.scala.subsystems.scalac import Scalac
 from pants.backend.scala.target_types import ScalaFieldSet
 from pants.core.goals.check import CheckRequest, CheckResult, CheckResults
 from pants.engine.addresses import Addresses
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.internals.graph import coarsened_targets as coarsened_targets_get
+from pants.engine.rules import Get, collect_rules, concurrently, implicitly, rule
 from pants.engine.target import CoarsenedTargets
 from pants.engine.unions import UnionRule
 from pants.jvm.compile import (
@@ -17,7 +18,7 @@ from pants.jvm.compile import (
     ClasspathEntryRequestFactory,
     FallibleClasspathEntry,
 )
-from pants.jvm.resolve.key import CoursierResolveKey
+from pants.jvm.resolve.coursier_fetch import select_coursier_resolve_for_targets
 from pants.util.logging import LogLevel
 
 logger = logging.getLogger(__name__)
@@ -33,17 +34,18 @@ async def scalac_check(
     request: ScalacCheckRequest,
     classpath_entry_request: ClasspathEntryRequestFactory,
 ) -> CheckResults:
-    coarsened_targets = await Get(
-        CoarsenedTargets, Addresses(field_set.address for field_set in request.field_sets)
+    coarsened_targets = await coarsened_targets_get(
+        **implicitly(Addresses(field_set.address for field_set in request.field_sets))
     )
 
     # NB: Each root can have an independent resolve, because there is no inherent relation
     # between them other than that they were on the commandline together.
-    resolves = await MultiGet(
-        Get(CoursierResolveKey, CoarsenedTargets([t])) for t in coarsened_targets
+    resolves = await concurrently(
+        select_coursier_resolve_for_targets(CoarsenedTargets([t]), **implicitly())
+        for t in coarsened_targets
     )
 
-    results = await MultiGet(
+    results = await concurrently(
         Get(
             FallibleClasspathEntry,
             ClasspathEntryRequest,

--- a/src/python/pants/backend/scala/goals/tailor.py
+++ b/src/python/pants/backend/scala/goals/tailor.py
@@ -21,8 +21,7 @@ from pants.core.goals.tailor import (
     PutativeTargets,
     PutativeTargetsRequest,
 )
-from pants.engine.fs import PathGlobs, Paths
-from pants.engine.internals.selectors import Get
+from pants.engine.intrinsics import path_globs_to_paths
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import Target
 from pants.engine.unions import UnionRule
@@ -70,7 +69,7 @@ async def find_putative_targets(
 
     if scala_subsystem.tailor_source_targets:
         all_scala_files_globs = req.path_globs("*.scala")
-        all_scala_files = await Get(Paths, PathGlobs, all_scala_files_globs)
+        all_scala_files = await path_globs_to_paths(all_scala_files_globs)
         unowned_scala_files = set(all_scala_files.files) - set(all_owned_sources)
         classified_unowned_scala_files = classify_source_files(unowned_scala_files)
         for tgt_type, paths in classified_unowned_scala_files.items():

--- a/src/python/pants/backend/scala/lint/scalafix/rules.py
+++ b/src/python/pants/backend/scala/lint/scalafix/rules.py
@@ -35,7 +35,7 @@ from pants.engine.intrinsics import (
     merge_digests,
 )
 from pants.engine.process import FallibleProcessResult
-from pants.engine.rules import Get, collect_rules, concurrently, implicitly, rule
+from pants.engine.rules import collect_rules, concurrently, implicitly, rule
 from pants.engine.target import FieldSet, Target
 from pants.engine.unions import UnionRule
 from pants.jvm.classpath import Classpath
@@ -122,7 +122,7 @@ async def _resolve_scalafix_rule_classpath(
     if not scalafix.rule_targets:
         return _MaybeClasspath(classpath=None)
 
-    classpath = await Get(Classpath, UnparsedAddressInputs, scalafix.rule_targets)
+    classpath = await classpath_get(**implicitly({scalafix.rule_targets: UnparsedAddressInputs}))
     return _MaybeClasspath(classpath)
 
 

--- a/src/python/pants/backend/scala/resolve/artifact.py
+++ b/src/python/pants/backend/scala/resolve/artifact.py
@@ -5,15 +5,15 @@ from __future__ import annotations
 
 from pants.backend.scala.target_types import ScalaArtifactFieldSet
 from pants.engine.fs import EMPTY_DIGEST
-from pants.engine.rules import Get, collect_rules, rule
+from pants.engine.rules import collect_rules, implicitly, rule
 from pants.engine.unions import UnionRule
 from pants.jvm.compile import (
     ClasspathDependenciesRequest,
     ClasspathEntry,
     ClasspathEntryRequest,
     CompileResult,
-    FallibleClasspathEntries,
     FallibleClasspathEntry,
+    compile_classpath_entries,
 )
 
 
@@ -25,7 +25,9 @@ class ScalaArtifactClasspathEntryRequest(ClasspathEntryRequest):
 async def scala_artifact_classpath(
     request: ScalaArtifactClasspathEntryRequest,
 ) -> FallibleClasspathEntry:
-    fallible_entries = await Get(FallibleClasspathEntries, ClasspathDependenciesRequest(request))
+    fallible_entries = await compile_classpath_entries(
+        **implicitly(ClasspathDependenciesRequest(request))
+    )
     classpath_entries = fallible_entries.if_all_succeeded()
     if classpath_entries is None:
         return FallibleClasspathEntry(

--- a/src/python/pants/backend/scala/resolve/lockfile.py
+++ b/src/python/pants/backend/scala/resolve/lockfile.py
@@ -4,9 +4,8 @@ from pants.backend.scala.dependency_inference.symbol_mapper import AllScalaTarge
 from pants.backend.scala.subsystems.scala import ScalaSubsystem
 from pants.backend.scala.util_rules.versions import (
     ScalaArtifactsForVersionRequest,
-    ScalaArtifactsForVersionResult,
+    resolve_scala_artifacts_for_version,
 )
-from pants.engine.internals.selectors import Get
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.jvm.goals.lockfile import (
@@ -78,8 +77,8 @@ async def validate_scala_runtime_is_present_in_resolve(
         return ValidateJvmArtifactsForResolveResult()
 
     scala_version = scala_subsystem.version_for_resolve(request.resolve_name)
-    scala_artifacts = await Get(
-        ScalaArtifactsForVersionResult, ScalaArtifactsForVersionRequest(scala_version)
+    scala_artifacts = await resolve_scala_artifacts_for_version(
+        ScalaArtifactsForVersionRequest(scala_version)
     )
 
     has_scala_library_artifact = False

--- a/src/python/pants/backend/scala/test/scalatest.py
+++ b/src/python/pants/backend/scala/test/scalatest.py
@@ -22,24 +22,26 @@ from pants.core.goals.test import (
     TestSubsystem,
 )
 from pants.core.target_types import FileSourceField
-from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
+from pants.core.util_rules.source_files import SourceFilesRequest, determine_source_files
 from pants.engine.addresses import Addresses
-from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
-from pants.engine.fs import Digest, DigestSubset, MergeDigests, PathGlobs, RemovePrefix, Snapshot
+from pants.engine.env_vars import EnvironmentVarsRequest
+from pants.engine.fs import DigestSubset, MergeDigests, PathGlobs, RemovePrefix
+from pants.engine.internals.graph import transitive_targets
+from pants.engine.internals.platform_rules import environment_vars_subset
+from pants.engine.intrinsics import digest_subset_to_digest, digest_to_snapshot, merge_digests
 from pants.engine.process import (
     InteractiveProcess,
-    Process,
     ProcessCacheScope,
-    ProcessResultWithRetries,
     ProcessWithRetries,
+    execute_process_with_retry,
 )
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import SourcesField, TransitiveTargets, TransitiveTargetsRequest
+from pants.engine.rules import collect_rules, concurrently, implicitly, rule
+from pants.engine.target import SourcesField, TransitiveTargetsRequest
 from pants.engine.unions import UnionRule
-from pants.jvm.classpath import Classpath
+from pants.jvm.classpath import classpath as classpath_get
 from pants.jvm.goals import lockfile
-from pants.jvm.jdk_rules import JdkEnvironment, JdkRequest, JvmProcess
-from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
+from pants.jvm.jdk_rules import JdkRequest, JvmProcess, jvm_process, prepare_jdk_environment
+from pants.jvm.resolve.coursier_fetch import ToolClasspathRequest, materialize_classpath_for_tool
 from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmDependenciesField, JvmJdkField
@@ -88,26 +90,25 @@ async def setup_scalatest_for_target(
     test_subsystem: TestSubsystem,
     test_extra_env: TestExtraEnv,
 ) -> TestSetup:
-    jdk, transitive_tgts = await MultiGet(
-        Get(JdkEnvironment, JdkRequest, JdkRequest.from_field(request.field_set.jdk_version)),
-        Get(TransitiveTargets, TransitiveTargetsRequest([request.field_set.address])),
+    jdk, transitive_tgts = await concurrently(
+        prepare_jdk_environment(**implicitly(JdkRequest.from_field(request.field_set.jdk_version))),
+        transitive_targets(TransitiveTargetsRequest([request.field_set.address]), **implicitly()),
     )
 
     lockfile_request = GenerateJvmLockfileFromTool.create(scalatest)
-    classpath, scalatest_classpath, files = await MultiGet(
-        Get(Classpath, Addresses([request.field_set.address])),
-        Get(ToolClasspath, ToolClasspathRequest(lockfile=lockfile_request)),
-        Get(
-            SourceFiles,
+    classpath, scalatest_classpath, files = await concurrently(
+        classpath_get(**implicitly(Addresses([request.field_set.address]))),
+        materialize_classpath_for_tool(ToolClasspathRequest(lockfile=lockfile_request)),
+        determine_source_files(
             SourceFilesRequest(
                 (dep.get(SourcesField) for dep in transitive_tgts.dependencies),
                 for_sources_types=(FileSourceField,),
                 enable_codegen=True,
-            ),
+            )
         ),
     )
 
-    input_digest = await Get(Digest, MergeDigests((*classpath.digests(), files.snapshot.digest)))
+    input_digest = await merge_digests(MergeDigests((*classpath.digests(), files.snapshot.digest)))
 
     toolcp_relpath = "__toolcp"
     extra_immutable_input_digests = {
@@ -129,8 +130,8 @@ async def setup_scalatest_for_target(
     if request.is_debug:
         extra_jvm_args.extend(jvm.debug_args)
 
-    field_set_extra_env = await Get(
-        EnvironmentVars, EnvironmentVarsRequest(request.field_set.extra_env_vars.value or ())
+    field_set_extra_env = await environment_vars_subset(
+        EnvironmentVarsRequest(request.field_set.extra_env_vars.value or ()), **implicitly()
     )
 
     process = JvmProcess(
@@ -172,18 +173,21 @@ async def run_scalatest_test(
 ) -> TestResult:
     field_set = batch.single_element
 
-    test_setup = await Get(TestSetup, TestSetupRequest(field_set, is_debug=False))
-    process = await Get(Process, JvmProcess, test_setup.process)
-    process_results = await Get(
-        ProcessResultWithRetries, ProcessWithRetries(process, test_subsystem.attempts_default)
+    test_setup = await setup_scalatest_for_target(
+        TestSetupRequest(field_set, is_debug=False), **implicitly()
+    )
+    process = await jvm_process(**implicitly(test_setup.process))
+    process_results = await execute_process_with_retry(
+        ProcessWithRetries(process, test_subsystem.attempts_default)
     )
     reports_dir_prefix = test_setup.reports_dir_prefix
 
-    xml_result_subset = await Get(
-        Digest,
-        DigestSubset(process_results.last.output_digest, PathGlobs([f"{reports_dir_prefix}/**"])),
+    xml_result_subset = await digest_subset_to_digest(
+        DigestSubset(process_results.last.output_digest, PathGlobs([f"{reports_dir_prefix}/**"]))
     )
-    xml_results = await Get(Snapshot, RemovePrefix(xml_result_subset, reports_dir_prefix))
+    xml_results = await digest_to_snapshot(
+        **implicitly(RemovePrefix(xml_result_subset, reports_dir_prefix))
+    )
 
     return TestResult.from_fallible_process_result(
         process_results=process_results.results,
@@ -197,8 +201,10 @@ async def run_scalatest_test(
 async def setup_scalatest_debug_request(
     batch: ScalatestTestRequest.Batch[ScalatestTestFieldSet, Any],
 ) -> TestDebugRequest:
-    setup = await Get(TestSetup, TestSetupRequest(batch.single_element, is_debug=True))
-    process = await Get(Process, JvmProcess, setup.process)
+    setup = await setup_scalatest_for_target(
+        TestSetupRequest(batch.single_element, is_debug=True), **implicitly()
+    )
+    process = await jvm_process(**implicitly(setup.process))
     return TestDebugRequest(
         InteractiveProcess.from_process(process, forward_signals_to_process=False, restartable=True)
     )


### PR DESCRIPTION
Migrate the Scala backends to call-by-name syntax.

Note: There is one remaining `Get` for a union invocation for a `ClasspathEntryRequest`.