### PR TITLE
[Call-by-name] migrate src/python/pants/backend/go

### DIFF
--- a/src/python/pants/backend/go/goals/generate.py
+++ b/src/python/pants/backend/go/goals/generate.py
@@ -12,36 +12,35 @@ from dataclasses import dataclass
 
 from pants.backend.go.target_types import GoPackageSourcesField
 from pants.backend.go.util_rules import first_party_pkg, goroot, sdk
-from pants.backend.go.util_rules.build_opts import GoBuildOptions, GoBuildOptionsFromTargetRequest
+from pants.backend.go.util_rules.build_opts import (
+    GoBuildOptionsFromTargetRequest,
+    go_extract_build_options_from_target,
+)
 from pants.backend.go.util_rules.first_party_pkg import (
-    FallibleFirstPartyPkgAnalysis,
-    FallibleFirstPartyPkgDigest,
     FirstPartyPkgAnalysis,
     FirstPartyPkgAnalysisRequest,
     FirstPartyPkgDigestRequest,
+    analyze_first_party_package,
+    setup_first_party_pkg_digest,
 )
 from pants.backend.go.util_rules.goroot import GoRoot
 from pants.build_graph.address import Address
-from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
-from pants.engine.fs import (
-    CreateDigest,
-    DigestContents,
-    DigestEntries,
-    FileEntry,
-    SnapshotDiff,
-    Workspace,
-)
+from pants.engine.env_vars import EnvironmentVarsRequest
+from pants.engine.fs import CreateDigest, FileEntry, SnapshotDiff, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
-from pants.engine.internals.native_engine import (
-    EMPTY_DIGEST,
-    AddPrefix,
-    Digest,
-    MergeDigests,
-    Snapshot,
+from pants.engine.internals.native_engine import EMPTY_DIGEST, AddPrefix, Digest, MergeDigests
+from pants.engine.internals.platform_rules import environment_vars_subset
+from pants.engine.internals.selectors import concurrently
+from pants.engine.intrinsics import (
+    add_prefix,
+    create_digest,
+    digest_to_snapshot,
+    get_digest_contents,
+    get_digest_entries,
+    merge_digests,
 )
-from pants.engine.internals.selectors import Get, MultiGet
-from pants.engine.process import Process, ProcessResult
-from pants.engine.rules import collect_rules, goal_rule, rule
+from pants.engine.process import Process, execute_process_or_raise
+from pants.engine.rules import collect_rules, goal_rule, implicitly, rule
 from pants.engine.target import Targets
 from pants.option.option_types import StrListOption
 from pants.option.subsystem import Subsystem
@@ -166,7 +165,7 @@ async def _run_generators(
     goroot: GoRoot,
     base_env: Mapping[str, str],
 ) -> Digest:
-    digest_contents = await Get(DigestContents, Digest, digest)
+    digest_contents = await get_digest_contents(digest)
     content: bytes | None = None
     for entry in digest_contents:
         if entry.path == os.path.join(dir_path, go_file):
@@ -220,19 +219,21 @@ async def _run_generators(
             args[i] = _expand_env(arg, env)
 
         # Invoke the subprocess and store its output for use as input root of next command (if any).
-        result = await Get(  # noqa: PNT30: this is inherently sequential
-            ProcessResult,
-            Process(
-                argv=args,
-                input_digest=digest,
-                working_directory=dir_path,
-                output_directories=["."],
-                env=env,
-                description=f"Process `go generate` directives in file: {os.path.join(dir_path, go_file)}",
+        result = await execute_process_or_raise(  # noqa: PNT30: this is inherently sequential
+            **implicitly(
+                Process(
+                    argv=args,
+                    input_digest=digest,
+                    working_directory=dir_path,
+                    output_directories=["."],
+                    env=env,
+                    description=f"Process `go generate` directives in file: {os.path.join(dir_path, go_file)}",
+                ),
             ),
         )
-        digest = await Get(  # noqa: PNT30: this is inherently sequential
-            Digest, AddPrefix(result.output_digest, dir_path)
+
+        digest = await add_prefix(  # noqa: PNT30: this is inherently sequential
+            AddPrefix(result.output_digest, dir_path)
         )
 
     return digest
@@ -246,11 +247,11 @@ class OverwriteMergeDigests:
 
 @rule
 async def merge_digests_with_overwrite(request: OverwriteMergeDigests) -> Digest:
-    orig_snapshot, new_snapshot, orig_digest_entries, new_digest_entries = await MultiGet(
-        Get(Snapshot, Digest, request.orig_digest),
-        Get(Snapshot, Digest, request.new_digest),
-        Get(DigestEntries, Digest, request.orig_digest),
-        Get(DigestEntries, Digest, request.new_digest),
+    orig_snapshot, new_snapshot, orig_digest_entries, new_digest_entries = await concurrently(
+        digest_to_snapshot(request.orig_digest),
+        digest_to_snapshot(request.new_digest),
+        get_digest_entries(request.orig_digest),
+        get_digest_entries(request.new_digest),
     )
 
     orig_snapshot_grouped = group_by_dir(orig_snapshot.files)
@@ -278,7 +279,7 @@ async def merge_digests_with_overwrite(request: OverwriteMergeDigests) -> Digest
         if isinstance(entry, FileEntry) and entry.path in new_files_to_keep:
             output_entries.append(entry)
 
-    digest = await Get(Digest, CreateDigest(output_entries))
+    digest = await create_digest(CreateDigest(output_entries))
     return digest
 
 
@@ -288,24 +289,25 @@ async def run_go_package_generators(
     goroot: GoRoot,
     subsystem: GoGenerateGoalSubsystem.EnvironmentAware,
 ) -> RunPackageGeneratorsResult:
-    build_opts = await Get(GoBuildOptions, GoBuildOptionsFromTargetRequest(request.address))
-    fallible_analysis, env = await MultiGet(
-        Get(
-            FallibleFirstPartyPkgAnalysis,
+    build_opts = await go_extract_build_options_from_target(
+        GoBuildOptionsFromTargetRequest(request.address), **implicitly()
+    )
+    fallible_analysis, env = await concurrently(
+        analyze_first_party_package(
             FirstPartyPkgAnalysisRequest(
                 request.address, build_opts=build_opts, extra_build_tags=("generate",)
             ),
+            **implicitly(),
         ),
-        Get(EnvironmentVars, EnvironmentVarsRequest(subsystem.env_vars)),
+        environment_vars_subset(EnvironmentVarsRequest(subsystem.env_vars), **implicitly()),
     )
     if not fallible_analysis.analysis:
         raise ValueError(f"Analysis failure for {request.address}: {fallible_analysis.stderr}")
     analysis = fallible_analysis.analysis
     dir_path = analysis.dir_path if analysis.dir_path else "."
 
-    fallible_pkg_digest = await Get(
-        FallibleFirstPartyPkgDigest,
-        FirstPartyPkgDigestRequest(request.address, build_opts=build_opts),
+    fallible_pkg_digest = await setup_first_party_pkg_digest(
+        FirstPartyPkgDigestRequest(request.address, build_opts=build_opts)
     )
     if fallible_pkg_digest.pkg_digest is None:
         raise ValueError(
@@ -320,8 +322,8 @@ async def run_go_package_generators(
         output_digest_for_go_file = await _run_generators(
             analysis, pkg_digest.digest, dir_path, go_file, goroot, env
         )
-        output_digest = await Get(  # noqa: PNT30: requires triage
-            Digest, OverwriteMergeDigests(output_digest, output_digest_for_go_file)
+        output_digest = await merge_digests_with_overwrite(  # noqa: PNT30: requires triage
+            OverwriteMergeDigests(output_digest, output_digest_for_go_file)
         )
 
     return RunPackageGeneratorsResult(output_digest)
@@ -330,11 +332,11 @@ async def run_go_package_generators(
 @goal_rule
 async def go_generate(targets: Targets, workspace: Workspace) -> GoGenerateGoal:
     go_package_targets = [tgt for tgt in targets if tgt.has_field(GoPackageSourcesField)]
-    results = await MultiGet(
-        Get(RunPackageGeneratorsResult, RunPackageGeneratorsRequest(tgt.address))
+    results = await concurrently(
+        run_go_package_generators(RunPackageGeneratorsRequest(tgt.address), **implicitly())
         for tgt in go_package_targets
     )
-    output_digest = await Get(Digest, MergeDigests([r.digest for r in results]))
+    output_digest = await merge_digests(MergeDigests([r.digest for r in results]))
     workspace.write_digest(output_digest)
     return GoGenerateGoal(exit_code=0)
 

--- a/src/python/pants/backend/go/goals/package_binary.py
+++ b/src/python/pants/backend/go/goals/package_binary.py
@@ -12,19 +12,25 @@ from pants.backend.go.target_types import (
     GoPackageTarget,
     GoThirdPartyPackageTarget,
 )
-from pants.backend.go.util_rules.binary import GoBinaryMainPackage, GoBinaryMainPackageRequest
-from pants.backend.go.util_rules.build_opts import GoBuildOptions, GoBuildOptionsFromTargetRequest
-from pants.backend.go.util_rules.build_pkg import BuiltGoPackage
+from pants.backend.go.util_rules.binary import (
+    GoBinaryMainPackageRequest,
+    determine_main_pkg_for_go_binary,
+)
+from pants.backend.go.util_rules.build_opts import (
+    GoBuildOptionsFromTargetRequest,
+    go_extract_build_options_from_target,
+)
+from pants.backend.go.util_rules.build_pkg import required_built_go_package
 from pants.backend.go.util_rules.build_pkg_target import BuildGoPackageTargetRequest
 from pants.backend.go.util_rules.first_party_pkg import (
-    FallibleFirstPartyPkgAnalysis,
     FirstPartyPkgAnalysisRequest,
+    analyze_first_party_package,
 )
-from pants.backend.go.util_rules.go_mod import GoModInfo, GoModInfoRequest
-from pants.backend.go.util_rules.link import LinkedGoBinary, LinkGoBinaryRequest
+from pants.backend.go.util_rules.go_mod import GoModInfoRequest, determine_go_mod_info
+from pants.backend.go.util_rules.link import LinkGoBinaryRequest, link_go_binary
 from pants.backend.go.util_rules.third_party_pkg import (
-    ThirdPartyPkgAnalysis,
     ThirdPartyPkgAnalysisRequest,
+    extract_package_info,
 )
 from pants.core.goals.package import (
     BuiltPackage,
@@ -34,9 +40,10 @@ from pants.core.goals.package import (
 )
 from pants.core.goals.run import RunFieldSet, RunInSandboxBehavior
 from pants.core.util_rules.environments import EnvironmentField
-from pants.engine.fs import AddPrefix, Digest
-from pants.engine.internals.selectors import Get, MultiGet
-from pants.engine.rules import collect_rules, rule
+from pants.engine.fs import AddPrefix
+from pants.engine.internals.selectors import concurrently
+from pants.engine.intrinsics import add_prefix
+from pants.engine.rules import collect_rules, implicitly, rule
 from pants.engine.unions import UnionRule
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
@@ -54,33 +61,33 @@ class GoBinaryFieldSet(PackageFieldSet, RunFieldSet):
 
 @rule(desc="Package Go binary", level=LogLevel.DEBUG)
 async def package_go_binary(field_set: GoBinaryFieldSet) -> BuiltPackage:
-    main_pkg, build_opts = await MultiGet(
-        Get(GoBinaryMainPackage, GoBinaryMainPackageRequest(field_set.main)),
-        Get(GoBuildOptions, GoBuildOptionsFromTargetRequest(field_set.address)),
+    main_pkg, build_opts = await concurrently(
+        determine_main_pkg_for_go_binary(GoBinaryMainPackageRequest(field_set.main)),
+        go_extract_build_options_from_target(
+            GoBuildOptionsFromTargetRequest(field_set.address), **implicitly()
+        ),
     )
 
     if main_pkg.is_third_party:
         assert isinstance(main_pkg.import_path, str)
 
         go_mod_address = main_pkg.address.maybe_convert_to_target_generator()
-        go_mod_info = await Get(GoModInfo, GoModInfoRequest(go_mod_address))
+        go_mod_info = await determine_go_mod_info(GoModInfoRequest(go_mod_address))
 
-        analysis = await Get(
-            ThirdPartyPkgAnalysis,
+        analysis = await extract_package_info(
             ThirdPartyPkgAnalysisRequest(
                 main_pkg.import_path,
                 go_mod_address,
                 go_mod_info.digest,
                 go_mod_info.mod_path,
                 build_opts=build_opts,
-            ),
+            )
         )
 
         package_name = analysis.name
     else:
-        main_pkg_analysis = await Get(
-            FallibleFirstPartyPkgAnalysis,
-            FirstPartyPkgAnalysisRequest(main_pkg.address, build_opts=build_opts),
+        main_pkg_analysis = await analyze_first_party_package(
+            FirstPartyPkgAnalysisRequest(main_pkg.address, build_opts=build_opts), **implicitly()
         )
         if not main_pkg_analysis.analysis:
             raise ValueError(
@@ -97,16 +104,16 @@ async def package_go_binary(field_set: GoBinaryFieldSet) -> BuiltPackage:
             "requires that main packages actually use `main` as the package name."
         )
 
-    built_package = await Get(
-        BuiltGoPackage,
-        BuildGoPackageTargetRequest(main_pkg.address, is_main=True, build_opts=build_opts),
+    built_package = await required_built_go_package(
+        **implicitly(
+            BuildGoPackageTargetRequest(main_pkg.address, is_main=True, build_opts=build_opts)
+        ),
     )
 
     main_pkg_a_file_path = built_package.import_paths_to_pkg_a_files["main"]
 
     output_filename = PurePath(field_set.output_path.value_or_default(file_ending=None))
-    binary = await Get(
-        LinkedGoBinary,
+    binary = await link_go_binary(
         LinkGoBinaryRequest(
             input_digest=built_package.digest,
             archives=(main_pkg_a_file_path,),
@@ -115,9 +122,10 @@ async def package_go_binary(field_set: GoBinaryFieldSet) -> BuiltPackage:
             output_filename=f"./{output_filename.name}",
             description=f"Link Go binary for {field_set.address}",
         ),
+        **implicitly(),
     )
 
-    renamed_output_digest = await Get(Digest, AddPrefix(binary.digest, str(output_filename.parent)))
+    renamed_output_digest = await add_prefix(AddPrefix(binary.digest, str(output_filename.parent)))
 
     artifact = BuiltPackageArtifact(relpath=str(output_filename))
     return BuiltPackage(renamed_output_digest, (artifact,))

--- a/src/python/pants/backend/go/goals/run_binary.py
+++ b/src/python/pants/backend/go/goals/run_binary.py
@@ -3,16 +3,14 @@
 
 import os.path
 
-from pants.backend.go.goals.package_binary import GoBinaryFieldSet
-from pants.core.goals.package import BuiltPackage, PackageFieldSet
+from pants.backend.go.goals.package_binary import GoBinaryFieldSet, package_go_binary
 from pants.core.goals.run import RunRequest
-from pants.engine.internals.selectors import Get
 from pants.engine.rules import collect_rules, rule
 
 
 @rule
 async def create_go_binary_run_request(field_set: GoBinaryFieldSet) -> RunRequest:
-    binary = await Get(BuiltPackage, PackageFieldSet, field_set)
+    binary = await package_go_binary(field_set)
     artifact_relpath = binary.artifacts[0].relpath
     assert artifact_relpath is not None
     return RunRequest(digest=binary.digest, args=(os.path.join("{chroot}", artifact_relpath),))

--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -12,25 +12,31 @@ from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from typing import Any
 
-from pants.backend.go.dependency_inference import GoModuleImportPathsMapping
 from pants.backend.go.subsystems.gotest import GoTestSubsystem
-from pants.backend.go.target_type_rules import GoImportPathMappingRequest
+from pants.backend.go.target_type_rules import (
+    GoImportPathMappingRequest,
+    map_import_paths_to_packages,
+)
 from pants.backend.go.target_types import (
     GoPackageSourcesField,
     GoTestExtraEnvVarsField,
     GoTestTimeoutField,
     SkipGoTestsField,
 )
-from pants.backend.go.util_rules.build_opts import GoBuildOptions, GoBuildOptionsFromTargetRequest
+from pants.backend.go.util_rules.build_opts import (
+    GoBuildOptionsFromTargetRequest,
+    go_extract_build_options_from_target,
+)
 from pants.backend.go.util_rules.build_pkg import (
     BuildGoPackageRequest,
-    BuiltGoPackage,
-    FallibleBuildGoPackageRequest,
-    FallibleBuiltGoPackage,
+    build_go_package,
+    required_built_go_package,
 )
 from pants.backend.go.util_rules.build_pkg_target import (
     BuildGoPackageRequestForStdlibRequest,
     BuildGoPackageTargetRequest,
+    setup_build_go_package_target_request,
+    setup_build_go_package_target_request_for_stdlib,
 )
 from pants.backend.go.util_rules.coverage import (
     GenerateCoverageSetupCodeRequest,
@@ -38,37 +44,48 @@ from pants.backend.go.util_rules.coverage import (
     GoCoverageConfig,
     GoCoverageData,
     GoCoverMode,
+    generate_go_coverage_setup_code,
 )
 from pants.backend.go.util_rules.first_party_pkg import (
-    FallibleFirstPartyPkgAnalysis,
-    FallibleFirstPartyPkgDigest,
     FirstPartyPkgAnalysis,
     FirstPartyPkgAnalysisRequest,
     FirstPartyPkgDigest,
     FirstPartyPkgDigestRequest,
+    analyze_first_party_package,
+    setup_first_party_pkg_digest,
 )
-from pants.backend.go.util_rules.go_mod import OwningGoMod, OwningGoModRequest
+from pants.backend.go.util_rules.go_mod import OwningGoModRequest, find_owning_go_mod
 from pants.backend.go.util_rules.goroot import GoRoot
-from pants.backend.go.util_rules.import_analysis import GoStdLibPackages, GoStdLibPackagesRequest
-from pants.backend.go.util_rules.link import LinkedGoBinary, LinkGoBinaryRequest
+from pants.backend.go.util_rules.import_analysis import (
+    GoStdLibPackagesRequest,
+    analyze_go_stdlib_packages,
+)
+from pants.backend.go.util_rules.link import LinkGoBinaryRequest, link_go_binary
 from pants.backend.go.util_rules.pkg_analyzer import PackageAnalyzerSetup
-from pants.backend.go.util_rules.tests_analysis import GeneratedTestMain, GenerateTestMainRequest
+from pants.backend.go.util_rules.tests_analysis import (
+    GeneratedTestMain,
+    GenerateTestMainRequest,
+    generate_testmain,
+)
 from pants.build_graph.address import Address
 from pants.core.goals.test import TestExtraEnv, TestFieldSet, TestRequest, TestResult, TestSubsystem
 from pants.core.target_types import FileSourceField
-from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
-from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
+from pants.core.util_rules.source_files import SourceFilesRequest, determine_source_files
+from pants.engine.env_vars import EnvironmentVarsRequest
 from pants.engine.fs import EMPTY_FILE_DIGEST, AddPrefix, Digest, MergeDigests
+from pants.engine.internals.graph import resolve_targets
 from pants.engine.internals.native_engine import EMPTY_DIGEST, Snapshot
+from pants.engine.internals.platform_rules import environment_vars_subset
+from pants.engine.intrinsics import add_prefix, digest_to_snapshot, merge_digests
 from pants.engine.process import (
     Process,
     ProcessCacheScope,
-    ProcessResult,
-    ProcessResultWithRetries,
     ProcessWithRetries,
+    execute_process_or_raise,
+    execute_process_with_retry,
 )
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import Dependencies, DependenciesRequest, SourcesField, Target, Targets
+from pants.engine.rules import collect_rules, concurrently, implicitly, rule
+from pants.engine.target import Dependencies, DependenciesRequest, SourcesField, Target
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet
 
@@ -238,22 +255,27 @@ async def prepare_go_test_binary(
     request: PrepareGoTestBinaryRequest,
     analyzer: PackageAnalyzerSetup,
 ) -> FalliblePrepareGoTestBinaryResult:
-    go_mod_addr = await Get(OwningGoMod, OwningGoModRequest(request.field_set.address))
-    package_mapping, build_opts = await MultiGet(
-        Get(GoModuleImportPathsMapping, GoImportPathMappingRequest(go_mod_addr.address)),
-        Get(GoBuildOptions, GoBuildOptionsFromTargetRequest(request.field_set.address)),
+    go_mod_addr = await find_owning_go_mod(
+        OwningGoModRequest(request.field_set.address), **implicitly()
+    )
+    package_mapping, build_opts = await concurrently(
+        map_import_paths_to_packages(
+            GoImportPathMappingRequest(go_mod_addr.address), **implicitly()
+        ),
+        go_extract_build_options_from_target(
+            GoBuildOptionsFromTargetRequest(request.field_set.address), **implicitly()
+        ),
     )
 
-    maybe_pkg_analysis, maybe_pkg_digest, dependencies = await MultiGet(
-        Get(
-            FallibleFirstPartyPkgAnalysis,
+    maybe_pkg_analysis, maybe_pkg_digest, dependencies = await concurrently(
+        analyze_first_party_package(
             FirstPartyPkgAnalysisRequest(request.field_set.address, build_opts=build_opts),
+            **implicitly(),
         ),
-        Get(
-            FallibleFirstPartyPkgDigest,
-            FirstPartyPkgDigestRequest(request.field_set.address, build_opts=build_opts),
+        setup_first_party_pkg_digest(
+            FirstPartyPkgDigestRequest(request.field_set.address, build_opts=build_opts)
         ),
-        Get(Targets, DependenciesRequest(request.field_set.dependencies)),
+        resolve_targets(**implicitly(DependenciesRequest(request.field_set.dependencies))),
     )
 
     def compilation_failure(
@@ -288,8 +310,7 @@ async def prepare_go_test_binary(
             ),
         )
 
-    testmain = await Get(
-        GeneratedTestMain,
+    testmain = await generate_testmain(
         GenerateTestMainRequest(
             digest=pkg_digest.digest,
             test_paths=FrozenOrderedSet(
@@ -316,25 +337,26 @@ async def prepare_go_test_binary(
             exit_code=0,
         )
 
-    testmain_analysis_input_digest = await Get(
-        Digest, MergeDigests([testmain.digest, analyzer.digest])
+    testmain_analysis_input_digest = await merge_digests(
+        MergeDigests([testmain.digest, analyzer.digest])
     )
-    testmain_analysis = await Get(
-        ProcessResult,
-        Process(
-            (analyzer.path, "."),
-            input_digest=testmain_analysis_input_digest,
-            description=f"Determine metadata for testmain for {request.field_set.address}",
-            level=LogLevel.DEBUG,
-            env={
-                "CGO_ENABLED": "1" if build_opts.cgo_enabled else "0",
-            },
-        ),
+
+    testmain_analysis = await execute_process_or_raise(
+        **implicitly(
+            Process(
+                (analyzer.path, "."),
+                input_digest=testmain_analysis_input_digest,
+                description=f"Determine metadata for testmain for {request.field_set.address}",
+                level=LogLevel.DEBUG,
+                env={
+                    "CGO_ENABLED": "1" if build_opts.cgo_enabled else "0",
+                },
+            ),
+        )
     )
     testmain_analysis_json = json.loads(testmain_analysis.stdout.decode())
 
-    stdlib_packages = await Get(
-        GoStdLibPackages,
+    stdlib_packages = await analyze_go_stdlib_packages(
         GoStdLibPackagesRequest(
             with_race_detector=build_opts.with_race_detector,
             cgo_enabled=build_opts.cgo_enabled,
@@ -349,12 +371,12 @@ async def prepare_go_test_binary(
 
         if dep_import_path in stdlib_packages:
             stdlib_build_request_gets.append(
-                Get(
-                    FallibleBuildGoPackageRequest,
+                setup_build_go_package_target_request_for_stdlib(
                     BuildGoPackageRequestForStdlibRequest(
                         import_path=dep_import_path,
                         build_opts=build_opts,
                     ),
+                    **implicitly(),
                 )
             )
             continue
@@ -382,13 +404,13 @@ async def prepare_go_test_binary(
                 f"in go_package at address '{request.field_set.address}'."
             )
 
-    fallible_testmain_import_build_requests = await MultiGet(
-        Get(
-            FallibleBuildGoPackageRequest,
+    fallible_testmain_import_build_requests = await concurrently(
+        setup_build_go_package_target_request(
             BuildGoPackageTargetRequest(
                 address=address,
                 build_opts=build_opts,
             ),
+            **implicitly(),
         )
         for address in sorted(inferred_dependencies)
     )
@@ -399,20 +421,20 @@ async def prepare_go_test_binary(
             return compilation_failure(build_request.exit_code, None, build_request.stderr)
         testmain_import_build_requests.append(build_request.request)
 
-    stdlib_build_requests = await MultiGet(stdlib_build_request_gets)
+    stdlib_build_requests = await concurrently(stdlib_build_request_gets)
     for build_request in stdlib_build_requests:
         assert build_request.request is not None
         testmain_import_build_requests.append(build_request.request)
 
     # Construct the build request for the package under test.
-    maybe_test_pkg_build_request = await Get(
-        FallibleBuildGoPackageRequest,
+    maybe_test_pkg_build_request = await setup_build_go_package_target_request(
         BuildGoPackageTargetRequest(
             request.field_set.address,
             for_tests=True,
             with_coverage=with_coverage,
             build_opts=build_opts,
         ),
+        **implicitly(),
     )
     if maybe_test_pkg_build_request.request is None:
         assert maybe_test_pkg_build_request.stderr is not None
@@ -427,14 +449,14 @@ async def prepare_go_test_binary(
     if testmain.has_xtests:
         # Build a synthetic package for xtests where the import path is the same as the package under test
         # but with "_test" appended.
-        maybe_xtest_pkg_build_request = await Get(
-            FallibleBuildGoPackageRequest,
+        maybe_xtest_pkg_build_request = await setup_build_go_package_target_request(
             BuildGoPackageTargetRequest(
                 request.field_set.address,
                 for_xtests=True,
                 with_coverage=with_coverage,
                 build_opts=build_opts,
             ),
+            **implicitly(),
         )
         if maybe_xtest_pkg_build_request.request is None:
             assert maybe_xtest_pkg_build_request.stderr is not None
@@ -461,14 +483,14 @@ async def prepare_go_test_binary(
         main_direct_deps.extend(coverage_transitive_deps)
 
         # Build the `main_direct_deps` when in coverage mode to obtain the "coverage variables" for those packages.
-        built_main_direct_deps = await MultiGet(
-            Get(BuiltGoPackage, BuildGoPackageRequest, build_req) for build_req in main_direct_deps
+        built_main_direct_deps = await concurrently(
+            required_built_go_package(**implicitly({build_req: BuildGoPackageRequest}))
+            for build_req in main_direct_deps
         )
         coverage_metadata = [
             pkg.coverage_metadata for pkg in built_main_direct_deps if pkg.coverage_metadata
         ]
-        coverage_setup_result = await Get(
-            GenerateCoverageSetupCodeResult,
+        coverage_setup_result = await generate_go_coverage_setup_code(
             GenerateCoverageSetupCodeRequest(
                 packages=FrozenOrderedSet(coverage_metadata),
                 cover_mode=request.coverage.coverage_mode,  # type: ignore[union-attr] # gated on with_coverage
@@ -477,13 +499,12 @@ async def prepare_go_test_binary(
         coverage_setup_digest = coverage_setup_result.digest
         coverage_setup_files = [GenerateCoverageSetupCodeResult.PATH]
 
-    testmain_input_digest = await Get(
-        Digest, MergeDigests([testmain.digest, coverage_setup_digest])
+    testmain_input_digest = await merge_digests(
+        MergeDigests([testmain.digest, coverage_setup_digest])
     )
 
     # Generate the synthetic main package which imports the test and/or xtest packages.
-    maybe_built_main_pkg = await Get(
-        FallibleBuiltGoPackage,
+    maybe_built_main_pkg = await build_go_package(
         BuildGoPackageRequest(
             import_path="main",
             pkg_name="main",
@@ -495,6 +516,7 @@ async def prepare_go_test_binary(
             direct_dependencies=tuple(main_direct_deps),
             minimum_go_version=pkg_analysis.minimum_go_version,
         ),
+        **implicitly(),
     )
     if maybe_built_main_pkg.output is None:
         assert maybe_built_main_pkg.stderr is not None
@@ -505,8 +527,7 @@ async def prepare_go_test_binary(
 
     main_pkg_a_file_path = built_main_pkg.import_paths_to_pkg_a_files["main"]
 
-    binary = await Get(
-        LinkedGoBinary,
+    binary = await link_go_binary(
         LinkGoBinaryRequest(
             input_digest=built_main_pkg.digest,
             archives=(main_pkg_a_file_path,),
@@ -515,6 +536,7 @@ async def prepare_go_test_binary(
             output_filename="./test_runner",  # TODO: Name test binary the way that `go` does?
             description=f"Link Go test binary for {request.field_set.address}",
         ),
+        **implicitly(),
     )
 
     return FalliblePrepareGoTestBinaryResult(
@@ -578,9 +600,8 @@ async def run_go_tests(
             coverage_packages=go_test_subsystem.coverage_packages,
         )
 
-    fallible_test_binary = await Get(
-        FalliblePrepareGoTestBinaryResult,
-        PrepareGoTestBinaryRequest(field_set=field_set, coverage=coverage),
+    fallible_test_binary = await prepare_go_test_binary(
+        PrepareGoTestBinaryRequest(field_set=field_set, coverage=coverage), **implicitly()
     )
 
     if fallible_test_binary.exit_code != 0:
@@ -603,21 +624,22 @@ async def run_go_tests(
     # This allows tests to open dependencies on `file` targets regardless of where they are
     # located. See https://dave.cheney.net/2016/05/10/test-fixtures-in-go.
     working_dir = field_set.address.spec_path
-    field_set_extra_env, dependencies, binary_with_prefix = await MultiGet(
-        Get(EnvironmentVars, EnvironmentVarsRequest(field_set.extra_env_vars.value or ())),
-        Get(Targets, DependenciesRequest(field_set.dependencies)),
-        Get(Digest, AddPrefix(test_binary.test_binary_digest, working_dir)),
+    field_set_extra_env, dependencies, binary_with_prefix = await concurrently(
+        environment_vars_subset(
+            EnvironmentVarsRequest(field_set.extra_env_vars.value or ()), **implicitly()
+        ),
+        resolve_targets(**implicitly(DependenciesRequest(field_set.dependencies))),
+        add_prefix(AddPrefix(test_binary.test_binary_digest, working_dir)),
     )
-    files_sources = await Get(
-        SourceFiles,
+    files_sources = await determine_source_files(
         SourceFilesRequest(
             (dep.get(SourcesField) for dep in dependencies),
             for_sources_types=(FileSourceField,),
             enable_codegen=True,
-        ),
+        )
     )
-    test_input_digest = await Get(
-        Digest, MergeDigests((binary_with_prefix, files_sources.snapshot.digest))
+    test_input_digest = await merge_digests(
+        MergeDigests((binary_with_prefix, files_sources.snapshot.digest))
     )
 
     extra_env = {
@@ -692,9 +714,8 @@ async def run_go_tests(
         output_files=output_files,
         level=LogLevel.DEBUG,
     )
-    results = await Get(
-        ProcessResultWithRetries,
-        ProcessWithRetries(go_test_process, test_subsystem.attempts_default),
+    results = await execute_process_with_retry(
+        ProcessWithRetries(go_test_process, test_subsystem.attempts_default)
     )
 
     coverage_data: GoCoverageData | None = None
@@ -712,10 +733,10 @@ async def run_go_tests(
     if output_files or output_test_binary:
         output_digest = results.last.output_digest
         if output_test_binary:
-            output_digest = await Get(
-                Digest, MergeDigests([output_digest, test_binary.test_binary_digest])
+            output_digest = await merge_digests(
+                MergeDigests([output_digest, test_binary.test_binary_digest])
             )
-        extra_output = await Get(Snapshot, Digest, output_digest)
+        extra_output = await digest_to_snapshot(output_digest)
 
     return TestResult.from_fallible_process_result(
         process_results=results.results,

--- a/src/python/pants/backend/go/util_rules/build_pkg_target.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target.py
@@ -8,9 +8,11 @@ import json
 from dataclasses import dataclass
 from typing import ClassVar, cast
 
-from pants.backend.go.dependency_inference import GoModuleImportPathsMapping
-from pants.backend.go.go_sources.load_go_binary import LoadedGoBinary, LoadedGoBinaryRequest
-from pants.backend.go.target_type_rules import GoImportPathMappingRequest
+from pants.backend.go.go_sources.load_go_binary import LoadedGoBinaryRequest, setup_go_binary
+from pants.backend.go.target_type_rules import (
+    GoImportPathMappingRequest,
+    map_import_paths_to_packages,
+)
 from pants.backend.go.target_types import (
     GoAssemblerFlagsField,
     GoCompilerFlagsField,
@@ -28,46 +30,49 @@ from pants.backend.go.util_rules.cgo import CGoCompilerFlags
 from pants.backend.go.util_rules.coverage import GoCoverMode
 from pants.backend.go.util_rules.embedcfg import EmbedConfig
 from pants.backend.go.util_rules.first_party_pkg import (
-    FallibleFirstPartyPkgAnalysis,
-    FallibleFirstPartyPkgDigest,
     FirstPartyPkgAnalysisRequest,
     FirstPartyPkgDigestRequest,
-    FirstPartyPkgImportPath,
     FirstPartyPkgImportPathRequest,
+    analyze_first_party_package,
+    compute_first_party_package_import_path,
+    setup_first_party_pkg_digest,
 )
 from pants.backend.go.util_rules.go_mod import (
-    GoModInfo,
     GoModInfoRequest,
-    OwningGoMod,
     OwningGoModRequest,
+    determine_go_mod_info,
+    find_owning_go_mod,
 )
 from pants.backend.go.util_rules.goroot import GoRoot
 from pants.backend.go.util_rules.import_analysis import (
     GoStdLibPackage,
-    GoStdLibPackages,
     GoStdLibPackagesRequest,
+    analyze_go_stdlib_packages,
 )
 from pants.backend.go.util_rules.pkg_pattern import match_simple_pattern
 from pants.backend.go.util_rules.third_party_pkg import (
-    ThirdPartyPkgAnalysis,
     ThirdPartyPkgAnalysisRequest,
+    extract_package_info,
 )
 from pants.build_graph.address import Address
 from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.environment import EnvironmentName
 from pants.engine.fs import CreateDigest, FileContent
-from pants.engine.internals.graph import AmbiguousCodegenImplementationsException
-from pants.engine.internals.native_engine import EMPTY_DIGEST, Digest, MergeDigests
-from pants.engine.internals.selectors import Get, MultiGet
-from pants.engine.process import FallibleProcessResult, Process
-from pants.engine.rules import collect_rules, rule
+from pants.engine.internals.graph import (
+    AmbiguousCodegenImplementationsException,
+    resolve_target,
+    resolve_targets,
+)
+from pants.engine.internals.native_engine import EMPTY_DIGEST, MergeDigests
+from pants.engine.internals.selectors import Get, concurrently
+from pants.engine.intrinsics import create_digest, execute_process, merge_digests
+from pants.engine.process import Process
+from pants.engine.rules import collect_rules, implicitly, rule
 from pants.engine.target import (
     Dependencies,
     DependenciesRequest,
     SourcesField,
     Target,
-    Targets,
-    WrappedTarget,
     WrappedTargetRequest,
 )
 from pants.engine.unions import UnionMembership, union
@@ -166,14 +171,15 @@ async def setup_build_go_package_target_request(
     union_membership: UnionMembership,
     goroot: GoRoot,
 ) -> FallibleBuildGoPackageRequest:
-    wrapped_target = await Get(
-        WrappedTarget,
+    wrapped_target = await resolve_target(
         WrappedTargetRequest(request.address, description_of_origin="<build_pkg_target.py>"),
+        **implicitly(),
     )
     target = wrapped_target.target
 
     codegen_request = maybe_get_codegen_request_type(target, request.build_opts, union_membership)
     if codegen_request:
+        # TODO need to move setup_build_go_package_target_request_for_stdlib around to resolve circular dependency
         codegen_result = await Get(
             FallibleBuildGoPackageRequest, GoCodegenBuildRequest, codegen_request
         )
@@ -183,14 +189,13 @@ async def setup_build_go_package_target_request(
     import_map: FrozenDict[str, str] = FrozenDict({})
 
     if target.has_field(GoPackageSourcesField):
-        _maybe_first_party_pkg_analysis, _maybe_first_party_pkg_digest = await MultiGet(
-            Get(
-                FallibleFirstPartyPkgAnalysis,
+        _maybe_first_party_pkg_analysis, _maybe_first_party_pkg_digest = await concurrently(
+            analyze_first_party_package(
                 FirstPartyPkgAnalysisRequest(target.address, build_opts=request.build_opts),
+                **implicitly(),
             ),
-            Get(
-                FallibleFirstPartyPkgDigest,
-                FirstPartyPkgDigestRequest(target.address, build_opts=request.build_opts),
+            setup_first_party_pkg_digest(
+                FirstPartyPkgDigestRequest(target.address, build_opts=request.build_opts)
             ),
         )
         if _maybe_first_party_pkg_analysis.analysis is None:
@@ -271,16 +276,15 @@ async def setup_build_go_package_target_request(
         base_import_path = import_path
 
         _go_mod_address = target.address.maybe_convert_to_target_generator()
-        _go_mod_info = await Get(GoModInfo, GoModInfoRequest(_go_mod_address))
-        _third_party_pkg_info = await Get(
-            ThirdPartyPkgAnalysis,
+        _go_mod_info = await determine_go_mod_info(GoModInfoRequest(_go_mod_address))
+        _third_party_pkg_info = await extract_package_info(
             ThirdPartyPkgAnalysisRequest(
                 import_path,
                 _go_mod_address,
                 _go_mod_info.digest,
                 _go_mod_info.mod_path,
                 build_opts=request.build_opts,
-            ),
+            )
         )
 
         # We error if trying to _build_ a package with issues (vs. only generating the target and
@@ -338,7 +342,9 @@ async def setup_build_go_package_target_request(
     if cgo_files:
         extra_stdlib_dependencies.update(["runtime/cgo", "syscall"])
 
-    direct_dependencies = await Get(Targets, DependenciesRequest(target[Dependencies]))
+    direct_dependencies = await resolve_targets(
+        **implicitly(DependenciesRequest(target[Dependencies]))
+    )
 
     first_party_dep_import_path_targets = []
     third_party_dep_import_path_targets = []
@@ -351,8 +357,8 @@ async def setup_build_go_package_target_request(
         elif bool(maybe_get_codegen_request_type(dep, request.build_opts, union_membership)):
             codegen_dep_import_path_targets.append(dep)
 
-    first_party_dep_import_path_results = await MultiGet(
-        Get(FirstPartyPkgImportPath, FirstPartyPkgImportPathRequest(tgt.address))
+    first_party_dep_import_path_results = await concurrently(
+        compute_first_party_package_import_path(FirstPartyPkgImportPathRequest(tgt.address))
         for tgt in first_party_dep_import_path_targets
     )
     first_party_dep_import_paths = {
@@ -388,9 +394,9 @@ async def setup_build_go_package_target_request(
     )
 
     if codegen_dep_import_path_targets:
-        go_mod_addr = await Get(OwningGoMod, OwningGoModRequest(request.address))
-        import_paths_mapping = await Get(
-            GoModuleImportPathsMapping, GoImportPathMappingRequest(go_mod_addr.address)
+        go_mod_addr = await find_owning_go_mod(OwningGoModRequest(request.address), **implicitly())
+        import_paths_mapping = await map_import_paths_to_packages(
+            GoImportPathMappingRequest(go_mod_addr.address), **implicitly()
         )
         for dep_tgt in codegen_dep_import_path_targets:
             codegen_dep_import_path = import_paths_mapping.address_to_import_path.get(
@@ -403,12 +409,11 @@ async def setup_build_go_package_target_request(
                 pkg_dependency_addresses_set.add(dep_tgt.address)
                 remaining_imports_set.difference_update([codegen_dep_import_path])
 
-    stdlib_packages = await Get(
-        GoStdLibPackages,
+    stdlib_packages = await analyze_go_stdlib_packages(
         GoStdLibPackagesRequest(
             with_race_detector=request.build_opts.with_race_detector,
             cgo_enabled=request.build_opts.cgo_enabled,
-        ),
+        )
     )
     stdlib_build_request_gets = []
     for remaining_import in remaining_imports_set:
@@ -429,14 +434,13 @@ async def setup_build_go_package_target_request(
         )
 
     pkg_dependency_addresses = sorted(pkg_dependency_addresses_set)
-    maybe_pkg_direct_dependencies = await MultiGet(
-        Get(
-            FallibleBuildGoPackageRequest,
-            BuildGoPackageTargetRequest(address, build_opts=request.build_opts),
+    maybe_pkg_direct_dependencies = await concurrently(
+        setup_build_go_package_target_request(
+            BuildGoPackageTargetRequest(address, build_opts=request.build_opts), **implicitly()
         )
         for address in pkg_dependency_addresses
     )
-    pkg_stdlib_dependencies = await MultiGet(stdlib_build_request_gets)
+    pkg_stdlib_dependencies = await concurrently(stdlib_build_request_gets)
 
     pkg_direct_dependencies = []
     for maybe_pkg_dep in maybe_pkg_direct_dependencies:
@@ -455,6 +459,7 @@ async def setup_build_go_package_target_request(
     if request.for_xtests and any(
         dep_import_path == base_import_path for dep_import_path in imports
     ):
+        # TODO need to move setup_build_go_package_target_request_for_stdlib around to resolve circular dependency
         maybe_base_pkg_dep = await Get(
             FallibleBuildGoPackageRequest,
             BuildGoPackageTargetRequest(
@@ -567,22 +572,21 @@ async def resolve_go_stdlib_embed_config(
         }
     ).encode("utf-8")
 
-    embedder, patterns_json_digest = await MultiGet(
-        Get(LoadedGoBinary, LoadedGoBinaryRequest("embedcfg", ("main.go",), "./embedder")),
-        Get(Digest, CreateDigest([FileContent("patterns.json", patterns_json)])),
+    embedder, patterns_json_digest = await concurrently(
+        setup_go_binary(
+            LoadedGoBinaryRequest("embedcfg", ("main.go",), "./embedder"), **implicitly()
+        ),
+        create_digest(CreateDigest([FileContent("patterns.json", patterns_json)])),
     )
-    input_digest = await Get(
-        Digest,
-        MergeDigests((patterns_json_digest, embedder.digest)),
-    )
-    embed_result = await Get(
-        FallibleProcessResult,
+    input_digest = await merge_digests(MergeDigests((patterns_json_digest, embedder.digest)))
+    embed_result = await execute_process(
         Process(
             ("./embedder", "patterns.json", request.package.pkg_source_path),
             input_digest=input_digest,
             description=f"Create embed mapping for {request.package.import_path}",
             level=LogLevel.DEBUG,
         ),
+        **implicitly(),
     )
     if embed_result.exit_code != 0:
         return _ResolveStdlibEmbedConfigResult(
@@ -602,12 +606,11 @@ async def setup_build_go_package_target_request_for_stdlib(
     request: BuildGoPackageRequestForStdlibRequest,
     goroot: GoRoot,
 ) -> FallibleBuildGoPackageRequest:
-    stdlib_packages = await Get(
-        GoStdLibPackages,
+    stdlib_packages = await analyze_go_stdlib_packages(
         GoStdLibPackagesRequest(
             with_race_detector=request.build_opts.with_race_detector,
             cgo_enabled=request.build_opts.cgo_enabled,
-        ),
+        )
     )
 
     pkg_info = stdlib_packages[request.import_path]
@@ -624,13 +627,13 @@ async def setup_build_go_package_target_request_for_stdlib(
         ):
             direct_dependency_import_pats.add("syscall")
 
-    direct_dependencies_wrapped = await MultiGet(
-        Get(
-            FallibleBuildGoPackageRequest,
+    direct_dependencies_wrapped = await concurrently(
+        setup_build_go_package_target_request_for_stdlib(
             BuildGoPackageRequestForStdlibRequest(
                 import_path=dep_import_path,
                 build_opts=request.build_opts,
             ),
+            **implicitly(),
         )
         for dep_import_path in sorted(direct_dependency_import_pats)
         if dep_import_path not in {"builtin", "C", "unsafe"}
@@ -646,8 +649,8 @@ async def setup_build_go_package_target_request_for_stdlib(
 
     embed_config: EmbedConfig | None = None
     if pkg_info.embed_patterns and pkg_info.embed_files:
-        embed_config_result = await Get(
-            _ResolveStdlibEmbedConfigResult, _ResolveStdlibEmbedConfigRequest(pkg_info)
+        embed_config_result = await resolve_go_stdlib_embed_config(
+            _ResolveStdlibEmbedConfigRequest(pkg_info)
         )
         if not embed_config_result.embed_config:
             assert embed_config_result.stderr is not None

--- a/src/python/pants/backend/go/util_rules/build_pkg_target_test.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target_test.py
@@ -39,14 +39,17 @@ from pants.backend.go.util_rules.build_pkg_target import (
     BuildGoPackageRequestForStdlibRequest,
     BuildGoPackageTargetRequest,
     GoCodegenBuildRequest,
+    setup_build_go_package_target_request,
 )
 from pants.backend.go.util_rules.go_mod import OwningGoMod, OwningGoModRequest
 from pants.backend.go.util_rules.import_analysis import GoStdLibPackages, GoStdLibPackagesRequest
 from pants.core.target_types import FilesGeneratorTarget, FileSourceField, FileTarget
-from pants.engine.addresses import Address, Addresses
-from pants.engine.fs import CreateDigest, Digest, FileContent, Snapshot
+from pants.engine.addresses import Address
+from pants.engine.fs import CreateDigest, FileContent, Snapshot
+from pants.engine.internals.graph import resolve_dependencies
 from pants.engine.internals.selectors import MultiGet
-from pants.engine.rules import Get, QueryRule, rule
+from pants.engine.intrinsics import create_digest
+from pants.engine.rules import Get, QueryRule, implicitly, rule
 from pants.engine.target import AllTargets, Dependencies, DependenciesRequest
 from pants.engine.unions import UnionRule
 from pants.testutil.rule_runner import RuleRunner
@@ -125,14 +128,15 @@ async def generate_from_file(request: GoCodegenBuildFilesRequest) -> FallibleBui
         }
         """
     )
-    digest = await Get(Digest, CreateDigest([FileContent("codegen/f.go", content.encode())]))
+    digest = await create_digest(CreateDigest([FileContent("codegen/f.go", content.encode())]))
 
-    deps = await Get(Addresses, DependenciesRequest(request.target[Dependencies]))
+    deps = await resolve_dependencies(
+        DependenciesRequest(request.target[Dependencies]), **implicitly()
+    )
     assert len(deps) == 1
     assert deps[0].generated_name == "github.com/google/uuid"
-    thirdparty_dep = await Get(
-        FallibleBuildGoPackageRequest,
-        BuildGoPackageTargetRequest(deps[0], build_opts=GoBuildOptions()),
+    thirdparty_dep = await setup_build_go_package_target_request(
+        BuildGoPackageTargetRequest(deps[0], build_opts=GoBuildOptions()), **implicitly()
     )
     assert thirdparty_dep.request is not None
 

--- a/src/python/pants/backend/go/util_rules/vendor.py
+++ b/src/python/pants/backend/go/util_rules/vendor.py
@@ -8,12 +8,12 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 
 from pants.backend.go.go_sources import load_go_binary
-from pants.backend.go.go_sources.load_go_binary import LoadedGoBinary, LoadedGoBinaryRequest
+from pants.backend.go.go_sources.load_go_binary import LoadedGoBinaryRequest, setup_go_binary
 from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.internals.native_engine import Digest, MergeDigests
-from pants.engine.internals.selectors import Get
-from pants.engine.process import Process, ProcessResult
-from pants.engine.rules import Rule, collect_rules, rule
+from pants.engine.intrinsics import merge_digests
+from pants.engine.process import Process, execute_process_or_raise
+from pants.engine.rules import Rule, collect_rules, implicitly, rule
 from pants.util.logging import LogLevel
 
 logger = logging.getLogger(__name__)
@@ -63,9 +63,9 @@ class VendorModulesParserSetup:
 @rule
 async def setup_vendor_modules_txt_parser() -> VendorModulesParserSetup:
     output_name = "__go_parse_vendor__"
-    binary = await Get(
-        LoadedGoBinary,
+    binary = await setup_go_binary(
         LoadedGoBinaryRequest("parse_vendor_modules", ("parse.go", "semver.go"), output_name),
+        **implicitly(),
     )
     return VendorModulesParserSetup(
         digest=binary.digest,
@@ -78,14 +78,15 @@ async def parse_vendor_modules_metadata(
     request: ParseVendorModulesMetadataRequest,
     parser: VendorModulesParserSetup,
 ) -> ParseVendorModulesMetadataResult:
-    input_digest = await Get(Digest, MergeDigests([request.digest, parser.digest]))
-    result = await Get(
-        ProcessResult,
-        Process(
-            argv=(parser.path, request.path),
-            input_digest=input_digest,
-            description=f"Parse vendor modules list: `{request.path}`",
-            level=LogLevel.DEBUG,
+    input_digest = await merge_digests(MergeDigests([request.digest, parser.digest]))
+    result = await execute_process_or_raise(
+        **implicitly(
+            Process(
+                argv=(parser.path, request.path),
+                input_digest=input_digest,
+                description=f"Parse vendor modules list: `{request.path}`",
+                level=LogLevel.DEBUG,
+            )
         ),
     )
 


### PR DESCRIPTION
The vast majority of the remaining go backend. The remaining Gets are either unions or circular calls

Please review/merge https://github.com/pantsbuild/pants/pull/22306 first. After that I'll rebase this branch. 

