### PR TITLE
[Call-by-name] `Migrated pants.backend.python` (part 3)

### DIFF
--- a/src/python/pants/backend/python/util_rules/dists.py
+++ b/src/python/pants/backend/python/util_rules/dists.py
@@ -16,24 +16,28 @@ from pants.backend.python.subsystems import setuptools
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.subsystems.setuptools import Setuptools
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
-from pants.backend.python.util_rules.pex import Pex, PexRequest, VenvPex, VenvPexProcess
+from pants.backend.python.util_rules.pex import Pex, PexRequest, VenvPexProcess, create_venv_pex
 from pants.backend.python.util_rules.pex import rules as pex_rules
 from pants.backend.python.util_rules.pex_requirements import EntireLockfile, PexRequirements
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.engine.fs import (
     CreateDigest,
     Digest,
-    DigestContents,
     DigestSubset,
     FileContent,
     MergeDigests,
     PathGlobs,
     RemovePrefix,
-    Snapshot,
 )
-from pants.engine.internals.selectors import Get
-from pants.engine.process import ProcessResult
-from pants.engine.rules import collect_rules, rule
+from pants.engine.intrinsics import (
+    create_digest,
+    digest_to_snapshot,
+    get_digest_contents,
+    merge_digests,
+    remove_prefix,
+)
+from pants.engine.process import fallible_to_exec_result_or_raise
+from pants.engine.rules import collect_rules, implicitly, rule
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.osutil import is_macos_big_sur
@@ -70,15 +74,16 @@ class BuildSystem:
 
 @rule
 async def find_build_system(request: BuildSystemRequest, _setuptools: Setuptools) -> BuildSystem:
-    digest_contents = await Get(
-        DigestContents,
-        DigestSubset(
-            request.digest,
-            PathGlobs(
-                globs=[os.path.join(request.working_directory, "pyproject.toml")],
-                glob_match_error_behavior=GlobMatchErrorBehavior.ignore,
-            ),
-        ),
+    digest_contents = await get_digest_contents(
+        **implicitly(
+            DigestSubset(
+                request.digest,
+                PathGlobs(
+                    globs=[os.path.join(request.working_directory, "pyproject.toml")],
+                    glob_match_error_behavior=GlobMatchErrorBehavior.ignore,
+                ),
+            )
+        )
     )
     ret = None
     if digest_contents:
@@ -202,23 +207,23 @@ def interpolate_backend_shim(dist_dir: str, request: DistBuildRequest) -> bytes:
 async def run_pep517_build(request: DistBuildRequest, python_setup: PythonSetup) -> DistBuildResult:
     # Note that this pex has no entrypoint. We use it to run our generated shim, which
     # in turn imports from and invokes the build backend.
-    build_backend_pex = await Get(
-        VenvPex,
-        PexRequest(
-            output_filename="build_backend.pex",
-            internal_only=True,
-            requirements=request.build_system.requires,
-            pex_path=request.extra_build_time_requirements,
-            interpreter_constraints=request.interpreter_constraints,
-        ),
+    build_backend_pex = await create_venv_pex(
+        **implicitly(
+            PexRequest(
+                output_filename="build_backend.pex",
+                internal_only=True,
+                requirements=request.build_system.requires,
+                pex_path=request.extra_build_time_requirements,
+                interpreter_constraints=request.interpreter_constraints,
+            )
+        )
     )
 
     # This is the setuptools dist directory, not Pants's, so we hardcode to dist/.
     dist_dir = "dist"
     backend_shim_name = "backend_shim.py"
     backend_shim_path = os.path.join(request.working_directory, backend_shim_name)
-    backend_shim_digest = await Get(
-        Digest,
+    backend_shim_digest = await create_digest(
         CreateDigest(
             [
                 FileContent(
@@ -226,10 +231,10 @@ async def run_pep517_build(request: DistBuildRequest, python_setup: PythonSetup)
                     interpolate_backend_shim(os.path.join(dist_dir, request.output_path), request),
                 ),
             ]
-        ),
+        )
     )
 
-    merged_digest = await Get(Digest, MergeDigests((request.input, backend_shim_digest)))
+    merged_digest = await merge_digests(MergeDigests((request.input, backend_shim_digest)))
 
     extra_env = {
         **(request.extra_build_time_env or {}),
@@ -238,22 +243,23 @@ async def run_pep517_build(request: DistBuildRequest, python_setup: PythonSetup)
     if python_setup.macos_big_sur_compatibility and is_macos_big_sur():
         extra_env["MACOSX_DEPLOYMENT_TARGET"] = "10.16"
 
-    result = await Get(
-        ProcessResult,
-        VenvPexProcess(
-            build_backend_pex,
-            argv=(backend_shim_name,),
-            input_digest=merged_digest,
-            extra_env=extra_env,
-            working_directory=request.working_directory,
-            output_directories=(dist_dir,),  # Relative to the working_directory.
-            description=(
-                f"Run {request.build_system.build_backend} for {request.target_address_spec}"
-                if request.target_address_spec
-                else f"Run {request.build_system.build_backend}"
-            ),
-            level=LogLevel.DEBUG,
-        ),
+    result = await fallible_to_exec_result_or_raise(
+        **implicitly(
+            VenvPexProcess(
+                build_backend_pex,
+                argv=(backend_shim_name,),
+                input_digest=merged_digest,
+                extra_env=extra_env,
+                working_directory=request.working_directory,
+                output_directories=(dist_dir,),  # Relative to the working_directory.
+                description=(
+                    f"Run {request.build_system.build_backend} for {request.target_address_spec}"
+                    if request.target_address_spec
+                    else f"Run {request.build_system.build_backend}"
+                ),
+                level=LogLevel.DEBUG,
+            )
+        )
     )
     output_lines = result.stdout.decode().splitlines()
     paths = {}
@@ -264,8 +270,8 @@ async def run_pep517_build(request: DistBuildRequest, python_setup: PythonSetup)
                     request.output_path, line[len(dist_type) + 2 :].strip()
                 )
     # Note that output_digest paths are relative to the working_directory.
-    output_digest = await Get(Digest, RemovePrefix(result.output_digest, dist_dir))
-    output_snapshot = await Get(Snapshot, Digest, output_digest)
+    output_digest = await remove_prefix(RemovePrefix(result.output_digest, dist_dir))
+    output_snapshot = await digest_to_snapshot(output_digest)
     for dist_type, path in paths.items():
         if path not in output_snapshot.files:
             raise BuildBackendError(

--- a/src/python/pants/backend/python/util_rules/entry_points.py
+++ b/src/python/pants/backend/python/util_rules/entry_points.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from pants.backend.python.dependency_inference.module_mapper import (
     PythonModuleOwners,
     PythonModuleOwnersRequest,
+    map_module_to_address,
 )
 from pants.backend.python.goals.pytest_runner import PytestPluginSetup, PytestPluginSetupRequest
 from pants.backend.python.target_types import (
@@ -24,9 +25,11 @@ from pants.backend.python.target_types import (
 )
 from pants.engine.addresses import Addresses, UnparsedAddressInputs
 from pants.engine.fs import CreateDigest, FileContent, PathGlobs, Paths
+from pants.engine.internals.graph import determine_explicitly_provided_dependencies
 from pants.engine.internals.native_engine import EMPTY_DIGEST, Address, Digest
-from pants.engine.internals.selectors import MultiGet
-from pants.engine.rules import Get, collect_rules, rule
+from pants.engine.internals.selectors import concurrently
+from pants.engine.intrinsics import create_digest, path_globs_to_paths
+from pants.engine.rules import Get, collect_rules, implicitly, rule
 from pants.engine.target import (
     DependenciesRequest,
     ExplicitlyProvidedDependencies,
@@ -95,14 +98,14 @@ async def get_filtered_entry_point_dependencies(
 ) -> EntryPointDependencies:
     # This is based on pants.backend.python.target_type_rules.infer_python_distribution_dependencies,
     # but handles multiple targets and filters the entry_points to just get the requested deps.
-    all_explicit_dependencies = await MultiGet(
-        Get(
-            ExplicitlyProvidedDependencies,
-            DependenciesRequest(tgt[PythonDistributionDependenciesField]),
+    all_explicit_dependencies = await concurrently(
+        determine_explicitly_provided_dependencies(
+            **implicitly(DependenciesRequest(tgt[PythonDistributionDependenciesField]))
         )
         for tgt in request.targets
     )
-    resolved_entry_points = await MultiGet(
+    # TODO: This is a circular import on call-by-name
+    resolved_entry_points = await concurrently(
         Get(
             ResolvedPythonDistributionEntryPoints,
             ResolvePythonDistributionEntryPointsRequest(tgt[PythonDistributionEntryPointsField]),
@@ -138,8 +141,10 @@ async def get_filtered_entry_point_dependencies(
                             explicitly_provided_deps,
                         )
                     )
-    filtered_module_owners = await MultiGet(
-        Get(PythonModuleOwners, PythonModuleOwnersRequest(entry_point.module, resolve=None))
+    filtered_module_owners = await concurrently(
+        map_module_to_address(
+            PythonModuleOwnersRequest(entry_point.module, resolve=None), **implicitly()
+        )
         for _, _, _, entry_point, _ in filtered_entry_point_modules
     )
 
@@ -243,9 +248,8 @@ async def infer_entry_point_dependencies(
         request.field_set.address, entry_point_deps
     )
 
-    entry_point_dependencies = await Get(
-        EntryPointDependencies,
-        GetEntryPointDependenciesRequest(dist_targets, group_predicate, predicate),
+    entry_point_dependencies = await get_filtered_entry_point_dependencies(
+        GetEntryPointDependenciesRequest(dist_targets, group_predicate, predicate)
     )
     return InferredDependencies(entry_point_dependencies.addresses)
 
@@ -267,7 +271,8 @@ async def generate_entry_points_txt(request: GenerateEntryPointsTxtRequest) -> E
     if not request.targets:
         return EntryPointsTxt(EMPTY_DIGEST)
 
-    all_resolved_entry_points = await MultiGet(
+    # TODO: This is a circular import on call-by-name
+    all_resolved_entry_points = await concurrently(
         Get(
             ResolvedPythonDistributionEntryPoints,
             ResolvePythonDistributionEntryPointsRequest(tgt[PythonDistributionEntryPointsField]),
@@ -283,8 +288,9 @@ async def generate_entry_points_txt(request: GenerateEntryPointsTxtRequest) -> E
         }
         for tgt, resolved_eps in zip(request.targets, all_resolved_entry_points)
     ]
-    resolved_paths = await MultiGet(
-        Get(Paths, PathGlobs(module_candidate_paths)) for module_candidate_paths in possible_paths
+    resolved_paths = await concurrently(
+        path_globs_to_paths(PathGlobs(module_candidate_paths))
+        for module_candidate_paths in possible_paths
     )
 
     entry_points_by_path: dict[str, list[tuple[Target, ResolvedPythonDistributionEntryPoints]]] = (
@@ -339,7 +345,7 @@ async def generate_entry_points_txt(request: GenerateEntryPointsTxtRequest) -> E
     if not entry_points_txt_files:
         digest = EMPTY_DIGEST
     else:
-        digest = await Get(Digest, CreateDigest(entry_points_txt_files))
+        digest = await create_digest(CreateDigest(entry_points_txt_files))
     return EntryPointsTxt(digest)
 
 
@@ -368,9 +374,8 @@ async def generate_entry_points_txt_from_entry_point_dependencies(
         request.target.address, entry_point_deps
     )
 
-    entry_points_txt = await Get(
-        EntryPointsTxt,
-        GenerateEntryPointsTxtRequest(dist_targets, group_predicate, predicate),
+    entry_points_txt = await generate_entry_points_txt(
+        GenerateEntryPointsTxtRequest(dist_targets, group_predicate, predicate)
     )
     return PytestPluginSetup(entry_points_txt.digest)
 

--- a/src/python/pants/backend/python/util_rules/faas.py
+++ b/src/python/pants/backend/python/util_rules/faas.py
@@ -14,8 +14,8 @@ from pathlib import Path
 from typing import ClassVar, cast
 
 from pants.backend.python.dependency_inference.module_mapper import (
-    PythonModuleOwners,
     PythonModuleOwnersRequest,
+    map_module_to_address,
 )
 from pants.backend.python.dependency_inference.rules import import_rules
 from pants.backend.python.dependency_inference.subsystem import (
@@ -28,33 +28,36 @@ from pants.backend.python.target_types import (
     PexLayout,
     PythonResolveField,
 )
-from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
-from pants.backend.python.util_rules.pex import CompletePlatforms, Pex
+from pants.backend.python.util_rules.pex import (
+    CompletePlatforms,
+    create_pex,
+    digest_complete_platform_addresses,
+)
 from pants.backend.python.util_rules.pex_from_targets import (
     InterpreterConstraintsRequest,
     PexFromTargetsRequest,
+    interpreter_constraints_for_targets,
 )
 from pants.backend.python.util_rules.pex_from_targets import rules as pex_from_targets_rules
-from pants.backend.python.util_rules.pex_venv import PexVenv, PexVenvLayout, PexVenvRequest
+from pants.backend.python.util_rules.pex_venv import PexVenvLayout, PexVenvRequest
+from pants.backend.python.util_rules.pex_venv import pex_venv as pex_venv_get
 from pants.backend.python.util_rules.pex_venv import rules as pex_venv_rules
 from pants.core.goals.package import BuiltPackage, BuiltPackageArtifact, OutputPathField
-from pants.engine.addresses import Address, UnparsedAddressInputs
+from pants.engine.addresses import Address
 from pants.engine.fs import (
     EMPTY_DIGEST,
     CreateDigest,
-    Digest,
     FileContent,
     GlobMatchErrorBehavior,
     PathGlobs,
-    Paths,
-    Snapshot,
 )
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.internals.graph import determine_explicitly_provided_dependencies
+from pants.engine.intrinsics import create_digest, digest_to_snapshot, path_globs_to_paths
+from pants.engine.rules import collect_rules, concurrently, implicitly, rule
 from pants.engine.target import (
     AsyncFieldMixin,
     Dependencies,
     DependenciesRequest,
-    ExplicitlyProvidedDependencies,
     FieldSet,
     InferDependenciesRequest,
     InferredDependencies,
@@ -64,7 +67,7 @@ from pants.engine.target import (
     StringSequenceField,
 )
 from pants.engine.unions import UnionRule
-from pants.source.source_root import SourceRoot, SourceRootRequest
+from pants.source.source_root import SourceRootRequest, get_source_root
 from pants.util.docutil import doc_url
 from pants.util.ordered_set import FrozenOrderedSet
 from pants.util.strutil import help_text, softwrap
@@ -169,14 +172,14 @@ async def resolve_python_faas_handler(
 
     # Use the engine to validate that the file exists and that it resolves to only one file.
     full_glob = os.path.join(address.spec_path, path)
-    handler_paths = await Get(
-        Paths,
+    handler_paths = await path_globs_to_paths(
         PathGlobs(
             [full_glob],
             glob_match_error_behavior=GlobMatchErrorBehavior.error,
             description_of_origin=f"{address}'s `{field_alias}` field",
-        ),
+        )
     )
+
     # We will have already raised if the glob did not match, i.e. if there were no files. But
     # we need to check if they used a file glob (`*` or `**`) that resolved to >1 file.
     if len(handler_paths.files) != 1:
@@ -186,11 +189,7 @@ async def resolve_python_faas_handler(
             f"name?\n\nAll matching files: {list(handler_paths.files)}."
         )
     handler_path = handler_paths.files[0]
-    source_root = await Get(
-        SourceRoot,
-        SourceRootRequest,
-        SourceRootRequest.for_file(handler_path),
-    )
+    source_root = await get_source_root(SourceRootRequest.for_file(handler_path))
     stripped_source_path = os.path.relpath(handler_path, source_root.path)
     module_base, _ = os.path.splitext(stripped_source_path)
     normalized_path = module_base.replace(os.path.sep, ".")
@@ -227,12 +226,11 @@ async def infer_faas_handler_dependency(
     if not python_infer_subsystem.entry_points:
         return InferredDependencies([])
 
-    explicitly_provided_deps, handler = await MultiGet(
-        Get(ExplicitlyProvidedDependencies, DependenciesRequest(request.field_set.dependencies)),
-        Get(
-            ResolvedPythonFaaSHandler,
-            ResolvePythonFaaSHandlerRequest(request.field_set.handler),
+    explicitly_provided_deps, handler = await concurrently(
+        determine_explicitly_provided_dependencies(
+            **implicitly(DependenciesRequest(request.field_set.dependencies))
         ),
+        resolve_python_faas_handler(ResolvePythonFaaSHandlerRequest(request.field_set.handler)),
     )
 
     # Only set locality if needed, to avoid unnecessary rule graph memoization misses.
@@ -240,18 +238,18 @@ async def infer_faas_handler_dependency(
     # misses than using the full spec_path.
     locality = None
     if python_infer_subsystem.ambiguity_resolution == AmbiguityResolution.by_source_root:
-        source_root = await Get(
-            SourceRoot, SourceRootRequest, SourceRootRequest.for_address(request.field_set.address)
+        source_root = await get_source_root(
+            SourceRootRequest.for_address(request.field_set.address)
         )
         locality = source_root.path
 
-    owners = await Get(
-        PythonModuleOwners,
+    owners = await map_module_to_address(
         PythonModuleOwnersRequest(
             handler.module,
             resolve=request.field_set.resolve.normalized_value(python_setup),
             locality=locality,
         ),
+        **implicitly(),
     )
     address = request.field_set.address
     explicitly_provided_deps.maybe_warn_of_ambiguous_dependency_inference(
@@ -350,9 +348,7 @@ def _format_platform_from_major_minor(py_major: int, py_minor: int) -> str:
 async def digest_complete_platforms(
     complete_platforms: PythonFaaSCompletePlatforms,
 ) -> CompletePlatforms:
-    return await Get(
-        CompletePlatforms, UnparsedAddressInputs, complete_platforms.to_unparsed_address_inputs()
-    )
+    return await digest_complete_platform_addresses(complete_platforms.to_unparsed_address_inputs())
 
 
 @dataclass(frozen=True)
@@ -372,7 +368,9 @@ class RuntimePlatforms:
 
 
 async def _infer_from_ics(request: RuntimePlatformsRequest) -> tuple[int, int]:
-    ics = await Get(InterpreterConstraints, InterpreterConstraintsRequest([request.address]))
+    ics = await interpreter_constraints_for_targets(
+        InterpreterConstraintsRequest([request.address]), **implicitly()
+    )
 
     # Future proofing: use naive non-universe-based IC requirement matching to determine if the
     # requirements cover exactly (and all patch versions of) one major.minor interpreter
@@ -416,9 +414,8 @@ async def _infer_from_ics(request: RuntimePlatformsRequest) -> tuple[int, int]:
 async def infer_runtime_platforms(request: RuntimePlatformsRequest) -> RuntimePlatforms:
     if request.complete_platforms.value is not None:
         # explicit complete platforms wins:
-        complete_platforms = await Get(
-            CompletePlatforms, PythonFaaSCompletePlatforms, request.complete_platforms
-        )
+
+        complete_platforms = await digest_complete_platforms(request.complete_platforms)
         # Don't bother trying to infer the runtime version if the user has provided their own
         # complete platform; they probably know what they're doing.
         return RuntimePlatforms(interpreter_version=None, complete_platforms=complete_platforms)
@@ -466,7 +463,9 @@ async def infer_runtime_platforms(request: RuntimePlatformsRequest) -> RuntimePl
     module = request.runtime.known_runtimes_complete_platforms_module()
 
     content = (importlib.resources.files(module) / file_name).read_bytes()
-    snapshot = await Get(Snapshot, CreateDigest([FileContent(file_name, content)]))
+    snapshot = await digest_to_snapshot(
+        **implicitly(CreateDigest([FileContent(file_name, content)]))
+    )
 
     return RuntimePlatforms(
         interpreter_version=version, complete_platforms=CompletePlatforms.from_snapshot(snapshot)
@@ -510,8 +509,7 @@ async def build_python_faas(
         *(request.pex_build_extra_args.value or ()),
     )
 
-    platforms_get = Get(
-        RuntimePlatforms,
+    platforms_get = infer_runtime_platforms(
         RuntimePlatformsRequest(
             address=request.address,
             target_name=request.target_name,
@@ -522,9 +520,9 @@ async def build_python_faas(
     )
 
     if request.handler:
-        platforms, handler = await MultiGet(
+        platforms, handler = await concurrently(
             platforms_get,
-            Get(ResolvedPythonFaaSHandler, ResolvePythonFaaSHandlerRequest(request.handler)),
+            resolve_python_faas_handler(ResolvePythonFaaSHandlerRequest(request.handler)),
         )
     else:
         platforms = await platforms_get
@@ -542,11 +540,10 @@ async def build_python_faas(
         reexported_handler_content = (
             f"from {handler.module} import {handler.func} as {reexported_handler_func}"
         )
-        additional_sources = await Get(
-            Digest,
+        additional_sources = await create_digest(
             CreateDigest(
                 [FileContent(reexported_handler_file, reexported_handler_content.encode())]
-            ),
+            )
         )
     else:
         additional_sources = EMPTY_DIGEST
@@ -567,7 +564,7 @@ async def build_python_faas(
         warn_for_transitive_files_targets=True,
     )
 
-    pex_result = await Get(Pex, PexFromTargetsRequest, pex_request)
+    pex_result = await create_pex(**implicitly({pex_request: PexFromTargetsRequest}))
 
     layout = PexVenvLayout(request.layout.value)
 
@@ -575,8 +572,7 @@ async def build_python_faas(
         file_ending="zip" if layout is PexVenvLayout.FLAT_ZIPPED else None
     )
 
-    result = await Get(
-        PexVenv,
+    result = await pex_venv_get(
         PexVenvRequest(
             pex=pex_result,
             layout=layout,

--- a/src/python/pants/backend/python/util_rules/lockfile_diff.py
+++ b/src/python/pants/backend/python/util_rules/lockfile_diff.py
@@ -13,15 +13,16 @@ from typing import Any
 from packaging.version import Version, parse
 
 from pants.backend.python.util_rules.pex_requirements import (
-    LoadedLockfile,
     LoadedLockfileRequest,
     Lockfile,
+    load_lockfile,
     strip_comments_from_pex_json_lockfile,
 )
 from pants.base.exceptions import EngineError
 from pants.core.goals.generate_lockfiles import LockfileDiff, LockfilePackages, PackageName
-from pants.engine.fs import Digest, DigestContents
-from pants.engine.rules import Get
+from pants.engine.fs import Digest
+from pants.engine.intrinsics import get_digest_contents
+from pants.engine.rules import implicitly
 from pants.util.frozendict import FrozenDict
 
 logger = logging.getLogger(__name__)
@@ -69,11 +70,8 @@ def _pex_lockfile_requirements(
 
 async def _parse_lockfile(lockfile: Lockfile) -> FrozenDict[str, Any] | None:
     try:
-        loaded = await Get(
-            LoadedLockfile,
-            LoadedLockfileRequest(lockfile),
-        )
-        fc = await Get(DigestContents, Digest, loaded.lockfile_digest)
+        loaded = await load_lockfile(LoadedLockfileRequest(lockfile), **implicitly())
+        fc = await get_digest_contents(loaded.lockfile_digest)
         parsed = await _parse_lockfile_content(next(iter(fc)).content, lockfile.url)
         return parsed
     except EngineError:
@@ -94,7 +92,7 @@ async def _parse_lockfile_content(content: bytes, url: str) -> FrozenDict[str, A
 async def _generate_python_lockfile_diff(
     digest: Digest, resolve_name: str, path: str
 ) -> LockfileDiff:
-    new_digest_contents = await Get(DigestContents, Digest, digest)
+    new_digest_contents = await get_digest_contents(digest)
     new_content = next(c for c in new_digest_contents if c.path == path).content
     new_content = strip_comments_from_pex_json_lockfile(new_content)
     new = await _parse_lockfile_content(new_content, path)

--- a/src/python/pants/backend/python/util_rules/package_dists.py
+++ b/src/python/pants/backend/python/util_rules/package_dists.py
@@ -407,7 +407,7 @@ async def create_dist_build_request(
     sdist_config_settings = dist_tgt.get(SDistConfigSettingsField).value or FrozenDict()
     backend_env_vars = dist_tgt.get(BuildBackendEnvVarsField).value
     if backend_env_vars:
-        await environment_vars_subset(
+        extra_build_time_env = await environment_vars_subset(
             EnvironmentVarsRequest(sorted(backend_env_vars)), **implicitly()
         )
     else:

--- a/src/python/pants/backend/python/util_rules/partition.py
+++ b/src/python/pants/backend/python/util_rules/partition.py
@@ -11,8 +11,9 @@ from typing import Protocol, TypeVar
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import InterpreterConstraintsField, PythonResolveField
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
-from pants.engine.rules import Get
-from pants.engine.target import AllTargets, FieldSet
+from pants.engine.internals.graph import find_all_targets
+from pants.engine.rules import implicitly
+from pants.engine.target import FieldSet
 from pants.util.ordered_set import OrderedSet
 
 ResolveName = str
@@ -64,7 +65,7 @@ async def _find_all_unique_interpreter_constraints(
 
     Returns the global interpreter constraints if no relevant targets were matched.
     """
-    all_tgts = await Get(AllTargets)
+    all_tgts = await find_all_targets(**implicitly())
     unique_constraints = {
         InterpreterConstraints.create_from_compatibility_fields(
             [tgt[InterpreterConstraintsField], *extra_constraints_per_tgt], python_setup

--- a/src/python/pants/backend/python/util_rules/vcs_versioning.py
+++ b/src/python/pants/backend/python/util_rules/vcs_versioning.py
@@ -28,20 +28,19 @@ from pants.backend.python.target_types import (
     VersionTemplateField,
     VersionVersionSchemeField,
 )
-from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
-from pants.core.util_rules.stripped_source_files import StrippedFileName, StrippedFileNameRequest
+from pants.backend.python.util_rules.pex import PexRequest, VenvPexProcess, create_venv_pex
+from pants.core.util_rules.stripped_source_files import StrippedFileNameRequest, strip_file_name
 from pants.engine.environment import ChosenLocalEnvironmentName, EnvironmentName
 from pants.engine.fs import CreateDigest, FileContent
-from pants.engine.internals.native_engine import Digest, Snapshot
-from pants.engine.internals.selectors import Get, MultiGet
-from pants.engine.intrinsics import execute_process
+from pants.engine.internals.selectors import concurrently
+from pants.engine.intrinsics import create_digest, digest_to_snapshot, execute_process
 from pants.engine.process import ProcessCacheScope
 from pants.engine.rules import collect_rules, implicitly, rule
 from pants.engine.target import AllTargets, GeneratedSources, GenerateSourcesRequest, Targets
 from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
 from pants.util.strutil import softwrap
-from pants.vcs.git import GitWorktreeRequest, MaybeGitWorktree
+from pants.vcs.git import GitWorktreeRequest, get_git_worktree
 
 
 class VCSVersioningError(Exception):
@@ -64,9 +63,10 @@ async def generate_python_from_setuptools_scm(
     # A MaybeGitWorktree is uncacheable, so this enclosing rule will run every time its result
     # is needed, and the process invocation below caches at session scope, meaning this rule
     # will always return a result based on the current underlying git state.
-    maybe_git_worktree = await Get(
-        MaybeGitWorktree,
-        {GitWorktreeRequest(): GitWorktreeRequest, local_environment_name.val: EnvironmentName},
+    maybe_git_worktree = await get_git_worktree(
+        **implicitly(
+            {GitWorktreeRequest(): GitWorktreeRequest, local_environment_name.val: EnvironmentName}
+        )
     )
     if not maybe_git_worktree.git_worktree:
         raise VCSVersioningError(
@@ -94,23 +94,23 @@ async def generate_python_from_setuptools_scm(
         tool_config["local_scheme"] = local_scheme
     config_path = "pyproject.synthetic.toml"
 
-    input_digest_get = Get(
-        Digest,
+    input_digest_get = create_digest(
         CreateDigest(
             [
                 FileContent(config_path, toml.dumps(config).encode()),
             ]
-        ),
+        )
     )
 
-    setuptools_scm_pex_get = Get(
-        VenvPex,
-        {
-            setuptools_scm.to_pex_request(): PexRequest,
-            local_environment_name.val: EnvironmentName,
-        },
+    setuptools_scm_pex_get = create_venv_pex(
+        **implicitly(
+            {
+                setuptools_scm.to_pex_request(): PexRequest,
+                local_environment_name.val: EnvironmentName,
+            }
+        )
     )
-    setuptools_scm_pex, input_digest = await MultiGet(setuptools_scm_pex_get, input_digest_get)
+    setuptools_scm_pex, input_digest = await concurrently(setuptools_scm_pex_get, input_digest_get)
 
     argv = ["--root", str(maybe_git_worktree.git_worktree.worktree), "--config", config_path]
 
@@ -133,8 +133,8 @@ async def generate_python_from_setuptools_scm(
     write_to = cast(str, request.protocol_target[VersionGenerateToField].value)
     write_to_template = cast(str, request.protocol_target[VersionTemplateField].value)
     output_content = write_to_template.format(version=version)
-    output_snapshot = await Get(
-        Snapshot, CreateDigest([FileContent(write_to, output_content.encode())])
+    output_snapshot = await digest_to_snapshot(
+        **implicitly(CreateDigest([FileContent(write_to, output_content.encode())]))
     )
     return GeneratedSources(output_snapshot)
 
@@ -171,8 +171,8 @@ async def map_to_python_modules(
         for tgt in vcs_version_targets
         if cast(str, tgt[VersionGenerateToField].value).endswith(suffix)
     ]
-    stripped_files = await MultiGet(
-        Get(StrippedFileName, StrippedFileNameRequest(cast(str, tgt[VersionGenerateToField].value)))
+    stripped_files = await concurrently(
+        strip_file_name(StrippedFileNameRequest(cast(str, tgt[VersionGenerateToField].value)))
         for tgt in targets
     )
     resolves_to_modules_to_providers: DefaultDict[


### PR DESCRIPTION
Focus on non-pex goals. 
This was a very manual migration, as the migration plan didn't really pick up much. There were also several cyclic deps, union rules, and order-of-operation cases - and since I'm looking to get the bulk migrated over today, I didn't want to spend anymore time on the extra 5-10 Gets.