### PR TITLE
tools/gh: propagate build arguments to cli

### DIFF
--- a/3rdparty/tools/gh/BUILD
+++ b/3rdparty/tools/gh/BUILD
@@ -56,6 +56,6 @@ relocated_files(
 
 run_shell_command(
     name="gh",
-    command="{chroot}/3rdparty/tools/gh/bin/gh",
+    command="{chroot}/3rdparty/tools/gh/bin/gh $@",
     execution_dependencies=[":relocated-gh"],
 )


### PR DESCRIPTION
Right now you can not run `pants run //3rdparty/tools/gh -- ...` because the arguments do not propagate to the CLI. Fix this.