### PR TITLE
Include .d.ts as explicit TypeScript extension for dep inference

### DIFF
--- a/docs/notes/2.29.x.md
+++ b/docs/notes/2.29.x.md
@@ -28,6 +28,10 @@ Enable setting missing common fields e.g "tags" for the `node_build_script`-symb
 
 Added missing help text to NodeBuildScriptEntryPointField.
 
+#### TypeScript
+
+Dependency inference now considers `.d.ts` declaration files. For example, `import { ... } from './declaration'` will be inferred to (also) refer to `./declaration.d.ts` if it exists.
+
 ### Plugin API changes
 
 ## Full Changelog

--- a/src/python/pants/backend/javascript/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/javascript/dependency_inference/rules_test.py
@@ -93,13 +93,18 @@ def test_infers_esmodule_js_dependencies(rule_runner: RuleRunner) -> None:
                 import { z } from "./moduleC";
                 import { w } from "./moduleD";
                 import { u } from "./moduleE";
+                import { v } from "./moduleF";
                 """
             ),
             "src/js/moduleA.mjs": "",
             "src/js/moduleB.jsx": "",
             "src/js/moduleC.ts": "",
             "src/js/moduleD.tsx": "",
+            # isolated .d.ts
             "src/js/moduleE.d.ts": "",
+            # separate .js and .d.ts
+            "src/js/moduleF.js": "",
+            "src/js/moduleF.d.ts": "",
         }
     )
 
@@ -115,6 +120,8 @@ def test_infers_esmodule_js_dependencies(rule_runner: RuleRunner) -> None:
         Address("src/js", relative_file_path="moduleC.ts", target_name="ts"),
         Address("src/js", relative_file_path="moduleD.tsx", target_name="tsx"),
         Address("src/js", relative_file_path="moduleE.d.ts", target_name="ts"),
+        Address("src/js", relative_file_path="moduleF.js", target_name="js"),
+        Address("src/js", relative_file_path="moduleF.d.ts", target_name="ts"),
     }
 
 
@@ -138,13 +145,18 @@ def test_infers_esmodule_js_dependencies_from_ancestor_files(rule_runner: RuleRu
                 import { z } from "../moduleC";
                 import { w } from "../moduleD";
                 import { u } from "../moduleE";
+                import { v } from "../moduleF";
                 """
             ),
             "src/js/moduleA.mjs": "",
             "src/js/moduleB.jsx": "",
             "src/js/moduleC.ts": "",
             "src/js/moduleD.tsx": "",
+            # isolated .d.ts
             "src/js/moduleE.d.ts": "",
+            # separate .js and .d.ts
+            "src/js/moduleF.js": "",
+            "src/js/moduleF.d.ts": "",
         }
     )
 
@@ -160,6 +172,8 @@ def test_infers_esmodule_js_dependencies_from_ancestor_files(rule_runner: RuleRu
         Address("src/js", relative_file_path="moduleC.ts", target_name="ts"),
         Address("src/js", relative_file_path="moduleD.tsx", target_name="tsx"),
         Address("src/js", relative_file_path="moduleE.d.ts", target_name="ts"),
+        Address("src/js", relative_file_path="moduleF.js", target_name="js"),
+        Address("src/js", relative_file_path="moduleF.d.ts", target_name="ts"),
     }
 
 

--- a/src/python/pants/backend/javascript/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/javascript/dependency_inference/rules_test.py
@@ -92,12 +92,14 @@ def test_infers_esmodule_js_dependencies(rule_runner: RuleRunner) -> None:
                 import { y } from "./moduleB";
                 import { z } from "./moduleC";
                 import { w } from "./moduleD";
+                import { u } from "./moduleE";
                 """
             ),
             "src/js/moduleA.mjs": "",
             "src/js/moduleB.jsx": "",
             "src/js/moduleC.ts": "",
             "src/js/moduleD.tsx": "",
+            "src/js/moduleE.d.ts": "",
         }
     )
 
@@ -112,6 +114,7 @@ def test_infers_esmodule_js_dependencies(rule_runner: RuleRunner) -> None:
         Address("src/js", relative_file_path="moduleB.jsx", target_name="jsx"),
         Address("src/js", relative_file_path="moduleC.ts", target_name="ts"),
         Address("src/js", relative_file_path="moduleD.tsx", target_name="tsx"),
+        Address("src/js", relative_file_path="moduleE.d.ts", target_name="ts"),
     }
 
 
@@ -134,12 +137,14 @@ def test_infers_esmodule_js_dependencies_from_ancestor_files(rule_runner: RuleRu
                 import { y } from "../moduleB";
                 import { z } from "../moduleC";
                 import { w } from "../moduleD";
+                import { u } from "../moduleE";
                 """
             ),
             "src/js/moduleA.mjs": "",
             "src/js/moduleB.jsx": "",
             "src/js/moduleC.ts": "",
             "src/js/moduleD.tsx": "",
+            "src/js/moduleE.d.ts": "",
         }
     )
 
@@ -154,6 +159,7 @@ def test_infers_esmodule_js_dependencies_from_ancestor_files(rule_runner: RuleRu
         Address("src/js", relative_file_path="moduleB.jsx", target_name="jsx"),
         Address("src/js", relative_file_path="moduleC.ts", target_name="ts"),
         Address("src/js", relative_file_path="moduleD.tsx", target_name="tsx"),
+        Address("src/js", relative_file_path="moduleE.d.ts", target_name="ts"),
     }
 
 

--- a/src/python/pants/backend/typescript/target_types.py
+++ b/src/python/pants/backend/typescript/target_types.py
@@ -17,7 +17,7 @@ from pants.engine.target import (
 )
 from pants.util.strutil import help_text
 
-TS_FILE_EXTENSIONS: tuple[str, ...] = (".ts",)
+TS_FILE_EXTENSIONS: tuple[str, ...] = (".ts", ".d.ts")
 TS_TEST_FILE_EXTENSIONS = tuple(f"*.test{ext}" for ext in TS_FILE_EXTENSIONS)
 
 


### PR DESCRIPTION
This adds `.d.ts` as an explicit extension, to ensure dependency inference understands that `import { ... } from './moduleE'` can refer to `./moduleE.d.ts`.

NB. these files were already identified as TypeScript sources (since they're covered by the existing `.ts` extension), but dependency inference failed to consider them. `tsc` accepts both `import { ... } from './moduleE'` and `import { ... } from './moduleE.d'`, but, previously, Pants only successfully inferred dependencies in the latter case.

Fixes #22471 