### PR TITLE
ensure error when duplicate declared targets exist in same directory (Cherry-pick of #22355)

### DIFF
--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -35,7 +35,7 @@ from pants.engine.internals.dep_rules import (
     DependencyRuleApplication,
     MaybeBuildFileDependencyRulesImplementation,
 )
-from pants.engine.internals.mapper import AddressFamily, AddressMap
+from pants.engine.internals.mapper import AddressFamily, AddressMap, DuplicateNameError
 from pants.engine.internals.parser import (
     BuildFilePreludeSymbols,
     BuildFileSymbolsInfo,
@@ -375,6 +375,7 @@ async def parse_address_family(
         )
         for fc, env_vars in zip(digest_contents, all_env_vars)
     ]
+    declared_address_maps.sort(key=lambda x: x.path)
 
     # Freeze defaults and dependency rules
     frozen_defaults = defaults_parser_state.get_frozen_defaults()
@@ -408,6 +409,15 @@ async def parse_address_family(
     name_to_path_and_declared_target: dict[str, tuple[str, TargetAdaptor]] = {}
     for declared_address_map in declared_address_maps:
         for name, target in declared_address_map.name_to_target_adaptor.items():
+            if name in name_to_path_and_declared_target:
+                # This is a duplicate declared name, raise an exception.
+                duplicate_path = name_to_path_and_declared_target[name][0]
+                raise DuplicateNameError(
+                    f"A target already exists at `{duplicate_path}` with name `{name}` and target type "
+                    f"`{target.type_alias}`. The `{name}` target in `{declared_address_map.path}` "
+                    "cannot use the same name."
+                )
+
             name_to_path_and_declared_target[name] = (declared_address_map.path, target)
 
     # We copy the dict so we can modify the original in the loop.


### PR DESCRIPTION
https://github.com/pantsbuild/pants/pull/21725 (which landed in 2.25.0.dev1) introduced a regression in `BUILD` file parsing where multiple declared targets (in different `BUILD` files in the same directory) would not result in an error. This is correctly an error on earlier versions of Pants. Fix the regression.
