### PR TITLE
[Call-by-name] migrate Java backends

### DIFF
--- a/src/python/pants/backend/java/dependency_inference/rules.py
+++ b/src/python/pants/backend/java/dependency_inference/rules.py
@@ -6,24 +6,26 @@ from collections import defaultdict
 from dataclasses import dataclass
 
 from pants.backend.java.dependency_inference import symbol_mapper
-from pants.backend.java.dependency_inference.java_parser import JavaSourceDependencyAnalysisRequest
+from pants.backend.java.dependency_inference.java_parser import (
+    JavaSourceDependencyAnalysisRequest,
+    resolve_fallible_result_to_analysis,
+)
 from pants.backend.java.dependency_inference.java_parser import rules as java_parser_rules
-from pants.backend.java.dependency_inference.types import JavaImport, JavaSourceDependencyAnalysis
+from pants.backend.java.dependency_inference.types import JavaImport
 from pants.backend.java.subsystems.java_infer import JavaInferSubsystem
 from pants.backend.java.target_types import JavaSourceField
-from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
+from pants.core.util_rules.source_files import SourceFilesRequest, determine_source_files
 from pants.core.util_rules.source_files import rules as source_files_rules
 from pants.engine.addresses import Address
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.internals.graph import determine_explicitly_provided_dependencies, resolve_target
+from pants.engine.rules import collect_rules, concurrently, implicitly, rule
 from pants.engine.target import (
     Dependencies,
     DependenciesRequest,
-    ExplicitlyProvidedDependencies,
     FieldSet,
     InferDependenciesRequest,
     InferredDependencies,
     SourcesField,
-    WrappedTarget,
     WrappedTargetRequest,
 )
 from pants.engine.unions import UnionRule
@@ -56,17 +58,6 @@ class JavaInferredDependenciesAndExportsRequest:
     source: SourcesField
 
 
-@rule(desc="Inferring Java dependencies by source analysis")
-async def infer_java_dependencies_via_source_analysis(
-    request: InferJavaSourceDependencies,
-) -> InferredDependencies:
-    jids = await Get(
-        JavaInferredDependencies,
-        JavaInferredDependenciesAndExportsRequest(request.field_set.source),
-    )
-    return InferredDependencies(jids.dependencies)
-
-
 @rule(desc="Inferring Java dependencies and exports by source analysis")
 async def infer_java_dependencies_and_exports_via_source_analysis(
     request: JavaInferredDependenciesAndExportsRequest,
@@ -79,17 +70,18 @@ async def infer_java_dependencies_and_exports_via_source_analysis(
 
     address = request.source.address
 
-    wrapped_tgt = await Get(
-        WrappedTarget, WrappedTargetRequest(address, description_of_origin="<infallible>")
+    wrapped_tgt = await resolve_target(
+        WrappedTargetRequest(address, description_of_origin="<infallible>"), **implicitly()
     )
     tgt = wrapped_tgt.target
-    source_files = await Get(SourceFiles, SourceFilesRequest([tgt[JavaSourceField]]))
+    source_files = await determine_source_files(SourceFilesRequest([tgt[JavaSourceField]]))
 
-    explicitly_provided_deps, analysis = await MultiGet(
-        Get(ExplicitlyProvidedDependencies, DependenciesRequest(tgt[Dependencies])),
-        Get(
-            JavaSourceDependencyAnalysis,
-            JavaSourceDependencyAnalysisRequest(source_files=source_files),
+    explicitly_provided_deps, analysis = await concurrently(
+        determine_explicitly_provided_dependencies(
+            **implicitly(DependenciesRequest(tgt[Dependencies]))
+        ),
+        resolve_fallible_result_to_analysis(
+            **implicitly(JavaSourceDependencyAnalysisRequest(source_files=source_files))
         ),
     )
 
@@ -153,6 +145,16 @@ async def infer_java_dependencies_and_exports_via_source_analysis(
         exports.remove(address)
 
     return JavaInferredDependencies(FrozenOrderedSet(dependencies), FrozenOrderedSet(exports))
+
+
+@rule(desc="Inferring Java dependencies by source analysis")
+async def infer_java_dependencies_via_source_analysis(
+    request: InferJavaSourceDependencies,
+) -> InferredDependencies:
+    jids = await infer_java_dependencies_and_exports_via_source_analysis(
+        JavaInferredDependenciesAndExportsRequest(request.field_set.source), **implicitly()
+    )
+    return InferredDependencies(jids.dependencies)
 
 
 def dependency_name(imp: JavaImport):

--- a/src/python/pants/backend/java/goals/check.py
+++ b/src/python/pants/backend/java/goals/check.py
@@ -9,7 +9,8 @@ from pants.backend.java.subsystems.javac import JavacSubsystem
 from pants.backend.java.target_types import JavaFieldSet
 from pants.core.goals.check import CheckRequest, CheckResult, CheckResults
 from pants.engine.addresses import Addresses
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.internals.graph import coarsened_targets as coarsened_targets_get
+from pants.engine.rules import Get, collect_rules, concurrently, implicitly, rule
 from pants.engine.target import CoarsenedTargets
 from pants.engine.unions import UnionRule
 from pants.jvm.compile import (
@@ -17,7 +18,7 @@ from pants.jvm.compile import (
     ClasspathEntryRequestFactory,
     FallibleClasspathEntry,
 )
-from pants.jvm.resolve.key import CoursierResolveKey
+from pants.jvm.resolve.coursier_fetch import select_coursier_resolve_for_targets
 from pants.util.logging import LogLevel
 
 logger = logging.getLogger(__name__)
@@ -33,17 +34,18 @@ async def javac_check(
     request: JavacCheckRequest,
     classpath_entry_request: ClasspathEntryRequestFactory,
 ) -> CheckResults:
-    coarsened_targets = await Get(
-        CoarsenedTargets, Addresses(field_set.address for field_set in request.field_sets)
+    coarsened_targets = await coarsened_targets_get(
+        **implicitly(Addresses(field_set.address for field_set in request.field_sets))
     )
 
     # NB: Each root can have an independent resolve, because there is no inherent relation
     # between them other than that they were on the commandline together.
-    resolves = await MultiGet(
-        Get(CoursierResolveKey, CoarsenedTargets([t])) for t in coarsened_targets
+    resolves = await concurrently(
+        select_coursier_resolve_for_targets(CoarsenedTargets([t]), **implicitly())
+        for t in coarsened_targets
     )
 
-    results = await MultiGet(
+    results = await concurrently(
         Get(
             FallibleClasspathEntry,
             ClasspathEntryRequest,

--- a/src/python/pants/backend/java/goals/tailor.py
+++ b/src/python/pants/backend/java/goals/tailor.py
@@ -19,8 +19,7 @@ from pants.core.goals.tailor import (
     PutativeTargets,
     PutativeTargetsRequest,
 )
-from pants.engine.fs import PathGlobs, Paths
-from pants.engine.internals.selectors import Get
+from pants.engine.intrinsics import path_globs_to_paths
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import Target
 from pants.engine.unions import UnionRule
@@ -51,7 +50,7 @@ async def find_putative_targets(
 
     if javac.tailor_source_targets:
         all_java_files_globs = req.path_globs("*.java")
-        all_java_files = await Get(Paths, PathGlobs, all_java_files_globs)
+        all_java_files = await path_globs_to_paths(all_java_files_globs)
         unowned_java_files = set(all_java_files.files) - set(all_owned_sources)
         classified_unowned_java_files = classify_source_files(unowned_java_files)
 


### PR DESCRIPTION
Migrate the Java backends to call-by-name syntax.

Note: There is still a `Get` for a union (i.e., `ClasspathEntryRequest`).