### PR TITLE
[Call-by-name] migrate tests in `src/python/pants/core/goals`

### DIFF
--- a/src/python/pants/core/goals/deploy_test.py
+++ b/src/python/pants/core/goals/deploy_test.py
@@ -17,9 +17,10 @@ from pants.core.goals.publish import (
 from pants.core.register import rules as core_rules
 from pants.engine import process
 from pants.engine.fs import EMPTY_DIGEST
+from pants.engine.internals.graph import resolve_targets
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.process import InteractiveProcess
-from pants.engine.rules import Get, rule
+from pants.engine.rules import implicitly, rule
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
     Dependencies,
@@ -27,7 +28,6 @@ from pants.engine.target import (
     StringField,
     StringSequenceField,
     Target,
-    Targets,
 )
 from pants.engine.unions import UnionRule
 from pants.testutil.rule_runner import RuleRunner
@@ -128,7 +128,7 @@ async def mock_deploy(field_set: MockDeployFieldSet) -> DeployProcess:
     if not field_set.destination.value:
         return DeployProcess(name="test-deploy", publish_dependencies=(), process=None)
 
-    dependencies = await Get(Targets, DependenciesRequest(field_set.dependencies))
+    dependencies = await resolve_targets(**implicitly(DependenciesRequest(field_set.dependencies)))
     dest = field_set.destination.value
     return DeployProcess(
         name="test-deploy",

--- a/src/python/pants/core/goals/export_integration_test.py
+++ b/src/python/pants/core/goals/export_integration_test.py
@@ -20,9 +20,8 @@ from pants.core.goals.export import (
 from pants.core.util_rules import archive, distdir
 from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.fs import CreateDigest, FileContent
-from pants.engine.internals.native_engine import Digest
-from pants.engine.internals.selectors import Get, MultiGet
-from pants.engine.rules import rule
+from pants.engine.intrinsics import create_digest
+from pants.engine.rules import concurrently, rule
 from pants.engine.unions import UnionRule
 from pants.testutil.rule_runner import RuleRunner, mock_console
 
@@ -90,8 +89,7 @@ async def export_mybin(req: _ExportMyBinForResolve) -> ExportResult:
     tool = classes[req.resolve]
     bins_to_export = tool.bins_to_export()
 
-    digest = await Get(
-        Digest,
+    digest = await create_digest(
         CreateDigest(
             [
                 *[FileContent(e.path_in_export, req.resolve.encode()) for e in bins_to_export],
@@ -113,8 +111,8 @@ async def export_mybin(req: _ExportMyBinForResolve) -> ExportResult:
 async def export_external_tools(
     request: ExportMyBinRequest, export: ExportSubsystem
 ) -> ExportResults:
-    maybe_tools = await MultiGet(
-        Get(ExportResult, _ExportMyBinForResolve(resolve)) for resolve in export.binaries
+    maybe_tools = await concurrently(
+        export_mybin(_ExportMyBinForResolve(resolve)) for resolve in export.binaries
     )
     return ExportResults(maybe_tools)
 

--- a/src/python/pants/core/goals/fix_test.py
+++ b/src/python/pants/core/goals/fix_test.py
@@ -35,7 +35,8 @@ from pants.engine.fs import (
     FileContent,
     Snapshot,
 )
-from pants.engine.rules import Get, QueryRule, collect_rules, rule
+from pants.engine.intrinsics import digest_to_snapshot
+from pants.engine.rules import Get, QueryRule, collect_rules, implicitly, rule
 from pants.engine.target import (
     FieldSet,
     MultipleSourcesField,
@@ -109,8 +110,10 @@ async def fortran_fmt_partition(request: FortranFmtRequest.PartitionRequest) -> 
 @rule
 async def fortran_fix(request: FortranFixRequest.Batch) -> FixResult:
     input = request.snapshot
-    output = await Get(
-        Snapshot, CreateDigest([FileContent(file, FORTRAN_FILE.content) for file in request.files])
+    output = await digest_to_snapshot(
+        **implicitly(
+            CreateDigest([FileContent(file, FORTRAN_FILE.content) for file in request.files])
+        )
     )
     return FixResult(
         input=input, output=output, stdout="", stderr="", tool_name=FortranFixRequest.tool_name
@@ -119,8 +122,10 @@ async def fortran_fix(request: FortranFixRequest.Batch) -> FixResult:
 
 @rule
 async def fortran_fmt(request: FortranFmtRequest.Batch) -> FmtResult:
-    output = await Get(
-        Snapshot, CreateDigest([FileContent(file, FORTRAN_FILE.content) for file in request.files])
+    output = await digest_to_snapshot(
+        **implicitly(
+            CreateDigest([FileContent(file, FORTRAN_FILE.content) for file in request.files])
+        )
     )
     return FmtResult(
         input=request.snapshot,

--- a/src/python/pants/core/goals/generate_snapshots_test.py
+++ b/src/python/pants/core/goals/generate_snapshots_test.py
@@ -14,8 +14,9 @@ from pants.core.goals.generate_snapshots import (
     GenerateSnapshotsFieldSet,
     GenerateSnapshotsResult,
 )
-from pants.engine.fs import CreateDigest, FileContent, Snapshot
-from pants.engine.rules import Get, rule
+from pants.engine.fs import CreateDigest, FileContent
+from pants.engine.intrinsics import digest_to_snapshot
+from pants.engine.rules import implicitly, rule
 from pants.engine.target import StringField, Target
 from pants.engine.unions import UnionRule
 from pants.testutil.rule_runner import RuleRunner
@@ -46,11 +47,12 @@ MOCK_SNAPSHOT_CONTENT = "mocked snapshot"
 async def mock_generate_snapshots(
     field_set: MockGenerateSnapshotsFieldSet,
 ) -> GenerateSnapshotsResult:
-    snapshot = await Get(
-        Snapshot,
-        CreateDigest(
-            [FileContent(path=MOCK_SNAPSHOT_FILENAME, content=MOCK_SNAPSHOT_CONTENT.encode())]
-        ),
+    snapshot = await digest_to_snapshot(
+        **implicitly(
+            CreateDigest(
+                [FileContent(path=MOCK_SNAPSHOT_FILENAME, content=MOCK_SNAPSHOT_CONTENT.encode())]
+            )
+        )
     )
     return GenerateSnapshotsResult(snapshot)
 

--- a/src/python/pants/core/goals/package_test.py
+++ b/src/python/pants/core/goals/package_test.py
@@ -19,8 +19,8 @@ from pants.core.goals.package import (
     TraverseIfNotPackageTarget,
 )
 from pants.engine.addresses import Address
-from pants.engine.fs import CreateDigest, Digest, FileContent
-from pants.engine.internals.selectors import Get
+from pants.engine.fs import CreateDigest, FileContent
+from pants.engine.intrinsics import create_digest
 from pants.engine.rules import rule
 from pants.engine.target import (
     Dependencies,
@@ -88,8 +88,8 @@ class MockPackageFieldSet(PackageFieldSet):
 @rule
 async def package_mock_target(field_set: MockPackageFieldSet) -> BuiltPackage:
     base_path = Path(f"base/{field_set.address.target_name}")
-    create_digest, relpaths = field_set.type.synth(base_path)
-    digest = await Get(Digest, CreateDigest, create_digest)
+    create_digest_request, relpaths = field_set.type.synth(base_path)
+    digest = await create_digest(create_digest_request)
     return BuiltPackage(
         digest, tuple(BuiltPackageArtifact(relpath=str(relpath)) for relpath in relpaths)
     )

--- a/src/python/pants/core/goals/repl_test.py
+++ b/src/python/pants/core/goals/repl_test.py
@@ -5,8 +5,9 @@ import pytest
 
 from pants.core.goals.repl import Repl, ReplImplementation, ReplRequest
 from pants.core.goals.repl import rules as repl_rules
-from pants.engine.fs import CreateDigest, Digest, FileContent
-from pants.engine.rules import Get, rule
+from pants.engine.fs import CreateDigest, FileContent
+from pants.engine.intrinsics import create_digest
+from pants.engine.rules import rule
 from pants.engine.unions import UnionRule
 from pants.testutil.rule_runner import RuleRunner, mock_console
 
@@ -18,7 +19,7 @@ class MockRepl(ReplImplementation):
 
 @rule
 async def create_mock_repl_request(repl: MockRepl) -> ReplRequest:
-    digest = await Get(Digest, CreateDigest([FileContent("repl.sh", b"exit 0")]))
+    digest = await create_digest(CreateDigest([FileContent("repl.sh", b"exit 0")]))
     return ReplRequest(
         digest=digest,
         args=("/bin/bash", "repl.sh"),

--- a/src/python/pants/core/goals/tailor_test.py
+++ b/src/python/pants/core/goals/tailor_test.py
@@ -29,9 +29,10 @@ from pants.core.goals.tailor import (
     resolve_specs_with_build,
 )
 from pants.core.util_rules import source_files
-from pants.engine.fs import DigestContents, FileContent, PathGlobs, Paths
+from pants.engine.fs import DigestContents, FileContent
 from pants.engine.internals.build_files import extract_build_file_options
-from pants.engine.rules import Get, QueryRule, rule
+from pants.engine.intrinsics import path_globs_to_paths
+from pants.engine.rules import QueryRule, rule
 from pants.engine.target import MultipleSourcesField, Target
 from pants.engine.unions import UnionRule
 from pants.source.filespec import FilespecMatcher
@@ -78,7 +79,7 @@ class PutativeFortranTargetsRequest(PutativeTargetsRequest):
 async def find_fortran_targets(
     req: PutativeFortranTargetsRequest, all_owned_sources: AllOwnedSources
 ) -> PutativeTargets:
-    all_fortran_files = await Get(Paths, PathGlobs, req.path_globs("*.f90"))
+    all_fortran_files = await path_globs_to_paths(req.path_globs("*.f90"))
     unowned_shell_files = set(all_fortran_files.files) - set(all_owned_sources)
 
     tests_filespec_matcher = FilespecMatcher(FortranTestsSources.default, ())


### PR DESCRIPTION
Migrate to call-by-name syntax in the test files in `src/python/pants/core/goals`. 