### PR TITLE
[Call-by-name] migrate src/python/pants/backend/go/util_rules 2

### DIFF
--- a/src/python/pants/backend/go/util_rules/coverage_html.py
+++ b/src/python/pants/backend/go/util_rules/coverage_html.py
@@ -16,9 +16,8 @@ from pants.backend.go.util_rules.coverage_profile import (
     GoCoverageProfile,
     parse_go_coverage_profiles,
 )
-from pants.engine.fs import DigestContents
 from pants.engine.internals.native_engine import Digest
-from pants.engine.internals.selectors import Get
+from pants.engine.intrinsics import get_digest_contents
 from pants.engine.rules import collect_rules, rule
 
 # Adapted from Go toolchain.
@@ -111,7 +110,7 @@ def _render_source_file(content: bytes, boundaries: Sequence[GoCoverageBoundary]
 async def render_go_coverage_profile_to_html(
     request: RenderGoCoverageProfileToHtmlRequest,
 ) -> RenderGoCoverageProfileToHtmlResult:
-    digest_contents = await Get(DigestContents, Digest, request.sources_digest)
+    digest_contents = await get_digest_contents(request.sources_digest)
     profiles = parse_go_coverage_profiles(
         request.raw_coverage_profile, description_of_origin=request.description_of_origin
     )

--- a/src/python/pants/backend/go/util_rules/go_bootstrap.py
+++ b/src/python/pants/backend/go/util_rules/go_bootstrap.py
@@ -10,9 +10,8 @@ from pants.backend.go.subsystems.golang import GolangSubsystem
 from pants.core.util_rules import asdf, search_paths
 from pants.core.util_rules.asdf import AsdfPathString, AsdfToolPathsResult
 from pants.core.util_rules.environments import EnvironmentTarget
-from pants.core.util_rules.search_paths import ValidatedSearchPaths, ValidateSearchPathsRequest
-from pants.engine.env_vars import PathEnvironmentVariable
-from pants.engine.internals.selectors import Get
+from pants.core.util_rules.search_paths import ValidateSearchPathsRequest, validate_search_paths
+from pants.engine.internals.platform_rules import environment_path_variable
 from pants.engine.rules import collect_rules, rule
 from pants.util.ordered_set import FrozenOrderedSet
 
@@ -40,7 +39,7 @@ async def _go_search_paths(
         AsdfPathString.LOCAL.value: asdf_result.local_tool_paths,
     }
 
-    path_variables = await Get(PathEnvironmentVariable)
+    path_variables = await environment_path_variable()
     expanded: list[str] = []
     for s in paths:
         if s == "<PATH>":
@@ -57,8 +56,7 @@ async def _go_search_paths(
 async def resolve_go_bootstrap(
     golang_subsystem: GolangSubsystem, golang_env_aware: GolangSubsystem.EnvironmentAware
 ) -> GoBootstrap:
-    search_paths = await Get(
-        ValidatedSearchPaths,
+    search_paths = await validate_search_paths(
         ValidateSearchPathsRequest(
             env_tgt=golang_env_aware.env_tgt,
             search_paths=tuple(golang_env_aware.raw_go_search_paths),
@@ -66,7 +64,7 @@ async def resolve_go_bootstrap(
             environment_key="golang_go_search_paths",
             is_default=golang_env_aware._is_default("_go_search_paths"),
             local_only=FrozenOrderedSet((AsdfPathString.STANDARD, AsdfPathString.LOCAL)),
-        ),
+        )
     )
     paths = await _go_search_paths(golang_env_aware.env_tgt, golang_subsystem, search_paths)
 

--- a/src/python/pants/backend/go/util_rules/goroot.py
+++ b/src/python/pants/backend/go/util_rules/goroot.py
@@ -13,12 +13,12 @@ from pants.core.util_rules.environments import EnvironmentTarget
 from pants.core.util_rules.system_binaries import (
     BinaryNotFoundError,
     BinaryPathRequest,
-    BinaryPaths,
     BinaryPathTest,
+    find_binary,
 )
-from pants.engine.internals.selectors import Get, MultiGet
-from pants.engine.process import Process, ProcessResult
-from pants.engine.rules import collect_rules, rule
+from pants.engine.internals.selectors import concurrently
+from pants.engine.process import Process, fallible_to_exec_result_or_raise
+from pants.engine.rules import collect_rules, implicitly, rule
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.strutil import bullet_list, softwrap
@@ -62,13 +62,13 @@ async def setup_goroot(
     golang_subsystem: GolangSubsystem, go_bootstrap: GoBootstrap, env_target: EnvironmentTarget
 ) -> GoRoot:
     search_paths = go_bootstrap.go_search_paths
-    all_go_binary_paths = await Get(
-        BinaryPaths,
+    all_go_binary_paths = await find_binary(
         BinaryPathRequest(
             search_path=search_paths,
             binary_name="go",
             test=BinaryPathTest(["version"]),
         ),
+        **implicitly(),
     )
     if not all_go_binary_paths.paths:
         raise BinaryNotFoundError(
@@ -87,15 +87,16 @@ async def setup_goroot(
 
     # `go env GOVERSION` does not work in earlier Go versions (like 1.15), so we must run
     # `go version` and `go env GOROOT` to calculate both the version and GOROOT.
-    version_results = await MultiGet(
-        Get(
-            ProcessResult,
-            Process(
-                (binary_path.path, "version"),
-                description=f"Determine Go version for {binary_path.path}",
-                level=LogLevel.DEBUG,
-                cache_scope=env_target.executable_search_path_cache_scope(),
-            ),
+    version_results = await concurrently(
+        fallible_to_exec_result_or_raise(
+            **implicitly(
+                Process(
+                    (binary_path.path, "version"),
+                    description=f"Determine Go version for {binary_path.path}",
+                    level=LogLevel.DEBUG,
+                    cache_scope=env_target.executable_search_path_cache_scope(),
+                )
+            )
         )
         for binary_path in all_go_binary_paths.paths
     )
@@ -119,15 +120,16 @@ async def setup_goroot(
         if compatible_go_version(
             compiler_version=version, target_version=golang_subsystem.minimum_expected_version
         ):
-            env_result = await Get(  # noqa: PNT30: requires triage
-                ProcessResult,
-                Process(
-                    (binary_path.path, "env", "-json"),
-                    description=f"Determine Go SDK metadata for {binary_path.path}",
-                    level=LogLevel.DEBUG,
-                    cache_scope=env_target.executable_search_path_cache_scope(),
-                    env={"GOPATH": "/does/not/matter"},
-                ),
+            env_result = await fallible_to_exec_result_or_raise(  # noqa: PNT30: requires triage
+                **implicitly(
+                    Process(
+                        (binary_path.path, "env", "-json"),
+                        description=f"Determine Go SDK metadata for {binary_path.path}",
+                        level=LogLevel.DEBUG,
+                        cache_scope=env_target.executable_search_path_cache_scope(),
+                        env={"GOPATH": "/does/not/matter"},
+                    )
+                )
             )
             sdk_metadata = json.loads(env_result.stdout.decode())
             return GoRoot(

--- a/src/python/pants/backend/go/util_rules/import_config.py
+++ b/src/python/pants/backend/go/util_rules/import_config.py
@@ -11,7 +11,7 @@ from typing import ClassVar
 from pants.backend.go.util_rules.build_opts import GoBuildOptions
 from pants.engine.fs import CreateDigest, FileContent
 from pants.engine.internals.native_engine import Digest
-from pants.engine.internals.selectors import Get
+from pants.engine.intrinsics import create_digest
 from pants.engine.rules import collect_rules, rule
 from pants.util.frozendict import FrozenDict
 
@@ -47,7 +47,7 @@ async def generate_import_config(request: ImportConfigRequest) -> ImportConfig:
         *(f"importmap {old}={new}" for old, new in import_map),
     ]
     content = "\n".join(lines).encode("utf-8")
-    result = await Get(Digest, CreateDigest([FileContent(ImportConfig.CONFIG_PATH, content)]))
+    result = await create_digest(CreateDigest([FileContent(ImportConfig.CONFIG_PATH, content)]))
     return ImportConfig(result)
 
 

--- a/src/python/pants/backend/go/util_rules/link.py
+++ b/src/python/pants/backend/go/util_rules/link.py
@@ -8,19 +8,20 @@ from dataclasses import dataclass
 from pants.backend.go.subsystems.golang import GolangSubsystem
 from pants.backend.go.util_rules import import_config
 from pants.backend.go.util_rules.build_opts import GoBuildOptions
-from pants.backend.go.util_rules.cgo_binaries import CGoBinaryPathRequest
-from pants.backend.go.util_rules.import_config import ImportConfig, ImportConfigRequest
+from pants.backend.go.util_rules.cgo_binaries import CGoBinaryPathRequest, find_cgo_binary_path
+from pants.backend.go.util_rules.import_config import ImportConfigRequest, generate_import_config
 from pants.backend.go.util_rules.link_defs import (
     ImplicitLinkerDependencies,
     ImplicitLinkerDependenciesHook,
 )
-from pants.backend.go.util_rules.sdk import GoSdkProcess, GoSdkToolIDRequest, GoSdkToolIDResult
-from pants.core.util_rules.system_binaries import BashBinary, BinaryPath, BinaryPathTest
+from pants.backend.go.util_rules.sdk import GoSdkProcess, GoSdkToolIDRequest, compute_go_tool_id
+from pants.core.util_rules.system_binaries import BashBinary, BinaryPathTest
 from pants.engine.fs import CreateDigest, Digest, Directory, FileContent
 from pants.engine.internals.native_engine import AddPrefix, MergeDigests
-from pants.engine.internals.selectors import MultiGet
-from pants.engine.process import ProcessResult
-from pants.engine.rules import Get, collect_rules, rule
+from pants.engine.internals.selectors import MultiGet, concurrently
+from pants.engine.intrinsics import add_prefix, create_digest, merge_digests
+from pants.engine.process import fallible_to_exec_result_or_raise
+from pants.engine.rules import Get, collect_rules, implicitly, rule
 from pants.engine.unions import UnionMembership
 from pants.util.frozendict import FrozenDict
 
@@ -54,17 +55,16 @@ class LinkerSetup:
 async def setup_go_linker(
     bash: BashBinary, golang_subsystem: GolangSubsystem.EnvironmentAware
 ) -> LinkerSetup:
-    extld_binary = await Get(
-        BinaryPath,
+    extld_binary = await find_cgo_binary_path(
         CGoBinaryPathRequest(
             binary_name=golang_subsystem.external_linker_binary_name,
             binary_path_test=BinaryPathTest(["--version"]),
         ),
+        **implicitly(),
     )
 
     extld_wrapper_path = "__pants_extld_wrapper__"
-    digest = await Get(
-        Digest,
+    digest = await create_digest(
         CreateDigest(
             [
                 FileContent(
@@ -79,7 +79,7 @@ async def setup_go_linker(
                     is_executable=True,
                 ),
             ]
-        ),
+        )
     )
     return LinkerSetup(digest, extld_wrapper_path)
 
@@ -112,22 +112,20 @@ async def link_go_binary(
                 implicit_dep_digests.append(implicit_linker_dep.digest)
 
     link_tmp_dir = "link-tmp"
-    link_tmp_dir_digest = await Get(Digest, CreateDigest([Directory(link_tmp_dir)]))
+    link_tmp_dir_digest = await create_digest(CreateDigest([Directory(link_tmp_dir)]))
 
-    link_tool_id, import_config = await MultiGet(
-        Get(GoSdkToolIDResult, GoSdkToolIDRequest("link")),
-        Get(
-            ImportConfig,
+    link_tool_id, import_config = await concurrently(
+        compute_go_tool_id(GoSdkToolIDRequest("link")),
+        generate_import_config(
             ImportConfigRequest(
                 FrozenDict(import_paths_to_pkg_a_files), build_opts=request.build_opts
-            ),
+            )
         ),
     )
 
-    import_config_digest = await Get(Digest, AddPrefix(import_config.digest, link_tmp_dir))
+    import_config_digest = await add_prefix(AddPrefix(import_config.digest, link_tmp_dir))
 
-    input_digest = await Get(
-        Digest,
+    input_digest = await merge_digests(
         MergeDigests(
             [
                 request.input_digest,
@@ -136,46 +134,47 @@ async def link_go_binary(
                 import_config_digest,
                 *implicit_dep_digests,
             ]
-        ),
+        )
     )
 
     maybe_race_arg = ["-race"] if request.build_opts.with_race_detector else []
     maybe_msan_arg = ["-msan"] if request.build_opts.with_msan else []
     maybe_asan_arg = ["-asan"] if request.build_opts.with_asan else []
 
-    result = await Get(
-        ProcessResult,
-        GoSdkProcess(
-            input_digest=input_digest,
-            command=(
-                "tool",
-                "link",
-                # Put the linker's temporary directory into the input root.
-                "-tmpdir",
-                f"__PANTS_SANDBOX_ROOT__/{link_tmp_dir}",
-                # Force `go tool link` to use a wrapper script as the "external linker" so that the script can
-                # replace any instances of `__PANTS_SANDBOX_ROOT__` in the linker arguments. This also allows
-                # Pants to know which external linker is in use and invalidate this `Process` as needed.
-                "-extld",
-                f"__PANTS_SANDBOX_ROOT__/{linker_setup.extld_wrapper_path}",
-                *maybe_race_arg,
-                *maybe_msan_arg,
-                *maybe_asan_arg,
-                "-importcfg",
-                f"{link_tmp_dir}/{import_config.CONFIG_PATH}",
-                "-o",
-                request.output_filename,
-                "-buildmode=exe",  # seen in `go build -x` output
-                *request.build_opts.linker_flags,
-                *request.archives,
+    result = await fallible_to_exec_result_or_raise(
+        **implicitly(
+            GoSdkProcess(
+                input_digest=input_digest,
+                command=(
+                    "tool",
+                    "link",
+                    # Put the linker's temporary directory into the input root.
+                    "-tmpdir",
+                    f"__PANTS_SANDBOX_ROOT__/{link_tmp_dir}",
+                    # Force `go tool link` to use a wrapper script as the "external linker" so that the script can
+                    # replace any instances of `__PANTS_SANDBOX_ROOT__` in the linker arguments. This also allows
+                    # Pants to know which external linker is in use and invalidate this `Process` as needed.
+                    "-extld",
+                    f"__PANTS_SANDBOX_ROOT__/{linker_setup.extld_wrapper_path}",
+                    *maybe_race_arg,
+                    *maybe_msan_arg,
+                    *maybe_asan_arg,
+                    "-importcfg",
+                    f"{link_tmp_dir}/{import_config.CONFIG_PATH}",
+                    "-o",
+                    request.output_filename,
+                    "-buildmode=exe",  # seen in `go build -x` output
+                    *request.build_opts.linker_flags,
+                    *request.archives,
+                ),
+                env={
+                    "__PANTS_GO_LINK_TOOL_ID": link_tool_id.tool_id,
+                },
+                description=f"Link Go binary: {request.output_filename}",
+                output_files=(request.output_filename,),
+                replace_sandbox_root_in_args=True,
             ),
-            env={
-                "__PANTS_GO_LINK_TOOL_ID": link_tool_id.tool_id,
-            },
-            description=f"Link Go binary: {request.output_filename}",
-            output_files=(request.output_filename,),
-            replace_sandbox_root_in_args=True,
-        ),
+        )
     )
 
     return LinkedGoBinary(result.output_digest)

--- a/src/python/pants/backend/go/util_rules/pkg_analyzer.py
+++ b/src/python/pants/backend/go/util_rules/pkg_analyzer.py
@@ -4,11 +4,10 @@
 from dataclasses import dataclass
 
 from pants.backend.go.go_sources import load_go_binary
-from pants.backend.go.go_sources.load_go_binary import LoadedGoBinary, LoadedGoBinaryRequest
+from pants.backend.go.go_sources.load_go_binary import LoadedGoBinaryRequest, setup_go_binary
 from pants.backend.go.util_rules.goroot import GoRoot
 from pants.engine.fs import Digest
-from pants.engine.internals.selectors import Get
-from pants.engine.rules import collect_rules, rule
+from pants.engine.rules import collect_rules, implicitly, rule
 
 
 @dataclass(frozen=True)
@@ -28,13 +27,13 @@ async def setup_go_package_analyzer(goroot: GoRoot) -> PackageAnalyzerSetup:
         "syslist.go",
         "tags.go1.17.go" if goroot.is_compatible_version("1.17") else "tags.go",
     )
-    binary = await Get(
-        LoadedGoBinary,
+    binary = await setup_go_binary(
         LoadedGoBinaryRequest(
             "analyze_package",
             sources,
             binary_path,
         ),
+        **implicitly(),
     )
     return PackageAnalyzerSetup(
         digest=binary.digest,

--- a/src/python/pants/backend/go/util_rules/third_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/third_party_pkg.py
@@ -13,7 +13,7 @@ from typing import Any
 
 import ijson.backends.python as ijson
 
-from pants.backend.go.go_sources.load_go_binary import LoadedGoBinary, LoadedGoBinaryRequest
+from pants.backend.go.go_sources.load_go_binary import LoadedGoBinaryRequest, setup_go_binary
 from pants.backend.go.target_types import GoModTarget
 from pants.backend.go.util_rules import pkg_analyzer
 from pants.backend.go.util_rules.build_opts import GoBuildOptions
@@ -27,17 +27,22 @@ from pants.engine.fs import (
     EMPTY_DIGEST,
     CreateDigest,
     Digest,
-    DigestContents,
     DigestSubset,
     FileContent,
     GlobExpansionConjunction,
     GlobMatchErrorBehavior,
     MergeDigests,
     PathGlobs,
-    Snapshot,
 )
-from pants.engine.process import FallibleProcessResult, Process, ProcessResult
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.intrinsics import (
+    create_digest,
+    digest_to_snapshot,
+    execute_process,
+    get_digest_contents,
+    merge_digests,
+)
+from pants.engine.process import Process, fallible_to_exec_result_or_raise
+from pants.engine.rules import collect_rules, concurrently, implicitly, rule
 from pants.util.dirutil import group_by_dir
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
@@ -206,17 +211,18 @@ async def analyze_module_dependencies(request: ModuleDescriptorsRequest) -> Modu
     #   closure that cannot be built, but we should  not blow up Pants. For example, a package that sets the
     #   special value `package documentation` and has no source files would naively error due to
     #   `build constraints exclude all Go files`, even though we should not error on that package.
-    mod_list_result = await Get(
-        ProcessResult,
-        GoSdkProcess(
-            command=["list", "-mod=readonly", "-e", "-m", "-json", "all"],
-            input_digest=request.digest,
-            output_directories=("gopath",),
-            working_dir=request.path if request.path else None,
-            # Allow downloads of the module metadata (i.e., go.mod files).
-            allow_downloads=True,
-            description="Analyze Go module dependencies.",
-        ),
+    mod_list_result = await fallible_to_exec_result_or_raise(
+        **implicitly(
+            GoSdkProcess(
+                command=["list", "-mod=readonly", "-e", "-m", "-json", "all"],
+                input_digest=request.digest,
+                output_directories=("gopath",),
+                working_dir=request.path if request.path else None,
+                # Allow downloads of the module metadata (i.e., go.mod files).
+                allow_downloads=True,
+                description="Analyze Go module dependencies.",
+            )
+        )
     )
 
     if len(mod_list_result.stdout) == 0:
@@ -297,9 +303,9 @@ async def _check_go_sum_has_not_changed(
     import_path: str,
     go_mod_address: Address,
 ) -> None:
-    input_entries, output_entries = await MultiGet(
-        Get(DigestContents, Digest, input_digest),
-        Get(DigestContents, Digest, output_digest),
+    input_entries, output_entries = await concurrently(
+        get_digest_contents(input_digest),
+        get_digest_contents(output_digest),
     )
 
     go_sum_path = os.path.join(dir_path, "go.sum")
@@ -338,18 +344,19 @@ async def analyze_go_third_party_module(
     analyzer: PackageAnalyzerSetup,
 ) -> AnalyzedThirdPartyModule:
     # Download the module.
-    download_result = await Get(
-        ProcessResult,
-        GoSdkProcess(
-            ("mod", "download", "-json", f"{request.name}@{request.version}"),
-            input_digest=request.go_mod_digest,  # for go.sum
-            working_dir=os.path.dirname(request.go_mod_path),
-            # Allow downloads of the module sources.
-            allow_downloads=True,
-            output_directories=("gopath",),
-            output_files=(os.path.join(os.path.dirname(request.go_mod_path), "go.sum"),),
-            description=f"Download Go module {request.name}@{request.version}.",
-        ),
+    download_result = await fallible_to_exec_result_or_raise(
+        **implicitly(
+            GoSdkProcess(
+                ("mod", "download", "-json", f"{request.name}@{request.version}"),
+                input_digest=request.go_mod_digest,  # for go.sum
+                working_dir=os.path.dirname(request.go_mod_path),
+                # Allow downloads of the module sources.
+                allow_downloads=True,
+                output_directories=("gopath",),
+                output_files=(os.path.join(os.path.dirname(request.go_mod_path), "go.sum"),),
+                description=f"Download Go module {request.name}@{request.version}.",
+            )
+        )
     )
 
     if len(download_result.stdout) == 0:
@@ -371,17 +378,18 @@ async def analyze_go_third_party_module(
     go_mod_relpath = strip_sandbox_prefix(module_metadata["GoMod"], "gopath/")
 
     # Subset the output directory to just the module sources and go.mod (which may be generated).
-    module_sources_snapshot = await Get(
-        Snapshot,
-        DigestSubset(
-            download_result.output_digest,
-            PathGlobs(
-                [f"{module_sources_relpath}/**", go_mod_relpath],
-                glob_match_error_behavior=GlobMatchErrorBehavior.error,
-                conjunction=GlobExpansionConjunction.all_match,
-                description_of_origin=f"the download of Go module {request.name}@{request.version}",
-            ),
-        ),
+    module_sources_snapshot = await digest_to_snapshot(
+        **implicitly(
+            DigestSubset(
+                download_result.output_digest,
+                PathGlobs(
+                    [f"{module_sources_relpath}/**", go_mod_relpath],
+                    glob_match_error_behavior=GlobMatchErrorBehavior.error,
+                    conjunction=GlobExpansionConjunction.all_match,
+                    description_of_origin=f"the download of Go module {request.name}@{request.version}",
+                ),
+            )
+        )
     )
 
     # Determine directories with potential Go packages in them.
@@ -402,18 +410,19 @@ async def analyze_go_third_party_module(
 
     # Analyze all of the packages in this module.
     analyzer_relpath = "__analyzer"
-    analysis_result = await Get(
-        ProcessResult,
-        Process(
-            [os.path.join(analyzer_relpath, analyzer.path), *candidate_package_dirs],
-            input_digest=module_sources_snapshot.digest,
-            immutable_input_digests={
-                analyzer_relpath: analyzer.digest,
-            },
-            description=f"Analyze metadata for Go third-party module: {request.name}@{request.version}",
-            level=LogLevel.DEBUG,
-            env={"CGO_ENABLED": "1" if request.build_opts.cgo_enabled else "0"},
-        ),
+    analysis_result = await fallible_to_exec_result_or_raise(
+        **implicitly(
+            Process(
+                [os.path.join(analyzer_relpath, analyzer.path), *candidate_package_dirs],
+                input_digest=module_sources_snapshot.digest,
+                immutable_input_digests={
+                    analyzer_relpath: analyzer.digest,
+                },
+                description=f"Analyze metadata for Go third-party module: {request.name}@{request.version}",
+                level=LogLevel.DEBUG,
+                env={"CGO_ENABLED": "1" if request.build_opts.cgo_enabled else "0"},
+            )
+        )
     )
 
     if len(analysis_result.stdout) == 0:
@@ -424,8 +433,7 @@ async def analyze_go_third_party_module(
         candidate_package_dirs, ijson.items(analysis_result.stdout, "", multiple_values=True)
     ):
         package_analysis_gets.append(
-            Get(
-                FallibleThirdPartyPkgAnalysis,
+            analyze_go_third_party_package(
                 AnalyzeThirdPartyPackageRequest(
                     pkg_json=_freeze_json_dict(pkg_json),
                     module_sources_digest=module_sources_snapshot.digest,
@@ -433,10 +441,10 @@ async def analyze_go_third_party_module(
                     module_import_path=request.name,
                     package_path=pkg_path,
                     minimum_go_version=request.minimum_go_version,
-                ),
+                )
             )
         )
-    analyzed_packages_fallible = await MultiGet(package_analysis_gets)
+    analyzed_packages_fallible = await concurrently(package_analysis_gets)
     analyzed_packages = [
         pkg.analysis for pkg in analyzed_packages_fallible if pkg.analysis and pkg.exit_code == 0
     ]
@@ -532,22 +540,23 @@ async def analyze_go_third_party_package(
                 "XTestEmbedPatterns": analysis.xtest_embed_patterns,
             }
         ).encode("utf-8")
-        embedder, patterns_json_digest = await MultiGet(
-            Get(LoadedGoBinary, LoadedGoBinaryRequest("embedcfg", ("main.go",), "./embedder")),
-            Get(Digest, CreateDigest([FileContent("patterns.json", patterns_json)])),
+        embedder, patterns_json_digest = await concurrently(
+            setup_go_binary(
+                LoadedGoBinaryRequest("embedcfg", ("main.go",), "./embedder"), **implicitly()
+            ),
+            create_digest(CreateDigest([FileContent("patterns.json", patterns_json)])),
         )
-        input_digest = await Get(
-            Digest,
-            MergeDigests((request.module_sources_digest, patterns_json_digest, embedder.digest)),
+        input_digest = await merge_digests(
+            MergeDigests((request.module_sources_digest, patterns_json_digest, embedder.digest))
         )
-        embed_result = await Get(
-            FallibleProcessResult,
+        embed_result = await execute_process(
             Process(
                 ("./embedder", "patterns.json", request.package_path),
                 input_digest=input_digest,
                 description=f"Create embed mapping for {import_path}",
                 level=LogLevel.DEBUG,
             ),
+            **implicitly(),
         )
         if embed_result.exit_code != 0:
             return FallibleThirdPartyPkgAnalysis(
@@ -579,21 +588,19 @@ async def analyze_go_third_party_package(
 async def download_and_analyze_third_party_packages(
     request: AllThirdPartyPackagesRequest,
 ) -> AllThirdPartyPackages:
-    module_analysis = await Get(
-        ModuleDescriptors,
+    module_analysis = await analyze_module_dependencies(
         ModuleDescriptorsRequest(
             digest=request.go_mod_digest,
             path=os.path.dirname(request.go_mod_path),
-        ),
+        )
     )
 
-    go_mod_digest = await Get(
-        Digest, MergeDigests([request.go_mod_digest, module_analysis.go_mods_digest])
+    go_mod_digest = await merge_digests(
+        MergeDigests([request.go_mod_digest, module_analysis.go_mods_digest])
     )
 
-    analyzed_modules = await MultiGet(
-        Get(
-            AnalyzedThirdPartyModule,
+    analyzed_modules = await concurrently(
+        analyze_go_third_party_module(
             AnalyzeThirdPartyModuleRequest(
                 go_mod_address=request.go_mod_address,
                 go_mod_digest=go_mod_digest,
@@ -604,6 +611,7 @@ async def download_and_analyze_third_party_packages(
                 minimum_go_version=mod.minimum_go_version,
                 build_opts=request.build_opts,
             ),
+            **implicitly(),
         )
         for mod in module_analysis.modules
     )
@@ -619,14 +627,13 @@ async def download_and_analyze_third_party_packages(
 
 @rule
 async def extract_package_info(request: ThirdPartyPkgAnalysisRequest) -> ThirdPartyPkgAnalysis:
-    all_packages = await Get(
-        AllThirdPartyPackages,
+    all_packages = await download_and_analyze_third_party_packages(
         AllThirdPartyPackagesRequest(
             request.go_mod_address,
             request.go_mod_digest,
             request.go_mod_path,
             build_opts=request.build_opts,
-        ),
+        )
     )
     pkg_info = all_packages.import_paths_to_pkg_info.get(request.import_path)
     if pkg_info:


### PR DESCRIPTION
More pieces of the `src/python/pants/backend/go/util_rules` migration