### PR TITLE
Reduce dependencies on PythonDistributionFieldSet.

### DIFF
--- a/src/python/pants/backend/python/goals/package_dists.py
+++ b/src/python/pants/backend/python/goals/package_dists.py
@@ -9,19 +9,27 @@ from pants.backend.python.util_rules.dists import run_pep517_build
 from pants.backend.python.util_rules.package_dists import create_dist_build_request
 from pants.backend.python.util_rules.package_dists import rules as package_dists_rules
 from pants.core.goals.package import BuiltPackage, BuiltPackageArtifact, PackageFieldSet
+from pants.engine.internals.native_engine import Address
 from pants.engine.intrinsics import digest_to_snapshot
 from pants.engine.rules import collect_rules, implicitly, rule
 from pants.engine.unions import UnionMembership, UnionRule
 
 
 @rule
-async def package_python_dist(
+async def dist_target_address(
     field_set: PythonDistributionFieldSet,
+) -> Address:
+    return field_set.address
+
+
+@rule
+async def package_python_dist(
+    dist_target_address: Address,
     python_setup: PythonSetup,
     union_membership: UnionMembership,
 ) -> BuiltPackage:
     dist_build_request = await create_dist_build_request(
-        field_set=field_set,
+        dist_target_address=dist_target_address,
         python_setup=python_setup,
         union_membership=union_membership,
         # raises an error if both dist_tgt.wheel and dist_tgt.sdist are False

--- a/src/python/pants/backend/python/goals/package_pex_binary_integration_test.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary_integration_test.py
@@ -20,7 +20,6 @@ from pants.backend.python.goals.package_pex_binary import (
 )
 from pants.backend.python.macros.python_artifact import PythonArtifact
 from pants.backend.python.providers.python_build_standalone import rules as pbs
-from pants.backend.python.subsystems.setuptools import PythonDistributionFieldSet
 from pants.backend.python.target_types import (
     PexBinary,
     PexLayout,
@@ -55,7 +54,6 @@ def rule_runner() -> PythonRuleRunner:
             *package_dists.rules(),
             QueryRule(BuiltPackage, [PexBinaryFieldSet]),
             QueryRule(PexFromTargetsRequestForBuiltPackage, [PexBinaryFieldSet]),
-            QueryRule(BuiltPackage, [PythonDistributionFieldSet]),
         ],
         target_types=[
             FileTarget,

--- a/src/python/pants/backend/python/util_rules/package_dists.py
+++ b/src/python/pants/backend/python/util_rules/package_dists.py
@@ -18,7 +18,6 @@ from typing import Any, DefaultDict, cast
 from pants.backend.python.macros.python_artifact import PythonArtifact
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.subsystems.setup_py_generation import SetupPyGeneration
-from pants.backend.python.subsystems.setuptools import PythonDistributionFieldSet
 from pants.backend.python.target_types import (
     BuildBackendEnvVarsField,
     GenerateSetupField,
@@ -374,7 +373,7 @@ class DistBuildEnvironment:
 
 
 async def create_dist_build_request(
-    field_set: PythonDistributionFieldSet,
+    dist_target_address: Address,
     python_setup: PythonSetup,
     union_membership: UnionMembership,
     validate_wheel_sdist: bool = True,
@@ -386,7 +385,7 @@ async def create_dist_build_request(
     """
 
     transitive_targets = await transitive_targets_get(
-        TransitiveTargetsRequest([field_set.address]), **implicitly()
+        TransitiveTargetsRequest([dist_target_address]), **implicitly()
     )
     exported_target = ExportedTarget(transitive_targets.roots[0])
 

--- a/src/python/pants/backend/python/util_rules/package_dists_test.py
+++ b/src/python/pants/backend/python/util_rules/package_dists_test.py
@@ -15,11 +15,9 @@ from pants.backend.python.subsystems.setup_py_generation import (
     FirstPartyDependencyVersionScheme,
     SetupPyGeneration,
 )
-from pants.backend.python.subsystems.setuptools import PythonDistributionFieldSet
 from pants.backend.python.target_types import (
     PexBinary,
     PythonDistribution,
-    PythonProvidesField,
     PythonRequirementTarget,
     PythonSourcesGeneratorTarget,
 )
@@ -1414,7 +1412,7 @@ def test_no_dist_type_selected() -> None:
             *python_sources.rules(),
             *target_types_rules.rules(),
             *SetupPyGeneration.rules(),
-            QueryRule(BuiltPackage, (PythonDistributionFieldSet,)),
+            QueryRule(BuiltPackage, (Address,)),
         ],
         target_types=[PythonDistribution],
         objects={"python_artifact": PythonArtifact},
@@ -1438,12 +1436,7 @@ def test_no_dist_type_selected() -> None:
         rule_runner.request(
             BuiltPackage,
             inputs=[
-                PythonDistributionFieldSet(
-                    address=address,
-                    provides=PythonProvidesField(
-                        PythonArtifact(name="aaa", version="2.2.2"), address
-                    ),
-                )
+                address,
             ],
         )
     assert 1 == len(exc_info.value.wrapped_exceptions)


### PR DESCRIPTION
Most of the places that used it really only needed its `address` field.