### PR TITLE
Delay experimental_test_shell_command deprecated alias removal to 2.30

### DIFF
--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -489,7 +489,7 @@ class ShellCommandTestTarget(Target):
     alias = "test_shell_command"
 
     deprecated_alias = "experimental_test_shell_command"
-    deprecated_alias_removal_version = "2.29.0.dev0"
+    deprecated_alias_removal_version = "2.30.0.dev0"
 
     core_fields = (
         *COMMON_TARGET_FIELDS,


### PR DESCRIPTION
The `experimental_test_shell_command` target was stabilised as `test_shell_command` in 2.27 (#22016), with scheduled removal in 2.29.0.dev0. This PR delays that by one release, because:

- it's minimal code for us to support (i.e. very little imposition on us)
- we're about to branch for 2.28.x and thus do 2.29.x dev releases, and thus delaying ensures that it's easier for people to test pre-releases: someone still using 2.26.x (e.g. in the process of upgrading to 2.27.0) can test 2.29.0.dev0 with fewer changes required.

(This is the only piece of prep required before cutting the first 2.29.x release, I think.)