### PR TITLE
ensure error when duplicate declared targets exist in same directory (Cherry-pick of #22355)

### DIFF
--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -1243,3 +1243,31 @@ def test_build_file_syntax_error(filename, contents, expect_failure, expected_me
 
     else:
         BUILDFileEnvVarExtractor.get_env_vars(MockFileContent(filename, contents))
+
+
+def test_build_file_duplicate_declared_names() -> None:
+    rule_runner = RuleRunner(
+        rules=[QueryRule(AddressFamily, [AddressFamilyDir])],
+        target_types=[MockTgt],
+    )
+    rule_runner.write_files(
+        {
+            "src/BUILD.foo": dedent(
+                """\
+                # Define a target.
+                mock_tgt(name="foo")
+                """
+            ),
+            "src/BUILD.bar": dedent(
+                """\
+                # Define a target..
+                mock_tgt(name="foo")
+                """
+            ),
+        },
+    )
+    with pytest.raises(
+        ExecutionError,
+        match="A target already exists at `src/BUILD.bar` with name `foo` and target type `mock_tgt`",
+    ):
+        _ = rule_runner.request(AddressFamily, [AddressFamilyDir("src")])


### PR DESCRIPTION
https://github.com/pantsbuild/pants/pull/21725 (which landed in 2.25.0.dev1) introduced a regression in `BUILD` file parsing where multiple declared targets (in different `BUILD` files in the same directory) would not result in an error. This is correctly an error on earlier versions of Pants. Fix the regression.
