### PR TITLE
configure `protoc` to generate Python type stubs directly

### DIFF
--- a/docs/notes/2.28.x.md
+++ b/docs/notes/2.28.x.md
@@ -30,6 +30,8 @@ The version of [Pex](https://github.com/pex-tool/pex) used by the Python backend
 
 The Python Build Standalone backend (`pants.backend.python.providers.experimental.python_build_standalone`) has release metadata current through PBS release `20250610`.
 
+See 
+
 #### Javascript
 
 Added support for using typescript targets, e.g. `typescript_source` or `tsx_source` for javascript goals like `test`
@@ -45,6 +47,10 @@ tsconfig.json and jsconfig.json "extends" are now correctly parsed from the top-
 Added an option to [the `[docker]` subsystem](https://www.pantsbuild.org/prerelease/reference/subsystems/docker) to allow
 bypassing the `suggest_renames` functionality. There are currently situations where this code path can
 [introduce performance degradation](https://github.com/pantsbuild/pants/issues/22246), and this flag allows the end user to work around that issue.
+
+#### Protobuf (Python)
+
+The new `[python-protobuf].generate_type_stubs` option configures `protoc` to directly generate type stubs which has been supported in recent versions of `protoc` for some time. This option should be preferred over the `[python-protobuf].mypy_plugin` option.
 
 ### Remote caching/execution
 

--- a/docs/notes/2.28.x.md
+++ b/docs/notes/2.28.x.md
@@ -30,7 +30,7 @@ The version of [Pex](https://github.com/pex-tool/pex) used by the Python backend
 
 The Python Build Standalone backend (`pants.backend.python.providers.experimental.python_build_standalone`) has release metadata current through PBS release `20250610`.
 
-See 
+Protobuf: See protobuf backend section for information about the new `[python-protobuf].generate_type_stubs` option.
 
 #### Javascript
 

--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
@@ -59,12 +59,28 @@ class PythonProtobufSubsystem(Subsystem):
         ),
     )
 
+    generate_type_stubs = BoolOption(
+        default=False,
+        mutually_exclusive_group="typestubs",
+        help=softwrap(
+            """
+            If True, then configure `protoc` to also generate `.pyi` type stubs for each generated
+            Python file. This option will work wih any recent version of `protoc` and should
+            be preferred over the `--python-protobuf-mypy-plugin` option.
+            """
+        ),
+    )
+
     mypy_plugin = BoolOption(
         default=False,
+        mutually_exclusive_group="typestubs",
         help=softwrap(
             """
             Use the `mypy-protobuf` plugin (https://github.com/dropbox/mypy-protobuf) to also
             generate `.pyi` type stubs.
+
+            Please prefer the `--python-protobuf-generate-type-stubs` option over this option
+            since recent versions of `protoc` have the ability to directly generate type stubs.
             """
         ),
     )

--- a/src/python/pants/backend/codegen/protobuf/python/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/python/rules.py
@@ -101,11 +101,13 @@ async def generate_python_from_protobuf(
         all_sources_stripped.snapshot.digest,
         empty_output_dir,
     ]
+
+    pyi_gen_option = "pyi_out:" if python_protobuf_subsystem.generate_type_stubs else ""
     protoc_argv = [
         os.path.join(protoc_relpath, downloaded_protoc_binary.exe),
-        "--python_out",
-        output_dir,
+        f"--python_out={pyi_gen_option}{output_dir}",
     ]
+
     complete_pex_env = pex_environment.in_sandbox(working_directory=None)
 
     if python_protobuf_subsystem.mypy_plugin:

--- a/src/python/pants/backend/codegen/protobuf/python/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/python/rules_integration_test.py
@@ -248,6 +248,42 @@ def test_bad_python_source_root(rule_runner: RuleRunner) -> None:
     "major_minor_interpreter",
     all_major_minor_python_versions(PythonProtobufMypyPlugin.default_interpreter_constraints),
 )
+def test_generate_type_stubs(rule_runner: RuleRunner, major_minor_interpreter: str) -> None:
+    rule_runner.write_files(
+        {
+            "src/protobuf/dir1/f.proto": dedent(
+                """\
+                syntax = "proto3";
+
+                package dir1;
+
+                message Person {
+                  string name = 1;
+                  int32 id = 2;
+                  string email = 3;
+                }
+                """
+            ),
+            "src/protobuf/dir1/BUILD": "protobuf_sources()",
+        }
+    )
+    assert_files_generated(
+        rule_runner,
+        Address("src/protobuf/dir1", relative_file_path="f.proto"),
+        source_roots=["src/protobuf"],
+        extra_args=[
+            "--python-protobuf-generate-type-stubs",
+            f"--mypy-protobuf-interpreter-constraints=['=={major_minor_interpreter}.*']",
+        ],
+        expected_files=["src/protobuf/dir1/f_pb2.py", "src/protobuf/dir1/f_pb2.pyi"],
+    )
+
+
+@pytest.mark.platform_specific_behavior
+@pytest.mark.parametrize(
+    "major_minor_interpreter",
+    all_major_minor_python_versions(PythonProtobufMypyPlugin.default_interpreter_constraints),
+)
 def test_mypy_plugin(rule_runner: RuleRunner, major_minor_interpreter: str) -> None:
     rule_runner.write_files(
         {

--- a/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
@@ -557,7 +557,8 @@ def test_source_plugin(rule_runner: PythonRuleRunner) -> None:
     assert "Success: no issues found in 1 source file" in result.stdout
 
 
-def test_protobuf_mypy(rule_runner: PythonRuleRunner) -> None:
+@pytest.mark.parametrize("protoc_type_stubs", (False, True), ids=("mypy_plugin", "protoc_direct"))
+def test_protobuf_mypy(rule_runner: PythonRuleRunner, protoc_type_stubs: bool) -> None:
     rule_runner = PythonRuleRunner(
         rules=[*rule_runner.rules, *protobuf_rules(), *protobuf_subsystem_rules()],
         target_types=[*rule_runner.target_types, ProtobufSourceTarget],
@@ -597,7 +598,11 @@ def test_protobuf_mypy(rule_runner: PythonRuleRunner) -> None:
     result = run_mypy(
         rule_runner,
         [tgt],
-        extra_args=["--python-protobuf-mypy-plugin"],
+        extra_args=[
+            "--python-protobuf-generate-type-stubs"
+            if protoc_type_stubs
+            else "--python-protobuf-mypy-plugin"
+        ],
     )
     assert len(result) == 1
     assert 'Argument "name" to "Person" has incompatible type "int"' in result[0].stdout


### PR DESCRIPTION
`protoc`'s Python generator has supported the generation of `.pyi` type stubs directly for some time. Add the new `[python-protobuf].generate_type_stubs` option to allow configuring generation of those type stubs (via the `pyi_out` generation option to the Python protoc generator).

This option is mutually exclusive with the `[python-protobuf].mypy_plugin` option since they both write `.pyi` files next to the generated Python code.