### PR TITLE
refactor environments-related target types and subsystem to avoid import cycle

### DIFF
--- a/src/python/pants/backend/adhoc/adhoc_tool_test.py
+++ b/src/python/pants/backend/adhoc/adhoc_tool_test.py
@@ -14,10 +14,10 @@ from pants.backend.adhoc.run_system_binary import rules as run_system_binary_rul
 from pants.backend.adhoc.target_types import AdhocToolTarget, SystemBinaryTarget
 from pants.backend.python.goals.run_python_source import rules as run_python_source_rules
 from pants.backend.python.target_types import PythonSourceTarget
+from pants.core.environments.target_types import LocalWorkspaceEnvironmentTarget
 from pants.core.target_types import ArchiveTarget, FilesGeneratorTarget
 from pants.core.target_types import rules as core_target_type_rules
 from pants.core.util_rules import archive, source_files
-from pants.core.util_rules.environments import LocalWorkspaceEnvironmentTarget
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
 from pants.engine.fs import EMPTY_SNAPSHOT, DigestContents

--- a/src/python/pants/backend/adhoc/target_types.py
+++ b/src/python/pants/backend/adhoc/target_types.py
@@ -7,8 +7,8 @@ from enum import Enum
 from typing import ClassVar
 
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
+from pants.core.environments.target_types import EnvironmentField
 from pants.core.util_rules.adhoc_process_support import PathEnvModifyMode
-from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.env_vars import EXTRA_ENV_VARS_USAGE_HELP
 from pants.engine.fs import GlobExpansionConjunction
 from pants.engine.process import ProcessCacheScope

--- a/src/python/pants/backend/awslambda/python/rules.py
+++ b/src/python/pants/backend/awslambda/python/rules.py
@@ -26,8 +26,8 @@ from pants.backend.python.util_rules.faas import (
     build_python_faas,
 )
 from pants.backend.python.util_rules.faas import rules as faas_rules
+from pants.core.environments.target_types import EnvironmentField
 from pants.core.goals.package import BuiltPackage, OutputPathField, PackageFieldSet
-from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel

--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -22,8 +22,8 @@ from pants.backend.python.util_rules.faas import (
     PythonFaaSRuntimeField,
 )
 from pants.backend.python.util_rules.faas import rules as faas_rules
+from pants.core.environments.target_types import EnvironmentField
 from pants.core.goals.package import OutputPathField
-from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.addresses import Address
 from pants.engine.rules import collect_rules
 from pants.engine.target import (

--- a/src/python/pants/backend/codegen/thrift/apache/rules.py
+++ b/src/python/pants/backend/codegen/thrift/apache/rules.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 
 from pants.backend.codegen.thrift.apache.subsystem import ApacheThriftSubsystem
 from pants.backend.codegen.thrift.target_types import ThriftSourceField
-from pants.core.util_rules.environments import EnvironmentTarget
+from pants.core.environments.target_types import EnvironmentTarget
 from pants.core.util_rules.source_files import SourceFilesRequest, determine_source_files
 from pants.core.util_rules.system_binaries import (
     BinaryNotFoundError,

--- a/src/python/pants/backend/docker/util_rules/docker_build_context_test.py
+++ b/src/python/pants/backend/docker/util_rules/docker_build_context_test.py
@@ -38,11 +38,11 @@ from pants.backend.python.target_types import PexBinary, PythonRequirementTarget
 from pants.backend.python.util_rules import pex_from_targets
 from pants.backend.shell.target_types import ShellSourcesGeneratorTarget, ShellSourceTarget
 from pants.backend.shell.target_types import rules as shell_target_types_rules
+from pants.core.environments.target_types import DockerEnvironmentTarget
 from pants.core.goals import package
 from pants.core.goals.package import BuiltPackage
 from pants.core.target_types import FilesGeneratorTarget, FileTarget
 from pants.core.target_types import rules as core_target_types_rules
-from pants.core.util_rules.environments import DockerEnvironmentTarget
 from pants.engine.addresses import Address
 from pants.engine.fs import EMPTY_DIGEST, EMPTY_SNAPSHOT, Snapshot
 from pants.engine.internals.scheduler import ExecutionError

--- a/src/python/pants/backend/go/goals/package_binary.py
+++ b/src/python/pants/backend/go/goals/package_binary.py
@@ -32,6 +32,7 @@ from pants.backend.go.util_rules.third_party_pkg import (
     ThirdPartyPkgAnalysisRequest,
     extract_package_info,
 )
+from pants.core.environments.target_types import EnvironmentField
 from pants.core.goals.package import (
     BuiltPackage,
     BuiltPackageArtifact,
@@ -39,7 +40,6 @@ from pants.core.goals.package import (
     PackageFieldSet,
 )
 from pants.core.goals.run import RunFieldSet, RunInSandboxBehavior
-from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.fs import AddPrefix
 from pants.engine.internals.selectors import concurrently
 from pants.engine.intrinsics import add_prefix

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -6,10 +6,10 @@ from __future__ import annotations
 import os
 from collections.abc import Iterable, Sequence
 
+from pants.core.environments.target_types import EnvironmentField
 from pants.core.goals.package import OutputPathField
 from pants.core.goals.run import RestartableField
 from pants.core.goals.test import TestExtraEnvVarsField, TestTimeoutField
-from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.addresses import Address
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,

--- a/src/python/pants/backend/go/util_rules/go_bootstrap.py
+++ b/src/python/pants/backend/go/util_rules/go_bootstrap.py
@@ -7,9 +7,9 @@ from collections.abc import Collection
 from dataclasses import dataclass
 
 from pants.backend.go.subsystems.golang import GolangSubsystem
+from pants.core.environments.target_types import EnvironmentTarget
 from pants.core.util_rules import asdf, search_paths
 from pants.core.util_rules.asdf import AsdfPathString, AsdfToolPathsResult
-from pants.core.util_rules.environments import EnvironmentTarget
 from pants.core.util_rules.search_paths import ValidateSearchPathsRequest, validate_search_paths
 from pants.engine.internals.platform_rules import environment_path_variable
 from pants.engine.rules import collect_rules, rule

--- a/src/python/pants/backend/go/util_rules/goroot.py
+++ b/src/python/pants/backend/go/util_rules/goroot.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from pants.backend.go.subsystems.golang import GolangSubsystem
 from pants.backend.go.util_rules import go_bootstrap
 from pants.backend.go.util_rules.go_bootstrap import GoBootstrap, compatible_go_version
-from pants.core.util_rules.environments import EnvironmentTarget
+from pants.core.environments.target_types import EnvironmentTarget
 from pants.core.util_rules.system_binaries import (
     BinaryNotFoundError,
     BinaryPathRequest,

--- a/src/python/pants/backend/google_cloud_function/python/rules.py
+++ b/src/python/pants/backend/google_cloud_function/python/rules.py
@@ -22,8 +22,8 @@ from pants.backend.python.util_rules.faas import (
     build_python_faas,
 )
 from pants.backend.python.util_rules.faas import rules as faas_rules
+from pants.core.environments.target_types import EnvironmentField
 from pants.core.goals.package import BuiltPackage, OutputPathField, PackageFieldSet
-from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel

--- a/src/python/pants/backend/google_cloud_function/python/target_types.py
+++ b/src/python/pants/backend/google_cloud_function/python/target_types.py
@@ -19,8 +19,8 @@ from pants.backend.python.util_rules.faas import (
     PythonFaaSRuntimeField,
 )
 from pants.backend.python.util_rules.faas import rules as faas_rules
+from pants.core.environments.target_types import EnvironmentField
 from pants.core.goals.package import OutputPathField
-from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.addresses import Address
 from pants.engine.rules import collect_rules
 from pants.engine.target import COMMON_TARGET_FIELDS, InvalidFieldException, StringField, Target

--- a/src/python/pants/backend/javascript/run/rules.py
+++ b/src/python/pants/backend/javascript/run/rules.py
@@ -19,8 +19,8 @@ from pants.backend.javascript.package_json import (
     NodeBuildScriptExtraEnvVarsField,
     NodePackageDependenciesField,
 )
+from pants.core.environments.target_types import EnvironmentField
 from pants.core.goals.run import RunFieldSet, RunInSandboxBehavior, RunRequest
-from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.env_vars import EnvironmentVarsRequest
 from pants.engine.internals.platform_rules import environment_vars_subset
 from pants.engine.rules import Rule, collect_rules, implicitly, rule

--- a/src/python/pants/backend/javascript/subsystems/nodejs.py
+++ b/src/python/pants/backend/javascript/subsystems/nodejs.py
@@ -13,9 +13,9 @@ from typing import ClassVar
 
 from nodesemver import min_satisfying
 
+from pants.core.environments.target_types import EnvironmentTarget
 from pants.core.util_rules import asdf, search_paths, system_binaries
 from pants.core.util_rules.asdf import AsdfPathString, AsdfToolPathsResult
-from pants.core.util_rules.environments import EnvironmentTarget
 from pants.core.util_rules.external_tool import (
     DownloadedExternalTool,
     ExternalToolRequest,

--- a/src/python/pants/backend/python/goals/package_pex_binary.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary.py
@@ -34,6 +34,7 @@ from pants.backend.python.target_types import (
 from pants.backend.python.target_types_rules import resolve_pex_entry_point
 from pants.backend.python.util_rules.pex import create_pex, digest_complete_platforms
 from pants.backend.python.util_rules.pex_from_targets import PexFromTargetsRequest
+from pants.core.environments.target_types import EnvironmentField
 from pants.core.goals.package import (
     BuiltPackage,
     BuiltPackageArtifact,
@@ -41,7 +42,6 @@ from pants.core.goals.package import (
     PackageFieldSet,
 )
 from pants.core.goals.run import RunFieldSet, RunInSandboxBehavior
-from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.rules import collect_rules, implicitly, rule
 from pants.engine.unions import UnionRule
 from pants.util.frozendict import FrozenDict

--- a/src/python/pants/backend/python/packaging/pyoxidizer/rules.py
+++ b/src/python/pants/backend/python/packaging/pyoxidizer/rules.py
@@ -24,6 +24,7 @@ from pants.backend.python.packaging.pyoxidizer.target_types import (
 )
 from pants.backend.python.target_types import GenerateSetupField, WheelField
 from pants.backend.python.util_rules.pex import PexProcess, create_pex, setup_pex_process
+from pants.core.environments.target_types import EnvironmentField
 from pants.core.goals.package import (
     BuiltPackage,
     BuiltPackageArtifact,
@@ -32,7 +33,6 @@ from pants.core.goals.package import (
     environment_aware_package,
 )
 from pants.core.goals.run import RunFieldSet, RunInSandboxBehavior, RunRequest
-from pants.core.util_rules.environments import EnvironmentField
 from pants.core.util_rules.system_binaries import BashBinary
 from pants.engine.fs import AddPrefix, CreateDigest, Digest, FileContent, MergeDigests, RemovePrefix
 from pants.engine.internals.graph import find_valid_field_sets, hydrate_sources, resolve_targets

--- a/src/python/pants/backend/python/packaging/pyoxidizer/target_types.py
+++ b/src/python/pants/backend/python/packaging/pyoxidizer/target_types.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 from pants.backend.python.target_types import GenerateSetupField, WheelField
+from pants.core.environments.target_types import EnvironmentField
 from pants.core.goals.package import OutputPathField
-from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
     AsyncFieldMixin,

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -19,10 +19,10 @@ from pants.backend.python.target_types import (
     PythonTestsXdistConcurrencyField,
     SkipPythonTestsField,
 )
+from pants.core.environments.target_types import EnvironmentField
 from pants.core.goals.resolves import ExportableTool
 from pants.core.goals.test import RuntimePackageDependenciesField, TestFieldSet
 from pants.core.util_rules.config_files import ConfigFilesRequest
-from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.rules import collect_rules
 from pants.engine.target import Target
 from pants.engine.unions import UnionRule

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -16,6 +16,7 @@ from packaging.utils import canonicalize_name as canonicalize_project_name
 
 from pants.backend.python.macros.python_artifact import PythonArtifact
 from pants.backend.python.subsystems.setup import PythonSetup
+from pants.core.environments.target_types import EnvironmentField
 from pants.core.goals.generate_lockfiles import UnrecognizedResolveNamesError
 from pants.core.goals.package import OutputPathField
 from pants.core.goals.run import RestartableField
@@ -25,7 +26,6 @@ from pants.core.goals.test import (
     TestsBatchCompatibilityTagField,
     TestSubsystem,
 )
-from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.addresses import Address, Addresses
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -53,8 +53,8 @@ from pants.backend.python.util_rules.pex_requirements import (
     validate_metadata,
 )
 from pants.build_graph.address import Address
+from pants.core.environments.target_types import EnvironmentTarget
 from pants.core.target_types import FileSourceField, ResourceSourceField
-from pants.core.util_rules.environments import EnvironmentTarget
 from pants.core.util_rules.stripped_source_files import StrippedFileNameRequest
 from pants.core.util_rules.stripped_source_files import rules as stripped_source_rules
 from pants.core.util_rules.stripped_source_files import strip_file_name

--- a/src/python/pants/backend/shell/goals/test.py
+++ b/src/python/pants/backend/shell/goals/test.py
@@ -17,6 +17,7 @@ from pants.backend.shell.util_rules.shell_command import (
     ShellCommandProcessFromTargetRequest,
     prepare_process_request_from_target,
 )
+from pants.core.environments.target_types import EnvironmentField
 from pants.core.goals.test import (
     TestDebugRequest,
     TestExtraEnv,
@@ -32,7 +33,6 @@ from pants.core.util_rules.adhoc_process_support import (
 )
 from pants.core.util_rules.adhoc_process_support import rules as adhoc_process_support_rules
 from pants.core.util_rules.adhoc_process_support import run_prepared_adhoc_process
-from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.fs import EMPTY_DIGEST, Snapshot
 from pants.engine.internals.graph import resolve_target
 from pants.engine.intrinsics import digest_to_snapshot

--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -25,8 +25,8 @@ from pants.backend.adhoc.target_types import (
     AdhocToolWorkspaceInvalidationSourcesField,
 )
 from pants.backend.shell.subsystems.shell_setup import ShellSetup
+from pants.core.environments.target_types import EnvironmentField
 from pants.core.goals.test import RuntimePackageDependenciesField, TestTimeoutField
-from pants.core.util_rules.environments import EnvironmentField
 from pants.core.util_rules.system_binaries import BinaryPathTest
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import (

--- a/src/python/pants/backend/shell/util_rules/shell_command.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command.py
@@ -32,6 +32,7 @@ from pants.backend.shell.target_types import (
 )
 from pants.backend.shell.util_rules.builtin import BASH_BUILTIN_COMMANDS
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
+from pants.core.environments.target_types import EnvironmentTarget
 from pants.core.goals.run import RunFieldSet, RunInSandboxBehavior, RunRequest
 from pants.core.target_types import FileSourceField
 from pants.core.util_rules.adhoc_process_support import (
@@ -46,11 +47,7 @@ from pants.core.util_rules.adhoc_process_support import (
     resolve_execution_environment,
 )
 from pants.core.util_rules.adhoc_process_support import rules as adhoc_process_support_rules
-from pants.core.util_rules.environments import (
-    EnvironmentNameRequest,
-    EnvironmentTarget,
-    resolve_environment_name,
-)
+from pants.core.util_rules.environments import EnvironmentNameRequest, resolve_environment_name
 from pants.core.util_rules.system_binaries import (
     BashBinary,
     BinaryShimsRequest,

--- a/src/python/pants/backend/shell/util_rules/shell_command_test.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command_test.py
@@ -23,6 +23,7 @@ from pants.backend.shell.util_rules.shell_command import (
     ShellCommandProcessFromTargetRequest,
 )
 from pants.backend.shell.util_rules.shell_command import rules as shell_command_rules
+from pants.core.environments.target_types import LocalWorkspaceEnvironmentTarget
 from pants.core.goals.run import RunRequest
 from pants.core.target_types import ArchiveTarget, FilesGeneratorTarget, FileSourceField
 from pants.core.target_types import rules as core_target_type_rules
@@ -31,7 +32,6 @@ from pants.core.util_rules.adhoc_process_support import (
     AdhocProcessRequest,
     PreparedAdhocProcessRequest,
 )
-from pants.core.util_rules.environments import LocalWorkspaceEnvironmentTarget
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
 from pants.engine.environment import EnvironmentName

--- a/src/python/pants/build_graph/build_configuration.py
+++ b/src/python/pants/build_graph/build_configuration.py
@@ -12,7 +12,7 @@ from typing import Any, DefaultDict
 
 from pants.backend.project_info.filter_targets import FilterSubsystem
 from pants.build_graph.build_file_aliases import BuildFileAliases
-from pants.core.util_rules.environments import EnvironmentsSubsystem
+from pants.core.environments.subsystems import EnvironmentsSubsystem
 from pants.engine.goal import GoalSubsystem
 from pants.engine.rules import Rule, RuleIndex
 from pants.engine.target import Target

--- a/src/python/pants/core/environments/BUILD
+++ b/src/python/pants/core/environments/BUILD
@@ -1,0 +1,4 @@
+# Copyright 2025 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_sources()

--- a/src/python/pants/core/environments/subsystems.py
+++ b/src/python/pants/core/environments/subsystems.py
@@ -1,0 +1,45 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from pants.option.global_options import GlobalOptions
+from pants.option.option_types import DictOption
+from pants.option.subsystem import Subsystem
+from pants.util.strutil import help_text, softwrap
+
+
+class EnvironmentsSubsystem(Subsystem):
+    options_scope = "environments-preview"
+    help = help_text(
+        """
+        A highly experimental subsystem to allow setting environment variables and executable
+        search paths for different environments, e.g. macOS vs. Linux.
+        """
+    )
+
+    names = DictOption[str](
+        help=softwrap(
+            """
+            A mapping of logical names to addresses to environment targets. For example:
+
+                [environments-preview.names]
+                linux_local = "//:linux_env"
+                macos_local = "//:macos_env"
+                centos6 = "//:centos6_docker_env"
+                linux_ci = "build-support:linux_ci_env"
+                macos_ci = "build-support:macos_ci_env"
+
+            To use an environment for a given target, specify the name in the `environment` field
+            on that target. Pants will consume the environment target at the address mapped from
+            that name.
+
+            Pants will ignore any environment targets that are not given a name via this option.
+            """
+        )
+    )
+
+    def remote_execution_used_globally(self, global_options: GlobalOptions) -> bool:
+        """If the environments mechanism is not used, `--remote-execution` toggles remote execution
+        globally."""
+        return not self.names and global_options.remote_execution

--- a/src/python/pants/core/environments/target_types.py
+++ b/src/python/pants/core/environments/target_types.py
@@ -1,0 +1,354 @@
+# Copyright 2025 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from pants.engine.environment import LOCAL_ENVIRONMENT_MATCHER, LOCAL_WORKSPACE_ENVIRONMENT_MATCHER
+from pants.engine.platform import Platform
+from pants.engine.target import (
+    COMMON_TARGET_FIELDS,
+    BoolField,
+    StringField,
+    StringSequenceField,
+    Target,
+)
+from pants.util.enums import match
+from pants.util.strutil import help_text
+
+
+class EnvironmentField(StringField):
+    alias = "environment"
+    default = LOCAL_ENVIRONMENT_MATCHER
+    value: str
+    help = help_text(
+        f"""
+        Specify which environment target to consume environment-sensitive options from.
+
+        Once environments are defined in `[environments-preview].names`, you can specify the environment
+        for this target by its name. Any fields that are defined in that environment will override
+        the values from options set by `pants.toml`, command line values, or environment variables.
+
+        You can specify multiple valid environments by using `parametrize`. If
+        `{LOCAL_ENVIRONMENT_MATCHER}` is specified, Pants will fall back to the `local_environment`
+        defined for the current platform, or no environment if no such environment exists.
+        """
+    )
+
+
+class FallbackEnvironmentField(StringField):
+    alias = "fallback_environment"
+    default = None
+
+
+class CompatiblePlatformsField(StringSequenceField):
+    alias = "compatible_platforms"
+    default = tuple(plat.value for plat in Platform)
+    valid_choices = Platform
+    value: tuple[str, ...]
+    help = help_text(
+        f"""
+        Which platforms this environment can be used with.
+
+        This is used for Pants to automatically determine which environment target to use for
+        the user's machine when the environment is set to the special value
+        `{LOCAL_ENVIRONMENT_MATCHER}`. Currently, there cannot be more than one environment target
+        registered in `[environments-preview].names` for a particular platform. If there is no
+        environment target for a certain platform, Pants will use the options system instead to
+        determine environment variables and executable search paths.
+        """
+    )
+
+
+class LocalCompatiblePlatformsField(CompatiblePlatformsField):
+    pass
+
+
+class LocalFallbackEnvironmentField(FallbackEnvironmentField):
+    help = help_text(
+        f"""
+        The environment to fallback to when this local environment cannot be used because the
+        field `{CompatiblePlatformsField.alias}` is not compatible with the local host.
+
+        Must be an environment name from the option `[environments-preview].names`, the
+        special string `{LOCAL_ENVIRONMENT_MATCHER}` to use the relevant local environment, or the
+        Python value `None` to error when this specific local environment cannot be used.
+
+        Tip: when targeting Linux, it can be particularly helpful to fallback to a
+        `docker_environment` or `remote_environment` target. That allows you to prefer using the
+        local host when possible, which often has less overhead (particularly compared to Docker).
+        If the local host is not compatible, then Pants will use Docker or remote execution to
+        still run in a similar environment.
+        """
+    )
+
+
+class LocalEnvironmentTarget(Target):
+    alias = "local_environment"
+    core_fields = (
+        *COMMON_TARGET_FIELDS,
+        LocalCompatiblePlatformsField,
+        LocalFallbackEnvironmentField,
+    )
+    help = help_text(
+        f"""
+        Configuration of a local execution environment for specific platforms.
+
+        Environment configuration includes the platforms the environment is compatible with, and
+        optionally a fallback environment, along with environment-aware options (such as
+        environment variables and search paths) used by Pants to execute processes in this
+        environment.
+
+        To use this environment, map this target's address with a memorable name in
+        `[environments-preview].names`. You can then consume this environment by specifying the name in
+        the `environment` field defined on other targets.
+
+        Only one `local_environment` may be defined in `[environments-preview].names` per platform, and
+        when `{LOCAL_ENVIRONMENT_MATCHER}` is specified as the environment, the
+        `local_environment` that matches the current platform (if defined) will be selected.
+        """
+        # TODO(#17096) Add a link to the environments docs once they land.
+    )
+
+
+class LocalWorkspaceCompatiblePlatformsField(CompatiblePlatformsField):
+    pass
+
+
+class LocalWorkspaceEnvironmentTarget(Target):
+    alias = "experimental_workspace_environment"
+    core_fields = (
+        *COMMON_TARGET_FIELDS,
+        LocalWorkspaceCompatiblePlatformsField,
+    )
+    help = help_text(
+        f"""
+        Configuration of a "workspace" execution environment for specific platforms.
+
+        A "workspace" environment is a local environment which executes build processes within
+        the repository and not in the usual execution sandbox. This is useful when interacting with
+        third-party build orchestration tools which may not run correctly when run from within the Pants
+        execution sandbox.
+
+        Environment configuration includes the platforms the environment is compatible with along with
+        environment-aware options (such as environment variables and search paths) used by Pants to execute
+        processes in this environment.
+
+        To use this environment, map this target's address with a memorable name in
+        `[environments-preview].names`. You can then consume this environment by specifying the name in
+        the `environment` field defined on other targets.
+
+        Only one `experimental_workspace_environment` may be defined in `[environments-preview].names` per platform, and
+        when `{LOCAL_WORKSPACE_ENVIRONMENT_MATCHER}` is specified as the environment, the
+        `experimental_workspace_environment` that matches the current platform (if defined) will be selected.
+
+        Caching and reproducibility:
+
+        Pants' caching relies on all process being reproducible based solely on inputs in the repository.
+        Processes executed in a workspace environment can easily accidentally read unexpected files,
+        that aren't specified as a dependency.  Thus, Pants puts that burden on you, the Pants user, to ensure
+        a process output only depends on its specified input files, and doesn't read anything else.
+
+        If a process isn't reproducible, re-running a build from the same source code could fail unexpectedly,
+        or give different output to an earlier build.
+
+        NOTE: This target type is EXPERIMENTAL and may change its semantics in subsequent Pants versions
+        without a deprecation cycle.
+        """
+    )
+
+
+class DockerImageField(StringField):
+    alias = "image"
+    required = True
+    value: str
+    help = help_text(
+        """
+        The docker image ID to use when this environment is loaded.
+
+        This value may be any image identifier that the local Docker installation can accept.
+        This includes image names with or without tags (e.g. `centos6` or `centos6:latest`), or
+        image names with an immutable digest (e.g. `centos@sha256:<some_sha256_value>`).
+
+        The choice of image ID can affect the reproducibility of builds. Consider using an
+        immutable digest if reproducibility is needed, but regularly ensure that the image
+        is free of relevant bugs or security vulnerabilities.
+
+        Note that in order to use an image as a `docker_environment` it must have a few tools:
+        - `/bin/sh`
+        - `/usr/bin/env`
+        - `bash`
+        - `tar`
+
+        While most images will have these preinstalled, users of base images such as Distroless or scratch will need to bake these tools into the image themselves. All of these except `bash` are available via busybox.
+        """
+    )
+
+
+class DockerPlatformField(StringField):
+    alias = "platform"
+    default = None
+    valid_choices = Platform
+    help = help_text(
+        """
+        If set, Docker will always use the specified platform when pulling and running the image.
+
+        If unset, Pants will default to the CPU architecture of your local host machine. For
+        example, if you are running on Apple Silicon, it will use `linux_arm64`, whereas running on
+        Intel macOS will use `linux_x86_64`. This mirrors Docker's behavior when `--platform` is
+        left off.
+        """
+    )
+
+    @property
+    def normalized_value(self) -> Platform:
+        if self.value is not None:
+            return Platform(self.value)
+        return match(
+            Platform.create_for_localhost(),
+            {
+                Platform.linux_x86_64: Platform.linux_x86_64,
+                Platform.macos_x86_64: Platform.linux_x86_64,
+                Platform.linux_arm64: Platform.linux_arm64,
+                Platform.macos_arm64: Platform.linux_arm64,
+            },
+        )
+
+
+class DockerFallbackEnvironmentField(FallbackEnvironmentField):
+    help = help_text(
+        f"""
+        The environment to fallback to when this Docker environment cannot be used because either
+        the global option `--docker-execution` is false, or the
+        field `{DockerPlatformField.alias}` is not compatible with the local host's CPU
+        architecture (this is only an issue when the local host is Linux; macOS is fine).
+
+        Must be an environment name from the option `[environments-preview].names`, the
+        special string `{LOCAL_ENVIRONMENT_MATCHER}` to use the relevant local environment, or the
+        Python value `None` to error when this specific Docker environment cannot be used.
+        """
+    )
+
+
+class DockerEnvironmentTarget(Target):
+    alias = "docker_environment"
+    core_fields = (
+        *COMMON_TARGET_FIELDS,
+        DockerImageField,
+        DockerPlatformField,
+        DockerFallbackEnvironmentField,
+    )
+    help = help_text(
+        """
+        Configuration of a Docker environment used for building your code.
+
+        Environment configuration includes both Docker-specific information (including the image
+        and platform choice), as well as environment-aware options (such as environment variables
+        and search paths) used by Pants to execute processes in this Docker environment.
+
+        To use this environment, map this target's address with a memorable name in
+        `[environments-preview].names`. You can then consume this environment by specifying the name in
+        the `environment` field defined on other targets.
+
+        Before running Pants using this environment, if you are using Docker Desktop, make sure the option
+        **Enable default Docker socket** is enabled, you can find it in **Docker Desktop Settings > Advanced**
+        panel. That option tells Docker to create a socket at `/var/run/docker.sock` which Pants can use to
+        communicate with Docker.
+        """
+        # TODO(#17096) Add a link to the environments docs once they land.
+    )
+
+
+class RemotePlatformField(StringField):
+    alias = "platform"
+    default = Platform.linux_x86_64.value
+    valid_choices = Platform
+    help = "The platform used by the remote execution environment."
+
+
+class RemoteExtraPlatformPropertiesField(StringSequenceField):
+    alias = "extra_platform_properties"
+    default = ()
+    value: tuple[str, ...]
+    help = help_text(
+        """
+        Platform properties to set on remote execution requests.
+
+        Format: `property=value`. Multiple values should be specified as multiple
+        occurrences of this flag.
+
+        Pants itself may add additional platform properties.
+        """
+    )
+
+
+class RemoteFallbackEnvironmentField(FallbackEnvironmentField):
+    help = help_text(
+        f"""
+        The environment to fallback to when remote execution is disabled via the global option
+        `--remote-execution`.
+
+        Must be an environment name from the option `[environments-preview].names`, the
+        special string `{LOCAL_ENVIRONMENT_MATCHER}` to use the relevant local environment, or the
+        Python value `None` to error when remote execution is disabled.
+
+        Tip: if you are using a Docker image with your remote execution environment (usually
+        enabled by setting the field `{RemoteExtraPlatformPropertiesField.alias}`), then it can be
+        useful to fallback to an equivalent `docker_image` target so that you have a consistent
+        execution environment.
+        """
+    )
+
+
+class RemoteEnvironmentCacheBinaryDiscovery(BoolField):
+    alias = "cache_binary_discovery"
+    default = False
+    help = help_text(
+        f"""
+        If true, will cache system binary discovery, e.g. finding Python interpreters.
+
+        When safe to do, it is preferable to set this option to `True` for faster performance by
+        avoiding wasted work. Otherwise, Pants will search for system binaries whenever the
+        Pants daemon is restarted.
+
+        However, it is only safe to set this to `True` if the remote execution environment has a
+        stable environment, e.g. the server will not change versions of installed system binaries.
+        Otherwise, you risk caching results that become stale when the server changes its
+        environment, which may break your builds. With some remote execution servers, you can
+        specify a Docker image to run with via the field
+        `{RemoteExtraPlatformPropertiesField.alias}`; if you are able to specify what Docker image
+        to use, and also use a pinned tag of the image, it is likely safe to set this field to true.
+        """
+    )
+
+
+class RemoteEnvironmentTarget(Target):
+    alias = "remote_environment"
+    core_fields = (
+        *COMMON_TARGET_FIELDS,
+        RemotePlatformField,
+        RemoteExtraPlatformPropertiesField,
+        RemoteFallbackEnvironmentField,
+        RemoteEnvironmentCacheBinaryDiscovery,
+    )
+    help = help_text(
+        """
+        Configuration of a remote execution environment used for building your code.
+
+        Environment configuration includes platform properties and a fallback environment, as well
+        as environment-aware options (such as environment variables and search paths) used by Pants
+        to execute processes in this remote environment.
+
+        Note that you must also configure remote execution with the global options like
+        `remote_execution` and `remote_execution_address`.
+
+        To use this environment, map this target's address with a memorable name in
+        `[environments-preview].names`. You can then consume this environment by specifying the name in
+        the `environment` field defined on other targets.
+
+        Often, it is only necessary to have a single `remote_environment` target for your
+        repository, but it can be useful to have >1 so that you can set different
+        `extra_platform_properties`. For example, with some servers, you could use this to
+        configure a different Docker image per environment.
+        """
+        # TODO(#17096) Add a link to the environments docs once they land.
+    )

--- a/src/python/pants/core/goals/export_test.py
+++ b/src/python/pants/core/goals/export_test.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from _pytest.monkeypatch import MonkeyPatch
 
 from pants.base.build_root import BuildRoot
+from pants.core.environments.target_types import EnvironmentField
 from pants.core.goals.export import (
     Export,
     ExportRequest,
@@ -22,7 +23,6 @@ from pants.core.goals.export import (
 )
 from pants.core.goals.generate_lockfiles import KnownUserResolveNames, KnownUserResolveNamesRequest
 from pants.core.util_rules.distdir import DistDir
-from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.addresses import Address
 from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import AddPrefix, CreateDigest, Digest, FileContent, MergeDigests, Workspace

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -13,6 +13,7 @@ from typing import Any, TypeVar
 import pytest
 
 from pants.base.specs import Specs
+from pants.core.environments.target_types import EnvironmentTarget
 from pants.core.goals.fix import FixFilesRequest, FixTargetsRequest
 from pants.core.goals.fmt import FmtFilesRequest, FmtTargetsRequest
 from pants.core.goals.lint import (
@@ -26,7 +27,7 @@ from pants.core.goals.lint import (
     lint,
 )
 from pants.core.util_rules.distdir import DistDir
-from pants.core.util_rules.environments import EnvironmentNameRequest, EnvironmentTarget
+from pants.core.util_rules.environments import EnvironmentNameRequest
 from pants.core.util_rules.partitions import PartitionerType, _EmptyMetadata
 from pants.engine.addresses import Address
 from pants.engine.fs import PathGlobs, SpecsPaths, Workspace

--- a/src/python/pants/core/goals/run_test.py
+++ b/src/python/pants/core/goals/run_test.py
@@ -11,6 +11,7 @@ from typing import cast
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
 
+from pants.core.environments.target_types import EnvironmentTarget
 from pants.core.goals.run import (
     Run,
     RunDebugAdapterRequest,
@@ -21,7 +22,7 @@ from pants.core.goals.run import (
     run,
 )
 from pants.core.subsystems.debug_adapter import DebugAdapterSubsystem
-from pants.core.util_rules.environments import EnvironmentNameRequest, EnvironmentTarget
+from pants.core.util_rules.environments import EnvironmentNameRequest
 from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent, Workspace
 from pants.engine.internals.specs_rules import (

--- a/src/python/pants/core/register.py
+++ b/src/python/pants/core/register.py
@@ -8,6 +8,12 @@ These are always activated and cannot be disabled.
 
 from pants.backend.codegen import export_codegen_goal
 from pants.build_graph.build_file_aliases import BuildFileAliases
+from pants.core.environments.target_types import (
+    DockerEnvironmentTarget,
+    LocalEnvironmentTarget,
+    LocalWorkspaceEnvironmentTarget,
+    RemoteEnvironmentTarget,
+)
 from pants.core.goals import (
     check,
     deploy,
@@ -50,12 +56,6 @@ from pants.core.util_rules import (
     stripped_source_files,
     subprocess_environment,
     system_binaries,
-)
-from pants.core.util_rules.environments import (
-    DockerEnvironmentTarget,
-    LocalEnvironmentTarget,
-    LocalWorkspaceEnvironmentTarget,
-    RemoteEnvironmentTarget,
 )
 from pants.core.util_rules.wrap_source import wrap_source_rule_and_target
 from pants.engine.internals.parametrize import Parametrize

--- a/src/python/pants/core/subsystems/python_bootstrap.py
+++ b/src/python/pants/core/subsystems/python_bootstrap.py
@@ -10,9 +10,9 @@ import sys
 from collections.abc import Collection
 from dataclasses import dataclass
 
+from pants.core.environments.target_types import EnvironmentTarget
 from pants.core.util_rules import asdf, search_paths
 from pants.core.util_rules.asdf import AsdfPathString, AsdfToolPathsResult
-from pants.core.util_rules.environments import EnvironmentTarget
 from pants.core.util_rules.search_paths import (
     ValidateSearchPathsRequest,
     VersionManagerSearchPathsRequest,

--- a/src/python/pants/core/subsystems/python_bootstrap_test.py
+++ b/src/python/pants/core/subsystems/python_bootstrap_test.py
@@ -11,6 +11,7 @@ from typing import TypeVar
 import pytest
 
 from pants.base.build_environment import get_pants_cachedir
+from pants.core.environments.target_types import LocalEnvironmentTarget
 from pants.core.subsystems.python_bootstrap import (
     _ExpandInterpreterSearchPathsRequest,
     _get_pex_python_paths,
@@ -20,7 +21,7 @@ from pants.core.subsystems.python_bootstrap import (
 from pants.core.subsystems.python_bootstrap import rules as python_bootstrap_rules
 from pants.core.util_rules import asdf
 from pants.core.util_rules.asdf import AsdfToolPathsRequest, AsdfToolPathsResult
-from pants.core.util_rules.environments import EnvironmentTarget, LocalEnvironmentTarget
+from pants.core.util_rules.environments import EnvironmentTarget
 from pants.core.util_rules.search_paths import (
     VersionManagerSearchPaths,
     VersionManagerSearchPathsRequest,

--- a/src/python/pants/core/subsystems/python_bootstrap_test.py
+++ b/src/python/pants/core/subsystems/python_bootstrap_test.py
@@ -11,7 +11,7 @@ from typing import TypeVar
 import pytest
 
 from pants.base.build_environment import get_pants_cachedir
-from pants.core.environments.target_types import LocalEnvironmentTarget
+from pants.core.environments.target_types import EnvironmentTarget, LocalEnvironmentTarget
 from pants.core.subsystems.python_bootstrap import (
     _ExpandInterpreterSearchPathsRequest,
     _get_pex_python_paths,
@@ -21,7 +21,6 @@ from pants.core.subsystems.python_bootstrap import (
 from pants.core.subsystems.python_bootstrap import rules as python_bootstrap_rules
 from pants.core.util_rules import asdf
 from pants.core.util_rules.asdf import AsdfToolPathsRequest, AsdfToolPathsResult
-from pants.core.util_rules.environments import EnvironmentTarget
 from pants.core.util_rules.search_paths import (
     VersionManagerSearchPaths,
     VersionManagerSearchPathsRequest,

--- a/src/python/pants/core/util_rules/adhoc_binaries.py
+++ b/src/python/pants/core/util_rules/adhoc_binaries.py
@@ -8,8 +8,8 @@ import sys
 from dataclasses import dataclass
 from textwrap import dedent  # noqa: PNT20
 
+from pants.core.environments.target_types import EnvironmentTarget
 from pants.core.subsystems.python_bootstrap import PythonBootstrapSubsystem
-from pants.core.util_rules.environments import EnvironmentTarget
 from pants.core.util_rules.system_binaries import BashBinary, SystemBinariesSubsystem, TarBinary
 from pants.engine.download_file import download_file
 from pants.engine.fs import DownloadFile

--- a/src/python/pants/core/util_rules/adhoc_binaries_test.py
+++ b/src/python/pants/core/util_rules/adhoc_binaries_test.py
@@ -6,16 +6,13 @@ import sys
 import pytest
 
 from pants.build_graph.address import Address
+from pants.core.environments.target_types import DockerEnvironmentTarget, LocalEnvironmentTarget
 from pants.core.util_rules import adhoc_binaries
 from pants.core.util_rules.adhoc_binaries import (
     _DownloadPythonBuildStandaloneBinaryRequest,
     _PythonBuildStandaloneBinary,
 )
-from pants.core.util_rules.environments import (
-    DockerEnvironmentTarget,
-    EnvironmentTarget,
-    LocalEnvironmentTarget,
-)
+from pants.core.util_rules.environments import EnvironmentTarget
 from pants.engine.environment import EnvironmentName
 from pants.testutil.rule_runner import QueryRule, RuleRunner, run_rule_with_mocks
 

--- a/src/python/pants/core/util_rules/adhoc_binaries_test.py
+++ b/src/python/pants/core/util_rules/adhoc_binaries_test.py
@@ -6,13 +6,16 @@ import sys
 import pytest
 
 from pants.build_graph.address import Address
-from pants.core.environments.target_types import DockerEnvironmentTarget, LocalEnvironmentTarget
+from pants.core.environments.target_types import (
+    DockerEnvironmentTarget,
+    EnvironmentTarget,
+    LocalEnvironmentTarget,
+)
 from pants.core.util_rules import adhoc_binaries
 from pants.core.util_rules.adhoc_binaries import (
     _DownloadPythonBuildStandaloneBinaryRequest,
     _PythonBuildStandaloneBinary,
 )
-from pants.core.util_rules.environments import EnvironmentTarget
 from pants.engine.environment import EnvironmentName
 from pants.testutil.rule_runner import QueryRule, RuleRunner, run_rule_with_mocks
 

--- a/src/python/pants/core/util_rules/asdf.py
+++ b/src/python/pants/core/util_rules/asdf.py
@@ -11,7 +11,7 @@ from pathlib import Path, PurePath
 
 from pants.base.build_environment import get_buildroot
 from pants.base.build_root import BuildRoot
-from pants.core.util_rules.environments import EnvironmentTarget
+from pants.core.environments.target_types import EnvironmentTarget
 from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.internals.selectors import Get
 from pants.engine.rules import _uncacheable_rule, collect_rules

--- a/src/python/pants/core/util_rules/asdf_test.py
+++ b/src/python/pants/core/util_rules/asdf_test.py
@@ -10,12 +10,12 @@ import pytest
 from pants.core.environments.target_types import (
     DockerEnvironmentTarget,
     DockerImageField,
+    EnvironmentTarget,
     LocalEnvironmentTarget,
     RemoteEnvironmentTarget,
 )
 from pants.core.util_rules import asdf
 from pants.core.util_rules.asdf import AsdfToolPathsRequest, AsdfToolPathsResult, get_asdf_data_dir
-from pants.core.util_rules.environments import EnvironmentTarget
 from pants.core.util_rules.testutil import fake_asdf_root, materialize_indices
 from pants.engine.addresses import Address
 from pants.engine.env_vars import CompleteEnvironmentVars, EnvironmentVars

--- a/src/python/pants/core/util_rules/asdf_test.py
+++ b/src/python/pants/core/util_rules/asdf_test.py
@@ -7,15 +7,15 @@ from pathlib import PurePath
 
 import pytest
 
-from pants.core.util_rules import asdf
-from pants.core.util_rules.asdf import AsdfToolPathsRequest, AsdfToolPathsResult, get_asdf_data_dir
-from pants.core.util_rules.environments import (
+from pants.core.environments.target_types import (
     DockerEnvironmentTarget,
     DockerImageField,
-    EnvironmentTarget,
     LocalEnvironmentTarget,
     RemoteEnvironmentTarget,
 )
+from pants.core.util_rules import asdf
+from pants.core.util_rules.asdf import AsdfToolPathsRequest, AsdfToolPathsResult, get_asdf_data_dir
+from pants.core.util_rules.environments import EnvironmentTarget
 from pants.core.util_rules.testutil import fake_asdf_root, materialize_indices
 from pants.engine.addresses import Address
 from pants.engine.env_vars import CompleteEnvironmentVars, EnvironmentVars

--- a/src/python/pants/core/util_rules/environments.py
+++ b/src/python/pants/core/util_rules/environments.py
@@ -12,6 +12,25 @@ from itertools import groupby
 from typing import Any, ClassVar, cast
 
 from pants.build_graph.address import Address, AddressInput
+from pants.core.environments.target_types import (
+    CompatiblePlatformsField,
+    DockerEnvironmentTarget,
+    DockerFallbackEnvironmentField,
+    DockerImageField,
+    DockerPlatformField,
+    EnvironmentField,
+    FallbackEnvironmentField,
+    LocalCompatiblePlatformsField,
+    LocalEnvironmentTarget,
+    LocalFallbackEnvironmentField,
+    LocalWorkspaceCompatiblePlatformsField,
+    LocalWorkspaceEnvironmentTarget,
+    RemoteEnvironmentCacheBinaryDiscovery,
+    RemoteEnvironmentTarget,
+    RemoteExtraPlatformPropertiesField,
+    RemoteFallbackEnvironmentField,
+    RemotePlatformField,
+)
 from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.environment import LOCAL_ENVIRONMENT_MATCHER, LOCAL_WORKSPACE_ENVIRONMENT_MATCHER
 from pants.engine.environment import ChosenLocalEnvironmentName as ChosenLocalEnvironmentName
@@ -30,8 +49,6 @@ from pants.engine.platform import Platform
 from pants.engine.process import ProcessCacheScope
 from pants.engine.rules import Get, QueryRule, collect_rules, concurrently, implicitly, rule
 from pants.engine.target import (
-    COMMON_TARGET_FIELDS,
-    BoolField,
     Field,
     FieldDefaultFactoryRequest,
     FieldDefaultFactoryResult,
@@ -46,7 +63,6 @@ from pants.option import custom_types
 from pants.option.global_options import GlobalOptions, KeepSandboxes
 from pants.option.option_types import DictOption, OptionInfo, collect_options_info
 from pants.option.subsystem import Subsystem
-from pants.util.enums import match
 from pants.util.frozendict import FrozenDict
 from pants.util.memo import memoized
 from pants.util.strutil import bullet_list, help_text, softwrap
@@ -90,209 +106,6 @@ class EnvironmentsSubsystem(Subsystem):
         return not self.names and global_options.remote_execution
 
 
-# -------------------------------------------------------------------------------------------
-# Environment targets
-# -------------------------------------------------------------------------------------------
-
-
-class EnvironmentField(StringField):
-    alias = "environment"
-    default = LOCAL_ENVIRONMENT_MATCHER
-    value: str
-    help = help_text(
-        f"""
-        Specify which environment target to consume environment-sensitive options from.
-
-        Once environments are defined in `[environments-preview].names`, you can specify the environment
-        for this target by its name. Any fields that are defined in that environment will override
-        the values from options set by `pants.toml`, command line values, or environment variables.
-
-        You can specify multiple valid environments by using `parametrize`. If
-        `{LOCAL_ENVIRONMENT_MATCHER}` is specified, Pants will fall back to the `local_environment`
-        defined for the current platform, or no environment if no such environment exists.
-        """
-    )
-
-
-class FallbackEnvironmentField(StringField):
-    alias = "fallback_environment"
-    default = None
-
-
-class CompatiblePlatformsField(StringSequenceField):
-    alias = "compatible_platforms"
-    default = tuple(plat.value for plat in Platform)
-    valid_choices = Platform
-    value: tuple[str, ...]
-    help = help_text(
-        f"""
-        Which platforms this environment can be used with.
-
-        This is used for Pants to automatically determine which environment target to use for
-        the user's machine when the environment is set to the special value
-        `{LOCAL_ENVIRONMENT_MATCHER}`. Currently, there cannot be more than one environment target
-        registered in `[environments-preview].names` for a particular platform. If there is no
-        environment target for a certain platform, Pants will use the options system instead to
-        determine environment variables and executable search paths.
-        """
-    )
-
-
-class LocalCompatiblePlatformsField(CompatiblePlatformsField):
-    pass
-
-
-class LocalFallbackEnvironmentField(FallbackEnvironmentField):
-    help = help_text(
-        f"""
-        The environment to fallback to when this local environment cannot be used because the
-        field `{CompatiblePlatformsField.alias}` is not compatible with the local host.
-
-        Must be an environment name from the option `[environments-preview].names`, the
-        special string `{LOCAL_ENVIRONMENT_MATCHER}` to use the relevant local environment, or the
-        Python value `None` to error when this specific local environment cannot be used.
-
-        Tip: when targeting Linux, it can be particularly helpful to fallback to a
-        `docker_environment` or `remote_environment` target. That allows you to prefer using the
-        local host when possible, which often has less overhead (particularly compared to Docker).
-        If the local host is not compatible, then Pants will use Docker or remote execution to
-        still run in a similar environment.
-        """
-    )
-
-
-class LocalEnvironmentTarget(Target):
-    alias = "local_environment"
-    core_fields = (
-        *COMMON_TARGET_FIELDS,
-        LocalCompatiblePlatformsField,
-        LocalFallbackEnvironmentField,
-    )
-    help = help_text(
-        f"""
-        Configuration of a local execution environment for specific platforms.
-
-        Environment configuration includes the platforms the environment is compatible with, and
-        optionally a fallback environment, along with environment-aware options (such as
-        environment variables and search paths) used by Pants to execute processes in this
-        environment.
-
-        To use this environment, map this target's address with a memorable name in
-        `[environments-preview].names`. You can then consume this environment by specifying the name in
-        the `environment` field defined on other targets.
-
-        Only one `local_environment` may be defined in `[environments-preview].names` per platform, and
-        when `{LOCAL_ENVIRONMENT_MATCHER}` is specified as the environment, the
-        `local_environment` that matches the current platform (if defined) will be selected.
-        """
-        # TODO(#17096) Add a link to the environments docs once they land.
-    )
-
-
-class LocalWorkspaceCompatiblePlatformsField(CompatiblePlatformsField):
-    pass
-
-
-class LocalWorkspaceEnvironmentTarget(Target):
-    alias = "experimental_workspace_environment"
-    core_fields = (
-        *COMMON_TARGET_FIELDS,
-        LocalWorkspaceCompatiblePlatformsField,
-    )
-    help = help_text(
-        f"""
-        Configuration of a "workspace" execution environment for specific platforms.
-
-        A "workspace" environment is a local environment which executes build processes within
-        the repository and not in the usual execution sandbox. This is useful when interacting with
-        third-party build orchestration tools which may not run correctly when run from within the Pants
-        execution sandbox.
-
-        Environment configuration includes the platforms the environment is compatible with along with
-        environment-aware options (such as environment variables and search paths) used by Pants to execute
-        processes in this environment.
-
-        To use this environment, map this target's address with a memorable name in
-        `[environments-preview].names`. You can then consume this environment by specifying the name in
-        the `environment` field defined on other targets.
-
-        Only one `experimental_workspace_environment` may be defined in `[environments-preview].names` per platform, and
-        when `{LOCAL_WORKSPACE_ENVIRONMENT_MATCHER}` is specified as the environment, the
-        `experimental_workspace_environment` that matches the current platform (if defined) will be selected.
-
-        Caching and reproducibility:
-
-        Pants' caching relies on all process being reproducible based solely on inputs in the repository.
-        Processes executed in a workspace environment can easily accidentally read unexpected files,
-        that aren't specified as a dependency.  Thus, Pants puts that burden on you, the Pants user, to ensure
-        a process output only depends on its specified input files, and doesn't read anything else.
-
-        If a process isn't reproducible, re-running a build from the same source code could fail unexpectedly,
-        or give different output to an earlier build.
-
-        NOTE: This target type is EXPERIMENTAL and may change its semantics in subsequent Pants versions
-        without a deprecation cycle.
-        """
-    )
-
-
-class DockerImageField(StringField):
-    alias = "image"
-    required = True
-    value: str
-    help = help_text(
-        """
-        The docker image ID to use when this environment is loaded.
-
-        This value may be any image identifier that the local Docker installation can accept.
-        This includes image names with or without tags (e.g. `centos6` or `centos6:latest`), or
-        image names with an immutable digest (e.g. `centos@sha256:<some_sha256_value>`).
-
-        The choice of image ID can affect the reproducibility of builds. Consider using an
-        immutable digest if reproducibility is needed, but regularly ensure that the image
-        is free of relevant bugs or security vulnerabilities.
-
-        Note that in order to use an image as a `docker_environment` it must have a few tools:
-        - `/bin/sh`
-        - `/usr/bin/env`
-        - `bash`
-        - `tar`
-
-        While most images will have these preinstalled, users of base images such as Distroless or scratch will need to bake these tools into the image themselves. All of these except `bash` are available via busybox.
-        """
-    )
-
-
-class DockerPlatformField(StringField):
-    alias = "platform"
-    default = None
-    valid_choices = Platform
-    help = help_text(
-        """
-        If set, Docker will always use the specified platform when pulling and running the image.
-
-        If unset, Pants will default to the CPU architecture of your local host machine. For
-        example, if you are running on Apple Silicon, it will use `linux_arm64`, whereas running on
-        Intel macOS will use `linux_x86_64`. This mirrors Docker's behavior when `--platform` is
-        left off.
-        """
-    )
-
-    @property
-    def normalized_value(self) -> Platform:
-        if self.value is not None:
-            return Platform(self.value)
-        return match(
-            Platform.create_for_localhost(),
-            {
-                Platform.linux_x86_64: Platform.linux_x86_64,
-                Platform.macos_x86_64: Platform.linux_x86_64,
-                Platform.linux_arm64: Platform.linux_arm64,
-                Platform.macos_arm64: Platform.linux_arm64,
-            },
-        )
-
-
 class DockerPlatformFieldDefaultFactoryRequest(FieldDefaultFactoryRequest):
     field_type = DockerPlatformField
 
@@ -302,151 +115,6 @@ def docker_platform_field_default_factory(
     _: DockerPlatformFieldDefaultFactoryRequest,
 ) -> FieldDefaultFactoryResult:
     return FieldDefaultFactoryResult(lambda f: f.normalized_value)
-
-
-class DockerFallbackEnvironmentField(FallbackEnvironmentField):
-    help = help_text(
-        f"""
-        The environment to fallback to when this Docker environment cannot be used because either
-        the global option `--docker-execution` is false, or the
-        field `{DockerPlatformField.alias}` is not compatible with the local host's CPU
-        architecture (this is only an issue when the local host is Linux; macOS is fine).
-
-        Must be an environment name from the option `[environments-preview].names`, the
-        special string `{LOCAL_ENVIRONMENT_MATCHER}` to use the relevant local environment, or the
-        Python value `None` to error when this specific Docker environment cannot be used.
-        """
-    )
-
-
-class DockerEnvironmentTarget(Target):
-    alias = "docker_environment"
-    core_fields = (
-        *COMMON_TARGET_FIELDS,
-        DockerImageField,
-        DockerPlatformField,
-        DockerFallbackEnvironmentField,
-    )
-    help = help_text(
-        """
-        Configuration of a Docker environment used for building your code.
-
-        Environment configuration includes both Docker-specific information (including the image
-        and platform choice), as well as environment-aware options (such as environment variables
-        and search paths) used by Pants to execute processes in this Docker environment.
-
-        To use this environment, map this target's address with a memorable name in
-        `[environments-preview].names`. You can then consume this environment by specifying the name in
-        the `environment` field defined on other targets.
-
-        Before running Pants using this environment, if you are using Docker Desktop, make sure the option
-        **Enable default Docker socket** is enabled, you can find it in **Docker Desktop Settings > Advanced**
-        panel. That option tells Docker to create a socket at `/var/run/docker.sock` which Pants can use to
-        communicate with Docker.
-        """
-        # TODO(#17096) Add a link to the environments docs once they land.
-    )
-
-
-class RemotePlatformField(StringField):
-    alias = "platform"
-    default = Platform.linux_x86_64.value
-    valid_choices = Platform
-    help = "The platform used by the remote execution environment."
-
-
-class RemoteExtraPlatformPropertiesField(StringSequenceField):
-    alias = "extra_platform_properties"
-    default = ()
-    value: tuple[str, ...]
-    help = help_text(
-        """
-        Platform properties to set on remote execution requests.
-
-        Format: `property=value`. Multiple values should be specified as multiple
-        occurrences of this flag.
-
-        Pants itself may add additional platform properties.
-        """
-    )
-
-
-class RemoteFallbackEnvironmentField(FallbackEnvironmentField):
-    help = help_text(
-        f"""
-        The environment to fallback to when remote execution is disabled via the global option
-        `--remote-execution`.
-
-        Must be an environment name from the option `[environments-preview].names`, the
-        special string `{LOCAL_ENVIRONMENT_MATCHER}` to use the relevant local environment, or the
-        Python value `None` to error when remote execution is disabled.
-
-        Tip: if you are using a Docker image with your remote execution environment (usually
-        enabled by setting the field `{RemoteExtraPlatformPropertiesField.alias}`), then it can be
-        useful to fallback to an equivalent `docker_image` target so that you have a consistent
-        execution environment.
-        """
-    )
-
-
-class RemoteEnvironmentCacheBinaryDiscovery(BoolField):
-    alias = "cache_binary_discovery"
-    default = False
-    help = help_text(
-        f"""
-        If true, will cache system binary discovery, e.g. finding Python interpreters.
-
-        When safe to do, it is preferable to set this option to `True` for faster performance by
-        avoiding wasted work. Otherwise, Pants will search for system binaries whenever the
-        Pants daemon is restarted.
-
-        However, it is only safe to set this to `True` if the remote execution environment has a
-        stable environment, e.g. the server will not change versions of installed system binaries.
-        Otherwise, you risk caching results that become stale when the server changes its
-        environment, which may break your builds. With some remote execution servers, you can
-        specify a Docker image to run with via the field
-        `{RemoteExtraPlatformPropertiesField.alias}`; if you are able to specify what Docker image
-        to use, and also use a pinned tag of the image, it is likely safe to set this field to true.
-        """
-    )
-
-
-class RemoteEnvironmentTarget(Target):
-    alias = "remote_environment"
-    core_fields = (
-        *COMMON_TARGET_FIELDS,
-        RemotePlatformField,
-        RemoteExtraPlatformPropertiesField,
-        RemoteFallbackEnvironmentField,
-        RemoteEnvironmentCacheBinaryDiscovery,
-    )
-    help = help_text(
-        """
-        Configuration of a remote execution environment used for building your code.
-
-        Environment configuration includes platform properties and a fallback environment, as well
-        as environment-aware options (such as environment variables and search paths) used by Pants
-        to execute processes in this remote environment.
-
-        Note that you must also configure remote execution with the global options like
-        `remote_execution` and `remote_execution_address`.
-
-        To use this environment, map this target's address with a memorable name in
-        `[environments-preview].names`. You can then consume this environment by specifying the name in
-        the `environment` field defined on other targets.
-
-        Often, it is only necessary to have a single `remote_environment` target for your
-        repository, but it can be useful to have >1 so that you can set different
-        `extra_platform_properties`. For example, with some servers, you could use this to
-        configure a different Docker image per environment.
-        """
-        # TODO(#17096) Add a link to the environments docs once they land.
-    )
-
-
-# -------------------------------------------------------------------------------------------
-# Rules
-# -------------------------------------------------------------------------------------------
 
 
 async def _warn_on_non_local_environments(specified_targets: Iterable[Target], source: str) -> None:

--- a/src/python/pants/core/util_rules/environments_test.py
+++ b/src/python/pants/core/util_rules/environments_test.py
@@ -10,12 +10,14 @@ from textwrap import dedent
 import pytest
 
 from pants.build_graph.address import Address, ResolveError
+from pants.core.environments.subsystems import EnvironmentsSubsystem
 from pants.core.environments.target_types import (
     CompatiblePlatformsField,
     DockerEnvironmentTarget,
     DockerImageField,
     DockerPlatformField,
     EnvironmentField,
+    EnvironmentTarget,
     FallbackEnvironmentField,
     LocalEnvironmentTarget,
     LocalWorkspaceEnvironmentTarget,
@@ -30,8 +32,6 @@ from pants.core.util_rules.environments import (
     ChosenLocalEnvironmentName,
     EnvironmentName,
     EnvironmentNameRequest,
-    EnvironmentsSubsystem,
-    EnvironmentTarget,
     NoFallbackEnvironmentError,
     SingleEnvironmentNameRequest,
     UnrecognizedEnvironmentError,

--- a/src/python/pants/core/util_rules/environments_test.py
+++ b/src/python/pants/core/util_rules/environments_test.py
@@ -10,27 +10,29 @@ from textwrap import dedent
 import pytest
 
 from pants.build_graph.address import Address, ResolveError
-from pants.core.util_rules import environments
-from pants.core.util_rules.environments import (
-    AllEnvironmentTargets,
-    AmbiguousEnvironmentError,
-    ChosenLocalEnvironmentName,
+from pants.core.environments.target_types import (
     CompatiblePlatformsField,
     DockerEnvironmentTarget,
     DockerImageField,
     DockerPlatformField,
     EnvironmentField,
+    FallbackEnvironmentField,
+    LocalEnvironmentTarget,
+    LocalWorkspaceEnvironmentTarget,
+    RemoteEnvironmentCacheBinaryDiscovery,
+    RemoteEnvironmentTarget,
+    RemoteExtraPlatformPropertiesField,
+)
+from pants.core.util_rules import environments
+from pants.core.util_rules.environments import (
+    AllEnvironmentTargets,
+    AmbiguousEnvironmentError,
+    ChosenLocalEnvironmentName,
     EnvironmentName,
     EnvironmentNameRequest,
     EnvironmentsSubsystem,
     EnvironmentTarget,
-    FallbackEnvironmentField,
-    LocalEnvironmentTarget,
-    LocalWorkspaceEnvironmentTarget,
     NoFallbackEnvironmentError,
-    RemoteEnvironmentCacheBinaryDiscovery,
-    RemoteEnvironmentTarget,
-    RemoteExtraPlatformPropertiesField,
     SingleEnvironmentNameRequest,
     UnrecognizedEnvironmentError,
     extract_process_config_from_environment,

--- a/src/python/pants/core/util_rules/search_paths.py
+++ b/src/python/pants/core/util_rules/search_paths.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any, ClassVar
 
 from pants.base.build_environment import get_buildroot
-from pants.core.util_rules.environments import EnvironmentTarget
+from pants.core.environments.target_types import EnvironmentTarget
 from pants.engine.collection import DeduplicatedCollection
 from pants.engine.env_vars import EnvironmentVars
 from pants.engine.rules import Rule, _uncacheable_rule, collect_rules, rule

--- a/src/python/pants/core/util_rules/search_paths_test.py
+++ b/src/python/pants/core/util_rules/search_paths_test.py
@@ -12,12 +12,12 @@ from pants.build_graph.address import Address
 from pants.core.environments.target_types import (
     DockerEnvironmentTarget,
     DockerImageField,
+    EnvironmentTarget,
     LocalEnvironmentTarget,
     RemoteEnvironmentTarget,
 )
 from pants.core.util_rules import search_paths
 from pants.core.util_rules.asdf import AsdfPathString
-from pants.core.util_rules.environments import EnvironmentTarget
 from pants.core.util_rules.search_paths import (
     ValidateSearchPathsRequest,
     VersionManagerSearchPaths,

--- a/src/python/pants/core/util_rules/search_paths_test.py
+++ b/src/python/pants/core/util_rules/search_paths_test.py
@@ -9,15 +9,15 @@ from contextlib import contextmanager
 import pytest
 
 from pants.build_graph.address import Address
-from pants.core.util_rules import search_paths
-from pants.core.util_rules.asdf import AsdfPathString
-from pants.core.util_rules.environments import (
+from pants.core.environments.target_types import (
     DockerEnvironmentTarget,
     DockerImageField,
-    EnvironmentTarget,
     LocalEnvironmentTarget,
     RemoteEnvironmentTarget,
 )
+from pants.core.util_rules import search_paths
+from pants.core.util_rules.asdf import AsdfPathString
+from pants.core.util_rules.environments import EnvironmentTarget
 from pants.core.util_rules.search_paths import (
     ValidateSearchPathsRequest,
     VersionManagerSearchPaths,

--- a/src/python/pants/core/util_rules/system_binaries.py
+++ b/src/python/pants/core/util_rules/system_binaries.py
@@ -16,8 +16,8 @@ from itertools import groupby
 from textwrap import dedent  # noqa: PNT20
 from typing import Self
 
+from pants.core.environments.target_types import EnvironmentTarget
 from pants.core.subsystems import python_bootstrap
-from pants.core.util_rules.environments import EnvironmentTarget
 from pants.engine.collection import DeduplicatedCollection
 from pants.engine.engine_aware import EngineAwareReturnType
 from pants.engine.fs import CreateDigest, FileContent, PathMetadataRequest

--- a/src/python/pants/engine/internals/platform_rules.py
+++ b/src/python/pants/engine/internals/platform_rules.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 
 import os
 
+from pants.core.environments.subsystems import EnvironmentsSubsystem
 from pants.core.environments.target_types import (
     DockerImageField,
     DockerPlatformField,
+    EnvironmentTarget,
     RemotePlatformField,
 )
-from pants.core.util_rules.environments import EnvironmentsSubsystem, EnvironmentTarget
 from pants.engine.env_vars import (
     CompleteEnvironmentVars,
     EnvironmentVars,

--- a/src/python/pants/engine/internals/platform_rules.py
+++ b/src/python/pants/engine/internals/platform_rules.py
@@ -5,13 +5,12 @@ from __future__ import annotations
 
 import os
 
-from pants.core.util_rules.environments import (
+from pants.core.environments.target_types import (
     DockerImageField,
     DockerPlatformField,
-    EnvironmentsSubsystem,
-    EnvironmentTarget,
     RemotePlatformField,
 )
+from pants.core.util_rules.environments import EnvironmentsSubsystem, EnvironmentTarget
 from pants.engine.env_vars import (
     CompleteEnvironmentVars,
     EnvironmentVars,

--- a/src/python/pants/engine/internals/platform_rules_test.py
+++ b/src/python/pants/engine/internals/platform_rules_test.py
@@ -9,15 +9,16 @@ from unittest.mock import Mock
 import pytest
 
 from pants.build_graph.address import Address
+from pants.core.environments.subsystems import EnvironmentsSubsystem
 from pants.core.environments.target_types import (
     DockerEnvironmentTarget,
     DockerImageField,
     DockerPlatformField,
+    EnvironmentTarget,
     LocalEnvironmentTarget,
     RemoteEnvironmentTarget,
     RemotePlatformField,
 )
-from pants.core.util_rules.environments import EnvironmentsSubsystem, EnvironmentTarget
 from pants.engine.env_vars import CompleteEnvironmentVars, EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.environment import EnvironmentName
 from pants.engine.internals.platform_rules import (

--- a/src/python/pants/engine/internals/platform_rules_test.py
+++ b/src/python/pants/engine/internals/platform_rules_test.py
@@ -9,16 +9,15 @@ from unittest.mock import Mock
 import pytest
 
 from pants.build_graph.address import Address
-from pants.core.util_rules.environments import (
+from pants.core.environments.target_types import (
     DockerEnvironmentTarget,
     DockerImageField,
     DockerPlatformField,
-    EnvironmentsSubsystem,
-    EnvironmentTarget,
     LocalEnvironmentTarget,
     RemoteEnvironmentTarget,
     RemotePlatformField,
 )
+from pants.core.util_rules.environments import EnvironmentsSubsystem, EnvironmentTarget
 from pants.engine.env_vars import CompleteEnvironmentVars, EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.environment import EnvironmentName
 from pants.engine.internals.platform_rules import (

--- a/src/python/pants/engine/process_test.py
+++ b/src/python/pants/engine/process_test.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from pants.core.util_rules.environments import LocalWorkspaceEnvironmentTarget
+from pants.core.environments.target_types import LocalWorkspaceEnvironmentTarget
 from pants.engine.environment import EnvironmentName
 from pants.engine.fs import (
     EMPTY_DIGEST,

--- a/src/python/pants/jvm/jdk_rules.py
+++ b/src/python/pants/jvm/jdk_rules.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import ClassVar
 
-from pants.core.util_rules.environments import EnvironmentTarget
+from pants.core.environments.target_types import EnvironmentTarget
 from pants.core.util_rules.system_binaries import BashBinary, LnBinary
 from pants.engine.fs import CreateDigest, Digest, FileContent, FileDigest, MergeDigests
 from pants.engine.intrinsics import create_digest, execute_process, merge_digests

--- a/src/python/pants/option/subsystem.py
+++ b/src/python/pants/option/subsystem.py
@@ -23,7 +23,7 @@ from pants.util.strutil import softwrap
 
 if TYPE_CHECKING:
     # Needed to avoid an import cycle.
-    from pants.core.util_rules.environments import EnvironmentTarget
+    from pants.core.environments.target_types import EnvironmentTarget
     from pants.engine.rules import Rule
 
 _SubsystemT = TypeVar("_SubsystemT", bound="Subsystem")
@@ -221,7 +221,7 @@ class Subsystem(metaclass=_SubsystemMeta):
     def _construct_env_aware_rule(cls) -> Rule:
         """Returns a `TaskRule` that will construct the target Subsystem.EnvironmentAware."""
         # Global-level imports are conditional, we need to re-import here for runtime use
-        from pants.core.util_rules.environments import EnvironmentTarget
+        from pants.core.environments.target_types import EnvironmentTarget
         from pants.engine.rules import TaskRule
 
         snake_scope = normalize_scope(cls.options_scope)


### PR DESCRIPTION
Extract the environments-related target types and subsystems into their own files to avoid an import cycle.

Motivation: While trying to switch `src/python/pants/engine/internals/build_files.py` to call-by-name syntax, the migration introduced an import cycle between `src/python/pants/core/util_rules/environments.py` and `src/python/pants/engine/internals/platform_rules.py` over an import of `DockerImageField` (among other classes).

The code in `src/python/pants/core/util_rules/environments.py` combines a subsystem, target types, and rules into a single file. This is not how Pants code is normally structured. Moreover, this (lack of) structure is preventing a switch to call-by-name syntax.

Solution: Move the target types into their own file and the subsystem to its own file.