### PR TITLE
Support using `.gitignore`'s not at build root

### DIFF
--- a/docs/notes/2.28.x.md
+++ b/docs/notes/2.28.x.md
@@ -20,6 +20,8 @@ The `run_rule_with_mocks()` test helper function, used to test `@rule`s both in 
 in third party plugin code, has been updated to support call-by-name. Several longstanding bugs
 in that function were also fixed.
 
+The `[GLOBAL].pants_ignore_use_gitignore` option now reads from all .gitignore files that are located at or below the BUILD_ROOT.
+
 ### Goals
 
 ### Backends

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1061,8 +1061,6 @@ class BootstrapOptions:
             Patterns from `[GLOBAL].pants_ignore` take precedence over these files' rules. For
             example, you can use `!my_pattern` in `pants_ignore` to have Pants operate on files
             that are gitignored.
-
-            Warning: this does not yet support reading nested gitignore files.
             """
         ),
     )


### PR DESCRIPTION
I was surprised to find this wasn't already the case, but wanted it now.

Is there a good enough case to be made that it is worth it to expose the old behavior? Imo it's not worth the option-space.

This change allows users to keep the old behavior by adding negative rules to `pants_ignore`, if somebody needs pants to watch non-versioned files.