### PR TITLE
Add better support for project that needs to compile into both scala2 and scala3

### DIFF
--- a/docs/docs/jvm/java-and-scala.mdx
+++ b/docs/docs/jvm/java-and-scala.mdx
@@ -441,7 +441,7 @@ jvm-default = "semanticdb"
 :::note Scalafix and Scala 3
 At the moment the support for Scalac 3 in Scalafix is limited, most of the syntactic rules work but not that many in the semantic front.
 
-Despite those raugh edges, Scalafix is a great linting tool for Scala 3, just note that the setup is different than from prior versions: Instead of adding a scalac plugin to our build, we only need to add the `-Xsemanticdb` flag to our `[scalac].args` settings, or  or the appropriate entry in `[scalac].args_for_resolve, to enable the generation of `.semanticdb` compiled files.
+Despite those rough edges, Scalafix is a great linting tool for Scala 3, just note that the setup is different than from prior versions: Instead of adding a scalac plugin to our build, we only need to add the `-Xsemanticdb` flag to our `[scalac].args` settings, or  or the appropriate entry in `[scalac].args_for_resolve, to enable the generation of `.semanticdb` compiled files.
 :::
 
 ## Working in an IDE

--- a/docs/docs/jvm/java-and-scala.mdx
+++ b/docs/docs/jvm/java-and-scala.mdx
@@ -441,7 +441,7 @@ jvm-default = "semanticdb"
 :::note Scalafix and Scala 3
 At the moment the support for Scalac 3 in Scalafix is limited, most of the syntactic rules work but not that many in the semantic front.
 
-Despite those raugh edges, Scalafix is a great linting tool for Scala 3, just note that the setup is different than from prior versions: Instead of adding a scalac plugin to our build, we only need to add the `-Xsemanticdb` flag to our `[scalac].args` settings to enable the generation of `.semanticdb` compiled files.
+Despite those raugh edges, Scalafix is a great linting tool for Scala 3, just note that the setup is different than from prior versions: Instead of adding a scalac plugin to our build, we only need to add the `-Xsemanticdb` flag to our `[scalac].args` settings, or  or the appropriate entry in `[scalac].args_for_resolve, to enable the generation of `.semanticdb` compiled files.
 :::
 
 ## Working in an IDE

--- a/docs/notes/2.28.x.md
+++ b/docs/notes/2.28.x.md
@@ -44,6 +44,11 @@ Added an option to [the `[docker]` subsystem](https://www.pantsbuild.org/prerele
 bypassing the `suggest_renames` functionality. There are currently situations where this code path can
 [introduce performance degradation](https://github.com/pantsbuild/pants/issues/22246), and this flag allows the end user to work around that issue.
 
+
+#### Scala
+
+Add an option to the `[scalac]` subsystem to allow configure different args for scalac per resolve.
+
 ### Plugin API changes
 
 PyO3, the interface crate between Rust and Python, has been upgraded to v0.25.0.

--- a/src/python/pants/backend/scala/bsp/rules.py
+++ b/src/python/pants/backend/scala/bsp/rules.py
@@ -388,7 +388,10 @@ async def handle_bsp_scalac_options_request(
     return HandleScalacOptionsResult(
         ScalacOptionsItem(
             target=request.bsp_target_id,
-            options=(*local_plugins.args(local_plugins_prefix), *scalac.parsed_args_for_resolve(resolve.name)),
+            options=(
+                *local_plugins.args(local_plugins_prefix),
+                *scalac.parsed_args_for_resolve(resolve.name),
+            ),
             classpath=classpath,
             class_directory=build_root.pathlib_path.joinpath(
                 f".pants.d/bsp/{jvm_classes_directory(request.bsp_target_id)}"

--- a/src/python/pants/backend/scala/bsp/rules.py
+++ b/src/python/pants/backend/scala/bsp/rules.py
@@ -388,7 +388,7 @@ async def handle_bsp_scalac_options_request(
     return HandleScalacOptionsResult(
         ScalacOptionsItem(
             target=request.bsp_target_id,
-            options=(*local_plugins.args(local_plugins_prefix), *scalac.args),
+            options=(*local_plugins.args(local_plugins_prefix), *scalac.parsed_args_for_resolve(resolve.name)),
             classpath=classpath,
             class_directory=build_root.pathlib_path.joinpath(
                 f".pants.d/bsp/{jvm_classes_directory(request.bsp_target_id)}"

--- a/src/python/pants/backend/scala/compile/scalac.py
+++ b/src/python/pants/backend/scala/compile/scalac.py
@@ -186,7 +186,6 @@ async def compile_scala_source(
     compilation_output_dir = "__out"
     compilation_empty_dir = await create_digest(CreateDigest([Directory(compilation_output_dir)]))
     merged_digest = await merge_digests(MergeDigests([sources_digest, compilation_empty_dir]))
-
     compile_result = await execute_process(
         **implicitly(
             JvmProcess(
@@ -198,7 +197,7 @@ async def compile_scala_source(
                     ":".join(tool_classpath.classpath_entries(toolcp_relpath)),
                     *local_plugins.args(local_scalac_plugins_relpath),
                     *(("-classpath", classpath_arg) if classpath_arg else ()),
-                    *scalac.args,
+                    *scalac.parsed_args_for_resolve(request.resolve.name),
                     "-d",
                     compilation_output_dir,
                     *sorted(

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser.py
@@ -291,7 +291,7 @@ async def create_analyze_scala_source_request(
     tgt = wrapped_tgt.target
     resolve = tgt[JvmResolveField].normalized_value(jvm)
     scala_version = scala_subsystem.version_for_resolve(resolve)
-    source3 = "-Xsource:3" in scalac.args
+    source3 = "-Xsource:3" in scalac.parsed_args_for_resolve(resolve)
 
     return AnalyzeScalaSourceRequest(source_files, scala_version, source3)
 

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
@@ -499,6 +499,7 @@ def test_scala_2_13_source3(rule_runner: RuleRunner) -> None:
     )
     assert analysis.imports_by_scope.get("foo") == (ScalaImport("bar", None, True),)
 
+
 def test_scala_3_default_args(rule_runner: RuleRunner) -> None:
     rule_runner.set_options(
         args=[
@@ -519,6 +520,7 @@ def test_scala_3_default_args(rule_runner: RuleRunner) -> None:
         ),
     )
     assert analysis.imports_by_scope.get("foo") == (ScalaImport("bar", None, True),)
+
 
 def test_extract_annotations(rule_runner: RuleRunner) -> None:
     analysis = _analyze(

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
@@ -478,12 +478,12 @@ def test_package_object(rule_runner: RuleRunner) -> None:
     ]
 
 
-def test_source3(rule_runner: RuleRunner) -> None:
+def test_scala_2_13_source3(rule_runner: RuleRunner) -> None:
     rule_runner.set_options(
         args=[
             "-ldebug",
             "--scala-version-for-resolve={'jvm-default':'2.13.8'}",
-            "--scalac-args=['-Xsource:3']",
+            "--scalac-args-for-resolve={'jvm-default':['-Xsource:3']}",
         ],
         env_inherit=PYTHON_BOOTSTRAP_ENV,
     )
@@ -499,6 +499,26 @@ def test_source3(rule_runner: RuleRunner) -> None:
     )
     assert analysis.imports_by_scope.get("foo") == (ScalaImport("bar", None, True),)
 
+def test_scala_3_default_args(rule_runner: RuleRunner) -> None:
+    rule_runner.set_options(
+        args=[
+            "-ldebug",
+            "--scala-version-for-resolve={'jvm-default':'3.3.0'}",
+            "--scalac-args=['']",
+        ],
+        env_inherit=PYTHON_BOOTSTRAP_ENV,
+    )
+    analysis = _analyze(
+        rule_runner,
+        textwrap.dedent(
+            """
+            package foo
+
+            import bar.*
+            """
+        ),
+    )
+    assert analysis.imports_by_scope.get("foo") == (ScalaImport("bar", None, True),)
 
 def test_extract_annotations(rule_runner: RuleRunner) -> None:
     analysis = _analyze(

--- a/src/python/pants/backend/scala/lint/scalafix/rules.py
+++ b/src/python/pants/backend/scala/lint/scalafix/rules.py
@@ -93,6 +93,7 @@ class ScalafixPartitionInfo:
     compile_classpath_entries: tuple[str, ...]
     rule_classpath_entries: tuple[str, ...]
     extra_immutable_input_digests: FrozenDict[str, Digest]
+    resolve_name: str
 
     @property
     def description(self) -> str:
@@ -241,6 +242,7 @@ async def _partition_scalafix(
                     **dict(rule_classpath.immutable_inputs(prefix=rulecp_relpath)),
                 }
             ),
+            resolve_name=classpath.classpath.resolve.name if classpath.classpath else jvm.default_resolve,
         )
 
     return Partitions(
@@ -321,7 +323,14 @@ async def _run_scalafix_process(
                         else ()
                     ),
                     *(("--check",) if request.check_only else ()),
-                    *((f"--scalac-options={arg}" for arg in scalac.args) if scalac.args else ()),
+                    *(
+                        (
+                            f"--scalac-options={arg}"
+                            for arg in scalac.parsed_args_for_resolve(partition_info.resolve_name)
+                        )
+                        if scalac.parsed_args_for_resolve(partition_info.resolve_name)
+                        else ()
+                    ),
                     *(f"--files={file}" for file in request.snapshot.files),
                 ],
                 classpath_entries=partition_info.runtime_classpath_entries,

--- a/src/python/pants/backend/scala/lint/scalafix/rules.py
+++ b/src/python/pants/backend/scala/lint/scalafix/rules.py
@@ -242,7 +242,9 @@ async def _partition_scalafix(
                     **dict(rule_classpath.immutable_inputs(prefix=rulecp_relpath)),
                 }
             ),
-            resolve_name=classpath.classpath.resolve.name if classpath.classpath else jvm.default_resolve,
+            resolve_name=classpath.classpath.resolve.name
+            if classpath.classpath
+            else jvm.default_resolve,
         )
 
     return Partitions(
@@ -303,7 +305,6 @@ async def _run_scalafix_process(
     merged_digest = await merge_digests(
         MergeDigests([partition_info.config_snapshot.digest, request.snapshot.digest])
     )
-
     return await execute_process(
         **implicitly(
             JvmProcess(
@@ -324,12 +325,10 @@ async def _run_scalafix_process(
                     ),
                     *(("--check",) if request.check_only else ()),
                     *(
-                        (
-                            f"--scalac-options={arg}"
-                            for arg in scalac.parsed_args_for_resolve(partition_info.resolve_name)
+                        f"--scalac-options={arg}"
+                        for arg in (
+                            scalac.parsed_args_for_resolve(partition_info.resolve_name) or ()
                         )
-                        if scalac.parsed_args_for_resolve(partition_info.resolve_name)
-                        else ()
                     ),
                     *(f"--files={file}" for file in request.snapshot.files),
                 ],

--- a/src/python/pants/backend/scala/subsystems/scalac.py
+++ b/src/python/pants/backend/scala/subsystems/scalac.py
@@ -23,10 +23,9 @@ class Scalac(Subsystem):
 
     args = ArgsListOption(example="-encoding UTF-8")
 
-
     args_for_resolve = DictOption[list[str]](
         help=softwrap(
-             """
+            """
             A dictionary mapping JVM resolve names to additional arguments to pass
             to `scalac` for that resolve. These arguments are appended to the
             global `[scalac].args` option when compiling Scala code using the
@@ -47,9 +46,8 @@ class Scalac(Subsystem):
         ),
     )
 
-
     def parsed_args_for_resolve(self, resolve_name: str) -> list[str]:
-        return self.args_for_resolve.get(resolve_name, []) + list(self.args)
+        return list(self.args) + self.args_for_resolve.get(resolve_name, [])
 
     def parsed_default_plugins(self) -> dict[str, list[str]]:
         return {

--- a/src/python/pants/backend/scala/subsystems/scalac.py
+++ b/src/python/pants/backend/scala/subsystems/scalac.py
@@ -23,6 +23,18 @@ class Scalac(Subsystem):
 
     args = ArgsListOption(example="-encoding UTF-8")
 
+
+    args_for_resolve = DictOption[list[str]](
+        help=softwrap(
+             """
+            A dictionary mapping JVM resolve names to additional arguments to pass
+            to `scalac` for that resolve. These arguments are appended to the
+            global `[scalac].args` option when compiling Scala code using the
+            resolve.
+            """
+        ),
+    )
+
     # TODO: see if we can use an actual list mechanism? If not, this seems like an OK option
     plugins_for_resolve = DictOption[str](
         help=softwrap(
@@ -34,6 +46,10 @@ class Scalac(Subsystem):
             """
         ),
     )
+
+
+    def parsed_args_for_resolve(self, resolve_name: str) -> list[str]:
+        return self.args_for_resolve.get(resolve_name, []) + list(self.args)
 
     def parsed_default_plugins(self) -> dict[str, list[str]]:
         return {


### PR DESCRIPTION
When trying to configure a pants project that compiles into both scala3 and scala2 I ran into an issue that I needed to configure different scalac args for each version.
I've added the options to configure an args per resolve similar to the plugin for resolve configuration.