### PR TITLE
upgrade to Rust v1.87.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,7 +44,7 @@ jobs:
       run: '# Set the default toolchain. Installs the toolchain if it is not already
         installed.
 
-        rustup default 1.86.0
+        rustup default 1.87.0
 
         cargo version
 
@@ -162,7 +162,7 @@ jobs:
       run: '# Set the default toolchain. Installs the toolchain if it is not already
         installed.
 
-        rustup default 1.86.0
+        rustup default 1.87.0
 
         cargo version
 
@@ -309,7 +309,7 @@ jobs:
       with:
         key: macOS13-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain')
           }}-v2
-        path: '~/.rustup/toolchains/1.86.0-*
+        path: '~/.rustup/toolchains/1.87.0-*
 
           ~/.rustup/update-hashes
 
@@ -434,7 +434,7 @@ jobs:
       with:
         key: macOS14-ARM64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain')
           }}-v2
-        path: '~/.rustup/toolchains/1.86.0-*
+        path: '~/.rustup/toolchains/1.87.0-*
 
           ~/.rustup/update-hashes
 
@@ -560,7 +560,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.86.0-*
+        path: '~/.rustup/toolchains/1.87.0-*
 
           ~/.rustup/update-hashes
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,7 +40,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: Linux-ARM64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.86.0-*
+        path: '~/.rustup/toolchains/1.87.0-*
 
           ~/.rustup/update-hashes
 
@@ -149,7 +149,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.86.0-*
+        path: '~/.rustup/toolchains/1.87.0-*
 
           ~/.rustup/update-hashes
 
@@ -268,7 +268,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: macOS13-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.86.0-*
+        path: '~/.rustup/toolchains/1.87.0-*
 
           ~/.rustup/update-hashes
 
@@ -374,7 +374,7 @@ jobs:
     - name: Install Rust toolchain
       run: '# Set the default toolchain. Installs the toolchain if it is not already installed.
 
-        rustup default 1.86.0
+        rustup default 1.87.0
 
         cargo version
 
@@ -452,7 +452,7 @@ jobs:
     - name: Install Rust toolchain
       run: '# Set the default toolchain. Installs the toolchain if it is not already installed.
 
-        rustup default 1.86.0
+        rustup default 1.87.0
 
         cargo version
 
@@ -548,7 +548,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: macOS13-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.86.0-*
+        path: '~/.rustup/toolchains/1.87.0-*
 
           ~/.rustup/update-hashes
 
@@ -634,7 +634,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: macOS14-ARM64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.86.0-*
+        path: '~/.rustup/toolchains/1.87.0-*
 
           ~/.rustup/update-hashes
 

--- a/src/rust/engine/dep_inference/src/javascript/tests.rs
+++ b/src/rust/engine/dep_inference/src/javascript/tests.rs
@@ -652,7 +652,7 @@ fn replaces_groups() {
         "#internal/*.js".to_string(),
         vec!["./src/internal/*.js".to_string()],
     );
-    let imports = imports_from_patterns("dir", &patterns, &"#internal/z.js");
+    let imports = imports_from_patterns("dir", &patterns, "#internal/z.js");
 
     assert_eq!(
         imports,
@@ -673,7 +673,7 @@ fn longest_prefix_wins() {
         vec!["./src/things/*.js".to_string()],
     );
 
-    let imports = imports_from_patterns("dir", &patterns, &"#internal/stuff/index.js");
+    let imports = imports_from_patterns("dir", &patterns, "#internal/stuff/index.js");
 
     assert_eq!(
         imports,

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -428,12 +428,7 @@ impl PosixFS {
         self.executor
             .spawn_blocking(
                 move || vfs.scandir_sync(&dir_relative_to_root),
-                |e| {
-                    Err(io::Error::new(
-                        io::ErrorKind::Other,
-                        format!("Synchronous scandir failed: {e}"),
-                    ))
-                },
+                |e| Err(io::Error::other(format!("Synchronous scandir failed: {e}"))),
             )
             .await
     }
@@ -657,7 +652,7 @@ impl Vfs<io::Error> for Arc<PosixFS> {
     }
 
     fn mk_error(msg: &str) -> io::Error {
-        io::Error::new(io::ErrorKind::Other, msg)
+        io::Error::other(msg)
     }
 }
 

--- a/src/rust/engine/options/src/arg_splitter_tests.rs
+++ b/src/rust/engine/options/src/arg_splitter_tests.rs
@@ -5,7 +5,6 @@ use crate::Scope;
 use crate::arg_splitter::{ArgSplitter, Args, NO_GOAL_NAME, PantsCommand, UNKNOWN_GOAL_NAME};
 use crate::flags::Flag;
 use crate::scope::GoalInfo;
-use shlex;
 use std::fs::File;
 use std::path::Path;
 use tempfile::TempDir;
@@ -16,7 +15,7 @@ fn _sv(v: &[&str]) -> Vec<String> {
 
 fn shlex_and_split_args(build_root: Option<&Path>, args_str: &str) -> PantsCommand {
     ArgSplitter::new(
-        &build_root.unwrap_or(TempDir::new().unwrap().path()),
+        build_root.unwrap_or(TempDir::new().unwrap().path()),
         vec![
             GoalInfo::new("run", false, false, vec![]),
             GoalInfo::new("check", false, false, vec![]),

--- a/src/rust/engine/options/src/fromfile_tests.rs
+++ b/src/rust/engine/options/src/fromfile_tests.rs
@@ -90,24 +90,24 @@ fn test_expand_fromfile_to_list() {
     }
 
     fn add<T>(items: Vec<T>) -> ListEdit<T> {
-        return ListEdit {
+        ListEdit {
             action: ListEditAction::Add,
             items: items,
-        };
+        }
     }
 
     fn remove<T>(items: Vec<T>) -> ListEdit<T> {
-        return ListEdit {
+        ListEdit {
             action: ListEditAction::Remove,
             items: items,
-        };
+        }
     }
 
     fn replace<T>(items: Vec<T>) -> ListEdit<T> {
-        return ListEdit {
+        ListEdit {
             action: ListEditAction::Replace,
             items: items,
-        };
+        }
     }
 
     do_test(
@@ -231,17 +231,17 @@ fn test_expand_fromfile_to_dict() {
     }
 
     fn add(items: HashMap<String, Val>) -> DictEdit {
-        return DictEdit {
+        DictEdit {
             action: DictEditAction::Add,
             items,
-        };
+        }
     }
 
     fn replace(items: HashMap<String, Val>) -> DictEdit {
-        return DictEdit {
+        DictEdit {
             action: DictEditAction::Replace,
             items,
-        };
+        }
     }
 
     do_test(

--- a/src/rust/engine/options/src/tests.rs
+++ b/src/rust/engine/options/src/tests.rs
@@ -74,7 +74,7 @@ fn with_setup(
                 .collect::<HashMap<_, _>>(),
         },
         Some(
-            vec![config_path, extra_config_path]
+            [config_path, extra_config_path]
                 .iter()
                 .map(|cp| ConfigSource::from_file(cp).unwrap())
                 .collect(),
@@ -789,7 +789,7 @@ fn test_cli_alias() {
 #[test]
 fn test_cli_alias_validation() {
     let buildroot = TempDir::new().unwrap();
-    File::create(&buildroot.path().join("BUILDROOT")).unwrap();
+    File::create(buildroot.path().join("BUILDROOT")).unwrap();
     assert_eq!(
         "Invalid alias in `[cli].alias` option: foo. This is already a registered goal or subsytem.",
     OptionParser::new(
@@ -809,8 +809,8 @@ fn test_cli_alias_validation() {
 #[test]
 fn test_spec_files() {
     let buildroot = TempDir::new().unwrap();
-    File::create(&buildroot.path().join("BUILDROOT")).unwrap();
-    File::create(&buildroot.path().join("extra_specs.txt"))
+    File::create(buildroot.path().join("BUILDROOT")).unwrap();
+    File::create(buildroot.path().join("extra_specs.txt"))
         .unwrap()
         .write_all("path/to/spec\nanother:spec".as_bytes())
         .unwrap();

--- a/src/rust/engine/process_execution/children/src/lib.rs
+++ b/src/rust/engine/process_execution/children/src/lib.rs
@@ -39,12 +39,9 @@ impl ManagedChild {
         // later.
         unsafe {
             command.pre_exec(|| {
-                nix::unistd::setsid().map(|_pgid| ()).map_err(|e| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::Other,
-                        format!("Could not create new pgid: {e}"),
-                    )
-                })
+                nix::unistd::setsid()
+                    .map(|_pgid| ())
+                    .map_err(|e| std::io::Error::other(format!("Could not create new pgid: {e}")))
             });
         };
 

--- a/src/rust/engine/process_execution/sandboxer/src/tests.rs
+++ b/src/rust/engine/process_execution/sandboxer/src/tests.rs
@@ -27,12 +27,12 @@ fn test_ensure_socket_file_removed() {
     file.write(b"SOME CONTENT").unwrap();
     file.flush().unwrap();
     assert!(fs::exists(&socket_path).unwrap());
-    let _ = fs::set_permissions(&subdir, fs::Permissions::from_mode(0o644)).unwrap();
+    fs::set_permissions(&subdir, fs::Permissions::from_mode(0o644)).unwrap();
     assert_eq!(
         Err("Permission denied (os error 13)".to_string()),
         ensure_socket_file_removed(&socket_path)
     );
-    let _ = fs::set_permissions(&subdir, fs::Permissions::from_mode(0o755)).unwrap();
+    fs::set_permissions(&subdir, fs::Permissions::from_mode(0o755)).unwrap();
 
     // Succeed in deleting otherwise.
     assert!(fs::exists(&socket_path).unwrap());
@@ -61,7 +61,7 @@ async fn test_sandboxer_service() {
             &sandbox_path,
             &sandbox_path,
             &DirectoryDigest::from_persisted_digest(dir_digest.as_digest()),
-            &vec![],
+            &[],
         )
         .await;
     assert_eq!(Ok(()), res);

--- a/src/rust/engine/process_execution/sandboxer/tests/integration_test.rs
+++ b/src/rust/engine/process_execution/sandboxer/tests/integration_test.rs
@@ -31,7 +31,7 @@ async fn test_sandboxer_process() {
 
     let dir = TempDir::new().unwrap();
     let dir_path = dir.path();
-    let (store_cli_opt, dir_digest) = test_util::prep_store(&dir_path).await;
+    let (store_cli_opt, dir_digest) = test_util::prep_store(dir_path).await;
     let pants_workdir = dir_path.join("workdir");
     let sandbox_path = dir_path.join("sandbox");
 

--- a/src/rust/engine/process_execution/src/tests.rs
+++ b/src/rust/engine/process_execution/src/tests.rs
@@ -198,7 +198,7 @@ async fn wrapper_script_supports_append_only_caches() {
         .unwrap();
 
     let mut cmd = tokio::process::Command::new("./wrapper");
-    cmd.args(&["/bin/sh", "-c", "echo xyzzy > file.txt"]);
+    cmd.args(["/bin/sh", "-c", "echo xyzzy > file.txt"]);
     cmd.current_dir(dummy_sandbox_path.path());
     cmd.stdin(Stdio::null());
     cmd.stdout(Stdio::piped());
@@ -259,7 +259,7 @@ async fn wrapper_script_supports_sandbox_root_replacements_in_args() {
         .unwrap();
 
     let mut cmd = tokio::process::Command::new("./wrapper");
-    cmd.args(&[
+    cmd.args([
         "/bin/sh",
         "-c",
         "echo xyzzy > foo.txt && echo __ROOT__/foo.txt",
@@ -309,7 +309,7 @@ async fn wrapper_script_supports_sandbox_root_replacements_in_environmenbt() {
         .unwrap();
 
     let mut cmd = tokio::process::Command::new("./wrapper");
-    cmd.args(&[
+    cmd.args([
         "/bin/sh",
         "-c",
         "echo xyzzy > $TEST_FILE_PATH && echo $TEST_FILE_PATH",

--- a/src/rust/engine/remote_provider/remote_provider_reapi/src/byte_store.rs
+++ b/src/rust/engine/remote_provider/remote_provider_reapi/src/byte_store.rs
@@ -514,7 +514,7 @@ mod tests {
         // NOTE[TSolberg]: This test is a bit of a hack, but it's the best way I could think of to
         // ensure that the size of the FindMissingBlobsRequest is roughly what we expect. The only
         // delta would be the encoding of the instance name.
-        for it in (0..10).into_iter().chain(1000..1010).chain(10000..10010) {
+        for it in (0..10).chain(1000..1010).chain(10000..10010) {
             while blobs.len() < it {
                 blobs.push(TestData::roland().digest().into());
             }

--- a/src/rust/engine/rust-toolchain
+++ b/src/rust/engine/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.86.0"
+channel = "1.87.0"
 # NB: We don't list the components (namely `clippy` and `rustfmt`) and instead rely on either the
 #  the profile being "default" (by-and-large the default profile) or the nice error message from
 #  `cargo fmt` and `cargo clippy` if the required component isn't installed

--- a/src/rust/engine/src/downloads.rs
+++ b/src/rust/engine/src/downloads.rs
@@ -378,7 +378,7 @@ mod tests {
                         // This error code is retryable.
                         (StatusCode::BAD_GATEWAY, &b"502"[..]).into_response()
                     } else if attempt == 1 {
-                        (StatusCode::OK, &TEST_RESPONSE[..]).into_response()
+                        (StatusCode::OK, TEST_RESPONSE).into_response()
                     } else {
                         (StatusCode::INTERNAL_SERVER_ERROR, &b"unexpected"[..]).into_response()
                     }

--- a/src/rust/engine/src/python.rs
+++ b/src/rust/engine/src/python.rs
@@ -637,21 +637,19 @@ mod pycomparedbool_tests {
         pyo3::prepare_freethreaded_python();
 
         Python::with_gil(|py| {
-            assert_eq!(
+            assert!(
                 PyComparedBool(Some(true))
                     .into_pyobject(py)
                     .unwrap()
                     .extract::<bool>()
-                    .unwrap(),
-                true
+                    .unwrap()
             );
-            assert_eq!(
-                PyComparedBool(Some(false))
+            assert!(
+                !PyComparedBool(Some(false))
                     .into_pyobject(py)
                     .unwrap()
                     .extract::<bool>()
-                    .unwrap(),
-                false
+                    .unwrap()
             );
             assert!(
                 PyComparedBool(None)

--- a/src/rust/engine/testutil/mock/src/cas_service.rs
+++ b/src/rust/engine/testutil/mock/src/cas_service.rs
@@ -185,6 +185,7 @@ impl StubCASResponder {
     }
 
     /// Returns an Err to propagate if this CAS responder is configured to always give an error
+    #[allow(clippy::result_large_err)]
     fn check_always_errors(&self) -> Result<(), Status> {
         if self.always_errors {
             Err(Status::internal(
@@ -195,6 +196,7 @@ impl StubCASResponder {
         }
     }
 
+    #[allow(clippy::result_large_err)]
     fn read_internal(&self, req: &ReadRequest) -> Result<Vec<ReadResponse>, Status> {
         let parsed_resource_name = parse_read_resource_name(&req.resource_name).map_err(|err| {
             Status::invalid_argument(format!("Failed to parse resource name: {err}"))

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -845,6 +845,7 @@ macro_rules! in_workunit {
     use futures::future::FutureExt;
     let mut store_handle = $crate::expect_workunit_store_handle();
     let level: log::Level  = $workunit_level;
+    #[allow(clippy::mem_replace_option_with_some)]
     let mut $workunit = {
       let workunit_metadata =
         if store_handle.store.max_level() >= level {


### PR DESCRIPTION
Upgrade to Rust v1.87.0 which was released on the 10 year anniversary of Rust.

- [Blog post](https://blog.rust-lang.org/2025/05/15/Rust-1.87.0/)
