### PR TITLE
[Call-by-name] Migrated remaining `pants.backend.python` that weren't cyclic deps or unions

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -60,7 +60,7 @@ from pants.engine.internals.graph import (
     find_owners,
     resolve_targets,
 )
-from pants.engine.rules import Get, concurrently, implicitly, rule
+from pants.engine.rules import concurrently, implicitly, rule
 from pants.engine.target import (
     DependenciesRequest,
     ExplicitlyProvidedDependencies,
@@ -268,7 +268,9 @@ async def _find_other_owners_for_unowned_imports(
     req: UnownedImportsPossibleOwnersRequest,
 ) -> UnownedImportsPossibleOwners:
     individual_possible_owners = await concurrently(
-        find_other_owners_for_unowned_import(UnownedImportPossibleOwnerRequest(r, req.original_resolve), **implicitly())
+        find_other_owners_for_unowned_import(
+            UnownedImportPossibleOwnerRequest(r, req.original_resolve), **implicitly()
+        )
         for r in req.unowned_imports
     )
 

--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -268,7 +268,7 @@ async def _find_other_owners_for_unowned_imports(
     req: UnownedImportsPossibleOwnersRequest,
 ) -> UnownedImportsPossibleOwners:
     individual_possible_owners = await concurrently(
-        Get(UnownedImportPossibleOwners, UnownedImportPossibleOwnerRequest(r, req.original_resolve))
+        find_other_owners_for_unowned_import(UnownedImportPossibleOwnerRequest(r, req.original_resolve), **implicitly())
         for r in req.unowned_imports
     )
 

--- a/src/python/pants/backend/python/target_types_rules.py
+++ b/src/python/pants/backend/python/target_types_rules.py
@@ -19,6 +19,7 @@ from typing import DefaultDict, cast
 from pants.backend.python.dependency_inference.module_mapper import (
     PythonModuleOwners,
     PythonModuleOwnersRequest,
+    map_module_to_address,
 )
 from pants.backend.python.dependency_inference.rules import import_rules
 from pants.backend.python.dependency_inference.subsystem import (
@@ -55,11 +56,17 @@ from pants.core.util_rules.unowned_dependency_behavior import (
     UnownedDependencyUsage,
 )
 from pants.engine.addresses import Address, Addresses, UnparsedAddressInputs
-from pants.engine.fs import GlobMatchErrorBehavior, PathGlobs, Paths
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.fs import GlobMatchErrorBehavior, PathGlobs
+from pants.engine.internals.graph import (
+    determine_explicitly_provided_dependencies,
+    resolve_target,
+    resolve_targets,
+    resolve_unparsed_address_inputs,
+)
+from pants.engine.intrinsics import path_globs_to_paths
+from pants.engine.rules import collect_rules, concurrently, implicitly, rule
 from pants.engine.target import (
     DependenciesRequest,
-    ExplicitlyProvidedDependencies,
     FieldDefaultFactoryRequest,
     FieldDefaultFactoryResult,
     FieldSet,
@@ -70,14 +77,12 @@ from pants.engine.target import (
     InvalidFieldException,
     TargetFilesGeneratorSettings,
     TargetFilesGeneratorSettingsRequest,
-    Targets,
     ValidatedDependencies,
     ValidateDependenciesRequest,
-    WrappedTarget,
     WrappedTargetRequest,
 )
 from pants.engine.unions import UnionMembership, UnionRule
-from pants.source.source_root import SourceRoot, SourceRootRequest
+from pants.source.source_root import SourceRootRequest, get_source_root
 from pants.util.docutil import doc_url
 from pants.util.frozendict import FrozenDict
 from pants.util.ordered_set import OrderedSet
@@ -174,14 +179,14 @@ async def resolve_pex_entry_point(request: ResolvePexEntryPointRequest) -> Resol
 
     # Use the engine to validate that the file exists and that it resolves to only one file.
     full_glob = os.path.join(address.spec_path, ep_val.module)
-    entry_point_paths = await Get(
-        Paths,
+    entry_point_paths = await path_globs_to_paths(
         PathGlobs(
             [full_glob],
             glob_match_error_behavior=GlobMatchErrorBehavior.error,
             description_of_origin=f"{address}'s `{request.entry_point_field.alias}` field",
-        ),
+        )
     )
+
     # We will have already raised if the glob did not match, i.e. if there were no files. But
     # we need to check if they used a file glob (`*` or `**`) that resolved to >1 file.
     if len(entry_point_paths.files) != 1:
@@ -197,11 +202,7 @@ async def resolve_pex_entry_point(request: ResolvePexEntryPointRequest) -> Resol
             )
         )
     entry_point_path = entry_point_paths.files[0]
-    source_root = await Get(
-        SourceRoot,
-        SourceRootRequest,
-        SourceRootRequest.for_file(entry_point_path),
-    )
+    source_root = await get_source_root(SourceRootRequest.for_file(entry_point_path))
     stripped_source_path = os.path.relpath(entry_point_path, source_root.path)
     module_base, _ = os.path.splitext(stripped_source_path)
     normalized_path = module_base.replace(os.path.sep, ".")
@@ -236,9 +237,11 @@ async def infer_pex_binary_entry_point_dependency(
     if entry_point_field.value is None:
         return InferredDependencies([])
 
-    explicitly_provided_deps, entry_point = await MultiGet(
-        Get(ExplicitlyProvidedDependencies, DependenciesRequest(request.field_set.dependencies)),
-        Get(ResolvedPexEntryPoint, ResolvePexEntryPointRequest(entry_point_field)),
+    explicitly_provided_deps, entry_point = await concurrently(
+        determine_explicitly_provided_dependencies(
+            **implicitly(DependenciesRequest(request.field_set.dependencies))
+        ),
+        resolve_pex_entry_point(ResolvePexEntryPointRequest(entry_point_field)),
     )
     if entry_point.val is None:
         return InferredDependencies([])
@@ -248,18 +251,18 @@ async def infer_pex_binary_entry_point_dependency(
     # misses than using the full spec_path.
     locality = None
     if python_infer_subsystem.ambiguity_resolution == AmbiguityResolution.by_source_root:
-        source_root = await Get(
-            SourceRoot, SourceRootRequest, SourceRootRequest.for_address(request.field_set.address)
+        source_root = await get_source_root(
+            SourceRootRequest.for_address(request.field_set.address)
         )
         locality = source_root.path
 
-    owners = await Get(
-        PythonModuleOwners,
+    owners = await map_module_to_address(
         PythonModuleOwnersRequest(
             entry_point.val.module,
             resolve=request.field_set.resolve.normalized_value(python_setup),
             locality=locality,
         ),
+        **implicitly(),
     )
     address = request.field_set.address
     explicitly_provided_deps.maybe_warn_of_ambiguous_dependency_inference(
@@ -396,7 +399,7 @@ async def resolve_python_distribution_entry_points(
 
     classified_entry_points = list(_classify_entry_points(all_entry_points))
 
-    # Pick out all target addresses up front, so we can use MultiGet later.
+    # Pick out all target addresses up front, so we can use concurrently later.
     #
     # This calls for a bit of trickery however (using the "y_by_x" mapping dicts), so we keep track
     # of which address belongs to which entry point. I.e. the `address_by_ref` and
@@ -408,16 +411,16 @@ async def resolve_python_distribution_entry_points(
 
     # Intermediate step, as Get(Targets) returns a deduplicated set which breaks in case of
     # multiple input refs that maps to the same target.
-    target_addresses = await Get(
-        Addresses,
+    target_addresses = await resolve_unparsed_address_inputs(
         UnparsedAddressInputs(
             target_refs,
             owning_address=address,
             description_of_origin=description_of_origin,
         ),
+        **implicitly(),
     )
     address_by_ref = dict(zip(target_refs, target_addresses))
-    targets = await Get(Targets, Addresses, target_addresses)
+    targets = await resolve_targets(**implicitly(target_addresses))
 
     # Check that we only have targets with a pex entry_point field.
     for target in targets:
@@ -435,11 +438,8 @@ async def resolve_python_distribution_entry_points(
                 )
             )
 
-    binary_entry_points = await MultiGet(
-        Get(
-            ResolvedPexEntryPoint,
-            ResolvePexEntryPointRequest(target[PexEntryPointField]),
-        )
+    binary_entry_points = await concurrently(
+        resolve_pex_entry_point(ResolvePexEntryPointRequest(target[PexEntryPointField]))
         for target in targets
     )
     binary_entry_point_by_address = {
@@ -514,17 +514,17 @@ async def infer_python_distribution_dependencies(
     if not python_infer_subsystem.entry_points:
         return InferredDependencies([])
 
-    explicitly_provided_deps, distribution_entry_points, provides_entry_points = await MultiGet(
-        Get(ExplicitlyProvidedDependencies, DependenciesRequest(request.field_set.dependencies)),
-        Get(
-            ResolvedPythonDistributionEntryPoints,
+    explicitly_provided_deps, distribution_entry_points, provides_entry_points = await concurrently(
+        determine_explicitly_provided_dependencies(
+            **implicitly(DependenciesRequest(request.field_set.dependencies))
+        ),
+        resolve_python_distribution_entry_points(
             ResolvePythonDistributionEntryPointsRequest(
                 entry_points_field=request.field_set.entry_points
-            ),
+            )
         ),
-        Get(
-            ResolvedPythonDistributionEntryPoints,
-            ResolvePythonDistributionEntryPointsRequest(provides_field=request.field_set.provides),
+        resolve_python_distribution_entry_points(
+            ResolvePythonDistributionEntryPointsRequest(provides_field=request.field_set.provides)
         ),
     )
 
@@ -538,8 +538,10 @@ async def infer_python_distribution_dependencies(
         for name, entry_point in entry_points.items()
     ]
     all_module_owners = iter(
-        await MultiGet(
-            Get(PythonModuleOwners, PythonModuleOwnersRequest(entry_point.module, resolve=None))
+        await concurrently(
+            map_module_to_address(
+                PythonModuleOwnersRequest(entry_point.module, resolve=None), **implicitly()
+            )
             for _, _, entry_point in all_module_entry_points
         )
     )
@@ -596,12 +598,12 @@ async def validate_python_dependencies(
     request: PythonValidateDependenciesRequest,
     python_setup: PythonSetup,
 ) -> ValidatedDependencies:
-    dependencies = await MultiGet(
-        Get(
-            WrappedTarget,
+    dependencies = await concurrently(
+        resolve_target(
             WrappedTargetRequest(
                 d, description_of_origin=f"the dependencies of {request.field_set.address}"
             ),
+            **implicitly(),
         )
         for d in request.dependencies
     )

--- a/src/python/pants/backend/python/util_rules/entry_points.py
+++ b/src/python/pants/backend/python/util_rules/entry_points.py
@@ -25,7 +25,7 @@ from pants.backend.python.target_types import (
 )
 from pants.engine.addresses import Addresses, UnparsedAddressInputs
 from pants.engine.fs import CreateDigest, FileContent, PathGlobs, Paths
-from pants.engine.internals.graph import determine_explicitly_provided_dependencies
+from pants.engine.internals.graph import determine_explicitly_provided_dependencies, resolve_targets
 from pants.engine.internals.native_engine import EMPTY_DIGEST, Address, Digest
 from pants.engine.internals.selectors import concurrently
 from pants.engine.intrinsics import create_digest, path_globs_to_paths
@@ -173,13 +173,14 @@ async def _get_entry_point_deps_targets_and_predicates(
             "Please file an issue if you see this error. This rule helper must not "
             "be called with an empty entry_point_dependencies field."
         )
-    targets = await Get(
-        Targets,
-        UnparsedAddressInputs(
-            entry_point_deps.value.keys(),
-            owning_address=owning_address,
-            description_of_origin=f"{PythonTestsEntryPointDependenciesField.alias} from {owning_address}",
-        ),
+    targets = await resolve_targets(
+        **implicitly(
+            UnparsedAddressInputs(
+                entry_point_deps.value.keys(),
+                owning_address=owning_address,
+                description_of_origin=f"{PythonTestsEntryPointDependenciesField.alias} from {owning_address}",
+            )
+        )
     )
 
     requested_entry_points: dict[Target, set[str]] = {}

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -564,6 +564,7 @@ async def _setup_pex_requirements(
             lockfile = request.requirements.lockfile
         else:
             complete_req_strings = None
+            # TODO: Call-by-name fails with "get_lockfile_for_resolve" has incompatible type "Pex | Resolve | None"; expected "Resolve" - need to narrow this (later)
             lockfile = await Get(Lockfile, Resolve, request.requirements.from_superset)
         loaded_lockfile = await load_lockfile(LoadedLockfileRequest(lockfile), **implicitly())
         argv = (


### PR DESCRIPTION
package_dists was bizarre. It was a series of rule functions, each below the next, which does one thing and you call the subsequent function.

For call by name, I basically had to flip the whole file upside down.