### PR TITLE
ensure error when duplicate declared targets exist in same directory

### DIFF
--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -1249,7 +1249,7 @@ def test_build_file_syntax_error(filename, contents, expect_failure, expected_me
 def test_build_file_duplicate_declared_names() -> None:
     rule_runner = RuleRunner(
         rules=[QueryRule(AddressFamily, [AddressFamilyDir])],
-        target_types=[MockTgt, MockGeneratedTarget, MockTargetGenerator],
+        target_types=[MockTgt],
     )
     rule_runner.write_files(
         {
@@ -1268,6 +1268,7 @@ def test_build_file_duplicate_declared_names() -> None:
         },
     )
     with pytest.raises(
-        ExecutionError, match="The target name `foo` was defined in multiple BUILD files"
+        ExecutionError,
+        match="A target already exists at `src/BUILD.bar` with name `foo` and target type `mock_tgt`",
     ):
         _ = rule_runner.request(AddressFamily, [AddressFamilyDir("src")])


### PR DESCRIPTION
https://github.com/pantsbuild/pants/pull/21725 (which landed in 2.25.0.dev1) introduced a regression in `BUILD` file parsing where multiple declared targets (in different `BUILD` files in the same directory) would not result in an error. This is correctly an error on earlier versions of Pants. Fix the regression.