### PR TITLE
perf: Migrate to call-by-name in build_files.py

### DIFF
--- a/src/python/pants/backend/javascript/package_json.py
+++ b/src/python/pants/backend/javascript/package_json.py
@@ -719,8 +719,7 @@ async def parse_package_json(content: FileContent) -> PackageJson:
 
 @rule
 async def read_package_jsons(globs: PathGlobs) -> PackageJsonForGlobs:
-    snapshot = await digest_to_snapshot(**implicitly(globs))
-    digest_contents = await get_digest_contents(snapshot.digest)
+    digest_contents = await get_digest_contents(**implicitly(globs))
     return PackageJsonForGlobs(
         await concurrently(parse_package_json(digest_content) for digest_content in digest_contents)
     )
@@ -769,10 +768,9 @@ class PnpmWorkspaces(FrozenDict[PackageJson, PnpmWorkspaceGlobs]):
 
 @rule
 async def pnpm_workspace_files(pkgs: AllPackageJson) -> PnpmWorkspaces:
-    snapshot = await digest_to_snapshot(
+    digest_contents = await get_digest_contents(
         **implicitly(PathGlobs(os.path.join(pkg.root_dir, "pnpm-workspace.yaml") for pkg in pkgs))
     )
-    digest_contents = await get_digest_contents(snapshot.digest)
 
     async def parse_package_globs(content: FileContent) -> PnpmWorkspaceGlobs:
         parsed = yaml.safe_load(content.content) or {"packages": ("**",)}


### PR DESCRIPTION
Was looking at potential rust port opportunities and got derailed and changed this. Side note: porting target adapters and build file stuff seems like a good candidate to use rust and not cache every intermediate.

Duplicates https://github.com/pantsbuild/pants/pull/22353, sorry!