### PR TITLE
Migrate union membership to rust

### DIFF
--- a/pants-plugins/pants_explorer/server/graphql/query/conftest.py
+++ b/pants-plugins/pants_explorer/server/graphql/query/conftest.py
@@ -45,7 +45,7 @@ def all_help_info(rule_runner: RuleRunner) -> AllHelpInfo:
     with rule_runner.pushd():
         all_help_info = HelpInfoExtracter.get_all_help_info(
             options=rule_runner.options_bootstrapper.full_options(
-                rule_runner.build_config, union_membership=UnionMembership({})
+                rule_runner.build_config, union_membership=UnionMembership.empty()
             ),
             union_membership=rule_runner.union_membership,
             consumed_scopes_mapper=fake_consumed_scopes_mapper,

--- a/src/python/pants/backend/build_files/fix/deprecations/renamed_fields_rules_test.py
+++ b/src/python/pants/backend/build_files/fix/deprecations/renamed_fields_rules_test.py
@@ -37,7 +37,9 @@ async def test_determine_renamed_fields() -> None:
         moved_fields = (DeprecatedField, OkayField)
 
     registered_targets = RegisteredTargetTypes.create([Tgt, TgtGenerator])
-    result = await determine_renamed_field_types.rule.func(registered_targets, UnionMembership({}))  # type: ignore[attr-defined]
+    result = await determine_renamed_field_types.rule.func(  # type: ignore[attr-defined]
+        registered_targets, UnionMembership.empty()
+    )
     deprecated_fields = FrozenDict({DeprecatedField.deprecated_alias: DeprecatedField.alias})
     assert result.target_field_renames == FrozenDict(
         {k: deprecated_fields for k in (TgtGenerator.alias, Tgt.alias, Tgt.deprecated_alias)}

--- a/src/python/pants/backend/go/util_rules/build_pkg_target.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import dataclasses
 import json
 from dataclasses import dataclass
-from typing import ClassVar, cast
+from typing import ClassVar
 
 from pants.backend.go.go_sources.load_go_binary import LoadedGoBinaryRequest, setup_go_binary
 from pants.backend.go.target_type_rules import (
@@ -78,7 +78,6 @@ from pants.engine.target import (
 from pants.engine.unions import UnionMembership, union
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
-from pants.util.ordered_set import FrozenOrderedSet
 from pants.util.strutil import bullet_list
 
 
@@ -286,9 +285,7 @@ def maybe_get_codegen_request_type(
 ) -> GoCodegenBuildRequest | None:
     if not tgt.has_field(SourcesField):
         return None
-    generate_request_types = cast(
-        FrozenOrderedSet[type[GoCodegenBuildRequest]], union_membership.get(GoCodegenBuildRequest)
-    )
+    generate_request_types = union_membership.get(GoCodegenBuildRequest)
     sources_field = tgt[SourcesField]
     relevant_requests = [
         req for req in generate_request_types if isinstance(sources_field, req.generate_from)

--- a/src/python/pants/backend/nfpm/util_rules/sandbox.py
+++ b/src/python/pants/backend/nfpm/util_rules/sandbox.py
@@ -42,6 +42,7 @@ from pants.engine.target import (
     TransitiveTargetsRequest,
 )
 from pants.engine.unions import UnionMembership
+from pants.util.ordered_set import FrozenOrderedSet
 
 
 class _DepCategory(Enum):
@@ -101,7 +102,7 @@ class _NfpmSortedDeps:
         union_membership: UnionMembership,
     ) -> _NfpmSortedDeps:
         package_field_set_types = (
-            union_membership.get(PackageFieldSet) - NFPM_PACKAGE_FIELD_SET_TYPES
+            FrozenOrderedSet(union_membership.get(PackageFieldSet)) - NFPM_PACKAGE_FIELD_SET_TYPES
         )
 
         nfpm_content_from_dependency_targets: list[NfpmContentFile] = []

--- a/src/python/pants/bsp/util_rules/compile.py
+++ b/src/python/pants/bsp/util_rules/compile.py
@@ -6,6 +6,7 @@ import logging
 import time
 import uuid
 from collections import defaultdict
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TypeVar
 
@@ -28,7 +29,6 @@ from pants.engine.intrinsics import merge_digests
 from pants.engine.rules import _uncacheable_rule, collect_rules, implicitly, rule
 from pants.engine.target import FieldSet
 from pants.engine.unions import UnionMembership, UnionRule
-from pants.util.ordered_set import FrozenOrderedSet
 
 _logger = logging.getLogger(__name__)
 
@@ -60,7 +60,7 @@ async def compile_bsp_target(
     union_membership: UnionMembership,
 ) -> BSPCompileResult:
     targets = await resolve_bsp_build_target_addresses(request.bsp_target, **implicitly())
-    compile_request_types: FrozenOrderedSet[type[BSPCompileRequest]] = union_membership.get(
+    compile_request_types: Sequence[type[BSPCompileRequest]] = union_membership.get(
         BSPCompileRequest
     )
     field_sets_by_request_type: dict[type[BSPCompileRequest], set[FieldSet]] = defaultdict(set)

--- a/src/python/pants/bsp/util_rules/resources.py
+++ b/src/python/pants/bsp/util_rules/resources.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TypeVar
 
@@ -23,7 +24,6 @@ from pants.engine.intrinsics import merge_digests
 from pants.engine.rules import _uncacheable_rule, collect_rules, implicitly, rule
 from pants.engine.target import FieldSet
 from pants.engine.unions import UnionMembership, UnionRule
-from pants.util.ordered_set import FrozenOrderedSet
 
 _logger = logging.getLogger(__name__)
 
@@ -47,7 +47,7 @@ async def resources_bsp_target(
     union_membership: UnionMembership,
 ) -> BSPResourcesResult:
     targets = await resolve_bsp_build_target_addresses(request.bsp_target, **implicitly())
-    resources_request_types: FrozenOrderedSet[type[BSPResourcesRequest]] = union_membership.get(
+    resources_request_types: Sequence[type[BSPResourcesRequest]] = union_membership.get(
         BSPResourcesRequest
     )
     field_sets_by_request_type: dict[type[BSPResourcesRequest], set[FieldSet]] = defaultdict(set)

--- a/src/python/pants/bsp/util_rules/targets.py
+++ b/src/python/pants/bsp/util_rules/targets.py
@@ -61,7 +61,7 @@ from pants.engine.target import (
 from pants.engine.unions import UnionMembership, UnionRule, union
 from pants.source.source_root import SourceRootsRequest, get_source_roots
 from pants.util.frozendict import FrozenDict
-from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
+from pants.util.ordered_set import OrderedSet
 from pants.util.strutil import bullet_list
 
 _logger = logging.getLogger(__name__)
@@ -358,8 +358,8 @@ async def generate_one_bsp_build_target_request(
     field_sets_by_request_type: dict[type[BSPBuildTargetsMetadataRequest], OrderedSet[FieldSet]] = (
         defaultdict(OrderedSet)
     )
-    metadata_request_types: FrozenOrderedSet[type[BSPBuildTargetsMetadataRequest]] = (
-        union_membership.get(BSPBuildTargetsMetadataRequest)
+    metadata_request_types: Sequence[type[BSPBuildTargetsMetadataRequest]] = union_membership.get(
+        BSPBuildTargetsMetadataRequest
     )
     metadata_request_types_by_lang_id: dict[str, type[BSPBuildTargetsMetadataRequest]] = {}
     for metadata_request_type in metadata_request_types:
@@ -584,8 +584,8 @@ async def resolve_one_dependency_module(
     field_sets_by_request_type: dict[type[BSPDependencyModulesRequest], list[FieldSet]] = (
         defaultdict(list)
     )
-    dep_module_request_types: FrozenOrderedSet[type[BSPDependencyModulesRequest]] = (
-        union_membership.get(BSPDependencyModulesRequest)
+    dep_module_request_types: Sequence[type[BSPDependencyModulesRequest]] = union_membership.get(
+        BSPDependencyModulesRequest
     )
     for tgt in targets:
         for dep_module_request_type in dep_module_request_types:

--- a/src/python/pants/core/goals/check_test.py
+++ b/src/python/pants/core/goals/check_test.py
@@ -30,7 +30,7 @@ from pants.engine.process import (
     ProcessResultMetadata,
 )
 from pants.engine.target import FieldSet, MultipleSourcesField, Target, Targets
-from pants.engine.unions import UnionMembership
+from pants.engine.unions import UnionMembership, UnionRule
 from pants.testutil.option_util import create_subsystem
 from pants.testutil.rule_runner import MockGet, RuleRunner, mock_console, run_rule_with_mocks
 from pants.util.logging import LogLevel
@@ -155,7 +155,7 @@ def run_typecheck_rule(
     targets: list[Target],
     only: list[str] | None = None,
 ) -> tuple[int, str]:
-    union_membership = UnionMembership({CheckRequest: request_types})
+    union_membership = UnionMembership.from_rules(UnionRule(CheckRequest, t) for t in request_types)
     check_subsystem = create_subsystem(CheckSubsystem, only=only or [])
     rule_runner = RuleRunner(bootstrap_args=["-lwarn"])
     with mock_console(rule_runner.options_bootstrapper) as (console, stdio_reader):

--- a/src/python/pants/core/goals/export_test.py
+++ b/src/python/pants/core/goals/export_test.py
@@ -93,7 +93,7 @@ def run_export_rule(
 ) -> tuple[int, str]:
     resolves = resolves or []
     binaries = binaries or []
-    union_membership = UnionMembership({ExportRequest: [MockExportRequest]})
+    union_membership = UnionMembership.from_rules([UnionRule(ExportRequest, MockExportRequest)])
     with open(os.path.join(rule_runner.build_root, "somefile"), "wb") as fp:
         fp.write(b"SOMEFILE")
 

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -34,7 +34,7 @@ from pants.engine.fs import PathGlobs, SpecsPaths, Workspace
 from pants.engine.internals.native_engine import EMPTY_SNAPSHOT, Snapshot
 from pants.engine.rules import QueryRule
 from pants.engine.target import Field, FieldSet, FilteredTargets, MultipleSourcesField, Target
-from pants.engine.unions import UnionMembership
+from pants.engine.unions import UnionMembership, UnionRule
 from pants.option.option_types import SkipOption
 from pants.option.subsystem import Subsystem
 from pants.testutil.option_util import create_goal_subsystem
@@ -329,17 +329,19 @@ def run_lint_rule(
     skip_formatters: bool = False,
     skip_fixers: bool = False,
 ) -> tuple[int, str]:
-    union_membership = UnionMembership(
+    union_membership = UnionMembership.from_rules(
         {
-            AbstractLintRequest: lint_request_types,
-            AbstractLintRequest.Batch: [rt.Batch for rt in lint_request_types],
-            LintTargetsRequest.PartitionRequest: [
-                rt.PartitionRequest
+            *[UnionRule(AbstractLintRequest, t) for t in lint_request_types],
+            *[UnionRule(AbstractLintRequest.Batch, rt.Batch) for rt in lint_request_types],
+            *[
+                UnionRule(LintTargetsRequest.PartitionRequest, rt.PartitionRequest)
                 for rt in lint_request_types
                 if issubclass(rt, LintTargetsRequest)
             ],
-            LintFilesRequest.PartitionRequest: [
-                rt.PartitionRequest for rt in lint_request_types if issubclass(rt, LintFilesRequest)
+            *[
+                UnionRule(LintFilesRequest.PartitionRequest, rt.PartitionRequest)
+                for rt in lint_request_types
+                if issubclass(rt, LintFilesRequest)
             ],
         }
     )

--- a/src/python/pants/core/goals/run_test.py
+++ b/src/python/pants/core/goals/run_test.py
@@ -36,7 +36,7 @@ from pants.engine.target import (
     TargetRootsToFieldSets,
     TargetRootsToFieldSetsRequest,
 )
-from pants.engine.unions import UnionMembership
+from pants.engine.unions import UnionMembership, UnionRule
 from pants.option.global_options import GlobalOptions, KeepSandboxes
 from pants.testutil.option_util import create_goal_subsystem, create_subsystem
 from pants.testutil.rule_runner import (
@@ -138,11 +138,8 @@ def single_target_run(
                     mock=rule_runner.run_interactive_process,
                 ),
             ],
-            union_membership=UnionMembership(
-                {
-                    RunFieldSet: [TestRunFieldSet],
-                    RunDebugAdapterRequest: [TestRunFieldSet],
-                },
+            union_membership=UnionMembership.from_rules(
+                {UnionRule(RunFieldSet, TestRunFieldSet)},
             ),
         )
 

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -73,7 +73,7 @@ from pants.engine.target import (
     TargetRootsToFieldSets,
     TargetRootsToFieldSetsRequest,
 )
-from pants.engine.unions import UnionMembership
+from pants.engine.unions import UnionMembership, UnionRule
 from pants.option.option_types import SkipOption
 from pants.option.subsystem import Subsystem
 from pants.testutil.option_util import create_goal_subsystem, create_subsystem
@@ -296,13 +296,13 @@ def run_test_rule(
         port="5678",
     )
     workspace = Workspace(rule_runner.scheduler, _enforce_effects=False)
-    union_membership = UnionMembership(
+    union_membership = UnionMembership.from_rules(
         {
-            TestFieldSet: [MockTestFieldSet],
-            TestRequest: [request_type],
-            TestRequest.PartitionRequest: [request_type.PartitionRequest],
-            TestRequest.Batch: [request_type.Batch],
-            CoverageDataCollection: [MockCoverageDataCollection],
+            UnionRule(TestFieldSet, MockTestFieldSet),
+            UnionRule(TestRequest, request_type),
+            UnionRule(TestRequest.PartitionRequest, request_type.PartitionRequest),
+            UnionRule(TestRequest.Batch, request_type.Batch),
+            UnionRule(CoverageDataCollection, MockCoverageDataCollection),
         }
     )
 

--- a/src/python/pants/core/util_rules/external_tool_test.py
+++ b/src/python/pants/core/util_rules/external_tool_test.py
@@ -27,7 +27,7 @@ from pants.engine.fs import CreateDigest, DigestContents, DownloadFile, FileCont
 from pants.engine.internals.native_engine import Digest
 from pants.engine.platform import Platform
 from pants.engine.rules import QueryRule
-from pants.engine.unions import UnionMembership
+from pants.engine.unions import UnionMembership, UnionRule
 from pants.option.scope import Scope, ScopedOptions
 from pants.testutil.option_util import create_subsystem
 from pants.testutil.pytest_util import no_exception
@@ -151,10 +151,12 @@ def test_export(rule_runner) -> None:
 
     Ensures we locate the class and prepare the Digest correctly
     """
-
     platform = Platform.linux_x86_64
-    union_membership = UnionMembership(
-        {ExportRequest: [ExportExternalToolRequest], ExportableTool: [TemplatedFooBar]}
+    union_membership = UnionMembership.from_rules(
+        {
+            UnionRule(ExportRequest, ExportExternalToolRequest),
+            UnionRule(ExportableTool, TemplatedFooBar),
+        }
     )
 
     templated_foobar = create_subsystem(

--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -69,7 +69,7 @@ def test_parse_address_family_empty() -> None:
             Parser(
                 build_root="",
                 registered_target_types=RegisteredTargetTypes({}),
-                union_membership=UnionMembership({}),
+                union_membership=UnionMembership.empty(),
                 object_aliases=BuildFileAliases(),
                 ignore_unrecognized_symbols=False,
             ),
@@ -77,7 +77,7 @@ def test_parse_address_family_empty() -> None:
             BuildFileOptions(("BUILD",)),
             BuildFilePreludeSymbols(FrozenDict(), ()),
             RegisteredTargetTypes({}),
-            UnionMembership({}),
+            UnionMembership.empty(),
             MaybeBuildFileDependencyRulesImplementation(None),
             SessionValues({CompleteEnvironmentVars: CompleteEnvironmentVars({})}),
         ],
@@ -108,7 +108,7 @@ def test_extend_synthetic_target() -> None:
             Parser(
                 build_root="",
                 registered_target_types=RegisteredTargetTypes({"resource": ResourceTarget}),
-                union_membership=UnionMembership({}),
+                union_membership=UnionMembership.empty(),
                 object_aliases=BuildFileAliases(),
                 ignore_unrecognized_symbols=False,
             ),
@@ -116,7 +116,7 @@ def test_extend_synthetic_target() -> None:
             BuildFileOptions(("BUILD",)),
             BuildFilePreludeSymbols(FrozenDict(), ()),
             RegisteredTargetTypes({"resource": ResourceTarget}),
-            UnionMembership({}),
+            UnionMembership.empty(),
             MaybeBuildFileDependencyRulesImplementation(None),
             SessionValues({CompleteEnvironmentVars: CompleteEnvironmentVars({})}),
         ],
@@ -193,7 +193,7 @@ def run_prelude_parsing_rule(prelude_content: str) -> BuildFilePreludeSymbols:
             Parser(
                 build_root="",
                 registered_target_types=RegisteredTargetTypes({"target": GenericTarget}),
-                union_membership=UnionMembership({}),
+                union_membership=UnionMembership.empty(),
                 object_aliases=BuildFileAliases(),
                 ignore_unrecognized_symbols=False,
             ),
@@ -916,7 +916,7 @@ def test_build_files_share_globals() -> None:
             Parser(
                 build_root="",
                 registered_target_types=RegisteredTargetTypes({}),
-                union_membership=UnionMembership({}),
+                union_membership=UnionMembership.empty(),
                 object_aliases=BuildFileAliases(),
                 ignore_unrecognized_symbols=False,
             ),

--- a/src/python/pants/engine/internals/defaults_test.py
+++ b/src/python/pants/engine/internals/defaults_test.py
@@ -70,7 +70,7 @@ def registered_target_types() -> RegisteredTargetTypes:
 
 @pytest.fixture
 def union_membership() -> UnionMembership:
-    return UnionMembership({})
+    return UnionMembership.empty()
 
 
 def test_assumptions(

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -2113,7 +2113,7 @@ def test_transitive_excludes_error() -> None:
         bad_value="!!//:bad",
         address=Address("demo"),
         registered_target_types=[Valid1, Valid2, Invalid],
-        union_membership=UnionMembership({}),
+        union_membership=UnionMembership.empty(),
     )
     assert "Bad value '!!//:bad' in the `dependencies` field for demo:demo" in exc.args[0]
     assert "work with these target types: ['valid1', 'valid2']" in exc.args[0]

--- a/src/python/pants/engine/internals/mapper_test.py
+++ b/src/python/pants/engine/internals/mapper_test.py
@@ -37,7 +37,7 @@ def parse_address_map(build_file: str, *, ignore_unrecognized_symbols: bool = Fa
     parser = Parser(
         build_root="",
         registered_target_types=RegisteredTargetTypes({"thing": GenericTarget}),
-        union_membership=UnionMembership({}),
+        union_membership=UnionMembership.empty(),
         object_aliases=BuildFileAliases(),
         ignore_unrecognized_symbols=ignore_unrecognized_symbols,
     )
@@ -49,7 +49,7 @@ def parse_address_map(build_file: str, *, ignore_unrecognized_symbols: bool = Fa
         EnvironmentVars({}),
         False,
         BuildFileDefaultsParserState.create(
-            "", BuildFileDefaults({}), RegisteredTargetTypes({}), UnionMembership({})
+            "", BuildFileDefaults({}), RegisteredTargetTypes({}), UnionMembership.empty()
         ),
         dependents_rules=None,
         dependencies_rules=None,

--- a/src/python/pants/engine/internals/native_engine.pyi
+++ b/src/python/pants/engine/internals/native_engine.pyi
@@ -259,6 +259,51 @@ class Address:
     def __gt__(self, other: Any) -> bool: ...
 
 # ------------------------------------------------------------------------------
+# Union
+# ------------------------------------------------------------------------------
+
+class UnionRule:
+    union_base: type
+    union_member: type
+
+    def __init__(self, union_base: type, union_member: type) -> None: ...
+
+_T = TypeVar("_T", bound=type)
+
+class UnionMembership:
+    @staticmethod
+    def from_rules(rules: Iterable[UnionRule]) -> UnionMembership: ...
+    @staticmethod
+    def empty() -> UnionMembership: ...
+    def __contains__(self, union_type: _T) -> bool: ...
+    def __getitem__(self, union_type: _T) -> Sequence[_T]:
+        """Get all members of this union type.
+
+        If the union type does not exist because it has no members registered, this will raise an
+        IndexError.
+
+        Note that the type hint assumes that all union members will have subclassed the union type
+        - this is only a convention and is not actually enforced. So, you may have inaccurate type
+        hints.
+        """
+
+    def get(self, union_type: _T) -> Sequence[_T]:
+        """Get all members of this union type.
+
+        If the union type does not exist because it has no members registered, return an empty
+        Sequence.
+
+        Note that the type hint assumes that all union members will have subclassed the union type
+        - this is only a convention and is not actually enforced. So, you may have inaccurate type
+        hints.
+        """
+
+    def items(self) -> Iterable[tuple[type, Sequence[type]]]: ...
+    def is_member(self, union_type: type, putative_member: type) -> bool: ...
+    def has_members(self, union_type: type) -> bool:
+        """Check whether the union has an implementation or not."""
+
+# ------------------------------------------------------------------------------
 # Scheduler
 # ------------------------------------------------------------------------------
 

--- a/src/python/pants/engine/internals/parser_test.py
+++ b/src/python/pants/engine/internals/parser_test.py
@@ -31,7 +31,7 @@ from pants.util.strutil import softwrap
 @pytest.fixture
 def defaults_parser_state() -> BuildFileDefaultsParserState:
     return BuildFileDefaultsParserState.create(
-        "", BuildFileDefaults({}), RegisteredTargetTypes({}), UnionMembership({})
+        "", BuildFileDefaults({}), RegisteredTargetTypes({}), UnionMembership.empty()
     )
 
 
@@ -39,7 +39,7 @@ def test_imports_banned(defaults_parser_state: BuildFileDefaultsParserState) -> 
     parser = Parser(
         build_root="",
         registered_target_types=RegisteredTargetTypes({}),
-        union_membership=UnionMembership({}),
+        union_membership=UnionMembership.empty(),
         object_aliases=BuildFileAliases(),
         ignore_unrecognized_symbols=False,
     )
@@ -69,7 +69,7 @@ def test_unrecognized_symbol(defaults_parser_state: BuildFileDefaultsParserState
             registered_target_types=RegisteredTargetTypes(
                 {alias: GenericTarget for alias in ("tgt", *extra_targets)}
             ),
-            union_membership=UnionMembership({}),
+            union_membership=UnionMembership.empty(),
             object_aliases=build_file_aliases,
             ignore_unrecognized_symbols=False,
         )
@@ -104,7 +104,7 @@ def test_unrecognized_symbol(defaults_parser_state: BuildFileDefaultsParserState
                 registered_target_types=RegisteredTargetTypes(
                     {alias: GenericTarget for alias in ("tgt", *extra_targets)}
                 ),
-                union_membership=UnionMembership({}),
+                union_membership=UnionMembership.empty(),
                 object_aliases=build_file_aliases,
                 ignore_unrecognized_symbols=True,
             )
@@ -140,7 +140,7 @@ def test_unrecognized_symbol_during_bootstrap_issue_19156(
     parser = Parser(
         build_root="",
         registered_target_types=RegisteredTargetTypes({"tgt": GenericTarget}),
-        union_membership=UnionMembership({}),
+        union_membership=UnionMembership.empty(),
         object_aliases=build_file_aliases,
         ignore_unrecognized_symbols=True,
     )
@@ -177,7 +177,7 @@ def test_unknown_target_for_defaults_during_bootstrap_issue_19445(
     parser = Parser(
         build_root="",
         registered_target_types=RegisteredTargetTypes({}),
-        union_membership=UnionMembership({}),
+        union_membership=UnionMembership.empty(),
         object_aliases=BuildFileAliases(),
         ignore_unrecognized_symbols=True,
     )
@@ -208,7 +208,7 @@ def test_unrecognized_symbol_in_prelude(
     parser = Parser(
         build_root="",
         registered_target_types=RegisteredTargetTypes({}),
-        union_membership=UnionMembership({}),
+        union_membership=UnionMembership.empty(),
         object_aliases=build_file_aliases,
         ignore_unrecognized_symbols=False,
     )

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -679,7 +679,7 @@ def register_rules(rule_index: RuleIndex, union_membership: UnionMembership) -> 
 
     # Compute a reverse index of union membership.
     member_type_to_base_types = defaultdict(list)
-    for base_type, member_types in union_membership.union_rules.items():
+    for base_type, member_types in union_membership.items():
         for member_type in member_types:
             member_type_to_base_types[member_type].append(base_type)
 

--- a/src/python/pants/engine/internals/scheduler_test_base.py
+++ b/src/python/pants/engine/internals/scheduler_test_base.py
@@ -44,7 +44,7 @@ class SchedulerTestBase:
             named_caches_dir=named_caches_dir,
             ca_certs_path=None,
             rules=rules,
-            union_membership=UnionMembership({}),
+            union_membership=UnionMembership.empty(),
             executor=self._executor,
             execution_options=DEFAULT_EXECUTION_OPTIONS,
             local_store_options=DEFAULT_LOCAL_STORE_OPTIONS,

--- a/src/python/pants/engine/internals/specs_rules_test.py
+++ b/src/python/pants/engine/internals/specs_rules_test.py
@@ -944,7 +944,7 @@ def test_no_applicable_targets_exception() -> None:
     exc = NoApplicableTargetsException(
         [],
         Specs.empty(),
-        UnionMembership({}),
+        UnionMembership.empty(),
         applicable_target_types=[Tgt1],
         goal_description="the `foo` goal",
     )
@@ -970,7 +970,7 @@ def test_no_applicable_targets_exception() -> None:
             ),
             ignores=RawSpecs(description_of_origin="tests"),
         ),
-        UnionMembership({}),
+        UnionMembership.empty(),
         applicable_target_types=[Tgt1, Tgt2],
         goal_description="the `foo` goal",
     )
@@ -1003,7 +1003,7 @@ def test_no_applicable_targets_exception() -> None:
             ),
             ignores=RawSpecs(description_of_origin="tests"),
         ),
-        UnionMembership({}),
+        UnionMembership.empty(),
         applicable_target_types=[Tgt1],
         goal_description="the `foo` goal",
     )
@@ -1018,7 +1018,7 @@ def test_no_applicable_targets_exception() -> None:
             ),
             ignores=RawSpecs(description_of_origin="tests"),
         ),
-        UnionMembership({}),
+        UnionMembership.empty(),
         applicable_target_types=[Tgt1],
         goal_description="the `foo` goal",
     )

--- a/src/python/pants/engine/rules_test.py
+++ b/src/python/pants/engine/rules_test.py
@@ -45,7 +45,7 @@ def create_scheduler(rules, validate=True):
         named_caches_dir="./.pants.d/named_caches",
         ca_certs_path=None,
         rules=rules,
-        union_membership=UnionMembership({}),
+        union_membership=UnionMembership.empty(),
         executor=PyExecutor(core_threads=2, max_threads=4),
         execution_options=DEFAULT_EXECUTION_OPTIONS,
         local_store_options=DEFAULT_LOCAL_STORE_OPTIONS,

--- a/src/python/pants/engine/unions_test.py
+++ b/src/python/pants/engine/unions_test.py
@@ -11,7 +11,6 @@ from pants.engine.unions import (
     is_union,
     union,
 )
-from pants.util.ordered_set import FrozenOrderedSet
 
 
 def test_simple() -> None:
@@ -48,11 +47,12 @@ def test_simple() -> None:
         ]
     )
 
-    assert union_membership == UnionMembership(
+    assert union_membership == UnionMembership.from_rules(
         {
-            Fruit: FrozenOrderedSet([Banana, Apple]),
-            CitrusFruit: FrozenOrderedSet([Orange]),
-            Vegetable: FrozenOrderedSet([Potato]),
+            UnionRule(Fruit, Banana),
+            UnionRule(Fruit, Apple),
+            UnionRule(CitrusFruit, Orange),
+            UnionRule(Vegetable, Potato),
         }
     )
 

--- a/src/python/pants/goal/stats_aggregator_integration_test.py
+++ b/src/python/pants/goal/stats_aggregator_integration_test.py
@@ -38,7 +38,7 @@ def test_memory_summary() -> None:
     result = run_pants(["--stats-memory-summary", "--version"])
     result.assert_success()
     assert "Memory summary" in result.stderr
-    assert "pants.engine.unions.UnionMembership" in result.stderr
+    assert "builtins.UnionMembership" in result.stderr
 
 
 def test_writing_to_output_file_plain_text() -> None:

--- a/src/python/pants/help/flag_error_help_printer.py
+++ b/src/python/pants/help/flag_error_help_printer.py
@@ -23,7 +23,7 @@ class FlagErrorHelpPrinter(MaybeColor):
             options,
             # We only care about the options-related help info, so we pass in
             # dummy values for the other arguments.
-            UnionMembership({}),
+            UnionMembership.empty(),
             lambda x: tuple(),
             RegisteredTargetTypes({}),
             BuildFileSymbolsInfo.from_info(),

--- a/src/python/pants/help/help_info_extracter_test.py
+++ b/src/python/pants/help/help_info_extracter_test.py
@@ -277,9 +277,9 @@ def test_get_all_help_info(tmp_path) -> None:
         known_scope_infos=[Global.get_scope_info(), Foo.get_scope_info(), Bar.get_scope_info()],
         include_derivation=True,
     )
-    Global.register_options_on_scope(options, UnionMembership({}))
-    Foo.register_options_on_scope(options, UnionMembership({}))
-    Bar.register_options_on_scope(options, UnionMembership({}))
+    Global.register_options_on_scope(options, UnionMembership.empty())
+    Foo.register_options_on_scope(options, UnionMembership.empty())
+    Bar.register_options_on_scope(options, UnionMembership.empty())
 
     @rule
     async def rule_info_test(foo: Foo) -> Target:  # type: ignore[empty-body]
@@ -296,7 +296,7 @@ def test_get_all_help_info(tmp_path) -> None:
 
     all_help_info = HelpInfoExtracter.get_all_help_info(
         options,
-        UnionMembership({}),
+        UnionMembership.empty(),
         fake_consumed_scopes_mapper,
         RegisteredTargetTypes({BazLibrary.alias: BazLibrary}),
         BuildFileSymbolsInfo.from_info(

--- a/src/python/pants/init/options_initializer.py
+++ b/src/python/pants/init/options_initializer.py
@@ -188,7 +188,7 @@ class OptionsInitializer:
             )
             options = no_arg_bootstrapper.full_options(
                 build_config,
-                union_membership=UnionMembership({}),
+                union_membership=UnionMembership.empty(),
             )
             FlagErrorHelpPrinter(options).handle_unknown_flags(err)
             if raise_:

--- a/src/python/pants/option/options_bootstrapper_test.py
+++ b/src/python/pants/option/options_bootstrapper_test.py
@@ -135,7 +135,7 @@ class TestOptionsBootstrapper:
                     ScopeInfo("foo"),
                     ScopeInfo("fruit"),
                 ],
-                union_membership=UnionMembership({}),
+                union_membership=UnionMembership.empty(),
             )
             # So we don't choke on these on the cmd line.
             opts.register("", "--pants-workdir")
@@ -182,7 +182,7 @@ class TestOptionsBootstrapper:
                     ScopeInfo("compile_apt"),
                     ScopeInfo("fruit"),
                 ],
-                union_membership=UnionMembership({}),
+                union_membership=UnionMembership.empty(),
             )
             # So we don't choke on these on the cmd line.
             options.register("", "--pants-config-files", type=list)
@@ -253,7 +253,7 @@ class TestOptionsBootstrapper:
                     ScopeInfo(""),
                     ScopeInfo("resolver"),
                 ],
-                union_membership=UnionMembership({}),
+                union_membership=UnionMembership.empty(),
             )
             opts_single_config.register("", "--pantsrc-files", type=list)
             opts_single_config.register("resolver", "--resolver")
@@ -269,14 +269,14 @@ class TestOptionsBootstrapper:
                     ScopeInfo(""),
                     ScopeInfo("foo"),
                 ],
-                union_membership=UnionMembership({}),
+                union_membership=UnionMembership.empty(),
             )
             opts2 = bootstrapper.full_options_for_scopes(
                 known_scope_infos=[
                     ScopeInfo("foo"),
                     ScopeInfo(""),
                 ],
-                union_membership=UnionMembership({}),
+                union_membership=UnionMembership.empty(),
             )
             assert opts1 is opts2
 
@@ -286,19 +286,19 @@ class TestOptionsBootstrapper:
                     ScopeInfo("foo"),
                     ScopeInfo(""),
                 ],
-                union_membership=UnionMembership({}),
+                union_membership=UnionMembership.empty(),
             )
             assert opts1 is opts3
 
             opts4 = bootstrapper.full_options_for_scopes(
                 known_scope_infos=[ScopeInfo("")],
-                union_membership=UnionMembership({}),
+                union_membership=UnionMembership.empty(),
             )
             assert opts1 is not opts4
 
             opts5 = bootstrapper.full_options_for_scopes(
                 known_scope_infos=[ScopeInfo("")],
-                union_membership=UnionMembership({}),
+                union_membership=UnionMembership.empty(),
             )
             assert opts4 is opts5
             assert opts1 is not opts5
@@ -371,7 +371,7 @@ def test_file_spec_args() -> None:
             known_scope_infos=[
                 ScopeInfo(""),
             ],
-            union_membership=UnionMembership({}),
+            union_membership=UnionMembership.empty(),
         )
         sorted_specs = sorted(options.specs)
         assert ["bar", "fleem:tgt", "foo", "morx:tgt"] == sorted_specs

--- a/src/python/pants/option/subsystem_test.py
+++ b/src/python/pants/option/subsystem_test.py
@@ -3,7 +3,7 @@
 
 import pytest
 
-from pants.engine.unions import UnionMembership
+from pants.engine.unions import UnionMembership, UnionRule
 from pants.option.errors import OptionsError
 from pants.option.option_types import BoolOption, StrListOption
 from pants.option.option_value_container import OptionValueContainer
@@ -71,7 +71,7 @@ def test_register_options_blessed(caplog) -> None:
         config_sources=[],
         known_scope_infos=[GoodToGo.get_scope_info()],
     )
-    GoodToGo.register_options_on_scope(options, UnionMembership({}))
+    GoodToGo.register_options_on_scope(options, UnionMembership.empty())
 
     assert not caplog.records, "The current blessed means of registering options should never warn."
 
@@ -94,7 +94,12 @@ def test_register_plugin_options() -> None:
     )
     Electrical.register_options_on_scope(
         options,
-        UnionMembership({Electrical.PluginOption: [LampPlugin, Blender]}),
+        UnionMembership.from_rules(
+            {
+                UnionRule(Electrical.PluginOption, LampPlugin),
+                UnionRule(Electrical.PluginOption, Blender),
+            }
+        ),
     )
 
     electrical_subsystem = Electrical(options.for_scope(Electrical.options_scope))

--- a/src/python/pants/testutil/option_util.py
+++ b/src/python/pants/testutil/option_util.py
@@ -54,7 +54,9 @@ def create_dynamic_remote_options(
     env = CompleteEnvironmentVars({})
     oi = OptionsInitializer(ob, rule_runner.EXECUTOR)
     _build_config = oi.build_config(ob, env)
-    options = oi.options(ob, env, _build_config, union_membership=UnionMembership({}), raise_=False)
+    options = oi.options(
+        ob, env, _build_config, union_membership=UnionMembership.empty(), raise_=False
+    )
     return DynamicRemoteOptions.from_options(
         options, env, remote_auth_plugin_func=_build_config.remote_auth_plugin_func
     )[0]

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -861,7 +861,9 @@ def mock_console(
         global_bootstrap_options = options_bootstrapper.bootstrap_options.for_global_scope()
         colors = (
             options_bootstrapper.full_options_for_scopes(
-                [GlobalOptions.get_scope_info()], UnionMembership({}), allow_unknown_options=True
+                [GlobalOptions.get_scope_info()],
+                UnionMembership.empty(),
+                allow_unknown_options=True,
             )
             .for_global_scope()
             .colors

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -963,6 +963,7 @@ version = "0.2.0"
 source = "git+https://github.com/stuhood/deepsize.git?rev=5c8bee5443fcafe4aaa9274490d354412d0955c1#5c8bee5443fcafe4aaa9274490d354412d0955c1"
 dependencies = [
  "deepsize_derive",
+ "indexmap 1.9.3",
  "internment",
  "log",
  "smallvec",

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -26,7 +26,7 @@ bytes = { workspace = true }
 cache = { path = "../cache" }
 concrete_time = { path = "../concrete_time" }
 crossbeam-channel = { workspace = true }
-deepsize = { workspace = true, features = ["internment", "smallvec"] }
+deepsize = { workspace = true, features = ["internment", "smallvec", "indexmap"] }
 dep_inference = { path = "../dep_inference" }
 derivative = { workspace = true }
 async-oncecell = { workspace = true }

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -77,6 +77,7 @@ fn native_engine(py: Python, m: &Bound<'_, PyModule>) -> PyO3Result<()> {
     externs::testutil::register(m)?;
     externs::workunits::register(m)?;
     externs::dep_inference::register(m)?;
+    externs::unions::register(py, m)?;
 
     m.add("PollTimeout", py.get_type::<PollTimeout>())?;
 

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -40,6 +40,7 @@ pub mod scheduler;
 mod stdio;
 mod target;
 pub mod testutil;
+mod unions;
 pub mod workunits;
 
 pub fn register(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {

--- a/src/rust/engine/src/externs/unions.rs
+++ b/src/rust/engine/src/externs/unions.rs
@@ -1,0 +1,210 @@
+// Copyright 2025 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+use crate::TypeId;
+use crate::externs::is_union;
+use deepsize::DeepSizeOf;
+use fnv::FnvBuildHasher;
+use indexmap::{IndexMap, IndexSet};
+use pyo3::exceptions;
+use pyo3::prelude::*;
+use pyo3::types::{PyTuple, PyType};
+use std::hash::{Hash, Hasher};
+
+#[pyclass(
+    frozen,
+    hash,
+    eq,
+    str = "UnionRule(union_base={union_base}, union_member={union_member})"
+)]
+#[derive(Debug)]
+pub struct UnionRule {
+    #[pyo3(get)]
+    pub union_base: Py<PyType>,
+    #[pyo3(get)]
+    pub union_member: Py<PyType>,
+}
+
+impl Hash for UnionRule {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        TypeId::from_owned(&self.union_base).hash(state);
+        TypeId::from_owned(&self.union_member).hash(state);
+    }
+}
+
+impl PartialEq for UnionRule {
+    fn eq(&self, other: &Self) -> bool {
+        TypeId::from_owned(&self.union_base).eq(&TypeId::from_owned(&other.union_base))
+            && TypeId::from_owned(&self.union_member).eq(&TypeId::from_owned(&other.union_member))
+    }
+}
+
+#[pymethods]
+impl UnionRule {
+    #[new]
+    fn __new__(union_base: Py<PyType>, union_member: Py<PyType>, py: Python) -> PyResult<Self> {
+        Self::validate_arguments(union_base.bind(py), union_member.bind(py), py)?;
+        Ok(Self {
+            union_base,
+            union_member,
+        })
+    }
+
+    fn __repr__(&self) -> String {
+        self.__pyo3__generated____str__()
+    }
+}
+impl UnionRule {
+    fn validate_arguments(
+        union_base: &Bound<'_, PyType>,
+        union_member: &Bound<'_, PyType>,
+        py: Python,
+    ) -> PyResult<()> {
+        if !is_union(py, union_base)? {
+            let mut msg = format!(
+                "The first argument must be a class annotated with @union (from pants.engine.unions), but was {union_base}."
+            );
+            if is_union(py, union_member)? {
+                msg.push_str(
+                    "\n\nHowever, the second argument was annotated with `@union`. Did you switch the first and second arguments to `UnionRule()`?"
+                )
+            }
+            return Err(PyErr::new::<exceptions::PyValueError, _>(msg));
+        }
+        Ok(())
+    }
+}
+
+#[pyclass(frozen, eq, hash, str = "UnionMembership({union_rules:?})")]
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct UnionMembership {
+    pub union_rules: IndexMap<TypeId, IndexSet<TypeId, FnvBuildHasher>, FnvBuildHasher>,
+}
+
+#[pymethods]
+impl UnionMembership {
+    #[staticmethod]
+    fn empty() -> Self {
+        Self::default()
+    }
+
+    #[staticmethod]
+    fn from_rules(rules_iter: &Bound<PyAny>) -> PyResult<Self> {
+        let mut union_rules: IndexMap<TypeId, IndexSet<TypeId, _>, _> = IndexMap::default();
+        for rule_obj in rules_iter.try_iter()? {
+            let rule: Bound<UnionRule> = rule_obj?.extract()?;
+            let rule_ref = rule.get();
+            let base = &rule_ref.union_base;
+            let member = &rule_ref.union_member;
+            union_rules
+                .entry(TypeId::from_owned(base))
+                .or_default()
+                .insert(TypeId::from_owned(member));
+        }
+
+        Ok(Self { union_rules })
+    }
+
+    fn is_member(
+        &self,
+        union_type: &Bound<PyType>,
+        putative_member: &Bound<PyType>,
+    ) -> PyResult<bool> {
+        self.union_rules
+            .get(&TypeId::new(union_type))
+            .map(|members| members.contains(&TypeId::new(putative_member)))
+            .ok_or_else(|| {
+                exceptions::PyTypeError::new_err(format!(
+                    "Not a registered union type: {union_type}"
+                ))
+            })
+    }
+
+    fn has_members(&self, union_type: &Bound<PyType>) -> bool {
+        self.union_rules.contains_key(&TypeId::new(union_type))
+    }
+
+    fn get<'a>(&self, union_type: &'a Bound<PyType>) -> PyResult<Bound<'a, PyTuple>> {
+        self.get_members_tuple(union_type)
+            .unwrap_or_else(|| Ok(PyTuple::empty(union_type.py())))
+    }
+
+    fn items(slf: PyRef<Self>) -> PyResult<Bound<PyTuple>> {
+        let into_pytype = |type_id: &TypeId| type_id.as_py_type(slf.py());
+        PyTuple::new(
+            slf.py(),
+            slf.union_rules
+                .iter()
+                .map(|(union_type_id, members)| {
+                    PyTuple::new(slf.py(), members.iter().map(into_pytype))
+                        .map(|members| (into_pytype(union_type_id), members))
+                })
+                .collect::<PyResult<Vec<_>>>()?,
+        )
+    }
+
+    fn __getitem__<'a>(&self, union_type: &'a Bound<PyType>) -> PyResult<Bound<'a, PyTuple>> {
+        self.get_members_tuple(union_type).unwrap_or_else(move || {
+            Err(exceptions::PyIndexError::new_err(format!(
+                "'{}' is not registered as a union.",
+                TypeId::new(union_type)
+            )))
+        })
+    }
+
+    fn __contains__(&self, union_type: &Bound<PyType>) -> bool {
+        self.union_rules.contains_key(&TypeId::new(union_type))
+    }
+
+    fn __repr__(&self) -> String {
+        self.__pyo3__generated____str__()
+    }
+}
+
+impl UnionMembership {
+    fn get_members_tuple<'a>(
+        &self,
+        union_type: &'a Bound<PyType>,
+    ) -> Option<PyResult<Bound<'a, PyTuple>>> {
+        self.union_rules
+            .get(&TypeId::new(union_type))
+            .map(|members| {
+                PyTuple::new(
+                    union_type.py(),
+                    members.into_iter().map(|id| id.as_py_type(union_type.py())),
+                )
+            })
+    }
+}
+
+impl Hash for UnionMembership {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        for (key, values) in &self.union_rules {
+            key.hash(state);
+            values.iter().for_each(|el| el.hash(state));
+        }
+    }
+}
+
+impl DeepSizeOf for UnionMembership {
+    fn deep_size_of_children(&self, _: &mut deepsize::Context) -> usize {
+        let map_size: usize = self.union_rules.capacity()
+            * (size_of::<(usize, TypeId, IndexSet<TypeId>)>() + size_of::<usize>());
+        map_size
+            + self
+                .union_rules
+                .iter()
+                .map(|(key, values)| {
+                    key.deep_size_of()
+                        + (values.iter().map(DeepSizeOf::deep_size_of).sum::<usize>()
+                            + values.capacity()
+                                * (size_of::<(usize, TypeId, ())>() + size_of::<usize>()))
+                })
+                .sum::<usize>()
+    }
+}
+
+pub fn register(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<UnionMembership>()?;
+    m.add_class::<UnionRule>()?;
+    Ok(())
+}

--- a/src/rust/engine/src/python.rs
+++ b/src/rust/engine/src/python.rs
@@ -134,6 +134,10 @@ impl TypeId {
         Self(py_type.as_type_ptr())
     }
 
+    pub fn from_owned(py_type: &Py<PyType>) -> Self {
+        Self(py_type.as_ptr() as *mut pyo3::ffi::PyTypeObject)
+    }
+
     pub fn as_py_type<'py>(&self, py: Python<'py>) -> Bound<'py, PyType> {
         // SAFETY: Dereferencing a pointer to a PyTypeObject is safe as long as the module defining the
         // type is not unloaded. That is true today, but would not be if we implemented support for hot


### PR DESCRIPTION
Net-nothing performance wise when ported, but it is a common input, and will be superfast if/when used on the rust side.