### PR TITLE
rust: upgrade to v1.88.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,7 +44,7 @@ jobs:
       run: '# Set the default toolchain. Installs the toolchain if it is not already
         installed.
 
-        rustup default 1.87.0
+        rustup default 1.88.0
 
         cargo version
 
@@ -162,7 +162,7 @@ jobs:
       run: '# Set the default toolchain. Installs the toolchain if it is not already
         installed.
 
-        rustup default 1.87.0
+        rustup default 1.88.0
 
         cargo version
 
@@ -309,7 +309,7 @@ jobs:
       with:
         key: macOS13-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain')
           }}-v2
-        path: '~/.rustup/toolchains/1.87.0-*
+        path: '~/.rustup/toolchains/1.88.0-*
 
           ~/.rustup/update-hashes
 
@@ -434,7 +434,7 @@ jobs:
       with:
         key: macOS14-ARM64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain')
           }}-v2
-        path: '~/.rustup/toolchains/1.87.0-*
+        path: '~/.rustup/toolchains/1.88.0-*
 
           ~/.rustup/update-hashes
 
@@ -560,7 +560,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.87.0-*
+        path: '~/.rustup/toolchains/1.88.0-*
 
           ~/.rustup/update-hashes
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,7 +40,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: Linux-ARM64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.87.0-*
+        path: '~/.rustup/toolchains/1.88.0-*
 
           ~/.rustup/update-hashes
 
@@ -149,7 +149,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.87.0-*
+        path: '~/.rustup/toolchains/1.88.0-*
 
           ~/.rustup/update-hashes
 
@@ -268,7 +268,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: macOS13-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.87.0-*
+        path: '~/.rustup/toolchains/1.88.0-*
 
           ~/.rustup/update-hashes
 
@@ -374,7 +374,7 @@ jobs:
     - name: Install Rust toolchain
       run: '# Set the default toolchain. Installs the toolchain if it is not already installed.
 
-        rustup default 1.87.0
+        rustup default 1.88.0
 
         cargo version
 
@@ -452,7 +452,7 @@ jobs:
     - name: Install Rust toolchain
       run: '# Set the default toolchain. Installs the toolchain if it is not already installed.
 
-        rustup default 1.87.0
+        rustup default 1.88.0
 
         cargo version
 
@@ -548,7 +548,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: macOS13-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.87.0-*
+        path: '~/.rustup/toolchains/1.88.0-*
 
           ~/.rustup/update-hashes
 
@@ -634,7 +634,7 @@ jobs:
       uses: actions/cache@v4
       with:
         key: macOS14-ARM64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.87.0-*
+        path: '~/.rustup/toolchains/1.88.0-*
 
           ~/.rustup/update-hashes
 

--- a/src/rust/engine/client/src/client.rs
+++ b/src/rust/engine/client/src/client.rs
@@ -38,11 +38,9 @@ pub async fn execute_command(
     for raw_fd in &raw_io_fds {
         match nix::sys::termios::tcgetattr(*raw_fd) {
             Ok(termios) => tty_settings.push((raw_fd, termios)),
-            Err(err) => debug!(
-                "Failed to save terminal attributes for file descriptor {fd}: {err}",
-                fd = raw_fd,
-                err = err
-            ),
+            Err(err) => {
+                debug!("Failed to save terminal attributes for file descriptor {raw_fd}: {err}")
+            }
         }
         if connection_settings.dynamic_ui {
             if let Ok(path) = nix::unistd::ttyname(*raw_fd) {
@@ -67,11 +65,7 @@ pub async fn execute_command(
         if let Err(err) =
             nix::sys::termios::tcsetattr(*raw_fd, nix::sys::termios::SetArg::TCSADRAIN, &termios)
         {
-            debug!(
-                "Failed to restore terminal attributes for file descriptor {fd}: {err}",
-                fd = raw_fd,
-                err = err
-            );
+            debug!("Failed to restore terminal attributes for file descriptor {raw_fd}: {err}");
         }
     }
     nailgun_result.map_err(|error| match error {

--- a/src/rust/engine/concrete_time/src/lib.rs
+++ b/src/rust/engine/concrete_time/src/lib.rs
@@ -80,7 +80,7 @@ impl TimeSpan {
         let duration = match end.checked_sub(start) {
             Some(d) => d,
             None => {
-                log::debug!("Invalid TimeSpan - start: {:?}, end: {:?}", start, end);
+                log::debug!("Invalid TimeSpan - start: {start:?}, end: {end:?}");
                 std::time::Duration::new(0, 0)
             }
         };

--- a/src/rust/engine/dep_inference/src/dockerfile/from.rs
+++ b/src/rust/engine/dep_inference/src/dockerfile/from.rs
@@ -80,7 +80,7 @@ impl<'a> StageCollector<'a> {
     pub fn get_stage(self, stage_number: usize) -> String {
         self.stage
             .map(str::to_string)
-            .unwrap_or_else(|| format!("stage{}", stage_number))
+            .unwrap_or_else(|| format!("stage{stage_number}"))
     }
 }
 

--- a/src/rust/engine/dep_inference/src/python/tests.rs
+++ b/src/rust/engine/dep_inference/src/python/tests.rs
@@ -311,8 +311,7 @@ fn assert_imports_strong_weak(code: &str, strong: &[&str], weak: &[&str]) {
         .collect::<HashSet<_>>();
     assert_eq!(
         expected_weak, found_weak,
-        "weak imports did not match, expected={:?} found={:?}",
-        expected_weak, found_weak
+        "weak imports did not match, expected={expected_weak:?} found={found_weak:?}"
     );
     let expected_strong = HashSet::from_iter(strong.iter().map(|s| s.to_string()));
     let found_strong = actual_strong
@@ -321,8 +320,7 @@ fn assert_imports_strong_weak(code: &str, strong: &[&str], weak: &[&str]) {
         .collect::<HashSet<_>>();
     assert_eq!(
         expected_strong, found_strong,
-        "strong imports did not match, expected={:?} found={:?}",
-        expected_strong, found_strong
+        "strong imports did not match, expected={expected_strong:?} found={found_strong:?}"
     );
 }
 

--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -256,7 +256,7 @@ impl BuildResultFS {
             Ok(Some(inode)) => Ok(dir_attr_for(inode)),
             Ok(None) => Err(libc::ENOENT),
             Err(err) => {
-                error!("Error getting directory for digest {:?}: {}", digest, err);
+                error!("Error getting directory for digest {digest:?}: {err}");
                 Err(libc::EINVAL)
             }
         }
@@ -347,7 +347,7 @@ impl BuildResultFS {
                             {
                                 let child_digest =
                                     require_digest(digest.as_ref()).map_err(|err| {
-                                        error!("Error parsing digest: {:?}", err);
+                                        error!("Error parsing digest: {err:?}");
                                         libc::ENOENT
                                     })?;
                                 let maybe_child_inode = match filetype {
@@ -372,8 +372,7 @@ impl BuildResultFS {
                                     }
                                     Err(err) => {
                                         error!(
-                                            "Error reading child directory {:?}: {}",
-                                            child_digest, err
+                                            "Error reading child directory {child_digest:?}: {err}"
                                         );
                                         return Err(libc::EINVAL);
                                     }
@@ -384,7 +383,7 @@ impl BuildResultFS {
                         }
                         Err(StoreError::MissingDigest { .. }) => Err(libc::ENOENT),
                         Err(err) => {
-                            error!("Error loading directory {:?}: {}", digest, err);
+                            error!("Error loading directory {digest:?}: {err}");
                             Err(libc::EINVAL)
                         }
                     }
@@ -432,7 +431,7 @@ impl fuser::Filesystem for BuildResultFS {
                     Ok(digest) => self
                         .inode_for_file(digest, true)
                         .map_err(|err| {
-                            error!("Error loading file by digest {}: {}", digest_str, err);
+                            error!("Error loading file by digest {digest_str}: {err}");
                             libc::EINVAL
                         })
                         .and_then(|maybe_inode| {
@@ -441,14 +440,14 @@ impl fuser::Filesystem for BuildResultFS {
                                 .ok_or(libc::ENOENT)
                         }),
                     Err(err) => {
-                        warn!("Invalid digest for file in digest root: {}", err);
+                        warn!("Invalid digest for file in digest root: {err}");
                         Err(libc::ENOENT)
                     }
                 },
                 (DIRECTORY_ROOT, Some(digest_str)) => match digest_from_filepath(digest_str) {
                     Ok(digest) => self.dir_attr_for(digest),
                     Err(err) => {
-                        warn!("Invalid digest for directory in directory root: {}", err);
+                        warn!("Invalid digest for directory in directory root: {err}");
                         Err(libc::ENOENT)
                     }
                 },
@@ -468,10 +467,7 @@ impl fuser::Filesystem for BuildResultFS {
                                 .map_err(|err| match err {
                                     StoreError::MissingDigest { .. } => libc::ENOENT,
                                     err => {
-                                        error!(
-                                            "Error reading directory {:?}: {}",
-                                            parent_digest, err
-                                        );
+                                        error!("Error reading directory {parent_digest:?}: {err}");
                                         libc::EINVAL
                                     }
                                 })?;
@@ -482,7 +478,7 @@ impl fuser::Filesystem for BuildResultFS {
                             Node::Directory(directory_node) => {
                                 let digest = require_digest(directory_node.digest.as_ref())
                                     .map_err(|err| {
-                                        error!("Error parsing digest: {:?}", err);
+                                        error!("Error parsing digest: {err:?}");
                                         libc::ENOENT
                                     })?;
                                 self.dir_attr_for(digest)
@@ -490,15 +486,12 @@ impl fuser::Filesystem for BuildResultFS {
                             Node::File(file_node) => {
                                 let digest =
                                     require_digest(file_node.digest.as_ref()).map_err(|err| {
-                                        error!("Error parsing digest: {:?}", err);
+                                        error!("Error parsing digest: {err:?}");
                                         libc::ENOENT
                                     })?;
                                 self.inode_for_file(digest, file_node.is_executable)
                                     .map_err(|err| {
-                                        error!(
-                                            "Error loading file by digest {}: {}",
-                                            filename, err
-                                        );
+                                        error!("Error loading file by digest {filename}: {err}");
                                         libc::EINVAL
                                     })
                                     .and_then(|maybe_inode| {
@@ -588,7 +581,7 @@ impl fuser::Filesystem for BuildResultFS {
                                     }
                                 }
                                 err => {
-                                    error!("Error loading bytes for {:?}: {}", digest, err);
+                                    error!("Error loading bytes for {digest:?}: {err}");
                                     if let Some(reply) = maybe_reply {
                                         reply.error(libc::EINVAL);
                                     }
@@ -666,7 +659,7 @@ pub fn mount<P: AsRef<Path>>(
     let (sender, receiver) = channel();
     let brfs = BuildResultFS::new(sender, runtime, store);
 
-    debug!("About to spawn_mount with options {:?}", options);
+    debug!("About to spawn_mount with options {options:?}");
     let result = fuser::spawn_mount2(brfs, &mount_path, &options);
     // N.B.: The session won't be used by the caller, but we return it since a reference must be
     // maintained to prevent early dropping which unmounts the filesystem.
@@ -742,10 +735,7 @@ async fn main() {
         let token = match std::fs::read_to_string(oauth_path) {
             Ok(token) => token,
             Err(err) => {
-                error!(
-                    "Error reading oauth bearer token from {:?}: {}",
-                    oauth_path, err
-                );
+                error!("Error reading oauth bearer token from {oauth_path:?}: {err}");
                 std::process::exit(1);
             }
         };
@@ -809,15 +799,12 @@ async fn main() {
 
     match mount(mount_path, store, runtime.clone()) {
         Err(err) => {
-            error!(
-                "Store {} failed to mount at {}: {}",
-                store_path, mount_path, err
-            );
+            error!("Store {store_path} failed to mount at {mount_path}: {err}");
             std::process::exit(1);
         }
         Ok((_, receiver)) => {
             match receiver.recv().unwrap() {
-                BRFSEvent::Init => debug!("Store {} mounted at {}", store_path, mount_path),
+                BRFSEvent::Init => debug!("Store {store_path} mounted at {mount_path}"),
                 BRFSEvent::Destroy => {
                     warn!("Externally unmounted before we could mount.");
                     return;
@@ -831,7 +818,7 @@ async fn main() {
                 match receiver.recv().unwrap_or(BRFSEvent::Destroy) {
                     BRFSEvent::Destroy => Some(Sig::Unmount),
                     event => {
-                        warn!("Received unexpected event {:?}", event);
+                        warn!("Received unexpected event {event:?}");
                         None
                     }
                 }
@@ -844,7 +831,7 @@ async fn main() {
             if let Some(sig) = shutdown_signal.next().await {
                 match sig {
                     Sig::Unmount => debug!("Externally unmounted"),
-                    sig => debug!("Received SIG{:?}", sig),
+                    sig => debug!("Received SIG{sig:?}"),
                 }
             }
         }

--- a/src/rust/engine/fs/brfs/src/syscall_tests.rs
+++ b/src/rust/engine/fs/brfs/src/syscall_tests.rs
@@ -6,7 +6,6 @@
 use super::mount;
 use super::tests::digest_to_filepath;
 use crate::tests::make_dirs;
-use libc;
 use std::ffi::CString;
 use std::path::Path;
 use store::Store;
@@ -38,7 +37,7 @@ async fn read_file_by_digest_exact_bytes() {
 
     unsafe {
         let fd = libc::open(path_to_cstring(&path).as_ptr(), 0);
-        assert!(fd > 0, "Bad fd {}", fd);
+        assert!(fd > 0, "Bad fd {fd}");
         let read_bytes = libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len());
         assert_eq!(test_bytes.len() as isize, read_bytes);
         assert_eq!(0, libc::close(fd));
@@ -52,7 +51,6 @@ fn path_to_cstring(path: &Path) -> CString {
 }
 
 fn make_buffer(size: usize) -> Vec<u8> {
-    let mut buf: Vec<u8> = Vec::new();
-    buf.resize(size, 0);
+    let buf: Vec<u8> = vec![0; size];
     buf
 }

--- a/src/rust/engine/fs/brfs/src/tests.rs
+++ b/src/rust/engine/fs/brfs/src/tests.rs
@@ -1,10 +1,7 @@
 // Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
-use tempfile;
-use testutil;
 
 use crate::mount;
-use hashing;
 use store::Store;
 use testutil::{
     data::{TestData, TestDirectory},

--- a/src/rust/engine/fs/src/glob_matching.rs
+++ b/src/rust/engine/fs/src/glob_matching.rs
@@ -591,7 +591,7 @@ trait GlobMatchingImplementation<E: Display + Send + Sync + 'static>: Vfs<E> {
                 if strict_match_behavior.should_throw_on_error() {
                     return Err(Self::mk_error(&msg));
                 } else {
-                    warn!("{}", msg);
+                    warn!("{msg}");
                 }
             }
         }

--- a/src/rust/engine/fs/store/benches/store.rs
+++ b/src/rust/engine/fs/store/benches/store.rs
@@ -43,7 +43,7 @@ pub fn criterion_benchmark_materialize(c: &mut Criterion) {
                 .sample_size(10)
                 .measurement_time(Duration::from_secs(30))
                 .bench_function(
-                    format!("materialize_directory({:?}, {}, {})", perms, count, size),
+                    format!("materialize_directory({perms:?}, {count}, {size})"),
                     |b| {
                         b.iter(|| {
                             // NB: We forget this child tempdir to avoid deleting things during the run.
@@ -99,7 +99,7 @@ pub fn criterion_benchmark_snapshot_capture(c: &mut Criterion) {
         cgroup
             .sample_size(10)
             .measurement_time(Duration::from_secs(30))
-            .bench_function(format!("snapshot_capture({:?})", params), |b| {
+            .bench_function(format!("snapshot_capture({params:?})"), |b| {
                 b.iter(|| {
                     for _ in 0..captures {
                         let _ = executor

--- a/src/rust/engine/fs/store/src/cli_options.rs
+++ b/src/rust/engine/fs/store/src/cli_options.rs
@@ -178,7 +178,7 @@ impl StoreCliOpt {
         let mut headers: BTreeMap<String, String> = collection_from_keyvalues(self.header.iter());
         if let Some(ref oauth_path) = oauth_bearer_token_path {
             let token = std::fs::read_to_string(oauth_path)
-                .map_err(|e| format!("Error reading oauth bearer token file: {}", e))?;
+                .map_err(|e| format!("Error reading oauth bearer token file: {e}"))?;
             headers.insert(
                 "authorization".to_owned(),
                 format!("Bearer {}", token.trim()),

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -1038,7 +1038,7 @@ impl Store {
                         )
                         .await
                     {
-                        log::debug!("Missing file digest from remote store: {:?}", file_digest);
+                        log::debug!("Missing file digest from remote store: {file_digest:?}");
                         in_workunit!(
                             "missing_file_counter",
                             Level::Trace,
@@ -1113,10 +1113,8 @@ impl Store {
             Ok(size) => {
                 if size > target_size_bytes {
                     log::warn!(
-                        "Garbage collection attempted to shrink the store to {} bytes but {} bytes \
-            are currently in use.",
-                        target_size_bytes,
-                        size
+                        "Garbage collection attempted to shrink the store to {target_size_bytes} bytes but {size} bytes \
+            are currently in use."
                     )
                 }
                 Ok(())

--- a/src/rust/engine/fs/store/src/local.rs
+++ b/src/rust/engine/fs/store/src/local.rs
@@ -311,7 +311,7 @@ impl ShardedFSDB {
                         .map_err(|e| format!("Failed to shutdown {tmp_path:?}: {e}"))?;
                     tokio::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o555))
                         .await
-                        .map_err(|e| format!("Failed to set permissions on {:?}: {e}", tmp_path))?;
+                        .map_err(|e| format!("Failed to set permissions on {tmp_path:?}: {e}"))?;
                     // NB: Syncing metadata to disk ensures the `hard_link` we do later has the opportunity
                     // to succeed. Otherwise, if later when we try to `hard_link` the metadata isn't
                     // persisted to disk, we'll get `No such file or directory`.
@@ -430,7 +430,7 @@ impl UnderlyingByteStore for ShardedFSDB {
             if should_retry? {
                 attempts += 1;
                 let msg = format!("Input {src:?} changed while reading.");
-                log::debug!("{}", msg);
+                log::debug!("{msg}");
                 if attempts > 10 {
                     return Err(format!("Failed to store {src:?}."));
                 }

--- a/src/rust/engine/grpc_util/src/channel.rs
+++ b/src/rust/engine/grpc_util/src/channel.rs
@@ -151,12 +151,12 @@ mod tests {
                 .unwrap();
         });
 
-        let uri = Uri::try_from(format!("http://{}", addr)).unwrap();
+        let uri = Uri::try_from(format!("http://{addr}")).unwrap();
 
         let mut channel = Channel::new(None, uri).await.unwrap();
 
         let request = Request::builder()
-            .uri(format!("http://{}", addr))
+            .uri(format!("http://{addr}"))
             .body(tonic::body::empty_body())
             .unwrap();
 
@@ -193,7 +193,7 @@ mod tests {
             server.serve(router().into_make_service()).await.unwrap();
         });
 
-        let uri = Uri::try_from(format!("https://{}", addr)).unwrap();
+        let uri = Uri::try_from(format!("https://{addr}")).unwrap();
 
         let mut tls_config = ClientConfig::builder()
             .with_root_certificates(RootCertStore::empty())
@@ -206,7 +206,7 @@ mod tests {
         let mut channel = Channel::new(Some(&tls_config), uri).await.unwrap();
 
         let request = Request::builder()
-            .uri(format!("https://{}", addr))
+            .uri(format!("https://{addr}"))
             .body(tonic::body::empty_body())
             .unwrap();
 
@@ -333,7 +333,7 @@ mod tests {
             server.serve(router().into_make_service()).await.unwrap();
         });
 
-        let uri = Uri::try_from(format!("https://{}", addr)).unwrap();
+        let uri = Uri::try_from(format!("https://{addr}")).unwrap();
 
         let mut tls_config =
             crate::tls::Config::new(Some(&cert_pem), Some((&cert_pem, &key_pem))).unwrap();
@@ -355,7 +355,7 @@ mod tests {
             0
         );
         let request = Request::builder()
-            .uri(format!("https://{}", addr))
+            .uri(format!("https://{addr}"))
             .body(tonic::body::empty_body())
             .unwrap();
 

--- a/src/rust/engine/grpc_util/src/tls.rs
+++ b/src/rust/engine/grpc_util/src/tls.rs
@@ -58,21 +58,21 @@ impl Config {
     ) -> Result<Self, String> {
         let root_ca_certs = root_ca_cert_file
             .map(|path| {
-                std::fs::read(path).map_err(|e| format!("Error reading root CA certs file: {}", e))
+                std::fs::read(path).map_err(|e| format!("Error reading root CA certs file: {e}"))
             })
             .transpose()?;
 
         let client_certs = client_certs_file
             .map(|path| {
                 std::fs::read(path)
-                    .map_err(|e| format!("Error reading client authentication certs file: {}", e))
+                    .map_err(|e| format!("Error reading client authentication certs file: {e}"))
             })
             .transpose()?;
 
         let client_key = client_key_file
             .map(|path| {
                 std::fs::read(path)
-                    .map_err(|e| format!("Error reading client authentication key file: {}", e))
+                    .map_err(|e| format!("Error reading client authentication key file: {e}"))
             })
             .transpose()?;
 
@@ -86,7 +86,7 @@ impl Config {
         }?;
 
         Self::new(root_ca_certs, mtls_data)
-            .map_err(|e| format!("failed parsing root CA certs: {}", e))
+            .map_err(|e| format!("failed parsing root CA certs: {e}"))
     }
 }
 

--- a/src/rust/engine/logging/src/logger.rs
+++ b/src/rust/engine/logging/src/logger.rs
@@ -131,7 +131,7 @@ impl PantsLogger {
     /// the `log` crate.
     pub fn log_from_python(message: &str, python_level: u64, target: &str) -> Result<(), String> {
         let level: PythonLogLevel = python_level.try_into().map_err(|err| format!("{err}"))?;
-        log!(target: target, level.into(), "{}", message);
+        log!(target: target, level.into(), "{message}");
         Ok(())
     }
 

--- a/src/rust/engine/nailgun/src/server.rs
+++ b/src/rust/engine/nailgun/src/server.rs
@@ -88,7 +88,7 @@ impl Server {
         listener: TcpListener,
     ) {
         let exit_result = Self::accept_loop(executor, config, nail, should_exit, listener).await;
-        info!("Server exiting with {:?}", exit_result);
+        info!("Server exiting with {exit_result:?}");
         let _ = exited.send(exit_result);
     }
 
@@ -118,7 +118,7 @@ impl Server {
                 }
             };
 
-            debug!("Accepted connection: {:?}", tcp_stream);
+            debug!("Accepted connection: {tcp_stream:?}");
 
             // There is a slightly delicate dance here: we wait for a connection to have acquired the
             // ongoing connections lock before proceeding to the next iteration of the loop. This

--- a/src/rust/engine/options/src/arg_splitter_tests.rs
+++ b/src/rust/engine/options/src/arg_splitter_tests.rs
@@ -52,7 +52,7 @@ fn test_spec_detection() {
                 flags: vec![],
                 passthru: None
             },
-            shlex_and_split_args(build_root, &format!("pants {}", maybe_spec))
+            shlex_and_split_args(build_root, &format!("pants {maybe_spec}"))
         );
     }
 
@@ -67,7 +67,7 @@ fn test_spec_detection() {
                 flags: vec![],
                 passthru: None,
             },
-            shlex_and_split_args(build_root, &format!("pants {}", spec))
+            shlex_and_split_args(build_root, &format!("pants {spec}"))
         );
     }
 
@@ -98,13 +98,13 @@ fn test_spec_detection() {
 
     for spec in unambiguous_specs {
         assert_spec(Some(temp_dir.path()), spec);
-        assert_spec(Some(temp_dir.path()), &format!("-{}", spec));
+        assert_spec(Some(temp_dir.path()), &format!("-{spec}"));
     }
     for spec in directories_vs_goals {
         assert_goal(Some(temp_dir.path()), spec);
         File::create(temp_dir.path().join(Path::new(spec))).unwrap();
         assert_spec(Some(temp_dir.path()), spec);
-        assert_spec(Some(temp_dir.path()), &format!("-{}", spec));
+        assert_spec(Some(temp_dir.path()), &format!("-{spec}"));
     }
 }
 

--- a/src/rust/engine/options/src/cli_alias.rs
+++ b/src/rust/engine/options/src/cli_alias.rs
@@ -16,10 +16,9 @@ fn validate_alias(
 ) -> Result<(), String> {
     if !VALID_ALIAS_RE.is_match(alias) {
         return Err(format!(
-            "Invalid alias in `[cli].alias` option: {}. May only contain alphanumerical \
+            "Invalid alias in `[cli].alias` option: {alias}. May only contain alphanumerical \
             letters and the separators `-` and `_`. Flags can be defined using `--`. \
-            A single dash is not allowed.",
-            alias
+            A single dash is not allowed."
         ));
     }
 
@@ -27,8 +26,7 @@ fn validate_alias(
         for (scope, args) in known_scopes_to_flags.iter() {
             if scope == alias {
                 return Err(format!(
-                    "Invalid alias in `[cli].alias` option: {}. This is already a registered goal or subsytem.",
-                    alias
+                    "Invalid alias in `[cli].alias` option: {alias}. This is already a registered goal or subsytem."
                 ));
             }
             if args.contains(alias) {
@@ -82,7 +80,7 @@ pub fn create_alias_map(
             if let Some(vs) = shlex::split(v) {
                 Ok((k.to_owned(), vs))
             } else {
-                Err(format!("Invalid value in `[cli].alias` option: {}. Failed to split according to shell rules: {}", k, v))
+                Err(format!("Invalid value in `[cli].alias` option: {k}. Failed to split according to shell rules: {v}"))
             }
         })
         .collect::<Result<_, _>>()?);

--- a/src/rust/engine/options/src/cli_alias_tests.rs
+++ b/src/rust/engine/options/src/cli_alias_tests.rs
@@ -163,8 +163,8 @@ fn test_alias_cycle() {
         // The order in which we encounter the cycle depends on unstable HashMap iteration order,
         // so we don't know the exact error message we'll get, just that these two strings must
         // be in it.
-        assert!(err_msg.contains(&format!("{} -> {}", x, y)));
-        assert!(err_msg.contains(&format!("{} -> {}", y, x)));
+        assert!(err_msg.contains(&format!("{x} -> {y}")));
+        assert!(err_msg.contains(&format!("{y} -> {x}")));
     }
 
     do_test_cycle("cycle", "other_alias");
@@ -198,10 +198,9 @@ fn test_invalid_alias_name() {
     fn do_test(alias: &str) {
         assert_eq!(
             format!(
-                "Invalid alias in `[cli].alias` option: {}. May only contain alphanumerical \
+                "Invalid alias in `[cli].alias` option: {alias}. May only contain alphanumerical \
         letters and the separators `-` and `_`. Flags can be defined using `--`. \
-        A single dash is not allowed.",
-                alias
+        A single dash is not allowed."
             ),
             cli_alias::create_alias_map(None, &owned_map(hashmap! {alias => ""})).unwrap_err()
         )

--- a/src/rust/engine/options/src/config.rs
+++ b/src/rust/engine/options/src/config.rs
@@ -39,8 +39,7 @@ pub(crate) fn interpolate_string(
         new_value.push_str(&value[last_match..m.start()]);
         let placeholder_name = &caps[1];
         let replacement = replacements.get(placeholder_name).ok_or(format!(
-            "Unknown value for placeholder `{}`",
-            placeholder_name
+            "Unknown value for placeholder `{placeholder_name}`"
         ))?;
         new_value.push_str(replacement);
         last_match = m.end();
@@ -370,13 +369,12 @@ impl ConfigReader {
             let section_table = section_table.as_table().unwrap();
             match section_to_valid_keys.get(section_name) {
                 None => {
-                    errors.push(format!("Invalid table name [{}]", section_name));
+                    errors.push(format!("Invalid table name [{section_name}]"));
                 }
                 Some(valid_keys) => {
                     for key in section_table.keys() {
                         if !(valid_keys.contains(key)) {
-                            errors
-                                .push(format!("Invalid option '{}' under [{}]", key, section_name));
+                            errors.push(format!("Invalid option '{key}' under [{section_name}]"));
                         }
                     }
                 }

--- a/src/rust/engine/options/src/fromfile_tests.rs
+++ b/src/rust/engine/options/src/fromfile_tests.rs
@@ -43,7 +43,7 @@ fn test_expand_fromfile() {
     );
     assert_eq!(
         Ok(Some("FOO".to_string())),
-        expand(format!("@{}", fromfile_path_str))
+        expand(format!("@{fromfile_path_str}"))
     );
     assert_eq!(Ok(None), expand("@?/does/not/exist".to_string()));
     let err = expand("@/does/not/exist".to_string()).unwrap_err();
@@ -62,7 +62,7 @@ fn test_fromfile_relative_to_buildroot() {
     assert_eq!(
         Ok(Some("FOO".to_string())),
         FromfileExpander::relative_to(BuildRoot::for_path(_tmpdir.keep()))
-            .expand(format!("@{}", fromfile_relpath_str))
+            .expand(format!("@{fromfile_relpath_str}"))
     );
 }
 

--- a/src/rust/engine/options/src/lib.rs
+++ b/src/rust/engine/options/src/lib.rs
@@ -389,11 +389,8 @@ impl OptionParser {
         let arg_splitter = ArgSplitter::new(buildroot.as_path(), known_goals.unwrap_or_default());
         let fromfile_expander = FromfileExpander::relative_to(buildroot.clone());
 
-        let mut seed_values = HashMap::from_iter(
-            env.env
-                .iter()
-                .map(|(k, v)| (format!("env.{k}", k = k), v.clone())),
-        );
+        let mut seed_values =
+            HashMap::from_iter(env.env.iter().map(|(k, v)| (format!("env.{k}"), v.clone())));
 
         // We bootstrap options in several steps.
 
@@ -556,10 +553,7 @@ impl OptionParser {
                 if let Val::String(s) = v {
                     Ok((k, s))
                 } else {
-                    Err(format!(
-                        "Values in [cli.alias] must be strings. Got: {:?}",
-                        v
-                    ))
+                    Err(format!("Values in [cli.alias] must be strings. Got: {v:?}"))
                 }
             })
             .collect::<Result<HashMap<_, _>, String>>()?;
@@ -906,7 +900,7 @@ impl OptionParser {
                         config_reader
                             .validate(section_to_valid_keys)
                             .iter()
-                            .map(|err| format!("{} in {}", err, path)),
+                            .map(|err| format!("{err} in {path}")),
                     );
                 }
             }

--- a/src/rust/engine/options/src/parse_tests.rs
+++ b/src/rust/engine/options/src/parse_tests.rs
@@ -30,7 +30,7 @@ fn check_with_arg<T: PartialEq + Debug>(
     arg: &'static str,
 ) {
     match res {
-        Ok(actual) => assert_eq!(expected, actual, "{}", arg),
+        Ok(actual) => assert_eq!(expected, actual, "{arg}"),
         Err(s) => panic!("{}", s.render("test")),
     }
 }
@@ -39,7 +39,7 @@ fn check_str(expected: &str, input: &str) {
     // This is slightly convoluted: quoted strings appear as list items,
     // so we generate a list, and then extract the parsed string out of
     // the Result<Vec<ListEdit<String>>, ...> returned by parse_list().
-    let parsed = String::parse_list(format!("[{}]", input).as_str())
+    let parsed = String::parse_list(format!("[{input}]").as_str())
         .unwrap()
         .first()
         .unwrap()
@@ -173,9 +173,7 @@ fn test_parse_list_from_empty_string() {
         let actual = T::parse_list("").unwrap_err().render("foo");
         assert!(
             actual.contains(&expected),
-            "Error message `{}` did not contain `{}`",
-            actual,
-            expected
+            "Error message `{actual}` did not contain `{expected}`"
         );
     }
     check_err::<bool>();

--- a/src/rust/engine/process_execution/children/src/lib.rs
+++ b/src/rust/engine/process_execution/children/src/lib.rs
@@ -102,7 +102,7 @@ impl ManagedChild {
             if self.check_child_has_exited()? {
                 return Ok(true);
             }
-            log::debug!("Waiting for {:?} to exit...", maybe_id);
+            log::debug!("Waiting for {maybe_id:?} to exit...");
             thread::sleep(GRACEFUL_SHUTDOWN_POLL_TIME);
         }
         // If we get here we have timed-out.
@@ -138,8 +138,7 @@ impl ManagedChild {
                 }
                 Err(e) => {
                     log::warn!(
-                        "An error occurred while waiting for graceful shutdown of process group ({}). Will try SIGKILL instead.",
-                        e
+                        "An error occurred while waiting for graceful shutdown of process group ({e}). Will try SIGKILL instead.",
                     );
                 }
             }

--- a/src/rust/engine/process_execution/docker/src/docker.rs
+++ b/src/rust/engine/process_execution/docker/src/docker.rs
@@ -296,9 +296,7 @@ async fn credentials_for_image(
                     Ok(credential) => credential,
                     Err(e) => {
                         log::warn!(
-                            "Failed to retrieve Docker credentials for server `{}`: {}",
-                            server,
-                            e
+                            "Failed to retrieve Docker credentials for server `{server}`: {e}"
                         );
                         return Ok(None);
                     }
@@ -391,7 +389,7 @@ async fn pull_image(
                 let mut result_stream =
                     docker.create_image(Some(create_image_options), None, credentials);
                 while let Some(msg) = result_stream.next().await {
-                    log::trace!("pull {}: {:?}", image, msg);
+                    log::trace!("pull {image}: {msg:?}");
                     match msg {
                         Ok(msg) => match msg {
                             CreateImageInfo {
@@ -503,7 +501,7 @@ impl process_execution::CommandRunner for CommandRunner<'_> {
                         "Attempt to clean up old containers timed out after {CONTAINER_CLEANUP_TIMEOUT_SECONDS} seconds"
                     ),
                 };
-                log::warn!("{}", message)
+                log::warn!("{message}")
             });
         }
         let keep_sandboxes = req.execution_environment.local_keep_sandboxes;
@@ -1114,7 +1112,7 @@ impl<'a> ContainerCache<'a> {
                             }
                         };
                         if let Err(msg) = check_state.await {
-                            log::warn!("{}", msg);
+                            log::warn!("{msg}");
                         }
                     });
                 }
@@ -1123,11 +1121,7 @@ impl<'a> ContainerCache<'a> {
                 }
             }
         } else {
-            log::warn!(
-                "Container for image `{}` and platform `{:#?}` not found",
-                image_name,
-                platform
-            );
+            log::warn!("Container for image `{image_name}` and platform `{platform:#?}` not found");
         }
     }
 

--- a/src/rust/engine/process_execution/docker/src/docker_tests.rs
+++ b/src/rust/engine/process_execution/docker/src/docker_tests.rs
@@ -87,7 +87,7 @@ async fn test_remove_old_images() {
     // Only the first container ID should be removed
     let container_ids = {
         let mut ids: Vec<String> = vec![];
-        for tup in vec![Some("old"), None].iter().cartesian_product(vec![
+        for tup in [Some("old"), None].iter().cartesian_product(vec![
             Some(FAKE_BUILD_ROOT),
             None,
             Some("/some/other/build/root"),
@@ -1267,7 +1267,7 @@ async fn run_prune_container_test(runner: &dyn DockerCommandTestRunner) -> bool 
             .containers
             .lock()
             .get(&key)
-            .map(|x| x.clone())
+            .cloned()
     }
     .unwrap();
     let container_id = &should_be_container_entry.get().unwrap().0;

--- a/src/rust/engine/process_execution/pe_nailgun/src/nailgun_pool.rs
+++ b/src/rust/engine/process_execution/pe_nailgun/src/nailgun_pool.rs
@@ -66,7 +66,7 @@ pub struct NailgunPool {
 
 impl NailgunPool {
     pub fn new(workdir_base: PathBuf, size: usize, store: Store, executor: Executor) -> Self {
-        debug!("Initializing Nailgun pool for {} processes...", size);
+        debug!("Initializing Nailgun pool for {size} processes...");
         NailgunPool {
             workdir_base,
             size,

--- a/src/rust/engine/process_execution/remote/src/remote.rs
+++ b/src/rust/engine/process_execution/remote/src/remote.rs
@@ -281,7 +281,7 @@ impl CommandRunner {
             }
 
             Some(Err(err)) => {
-                debug!("wait_on_operation_stream: got error: {:?}", err);
+                debug!("wait_on_operation_stream: got error: {err:?}");
                 let status_proto = StatusProto {
                     code: err.code() as i32,
                     message: err.message().to_string(),
@@ -416,7 +416,7 @@ impl CommandRunner {
                     &workunit_store,
                     WorkunitMetadata::default(),
                 ),
-                Err(s) => warn!("{}", s),
+                Err(s) => warn!("{s}"),
             }
         }
 
@@ -439,7 +439,7 @@ impl CommandRunner {
                     &workunit_store,
                     WorkunitMetadata::default(),
                 ),
-                Err(s) => warn!("{}", s),
+                Err(s) => warn!("{s}"),
             }
         }
 
@@ -462,7 +462,7 @@ impl CommandRunner {
                     &workunit_store,
                     WorkunitMetadata::default(),
                 ),
-                Err(s) => warn!("{}", s),
+                Err(s) => warn!("{s}"),
             }
         }
 
@@ -485,7 +485,7 @@ impl CommandRunner {
                     &workunit_store,
                     WorkunitMetadata::default(),
                 ),
-                Err(s) => warn!("{}", s),
+                Err(s) => warn!("{s}"),
             }
         }
     }
@@ -567,7 +567,7 @@ impl CommandRunner {
         environment: ProcessExecutionEnvironment,
         operation_or_status: OperationOrStatus,
     ) -> Result<FallibleProcessResultWithPlatform, ExecutionError> {
-        trace!("Got operation response: {:?}", operation_or_status);
+        trace!("Got operation response: {operation_or_status:?}");
 
         let status = match operation_or_status {
             OperationOrStatus::Operation(operation) => {
@@ -595,7 +595,7 @@ impl CommandRunner {
                     }
                 };
 
-                debug!("Got (nested) execute response: {:?}", execute_response);
+                debug!("Got (nested) execute response: {execute_response:?}");
 
                 if let Some(ref metadata) = execute_response
                     .result
@@ -731,7 +731,7 @@ impl CommandRunner {
                 let multiplier = thread_rng().gen_range(0..2_u32.pow(num_retries) + 1);
                 let sleep_time = self.retry_interval_duration * multiplier;
                 let sleep_time = sleep_time.min(MAX_BACKOFF_DURATION);
-                debug!("delaying {:?} before retry", sleep_time);
+                debug!("delaying {sleep_time:?} before retry");
                 tokio::time::sleep(sleep_time).await;
             }
 
@@ -848,7 +848,7 @@ impl CommandRunner {
                         // Check if the number of request attempts sent thus far have exceeded the number
                         // of retries allowed since the last successful connection. (There is no point in
                         // continually submitting a request if ultimately futile.)
-                        trace!("retryable error: {}", e);
+                        trace!("retryable error: {e}");
                         if num_retries >= MAX_RETRIES {
                             workunit.increment_counter(Metric::RemoteExecutionRPCErrors, 1);
                             return Err(format!(
@@ -862,8 +862,7 @@ impl CommandRunner {
                     }
                     ExecutionError::MissingRemoteDigests(missing_digests) => {
                         trace!(
-                            "Server reported missing digests; trying to upload: {:?}",
-                            missing_digests,
+                            "Server reported missing digests; trying to upload: {missing_digests:?}",
                         );
 
                         let _ = self

--- a/src/rust/engine/process_execution/sandboxer/src/lib.rs
+++ b/src/rust/engine/process_execution/sandboxer/src/lib.rs
@@ -282,13 +282,10 @@ impl SandboxerClient {
         for _ in 0..20 {
             tokio::time::sleep(sleep_time).await;
             slept += sleep_time;
-            debug!(
-                "Waited {:?} to connect to sandboxer at {:?}",
-                slept, socket_path
-            );
+            debug!("Waited {slept:?} to connect to sandboxer at {socket_path:?}");
             maybe_client = SandboxerClient::connect(socket_path).await;
             if maybe_client.is_ok() {
-                debug!("Connected to sandboxer at {:?}", socket_path);
+                debug!("Connected to sandboxer at {socket_path:?}");
                 break;
             }
         }
@@ -468,7 +465,7 @@ impl Sandboxer {
             .map(|rp| {
                 rp.to_str()
                     .map(str::to_string)
-                    .ok_or_else(|| format!("Path is not valid string: {:?}", rp))
+                    .ok_or_else(|| format!("Path is not valid string: {rp:?}"))
             })
             .collect::<Result<Vec<_>, _>>()?;
         let ret = self

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -152,9 +152,8 @@ impl crate::CommandRunner for CommandRunner {
                         }
                         Err(err) => {
                             debug!(
-                                "Error loading process execution result from local cache: {} \
-                - continuing to execute",
-                                err
+                                "Error loading process execution result from local cache: {err} \
+                - continuing to execute"
                             );
                             workunit.increment_counter(Metric::LocalCacheReadErrors, 1);
                             // Falling through to re-execute.
@@ -182,8 +181,7 @@ impl crate::CommandRunner for CommandRunner {
             in_workunit!("local_cache_write", Level::Trace, |workunit| async move {
                 if let Err(err) = self.store(&key, &result).await {
                     warn!(
-            "Error storing process execution result to local cache: {} - ignoring and continuing",
-            err
+            "Error storing process execution result to local cache: {err} - ignoring and continuing"
           );
                     workunit.increment_counter(Metric::LocalCacheWriteErrors, 1);
                 }

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -528,27 +528,24 @@ impl FromStr for ProcessConcurrency {
             let parts = s.split(',').collect::<Vec<_>>();
             if parts.len() != 2 {
                 return Err(format!(
-                    "Expected two values for concurrency range, got: {}",
-                    s
+                    "Expected two values for concurrency range, got: {s}"
                 ));
             }
             let min = parts[0]
                 .parse::<usize>()
-                .map_err(|e| format!("Invalid min value: {}", e))?;
+                .map_err(|e| format!("Invalid min value: {e}"))?;
             let max = parts[1]
                 .parse::<usize>()
-                .map_err(|e| format!("Invalid max value: {}", e))?;
+                .map_err(|e| format!("Invalid max value: {e}"))?;
 
             if min < 1 {
                 return Err(format!(
-                    "Minimum concurrency must be at least 1, got: {}",
-                    min
+                    "Minimum concurrency must be at least 1, got: {min}"
                 ));
             }
             if max < min {
                 return Err(format!(
-                    "Maximum concurrency must be at least the minimum concurrency, got: {} and {}",
-                    max, min
+                    "Maximum concurrency must be at least the minimum concurrency, got: {max} and {min}"
                 ));
             }
 
@@ -559,9 +556,9 @@ impl FromStr for ProcessConcurrency {
         } else {
             let exactly = s
                 .parse::<usize>()
-                .map_err(|e| format!("Invalid concurrency value: {}", e))?;
+                .map_err(|e| format!("Invalid concurrency value: {e}"))?;
             if exactly < 1 {
-                return Err(format!("Concurrency must be at least 1, got: {}", exactly));
+                return Err(format!("Concurrency must be at least 1, got: {exactly}"));
             }
             Ok(ProcessConcurrency::Range {
                 min: Some(exactly),

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -734,8 +734,7 @@ pub async fn prepare_workdir(
                 .await
                 .map_err(|e| {
                     format!(
-                        "materialize_directory() request to sandboxer process failed: {}",
-                        e
+                        "materialize_directory() request to sandboxer process failed: {e}"
                     )
                 })?;
         } else {

--- a/src/rust/engine/remote_provider/remote_provider_reapi/src/byte_store.rs
+++ b/src/rust/engine/remote_provider/remote_provider_reapi/src/byte_store.rs
@@ -210,8 +210,7 @@ impl Provider {
                 // likely be a remote error too, because our write will be too short, but the local error is
                 // the interesting root cause)
                 return Err(ByteStoreError::Other(format!(
-                    "Uploading file with digest {:?}: failed to read local source: {}",
-                    digest, read_err
+                    "Uploading file with digest {digest:?}: failed to read local source: {read_err}"
                 )));
             }
 
@@ -272,8 +271,7 @@ impl Provider {
 
                 if !results.contains_key(&digest) {
                     return Err(format!(
-                        "Batch read returned unexpected digest {:?} in batch response",
-                        digest
+                        "Batch read returned unexpected digest {digest:?} in batch response"
                     ));
                 }
 

--- a/src/rust/engine/remote_provider/remote_provider_reapi/src/byte_store_tests.rs
+++ b/src/rust/engine/remote_provider/remote_provider_reapi/src/byte_store_tests.rs
@@ -220,9 +220,7 @@ fn assert_cas_store(cas: &StubCAS, testdata: &TestData, chunks: usize, chunk_siz
     for &size in write_message_sizes.iter() {
         assert!(
             size <= chunk_size,
-            "Size {} should have been <= {}",
-            size,
-            chunk_size
+            "Size {size} should have been <= {chunk_size}"
         );
     }
 }

--- a/src/rust/engine/rule_graph/src/builder.rs
+++ b/src/rust/engine/rule_graph/src/builder.rs
@@ -47,7 +47,7 @@ impl<R: Rule> std::fmt::Display for Node<R> {
                 explicit_args_arity,
             } => {
                 let explicit_args_arity: Cow<str> = if *explicit_args_arity > 0 {
-                    format!(" <{}>", explicit_args_arity).into()
+                    format!(" <{explicit_args_arity}>").into()
                 } else {
                     "".into()
                 };
@@ -879,7 +879,7 @@ impl<R: Rule> Builder<R> {
                 };
 
             if looping {
-                log::trace!("{}", trace_str);
+                log::trace!("{trace_str}");
 
                 maybe_in_loop.insert(node_id);
                 if maybe_in_loop.len() > 5 {
@@ -957,7 +957,7 @@ impl<R: Rule> Builder<R> {
                 }
 
                 if looping {
-                    log::trace!("node: creating: {:?}", replacement_id);
+                    log::trace!("node: creating: {replacement_id:?}");
                 }
 
                 // Give all dependents edges to the new node.
@@ -972,7 +972,7 @@ impl<R: Rule> Builder<R> {
                         }
                     }
                     if looping {
-                        log::trace!("dependent edge: adding: ({:?}, {})", dependent_id, edge);
+                        log::trace!("dependent edge: adding: ({dependent_id:?}, {edge})");
                     }
                     graph.add_edge(*dependent_id, replacement_id, edge);
                 }

--- a/src/rust/engine/rule_graph/src/lib.rs
+++ b/src/rust/engine/rule_graph/src/lib.rs
@@ -464,7 +464,7 @@ impl<R: Rule> RuleGraph<R> {
             "{}",
             queries_strs
                 .iter()
-                .map(|q| format!("    {}", q))
+                .map(|q| format!("    {q}"))
                 .collect::<Vec<String>>()
                 .join(",\n")
         )?;

--- a/src/rust/engine/rust-toolchain
+++ b/src/rust/engine/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.87.0"
+channel = "1.88.0"
 # NB: We don't list the components (namely `clippy` and `rustfmt`) and instead rely on either the
 #  the profile being "default" (by-and-large the default profile) or the nice error message from
 #  `cargo fmt` and `cargo clippy` if the required component isn't installed

--- a/src/rust/engine/sharded_lmdb/src/lib.rs
+++ b/src/rust/engine/sharded_lmdb/src/lib.rs
@@ -139,7 +139,7 @@ impl ShardedLmdb {
             mask.rotate_left(Self::shard_shift(shard_count) as u32)
         };
 
-        trace!("Initializing ShardedLmdb at root {:?}", root_path);
+        trace!("Initializing ShardedLmdb at root {root_path:?}");
         let mut lmdbs = HashMap::new();
 
         for (env, dir, environment_id) in
@@ -580,7 +580,7 @@ impl ShardedLmdb {
 
                                     if should_retry {
                                         let msg = format!("Input {read:?} changed while reading.");
-                                        log::debug!("{}", msg);
+                                        log::debug!("{msg}");
                                         return Err(StoreError::Retry(msg));
                                     }
 

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -779,7 +779,7 @@ impl Core {
         // Shutdown the Sessions, which will prevent new work from starting and then await any ongoing
         // work.
         if let Err(msg) = self.sessions.shutdown(timeout).await {
-            log::warn!("During shutdown: {}", msg);
+            log::warn!("During shutdown: {msg}");
         }
         // Then clear the Graph to ensure that drop handlers run (particularly for running processes).
         self.graph.clear();
@@ -832,11 +832,7 @@ impl Invalidatable for InvalidatableGraph {
         let (level, caller) = caller_to_logging_info(caller);
         log!(
             level,
-            "{} invalidation: cleared {} and dirtied {} nodes for: {:?}",
-            caller,
-            cleared,
-            dirtied,
-            paths
+            "{caller} invalidation: cleared {cleared} and dirtied {dirtied} nodes for: {paths:?}"
         );
         cleared + dirtied
     }
@@ -847,10 +843,7 @@ impl Invalidatable for InvalidatableGraph {
         let (level, caller) = caller_to_logging_info(caller);
         log!(
             level,
-            "{} invalidation: cleared {} and dirtied {} nodes for all paths",
-            caller,
-            cleared,
-            dirtied
+            "{caller} invalidation: cleared {cleared} and dirtied {dirtied} nodes for all paths"
         );
         cleared + dirtied
     }
@@ -937,7 +930,7 @@ impl SessionCore {
                 // There are no live or invalidated sources of this Digest. Directly fail.
                 return result.map_err(|e| {
                     let suffix = if let Some(workunit_data) = workunit.workunit() {
-                        &format!(", with workunit: {:?}", workunit_data)
+                        &format!(", with workunit: {workunit_data:?}")
                     } else {
                         ""
                     };

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -779,8 +779,8 @@ fn scheduler_create<'py>(
     ca_certs_path: Option<PathBuf>,
 ) -> PyO3Result<PyScheduler> {
     match fs::increase_limits() {
-        Ok(msg) => debug!("{}", msg),
-        Err(e) => warn!("{}", e),
+        Ok(msg) => debug!("{msg}"),
+        Err(e) => warn!("{e}"),
     }
     let types = types_ptr
         .borrow()
@@ -1122,7 +1122,7 @@ fn session_poll_workunits(
         })
     })
     .unwrap_or_else(|e| {
-        log::warn!("Panic in `session_poll_workunits`: {:?}", e);
+        log::warn!("Panic in `session_poll_workunits`: {e:?}");
         std::panic::resume_unwind(e);
     })
 }
@@ -1706,10 +1706,10 @@ fn maybe_set_panic_handler() {
             panic_str.push_str(&panic_location_str);
         }
 
-        error!("{}", panic_str);
+        error!("{panic_str}");
 
         let panic_file_bug_str = "Please set RUST_BACKTRACE=1, re-run, and then file a bug at https://github.com/pantsbuild/pants/issues.";
-        error!("{}", panic_file_bug_str);
+        error!("{panic_file_bug_str}");
     }));
 }
 

--- a/src/rust/engine/src/externs/options.rs
+++ b/src/rust/engine/src/externs/options.rs
@@ -164,8 +164,7 @@ impl PyOptionId {
             None => None,
             Some(s) => {
                 return Err(ParseError::new_err(format!(
-                    "Switch value should contain a single character, but was: {}",
-                    s
+                    "Switch value should contain a single character, but was: {s}"
                 )));
             }
         };

--- a/src/rust/engine/src/externs/target.rs
+++ b/src/rust/engine/src/externs/target.rs
@@ -156,7 +156,7 @@ impl Field {
         )
         .unwrap();
         if let Ok(default) = self_.getattr("default") {
-            write!(result, ", default={})", default).unwrap();
+            write!(result, ", default={default})").unwrap();
         } else {
             write!(result, ")").unwrap();
         }

--- a/src/rust/engine/src/intrinsics/digests.rs
+++ b/src/rust/engine/src/intrinsics/digests.rs
@@ -387,11 +387,11 @@ fn path_metadata_request(single_path: Value) -> PyGeneratorResponseNativeCall {
                 .map_err(|e| format!("Failed to get `namespace` for field: {e}"))?;
             match namespace {
                 PyPathNamespace::Workspace => SubjectPath::new_workspace(&path).map_err(|_| {
-                    format!("path_metadata_request error: path for PathNamespace.WORKSPACE must be a relative path. Instead, got `{}`", path)
+                    format!("path_metadata_request error: path for PathNamespace.WORKSPACE must be a relative path. Instead, got `{path}`")
                 }),
                 PyPathNamespace::System => SubjectPath::new_system(&path).map_err(|_| {
                     format!(
-                        "path_metadata_request error: path for PathNamespace.SYSTEM must be an absolute path. Instead, got `{}`", path
+                        "path_metadata_request error: path for PathNamespace.SYSTEM must be an absolute path. Instead, got `{path}`"
                     )
                 }),
             }

--- a/src/rust/engine/src/intrinsics/interactive_process.rs
+++ b/src/rust/engine/src/intrinsics/interactive_process.rs
@@ -178,9 +178,9 @@ pub async fn interactive_process_inner(
       // then wait for it to exit (to avoid zombies).
       if let Err(e) = subprocess.attempt_shutdown_sync() {
         // Failed to kill the PGID: try the non-group form.
-        log::warn!("Failed to kill spawned process group ({}). Will try killing only the top process.\n\
+        log::warn!("Failed to kill spawned process group ({e}). Will try killing only the top process.\n\
                   This is unexpected: please file an issue about this problem at \
-                  [https://github.com/pantsbuild/pants/issues/new]", e);
+                  [https://github.com/pantsbuild/pants/issues/new]");
         subprocess.kill().map_err(|e| format!("Failed to interrupt child process: {e}")).await?;
       };
       subprocess.wait().await.map_err(|e| e.to_string())

--- a/src/rust/engine/src/nodes/execute_process.rs
+++ b/src/rust/engine/src/nodes/execute_process.rs
@@ -143,7 +143,7 @@ impl ExecuteProcess {
                         Ok(Some(ProcessConcurrency::Range { min, max }))
                     }
                     Some(kind) if kind == "exclusive" => Ok(Some(ProcessConcurrency::Exclusive)),
-                    _ => Err(format!("Unknown ProcessConcurrency kind: {:?}", kind_opt)),
+                    _ => Err(format!("Unknown ProcessConcurrency kind: {kind_opt:?}")),
                 }
             }
         }?;

--- a/src/rust/engine/src/nodes/mod.rs
+++ b/src/rust/engine/src/nodes/mod.rs
@@ -174,7 +174,7 @@ async fn select(
                 select_reentry(context, params, &reentry.query).await
             }
             &rule_graph::EntryWithDeps::Root(_) => {
-                panic!("Not a runtime-executable entry! {:?}", entry)
+                panic!("Not a runtime-executable entry! {entry:?}")
             }
         },
         &rule_graph::Entry::Param(type_id) => {
@@ -182,8 +182,7 @@ async fn select(
                 Ok(key.to_value())
             } else {
                 Err(throw(format!(
-                    "Expected a Param of type {} to be present, but had only: {}",
-                    type_id, params,
+                    "Expected a Param of type {type_id} to be present, but had only: {params}",
                 )))
             }
         }

--- a/src/rust/engine/src/python.rs
+++ b/src/rust/engine/src/python.rs
@@ -655,7 +655,7 @@ mod pycomparedbool_tests {
                 PyComparedBool(None)
                     .into_pyobject(py)
                     .unwrap()
-                    .is(&py.NotImplemented()),
+                    .is(py.NotImplemented()),
             );
         })
     }

--- a/src/rust/engine/src/session.rs
+++ b/src/rust/engine/src/session.rs
@@ -317,7 +317,7 @@ impl Session {
             }
         };
         if let Err(e) = result {
-            warn!("{}", e);
+            warn!("{e}");
         }
     }
 
@@ -469,14 +469,14 @@ impl Sessions {
                     let cancelled = handle.cancelled.clone();
                     let cancellation_triggered = async move {
                         cancelled.triggered().await;
-                        log::info!("Shutdown completed: {:?}", build_id)
+                        log::info!("Shutdown completed: {build_id:?}")
                     };
                     (handle.build_id.clone(), cancellation_triggered)
                 })
                 .unzip();
 
             if !build_ids.is_empty() {
-                log::info!("Waiting for shutdown of: {:?}", build_ids);
+                log::info!("Waiting for shutdown of: {build_ids:?}");
                 tokio::time::timeout(timeout, future::join_all(cancellation_latches))
                     .await
                     .map_err(|_| format!("Some Sessions did not shutdown within {timeout:?}."))?;

--- a/src/rust/engine/src/tasks.rs
+++ b/src/rust/engine/src/tasks.rs
@@ -256,7 +256,7 @@ impl Tasks {
             // Note that the Python code calling this function has already verified that there
             // is a relevant union type in the inputs, so this should never panic in practice.
             let union_type = inputs.iter().find(|t| t.is_union()).unwrap_or_else(|| {
-                panic!("No union argument found in inputs of call to {}", rule_id)
+                panic!("No union argument found in inputs of call to {rule_id}")
             });
             // Add calls for each vtable member. At runtime we'll select the relevant one.
             for (member_type, member_rule) in vtable_entries.iter() {

--- a/src/rust/engine/stdio/src/lib.rs
+++ b/src/rust/engine/stdio/src/lib.rs
@@ -261,7 +261,7 @@ impl Destination {
         );
         std::mem::drop(destination);
         self.console_clear();
-        log::warn!("{}", error_str);
+        log::warn!("{error_str}");
         self.write_stdout(content);
     }
 
@@ -329,7 +329,7 @@ impl Destination {
         );
         std::mem::drop(destination);
         self.console_clear();
-        log::warn!("{}", error_str);
+        log::warn!("{error_str}");
         self.write_stderr(content);
     }
 

--- a/src/rust/engine/task_executor/src/lib.rs
+++ b/src/rust/engine/task_executor/src/lib.rs
@@ -279,10 +279,7 @@ impl TailTasks {
         let inner = match &mut *guard {
             Some(inner) => inner,
             None => {
-                log::warn!(
-                    "Session end task `{}` submitted after session completed.",
-                    name
-                );
+                log::warn!("Session end task `{name}` submitted after session completed.");
                 return;
             }
         };

--- a/src/rust/engine/watch/src/lib.rs
+++ b/src/rust/engine/watch/src/lib.rs
@@ -158,7 +158,7 @@ impl InvalidationWatcher {
                 };
 
                 // Log and send the exit code.
-                warn!("File watcher exiting with: {}", exit_msg);
+                warn!("File watcher exiting with: {exit_msg}");
                 let _ = liveness_sender.send(exit_msg);
             })
             .map_err(|e| format!("Failed to start fs-watcher thread: {e}"))
@@ -216,7 +216,7 @@ impl InvalidationWatcher {
                     &path_relative_to_build_root,
                     /* is_dir */ false,
                 ) {
-                    trace!("notify ignoring {:?}", path_relative_to_build_root);
+                    trace!("notify ignoring {path_relative_to_build_root:?}");
                     None
                 } else {
                     Some(path_relative_to_build_root)

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -102,7 +102,7 @@ impl RunningWorkunitGraph {
     ) -> Option<Workunit> {
         match self.entries.entry(span_id) {
             hash_map::Entry::Vacant(_) => {
-                log::warn!("No previously-started workunit found for id: {}", span_id);
+                log::warn!("No previously-started workunit found for id: {span_id}");
                 None
             }
             hash_map::Entry::Occupied(mut entry) => {
@@ -130,7 +130,7 @@ impl RunningWorkunitGraph {
 
                 match workunit.state {
                     WorkunitState::Completed { .. } => {
-                        log::warn!("Workunit {} was already completed", span_id);
+                        log::warn!("Workunit {span_id} was already completed");
                     }
                     WorkunitState::Started { start_time, .. } => {
                         let time_span =
@@ -282,7 +282,7 @@ impl Workunit {
             "".to_string()
         };
 
-        log!(self.level, "{} {}{}", state, effective_identifier, message);
+        log!(self.level, "{state} {effective_identifier}{message}");
     }
 }
 
@@ -658,7 +658,7 @@ impl WorkunitStore {
         let start_time = match workunit.state {
             WorkunitState::Started { start_time, .. } => start_time,
             _ => {
-                log::warn!("Workunit {} was already completed", span_id);
+                log::warn!("Workunit {span_id} was already completed");
                 return;
             }
         };


### PR DESCRIPTION
Upgrade to [Rust v1.88.0](https://blog.rust-lang.org/2025/06/26/Rust-1.88.0/).

Notable updates in this release:
- "Let chains" - multple let forms in `if` and `while` statements (in 2024 edition)
- "Boolean configuration" - `#cfg` forms accept `true` and `false` now.
- Cargo automatic cache cleaning
