### PR TITLE
Mention call-by-name migration with real-world numbers in 2.28 release notes

### DIFF
--- a/docs/notes/2.28.x.md
+++ b/docs/notes/2.28.x.md
@@ -12,11 +12,14 @@ Thank you to [Klaviyo](https://www.klaviyo.com/) for their Platinum tier support
 
 ### Highlights
 
-The plugin API introduces polymorphic rules, which support runtime polymorphism with @rule call-by-name semantics.
+- Significantly faster start-up when starting the Pants daemon.
+- The plugin API introduces polymorphic rules, which support runtime polymorphism with @rule call-by-name semantics.
 
 ### Deprecations
 
 ### General
+
+Pants start-up is now significantly faster, with some real-world codebases reporting time to start the daemon cut to 30-40% of what it was in 2.27.0 (2.5-3✕ faster). The exact speed-up will depend on the backends enabled. This affects runs that don't have (or don't use) an existing Pants daemon, such as the first invocation in CI or invocations using `--no-pantsd`. The majority of this speed-up is due to the switch to [using "call-by-name" in most backends](https://github.com/pantsbuild/pants/issues/21065). There'll be continued speed-ups in future versions, as we finish off the final pieces of that migration.
 
 ### Goals
 


### PR DESCRIPTION
We've done the majority of #21065 in 2.28 and seen good speed-ups, but it wasn't previously mentioned in release notes (e.g. we didn't bother having each "call-by-name week" PR update the notes, because that would've been a lot of noise and merge conflicts).

The speed-ups mentioned are on:

- my work code-base, with start-up going from ~5.3s in 2.27.0, to 2.0s in 2.28.0a0
- the Pants codebase

For my work code-base, I measured using `hyperfine -L version '2.27.0,2.28.0.dev1,2.28.0a0,2.29.0.dev0' -w 2 -r 5 'PANTS_VERSION={version} pants --no-pantsd version'` all on a single revision (i.e. the underlying code didn't change, only the Pants version), and saw numbers like:

![image](https://github.com/user-attachments/assets/9e2bd4f3-14ef-4c67-8314-485972845bfe)

<details><summary>Click for CSV details</summary>

```csv
Version,mean,min,max
2.27.0,5.335,5.301,5.419
2.28.0.dev0,4.618,4.571,4.648
2.28.0.dev1,2.877,2.832,3.003
2.28.0.dev2,2.742,2.720,2.780
2.28.0.dev3,2.745,2.734,2.759
2.28.0.dev4,2.748,2.707,2.835
2.28.0a0,2.045,2.027,2.072
2.29.0.dev0,1.843,1.834,1.860
```

</details>

For Pants, I checked out 2.27.0 and 2.28.0a0 respectively, ran `pants version` to build the native code, and then `hyperfine -w 2 -r 5 'pants --no-pantsd version'`. On 2.27.0, this reported ~18.2s; on 2.28.0a0, 6.0s. NB. this runs on different versions of the codebase, and so it's not a true apples-to-apples comparison (of only the difference between versions), but I imagine it's close enough.