### PR TITLE
[Call-by-name] manual migration of adhoc backend

### DIFF
--- a/src/python/pants/backend/adhoc/code_quality_tool.py
+++ b/src/python/pants/backend/adhoc/code_quality_tool.py
@@ -10,6 +10,7 @@ from pants.core.goals.lint import Lint, LintFilesRequest, LintResult
 from pants.core.util_rules.adhoc_process_support import (
     ToolRunner,
     ToolRunnerRequest,
+    create_tool_runner,
     prepare_env_vars,
 )
 from pants.core.util_rules.adhoc_process_support import rules as adhoc_process_support_rules
@@ -21,13 +22,12 @@ from pants.engine.internals.build_files import resolve_address
 from pants.engine.internals.graph import resolve_targets
 from pants.engine.internals.native_engine import (
     AddressInput,
-    Digest,
     FilespecMatcher,
     MergeDigests,
     Snapshot,
 )
-from pants.engine.internals.selectors import Get, MultiGet
-from pants.engine.intrinsics import execute_process, merge_digests
+from pants.engine.internals.selectors import concurrently
+from pants.engine.intrinsics import digest_to_snapshot, execute_process, merge_digests
 from pants.engine.process import FallibleProcessResult, Process
 from pants.engine.rules import Rule, collect_rules, implicitly, rule
 from pants.engine.target import (
@@ -300,7 +300,7 @@ class CodeQualityToolRuleBuilder:
             if subsystem.skip:
                 return Partitions()
 
-            cqt = await Get(CodeQualityTool, CodeQualityToolAddressString(address=self.target))
+            cqt = await find_code_quality_tool(CodeQualityToolAddressString(address=self.target))
 
             matching_filepaths = FilespecMatcher(
                 includes=cqt.file_glob_include,
@@ -311,13 +311,12 @@ class CodeQualityToolRuleBuilder:
 
         @rule(canonical_name_suffix=self.scope)
         async def run_code_quality(request: CodeQualityProcessingRequest.Batch) -> LintResult:
-            sources_snapshot, code_quality_tool_runner = await MultiGet(
-                Get(Snapshot, PathGlobs(request.elements)),
-                Get(ToolRunner, CodeQualityToolAddressString(address=self.target)),
+            sources_snapshot, code_quality_tool_runner = await concurrently(
+                digest_to_snapshot(**implicitly(PathGlobs(request.elements))),
+                create_tool_runner(**implicitly(CodeQualityToolAddressString(address=self.target))),
             )
 
-            proc_result = await Get(
-                FallibleProcessResult,
+            proc_result = await process_files(
                 CodeQualityToolBatch(
                     runner=code_quality_tool_runner,
                     sources_snapshot=sources_snapshot,
@@ -353,7 +352,7 @@ class CodeQualityToolRuleBuilder:
             if subsystem.skip:
                 return Partitions()
 
-            cqt = await Get(CodeQualityTool, CodeQualityToolAddressString(address=self.target))
+            cqt = await find_code_quality_tool(CodeQualityToolAddressString(address=self.target))
 
             matching_filepaths = FilespecMatcher(
                 includes=cqt.file_glob_include,
@@ -366,12 +365,11 @@ class CodeQualityToolRuleBuilder:
         async def run_code_quality(request: CodeQualityProcessingRequest.Batch) -> FmtResult:
             sources_snapshot = request.snapshot
 
-            code_quality_tool_runner = await Get(
-                ToolRunner, CodeQualityToolAddressString(address=self.target)
-            )
+            cqt = await find_code_quality_tool(CodeQualityToolAddressString(address=self.target))
+            code_quality_tool_runner_request = await runner_request_for_code_quality_tool(cqt)
+            code_quality_tool_runner = await create_tool_runner(code_quality_tool_runner_request)
 
-            proc_result = await Get(
-                FallibleProcessResult,
+            proc_result = await process_files(
                 CodeQualityToolBatch(
                     runner=code_quality_tool_runner,
                     sources_snapshot=sources_snapshot,
@@ -379,7 +377,7 @@ class CodeQualityToolRuleBuilder:
                 ),
             )
 
-            output = await Get(Snapshot, Digest, proc_result.output_digest)
+            output = await digest_to_snapshot(proc_result.output_digest)
 
             return FmtResult(
                 input=request.snapshot,
@@ -415,7 +413,7 @@ class CodeQualityToolRuleBuilder:
             if subsystem.skip:
                 return Partitions()
 
-            cqt = await Get(CodeQualityTool, CodeQualityToolAddressString(address=self.target))
+            cqt = await find_code_quality_tool(CodeQualityToolAddressString(address=self.target))
 
             matching_filepaths = FilespecMatcher(
                 includes=cqt.file_glob_include,
@@ -428,12 +426,11 @@ class CodeQualityToolRuleBuilder:
         async def run_code_quality(request: CodeQualityProcessingRequest.Batch) -> FixResult:
             sources_snapshot = request.snapshot
 
-            code_quality_tool_runner = await Get(
-                ToolRunner, CodeQualityToolAddressString(address=self.target)
-            )
+            cqt = await find_code_quality_tool(CodeQualityToolAddressString(address=self.target))
+            code_quality_tool_runner_request = await runner_request_for_code_quality_tool(cqt)
+            code_quality_tool_runner = await create_tool_runner(code_quality_tool_runner_request)
 
-            proc_result = await Get(
-                FallibleProcessResult,
+            proc_result = await process_files(
                 CodeQualityToolBatch(
                     runner=code_quality_tool_runner,
                     sources_snapshot=sources_snapshot,
@@ -441,7 +438,7 @@ class CodeQualityToolRuleBuilder:
                 ),
             )
 
-            output = await Get(Snapshot, Digest, proc_result.output_digest)
+            output = await digest_to_snapshot(proc_result.output_digest)
 
             return FixResult(
                 input=request.snapshot,


### PR DESCRIPTION
The last few Get calls in the adhoc backend are not visible to the migrate-call-by-name tool because the rules are functions in the body of methods on a dataclass for building some rules on the fly.