### PR TITLE
Fix environment targets with empty sequence fields overriding global configuration 

### DIFF
--- a/docs/notes/2.29.x.md
+++ b/docs/notes/2.29.x.md
@@ -18,6 +18,10 @@ Thank you to [Klaviyo](https://www.klaviyo.com/) for their Platinum tier support
 
 Adds a label to `docker_environment` containers so pantsd can cleanup any old, dead containers on startup. This prevents [old containers existing forever](https://github.com/pantsbuild/pants/issues/18307) in the event of a pantsd crash.
 
+Fixed an issue where environment targets with empty sequence fields would override global configuration instead of inheriting from it. This affected multiple backends including Docker, Python, and NodeJS. For the Docker backend, empty `docker_env_vars` fields in `docker_environment` targets would prevent inheritance from global `[docker].env_vars` settings, causing Docker buildx to fail due to missing required environment variables like `HOME`. (See [#20605](https://github.com/pantsbuild/pants/issues/20605))
+
+
+
 ### Goals
 
 ### Backends

--- a/src/python/pants/core/environments/rules.py
+++ b/src/python/pants/core/environments/rules.py
@@ -49,6 +49,7 @@ from pants.engine.intrinsics import docker_resolve_image
 from pants.engine.platform import Platform
 from pants.engine.rules import Get, QueryRule, collect_rules, concurrently, implicitly, rule
 from pants.engine.target import (
+    NO_VALUE,
     Field,
     FieldDefaultFactoryRequest,
     FieldDefaultFactoryResult,
@@ -765,20 +766,39 @@ def _add_option_field_for(
                 "value type."
             )
 
-    # The below class will never be used for static type checking outside of this function.
-    # so it's reasonably safe to use `ignore[name-defined]`. Ensure that all this remains valid
-    # if `_SIMPLE_OPTIONS` or `_LIST_OPTIONS` are ever modified.
-    class OptionField(field_type, _EnvironmentSensitiveOptionFieldMixin):  # type: ignore[valid-type, misc]
-        alias = f"{scope}_{snake_name}".replace("-", "_")
-        required = False
-        value: Any
-        help = (
+    class_attrs = {
+        "alias": f"{scope}_{snake_name}".replace("-", "_"),
+        "required": False,
+        "help": (
             f"Overrides the default value from the option `[{scope}].{snake_name}` when this "
             "environment target is active."
-        )
-        subsystem = env_aware_t
-        option_name = option.args[0]
+        ),
+        "subsystem": env_aware_t,
+        "option_name": option.args[0],
+    }
 
+    # For sequence fields, use special handling to distinguish "not specified" from "explicitly empty"
+    if issubclass(field_type, SequenceField):
+        class_attrs["none_is_valid_value"] = True
+
+        def compute_value(cls, raw_value: Any | None, address: Address) -> Any | None:
+            # When field is not specified in BUILD file, return None to indicate inheritance
+            if raw_value is NO_VALUE:
+                return None
+            # When explicitly set to empty list, return empty tuple (don't inherit)
+            elif raw_value == []:
+                return ()
+            # For other values, use normal field processing
+            else:
+                return field_type.compute_value(raw_value, address)
+
+        class_attrs["compute_value"] = classmethod(compute_value)
+
+    # Create the OptionField class dynamically
+    OptionField = cast(
+        "type[Field]",
+        type("OptionField", (field_type, _EnvironmentSensitiveOptionFieldMixin), class_attrs),
+    )
     setattr(OptionField, "__qualname__", f"{option_type.__qualname__}.{OptionField.__name__}")
 
     return [
@@ -804,13 +824,6 @@ def resolve_environment_sensitive_option(name: str, subsystem: Subsystem.Environ
 
     maybe = options.get((type(subsystem), name))
     if maybe is None or maybe.value is None:
-        return None
-
-    # For sequence fields, treat empty sequences as "not specified" to allow fallback
-    # to global configuration. This handles cases where environment fields are created
-    # with default empty values (e.g., () for StringSequenceField) but user didn't
-    # explicitly set any values.
-    if isinstance(maybe, SequenceField) and not maybe.value:
         return None
 
     return maybe.value

--- a/src/python/pants/core/environments/rules.py
+++ b/src/python/pants/core/environments/rules.py
@@ -53,6 +53,7 @@ from pants.engine.target import (
     FieldDefaultFactoryRequest,
     FieldDefaultFactoryResult,
     FieldSet,
+    SequenceField,
     StringField,
     StringSequenceField,
     Target,
@@ -804,8 +805,15 @@ def resolve_environment_sensitive_option(name: str, subsystem: Subsystem.Environ
     maybe = options.get((type(subsystem), name))
     if maybe is None or maybe.value is None:
         return None
-    else:
-        return maybe.value
+
+    # For sequence fields, treat empty sequences as "not specified" to allow fallback
+    # to global configuration. This handles cases where environment fields are created
+    # with default empty values (e.g., () for StringSequenceField) but user didn't
+    # explicitly set any values.
+    if isinstance(maybe, SequenceField) and not maybe.value:
+        return None
+
+    return maybe.value
 
 
 @memoized

--- a/src/python/pants/core/environments/rules.py
+++ b/src/python/pants/core/environments/rules.py
@@ -785,12 +785,8 @@ def _add_option_field_for(
             # When field is not specified in BUILD file, return None to indicate inheritance
             if raw_value is NO_VALUE:
                 return None
-            # When explicitly set to empty list, return empty tuple (don't inherit)
-            elif raw_value == []:
-                return ()
             # For other values, use normal field processing
-            else:
-                return field_type.compute_value(raw_value, address)
+            return field_type.compute_value(raw_value, address)
 
         class_attrs["compute_value"] = classmethod(compute_value)
 


### PR DESCRIPTION
I remember hitting #20605 a while ago locally while trying out environments and it was super frustrating so decided to take a look. Turns out there's quite a few related issues!

## Related issues

Fixes #20605
Fixes #18544
Fixes #18764
Fixes #18915
Fixes #19280

## Reproduction

I couldn't get an integration test to work, but here's what I used to reproduce it locally (on ARM Mac).

### File Structure
```
├── BUILD
├── docker/
│   ├── BUILD
│   └── Dockerfile
├── src/
│   ├── BUILD
│   └── main.py
└── pants.toml
```

### pants.toml
```toml
[GLOBAL]
pants_version = "2.28.0a0"

backend_packages = [
    "pants.backend.docker",
    "pants.backend.python",
]

[docker]
env_vars = ["HOME=/test"]
use_buildx = true

[python]
interpreter_constraints = [">=3.8,<4"]

[python-bootstrap]
search_path = ["<PYENV>"]
```

### BUILD
```python
docker_environment(
    name="docker_env",
    image="ubuntu:20.04",
    python_bootstrap_search_path=["<PATH>"]
)
```

### docker/BUILD
```python
docker_image(
    name="test_img",
    dependencies=["src:app"]
)
```

### docker/Dockerfile
```dockerfile
FROM ubuntu:20.04
RUN apt-get update && apt-get install -y python3
COPY src/app.pex /app.pex
RUN chmod +x /app.pex
CMD ["python3", "/app.pex"]
```

### src/BUILD
```python
pex_binary(
    name="app",
    entry_point="main.py",
)
```

### src/main.py
```python
print("Hello from Docker!")
```

### Reproduction Steps

1. **Without fix**: Run `pants package docker:test_img`
   - **Expected**: Should build successfully with inherited `HOME=/test` environment variable
   - **Actual**: Fails with Docker buildx error due to missing HOME environment variable

2. **With fix**: Apply the fix to `resolve_environment_sensitive_option()` and run the same command
   - **Result**: Builds successfully with inherited environment variables

### Key Points

- The `docker_environment` target doesn't specify `docker_env_vars` explicitly
- Global `[docker]` section sets `env_vars = ["HOME=/test"]` and `use_buildx = true`  
- The bug occurs because empty `docker_env_vars=()` field overrides global configuration
- Docker buildx requires the HOME environment variable to function properly
- Without the fix, the empty field prevents inheritance from global config
