### PR TITLE
Draft: Fix ambiguity resolution with by_source_root

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/module_mapper.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper.py
@@ -7,7 +7,6 @@ import enum
 import functools
 import itertools
 import logging
-import os
 from collections import defaultdict
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
@@ -480,7 +479,6 @@ async def map_module_to_address(
         if possible_provider.ancestry == val[0]:
             val[1].append(possible_provider.provider)
 
-
     if request.locality:
         # For each provider type, if we have more than one provider left, prefer
         # the one with the closest common ancestor to the requester.
@@ -491,15 +489,14 @@ async def map_module_to_address(
             providers_with_best_match: list[ModuleProvider] = []
             best_match_score = -1
             for provider in providers:
-                
                 # Normalize paths to use forward slashes consistently
                 normalized_locality = request.locality.replace("\\", "/")
                 normalized_provider_path = provider.addr.spec_path.replace("\\", "/")
-                
+
                 # Find common ancestor by comparing path segments
                 locality_parts = normalized_locality.split("/")
                 provider_parts = normalized_provider_path.split("/")
-                
+
                 # Count matching segments from the beginning
                 matching_segments = 0
                 for loc_part, prov_part in zip(locality_parts, provider_parts):
@@ -507,14 +504,13 @@ async def map_module_to_address(
                         matching_segments += 1
                     else:
                         break
-                
+
                 # Calculate match score: prefer providers at the same directory level
                 # Score = (matching_segments * 1000) - abs(len(locality_parts) - len(provider_parts))
                 # This way, providers in the same directory get higher scores than subdirectories
                 depth_difference = abs(len(locality_parts) - len(provider_parts))
                 match_score = (matching_segments * 1000) - depth_difference
-                
-                
+
                 if match_score > best_match_score:
                     best_match_score = match_score
                     providers_with_best_match = []

--- a/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
@@ -895,7 +895,7 @@ def test_resolving_ambiguity_by_filesystem_proximity(rule_runner: RuleRunner) ->
 
 def test_resolving_ambiguity_with_source_root_as_repo_root(rule_runner: RuleRunner) -> None:
     """Test ambiguity resolution when source root is the repo root.
-    
+
     This tests the fix for the issue where ambiguity_resolution = "by_source_root"
     doesn't work properly when the source root is the repository root.
     """

--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -69,7 +69,6 @@ from pants.engine.target import (
     InferredDependencies,
 )
 from pants.engine.unions import UnionRule
-from pants.source.source_root import SourceRootRequest, get_source_root
 from pants.util.docutil import doc_url
 from pants.util.strutil import bullet_list, softwrap
 


### PR DESCRIPTION
Fixes #22458 

When ambiguity_resolution = "by_source_root" is set and the source root is the repository root, the ambiguity resolution was not working correctly.

The issue was:
1. The code was using the source root path instead of the requesting file's directory path for locality comparison
2. When source root is ".", all providers had the same common ancestor length
3. os.path.commonpath() could fail on Windows with mixed path separators

This fix:
- Changes locality from source root to the actual file's directory path
- Replaces os.path.commonpath() with a custom algorithm that normalizes paths and prefers providers at the same directory level
- Adds scoring that considers both path segment matches and depth difference

This fixes the issue on my test case, but please study carefully, as don't have deep understanding of pants.