### PR TITLE
[Call-by-name] migrate various files in `src/python/pants/jvm`

### DIFF
--- a/src/python/pants/jvm/classpath.py
+++ b/src/python/pants/jvm/classpath.py
@@ -10,11 +10,13 @@ from dataclasses import dataclass
 from pants.core.util_rules import system_binaries
 from pants.core.util_rules.system_binaries import UnzipBinary
 from pants.engine.fs import Digest, MergeDigests, RemovePrefix
-from pants.engine.process import Process, ProcessResult
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.intrinsics import merge_digests, remove_prefix
+from pants.engine.process import Process, execute_process_or_raise
+from pants.engine.rules import Get, collect_rules, concurrently, implicitly, rule
 from pants.engine.target import CoarsenedTargets
 from pants.jvm.compile import ClasspathEntry, ClasspathEntryRequest, ClasspathEntryRequestFactory
 from pants.jvm.compile import rules as jvm_compile_rules
+from pants.jvm.resolve.coursier_fetch import select_coursier_resolve_for_targets
 from pants.jvm.resolve.key import CoursierResolveKey
 from pants.util.logging import LogLevel
 
@@ -77,10 +79,10 @@ async def classpath(
 ) -> Classpath:
     # Compute a single shared resolve for all of the roots, which will validate that they
     # are compatible with one another.
-    resolve = await Get(CoursierResolveKey, CoarsenedTargets, coarsened_targets)
+    resolve = await select_coursier_resolve_for_targets(coarsened_targets, **implicitly())
 
     # Then request classpath entries for each root.
-    classpath_entries = await MultiGet(
+    classpath_entries = await concurrently(
         Get(
             ClasspathEntry,
             ClasspathEntryRequest,
@@ -108,28 +110,31 @@ async def loose_classfiles(
     classpath_entry: ClasspathEntry, unzip_binary: UnzipBinary
 ) -> LooseClassfiles:
     dest_dir = "dest"
-    process_results = await MultiGet(
-        Get(
-            ProcessResult,
-            Process(
-                argv=[
-                    unzip_binary.path,
-                    "-d",
-                    dest_dir,
-                    filename,
-                ],
-                output_directories=(dest_dir,),
-                description=f"Extract {filename}",
-                immutable_input_digests=dict(ClasspathEntry.immutable_inputs([classpath_entry])),
-                level=LogLevel.TRACE,
-            ),
+    process_results = await concurrently(
+        execute_process_or_raise(
+            **implicitly(
+                Process(
+                    argv=[
+                        unzip_binary.path,
+                        "-d",
+                        dest_dir,
+                        filename,
+                    ],
+                    output_directories=(dest_dir,),
+                    description=f"Extract {filename}",
+                    immutable_input_digests=dict(
+                        ClasspathEntry.immutable_inputs([classpath_entry])
+                    ),
+                    level=LogLevel.TRACE,
+                )
+            )
         )
         for filename in ClasspathEntry.immutable_inputs_args([classpath_entry])
     )
 
-    merged_digest = await Get(Digest, MergeDigests(pr.output_digest for pr in process_results))
+    merged_digest = await merge_digests(MergeDigests(pr.output_digest for pr in process_results))
 
-    return LooseClassfiles(await Get(Digest, RemovePrefix(merged_digest, dest_dir)))
+    return LooseClassfiles(await remove_prefix(RemovePrefix(merged_digest, dest_dir)))
 
 
 def rules():

--- a/src/python/pants/jvm/compile.py
+++ b/src/python/pants/jvm/compile.py
@@ -21,9 +21,9 @@ from pants.engine.collection import Collection
 from pants.engine.engine_aware import EngineAwareReturnType
 from pants.engine.environment import EnvironmentName
 from pants.engine.fs import Digest
-from pants.engine.internals.selectors import Get, MultiGet
+from pants.engine.internals.selectors import Get
 from pants.engine.process import FallibleProcessResult
-from pants.engine.rules import collect_rules, rule
+from pants.engine.rules import collect_rules, concurrently, rule
 from pants.engine.target import (
     CoarsenedTarget,
     Field,
@@ -443,7 +443,7 @@ def classpath_dependency_requests(
 @rule
 async def compile_classpath_entries(requests: ClasspathEntryRequests) -> FallibleClasspathEntries:
     return FallibleClasspathEntries(
-        await MultiGet(
+        await concurrently(
             Get(FallibleClasspathEntry, ClasspathEntryRequest, request) for request in requests
         )
     )

--- a/src/python/pants/jvm/dependency_inference/symbol_mapper.py
+++ b/src/python/pants/jvm/dependency_inference/symbol_mapper.py
@@ -10,7 +10,7 @@ from typing import Any
 
 from pants.build_graph.address import Address
 from pants.engine.environment import EnvironmentName
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.rules import Get, collect_rules, concurrently, rule
 from pants.engine.unions import UnionMembership, union
 from pants.jvm.dependency_inference.artifact_mapper import (
     AllJvmTypeProvidingTargets,
@@ -84,7 +84,7 @@ async def merge_symbol_mappings(
     jvm: JvmSubsystem,
     third_party_mapping: ThirdPartySymbolMapping,
 ) -> SymbolMapping:
-    all_firstparty_mappings = await MultiGet(
+    all_firstparty_mappings = await concurrently(
         Get(
             SymbolMap,
             FirstPartyMappingRequest,

--- a/src/python/pants/jvm/jdk_rules.py
+++ b/src/python/pants/jvm/jdk_rules.py
@@ -17,13 +17,13 @@ from typing import ClassVar
 from pants.core.util_rules.environments import EnvironmentTarget
 from pants.core.util_rules.system_binaries import BashBinary, LnBinary
 from pants.engine.fs import CreateDigest, Digest, FileContent, FileDigest, MergeDigests
-from pants.engine.internals.selectors import Get
-from pants.engine.process import FallibleProcessResult, Process, ProcessCacheScope
-from pants.engine.rules import collect_rules, rule
+from pants.engine.intrinsics import create_digest, execute_process, merge_digests
+from pants.engine.process import Process, ProcessCacheScope
+from pants.engine.rules import collect_rules, implicitly, rule
 from pants.engine.target import CoarsenedTarget
 from pants.jvm.compile import ClasspathEntry
 from pants.jvm.resolve.coordinate import Coordinate, Coordinates
-from pants.jvm.resolve.coursier_fetch import CoursierLockfileEntry
+from pants.jvm.resolve.coursier_fetch import CoursierLockfileEntry, coursier_fetch_one_coord
 from pants.jvm.resolve.coursier_setup import Coursier
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmJdkField
@@ -165,8 +165,7 @@ def parse_jre_major_version(version_lines: str) -> int | None:
 
 @rule
 async def fetch_nailgun() -> Nailgun:
-    nailgun = await Get(
-        ClasspathEntry,
+    nailgun = await coursier_fetch_one_coord(
         CoursierLockfileEntry(
             coord=Coordinate.from_coord_str("com.martiansoftware:nailgun-server:0.9.1"),
             file_name="com.martiansoftware_nailgun-server_0.9.1.jar",
@@ -176,23 +175,10 @@ async def fetch_nailgun() -> Nailgun:
                 fingerprint="4518faa6bf4bd26fccdc4d85e1625dc679381a08d56872d8ad12151dda9cef25",
                 serialized_bytes_length=32927,
             ),
-        ),
+        )
     )
 
     return Nailgun(nailgun)
-
-
-@rule
-async def internal_jdk(jvm: JvmSubsystem) -> InternalJdk:
-    """Creates a `JdkEnvironment` object based on the JVM subsystem options.
-
-    This is used for providing a predictable JDK version for Pants' internal usage rather than for
-    matching compatibility with source files (e.g. compilation/testing).
-    """
-
-    request = JdkRequest(jvm.tool_jdk) if jvm.tool_jdk is not None else JdkRequest.SYSTEM
-    env = await Get(JdkEnvironment, JdkRequest, request)
-    return InternalJdk.from_jdk_environment(env)
 
 
 @rule
@@ -243,8 +229,7 @@ async def prepare_jdk_environment(
         **coursier.env,
     }
 
-    java_version_result = await Get(
-        FallibleProcessResult,
+    java_version_result = await execute_process(
         Process(
             argv=(
                 bash.path,
@@ -258,6 +243,7 @@ async def prepare_jdk_environment(
             cache_scope=env_target.executable_search_path_cache_scope(),
             level=LogLevel.DEBUG,
         ),
+        **implicitly(),
     )
 
     if java_version_result.exit_code != 0:
@@ -289,8 +275,7 @@ async def prepare_jdk_environment(
         exec "$@"
         """
     )
-    jdk_preparation_script_digest = await Get(
-        Digest,
+    jdk_preparation_script_digest = await create_digest(
         CreateDigest(
             [
                 FileContent(
@@ -303,8 +288,7 @@ async def prepare_jdk_environment(
     )
 
     return JdkEnvironment(
-        _digest=await Get(
-            Digest,
+        _digest=await merge_digests(
             MergeDigests(
                 [
                     jdk_preparation_script_digest,
@@ -318,6 +302,19 @@ async def prepare_jdk_environment(
         jre_major_version=jre_major_version,
         java_home_command=java_home_command,
     )
+
+
+@rule
+async def internal_jdk(jvm: JvmSubsystem) -> InternalJdk:
+    """Creates a `JdkEnvironment` object based on the JVM subsystem options.
+
+    This is used for providing a predictable JDK version for Pants' internal usage rather than for
+    matching compatibility with source files (e.g. compilation/testing).
+    """
+
+    request = JdkRequest(jvm.tool_jdk) if jvm.tool_jdk is not None else JdkRequest.SYSTEM
+    env = await prepare_jdk_environment(**implicitly({request: JdkRequest}))
+    return InternalJdk.from_jdk_environment(env)
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/jvm/util_rules.py
+++ b/src/python/pants/jvm/util_rules.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from pants.engine.fs import Digest, DigestEntries, DigestSubset, FileDigest, FileEntry, PathGlobs
-from pants.engine.rules import Get, collect_rules, rule
+from pants.engine.fs import Digest, DigestSubset, FileDigest, FileEntry, PathGlobs
+from pants.engine.intrinsics import digest_subset_to_digest, get_digest_entries
+from pants.engine.rules import collect_rules, rule
 
 
 @dataclass(frozen=True)
@@ -17,8 +18,10 @@ class ExtractFileDigest:
 
 @rule
 async def digest_to_file_digest(request: ExtractFileDigest) -> FileDigest:
-    digest = await Get(Digest, DigestSubset(request.digest, PathGlobs([request.file_path])))
-    digest_entries = await Get(DigestEntries, Digest, digest)
+    digest = await digest_subset_to_digest(
+        DigestSubset(request.digest, PathGlobs([request.file_path]))
+    )
+    digest_entries = await get_digest_entries(digest)
 
     if len(digest_entries) == 0:
         raise Exception(f"ExtractFileDigest: '{request.file_path}' not found in {request.digest}.")


### PR DESCRIPTION
Migrate various files in `src/python/pants/jvm` to call-by-name syntax. Union invocations have been left alone.