### PR TITLE
[Call-by-name] migrate `src/python/pants/jvm/goals/lockfile.py`

### DIFF
--- a/src/python/pants/jvm/goals/lockfile.py
+++ b/src/python/pants/jvm/goals/lockfile.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Mapping
+from collections.abc import Coroutine, Mapping
 from dataclasses import dataclass
 
 from pants.core.goals.generate_lockfiles import (
@@ -20,9 +20,10 @@ from pants.core.goals.generate_lockfiles import (
 )
 from pants.core.goals.resolves import ExportableTool
 from pants.engine.environment import EnvironmentName
-from pants.engine.fs import CreateDigest, Digest, FileContent
-from pants.engine.internals.selectors import MultiGet
-from pants.engine.rules import Get, collect_rules, rule
+from pants.engine.fs import CreateDigest, FileContent
+from pants.engine.internals.selectors import concurrently
+from pants.engine.intrinsics import create_digest
+from pants.engine.rules import Get, collect_rules, implicitly, rule
 from pants.engine.target import AllTargets
 from pants.engine.unions import UnionMembership, UnionRule, union
 from pants.jvm.resolve import coursier_fetch
@@ -31,8 +32,12 @@ from pants.jvm.resolve.common import (
     ArtifactRequirements,
     GatherJvmCoordinatesRequest,
 )
-from pants.jvm.resolve.coursier_fetch import CoursierResolvedLockfile
-from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool, JvmToolBase
+from pants.jvm.resolve.coursier_fetch import coursier_resolve_lockfile
+from pants.jvm.resolve.jvm_tool import (
+    GenerateJvmLockfileFromTool,
+    JvmToolBase,
+    gather_coordinates_for_jvm_lockfile,
+)
 from pants.jvm.resolve.lockfile_metadata import JVMLockfileMetadata
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmArtifactResolveField, JvmResolveField
@@ -75,7 +80,7 @@ async def generate_jvm_lockfile(
     request: GenerateJvmLockfile,
     generate_lockfiles_subsystem: GenerateLockfilesSubsystem,
 ) -> GenerateLockfileResult:
-    resolved_lockfile = await Get(CoursierResolvedLockfile, ArtifactRequirements, request.artifacts)
+    resolved_lockfile = await coursier_resolve_lockfile(request.artifacts)
     regenerate_command = (
         generate_lockfiles_subsystem.custom_command or f"{bin_name()} generate-lockfiles"
     )
@@ -88,9 +93,8 @@ async def generate_jvm_lockfile(
         delimeter="#",
     )
 
-    lockfile_digest = await Get(
-        Digest,
-        CreateDigest([FileContent(request.lockfile_dest, resolved_lockfile_contents)]),
+    lockfile_digest = await create_digest(
+        CreateDigest([FileContent(request.lockfile_dest, resolved_lockfile_contents)])
     )
     return GenerateLockfileResult(lockfile_digest, request.resolve_name, request.lockfile_dest)
 
@@ -147,19 +151,19 @@ async def validate_jvm_artifacts_for_resolve(
     )
 
 
-async def _plan_generate_lockfile(resolve, resolve_to_artifacts, tools) -> Get:
+async def _plan_generate_lockfile(resolve, resolve_to_artifacts, tools) -> Get | Coroutine:
     """Generate a JVM lockfile request for each requested resolve.
 
     This step also allows other backends to validate the proposed set of artifact requirements for
     each resolve.
     """
     if resolve in resolve_to_artifacts:
-        return Get(
-            GenerateJvmLockfile,
+        return validate_jvm_artifacts_for_resolve(
             _ValidateJvmArtifactsRequest(
                 artifacts=ArtifactRequirements(resolve_to_artifacts[resolve]),
                 resolve_name=resolve,
             ),
+            **implicitly(),
         )
     elif resolve in tools:
         tool_cls: type[JvmToolBase] = tools[resolve]
@@ -172,12 +176,12 @@ async def _plan_generate_lockfile(resolve, resolve_to_artifacts, tools) -> Get:
         )
 
     else:
-        return Get(
-            GenerateJvmLockfile,
+        return validate_jvm_artifacts_for_resolve(
             _ValidateJvmArtifactsRequest(
                 artifacts=ArtifactRequirements(()),
                 resolve_name=resolve,
             ),
+            **implicitly(),
         )
 
 
@@ -198,11 +202,11 @@ async def setup_user_lockfile_requests(
 
     tools = ExportableTool.filter_for_subclasses(union_membership, JvmToolBase)
 
-    gets = []
+    gets: list[Get | Coroutine] = []
     for resolve in requested:
         gets.append(await _plan_generate_lockfile(resolve, resolve_to_artifacts, tools))
 
-    jvm_lockfile_requests = await MultiGet(*gets)
+    jvm_lockfile_requests = await concurrently(*gets)
 
     return UserGenerateLockfiles(jvm_lockfile_requests)
 
@@ -211,9 +215,8 @@ async def setup_user_lockfile_requests(
 async def setup_lockfile_request_from_tool(
     request: GenerateJvmLockfileFromTool,
 ) -> GenerateJvmLockfile:
-    artifacts = await Get(
-        ArtifactRequirements,
-        GatherJvmCoordinatesRequest(request.artifact_inputs, request.artifact_option_name),
+    artifacts = await gather_coordinates_for_jvm_lockfile(
+        GatherJvmCoordinatesRequest(request.artifact_inputs, request.artifact_option_name)
     )
     return GenerateJvmLockfile(
         artifacts=artifacts,


### PR DESCRIPTION
Migrate `src/python/pants/jvm/goals/lockfile` to call-by-name syntax except for a union invocation.