### PR TITLE
fix: missing common targets for node_build_script

### DIFF
--- a/src/python/pants/backend/javascript/package_json_test.py
+++ b/src/python/pants/backend/javascript/package_json_test.py
@@ -164,7 +164,7 @@ def test_generates_build_script_targets(
                 """\
                 package_json(
                     scripts=[
-                        node_build_script(entry_point="build", output_directories=["www/"])
+                        node_build_script(entry_point="build", output_directories=["www/"], description="builds the project", tags=["build"])
                     ]
                 )
                 """


### PR DESCRIPTION
Summary
--

While the NodeBuildScriptTarget includes `COMMON_TARGET_FIELDS`(description, tags), the addition of these fields result in an error -
`TypeError: NodeBuildScript.create() got an unexpected keyword argument 'description'`

Adding both the fields to the NodeBuildScript class