### PR TITLE
Fix polymorphic call-by-name

### DIFF
--- a/src/python/pants/core/goals/generate_snapshots.py
+++ b/src/python/pants/core/goals/generate_snapshots.py
@@ -20,7 +20,7 @@ from pants.engine.unions import UnionMembership, union
 logger = logging.getLogger(__name__)
 
 
-@union
+@union(in_scope_types=[EnvironmentName])
 class GenerateSnapshotsFieldSet(FieldSet, metaclass=ABCMeta):
     """The fields necessary to generate snapshots from a target."""
 

--- a/src/python/pants/engine/internals/native_engine.pyi
+++ b/src/python/pants/engine/internals/native_engine.pyi
@@ -839,6 +839,7 @@ def tasks_add_call(
     rule_id: str,
     explicit_args_arity: int,
     vtable_entries: Sequence[tuple[type, str]] | None,
+    in_scope_types: Sequence[type] | None,
 ) -> None: ...
 def tasks_add_get(tasks: PyTasks, output: type, inputs: Sequence[type]) -> None: ...
 def tasks_add_get_union(

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -761,8 +761,8 @@ def register_rules(rule_index: RuleIndex, union_membership: UnionMembership) -> 
                     awaitable.input_types,
                     awaitable.rule_id,
                     awaitable.explicit_args_arity,
-                    None,
-                    None,
+                    vtable_entries=None,
+                    in_scope_types=None,
                 )
             else:
                 # Otherwise, the Get subject is a "concrete" type, so add a single Get edge.

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -726,6 +726,8 @@ def register_rules(rule_index: RuleIndex, union_membership: UnionMembership) -> 
                             # polymorphic rule for the union member.
                             if member_rule.output_type == awaitable.output_type:
                                 vtable_entries.append((member_type, member_rule.canonical_name))
+                        in_scope_types = union_in_scope_types(union)
+                        assert in_scope_types is not None
                         native_engine.tasks_add_call(
                             tasks,
                             awaitable.output_type,
@@ -733,6 +735,7 @@ def register_rules(rule_index: RuleIndex, union_membership: UnionMembership) -> 
                             awaitable.rule_id,
                             awaitable.explicit_args_arity,
                             vtable_entries,
+                            in_scope_types,
                         )
                 else:
                     # This is a union Get.
@@ -758,6 +761,7 @@ def register_rules(rule_index: RuleIndex, union_membership: UnionMembership) -> 
                     awaitable.input_types,
                     awaitable.rule_id,
                     awaitable.explicit_args_arity,
+                    None,
                     None,
                 )
             else:

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -1318,10 +1318,8 @@ fn tasks_add_call<'py>(
 ) {
     let output = TypeId::new(output);
     let inputs = inputs.into_iter().map(|t| TypeId::new(&t)).collect();
-    let in_scope_types = in_scope_types.map(|ist|
-        ist.into_iter()
-        .map(|t| TypeId::new(&t))
-        .collect());
+    let in_scope_types =
+        in_scope_types.map(|ist| ist.into_iter().map(|t| TypeId::new(&t)).collect());
     py_tasks.borrow_mut().0.get(py).borrow_mut().add_call(
         output,
         inputs,

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -1314,9 +1314,14 @@ fn tasks_add_call<'py>(
     rule_id: String,
     explicit_args_arity: u16,
     vtable_entries: Option<Vec<(Bound<'py, PyType>, String)>>,
+    in_scope_types: Option<Vec<Bound<'py, PyType>>>,
 ) {
     let output = TypeId::new(output);
     let inputs = inputs.into_iter().map(|t| TypeId::new(&t)).collect();
+    let in_scope_types = in_scope_types.map(|ist|
+        ist.into_iter()
+        .map(|t| TypeId::new(&t))
+        .collect());
     py_tasks.borrow_mut().0.get(py).borrow_mut().add_call(
         output,
         inputs,
@@ -1327,6 +1332,7 @@ fn tasks_add_call<'py>(
                 .map(|(k, v)| (TypeId::new(&k), RuleId::from_string(v)))
                 .collect()
         }),
+        in_scope_types,
     );
 }
 

--- a/src/rust/engine/src/nodes/task.rs
+++ b/src/rust/engine/src/nodes/task.rs
@@ -81,11 +81,12 @@ impl Task {
             .entry_for(&dependency_key)
             .or_else(|| {
                 // The Get might have involved a @union: if so, include its in_scope types in the
-                // lookup. This just means setting in_scope_params to non-None, to signal that
-                // in_scope types should be considered. For call-by-name the in_scope types are
-                // the explicit params passed to the call, and the in_scope_params field acts
-                // as a bool.
-                edges.entry_for(&dependency_key.in_scope_params(vec![]))
+                // lookup.
+                let in_scope_types = call
+                    .input_types
+                    .iter()
+                    .find_map(|t| t.union_in_scope_types())?;
+                edges.entry_for(&dependency_key.in_scope_params(in_scope_types))
             })
             .ok_or_else(|| {
                 // NB: The Python constructor for `Call()` will have already errored if

--- a/src/rust/engine/src/tasks.rs
+++ b/src/rust/engine/src/tasks.rs
@@ -251,9 +251,10 @@ impl Tasks {
             // and instead let the in-scope types be defined by the signature of the polymorphic
             // rule (i.e., they would be the explicit params in the signature other than the union
             // type). However this would require access to the rule's signature (which is distinct
-            // from the call's signature, as the call may omit params) both here and in gen_call()
-            // in task.rs. So for now we continue to use the legacy in_scope_types @union arg,
-            // and we can revisit once we're fully call-by-name.
+            // from the call's signature) both here and in gen_call() in task.rs. So for now we
+            // continue to use the legacy in_scope_types @union arg, and we can revisit once we're
+            // fully call-by-name.
+            // See https://github.com/pantsbuild/pants/issues/22483
             let in_scope_types = in_scope_types.unwrap_or_else(|| {
                 panic!("No in_scope_types passed in for a polymorphic call");
             });

--- a/src/rust/engine/src/tasks.rs
+++ b/src/rust/engine/src/tasks.rs
@@ -237,6 +237,7 @@ impl Tasks {
         rule_id: RuleId,
         explicit_args_arity: u16,
         vtable_entries: Option<HashMap<TypeId, RuleId>>,
+        in_scope_types: Option<Vec<TypeId>>,
     ) {
         let calls = &mut self
             .preparing
@@ -245,13 +246,17 @@ impl Tasks {
             .gets;
 
         if let Some(vtable_entries) = vtable_entries {
-            // This is a polymorphic call. In this case we set in_scope_params() to an empty vec,
-            // so that only the explicit params passed to the call are considered by the solver.
-            // This ensures stability of the API of the polymorphic rule (and also prevents the
-            // engine from having to do unnecessary solving for these calls).
-            // Once we are fully call-by-name we can deprecate and remove the `in_scope_types`
-            // keyword of the @union decorator, since for call-by-name we take the set of
-            // params from the call itself, as you'd expect.
+            // This is a polymorphic call, so in_scope_types must be provided by the caller.
+            // TODO: We would like to deprecate the in_scope_types argument to the @union decorator,
+            // and instead let the in-scope types be defined by the signature of the polymorphic
+            // rule (i.e., they would be the explicit params in the signature other than the union
+            // type). However this would require access to the rule's signature (which is distinct
+            // from the call's signature, as the call may omit params) both here and in gen_call()
+            // in task.rs. So for now we continue to use the legacy in_scope_types @union arg,
+            // and we can revisit once we're fully call-by-name.
+            let in_scope_types = in_scope_types.unwrap_or_else(|| {
+                panic!("No in_scope_types passed in for a polymorphic call");
+            });
 
             // Note that the Python code calling this function has already verified that there
             // is a relevant union type in the inputs, so this should never panic in practice.
@@ -268,7 +273,7 @@ impl Tasks {
                 calls.push(
                     DependencyKey::for_known_rule(member_rule.clone(), output, explicit_args_arity)
                         .provided_params(member_rule_inputs)
-                        .in_scope_params(vec![]),
+                        .in_scope_params(in_scope_types.clone()),
                 );
             }
             self.vtable.insert(rule_id.clone(), vtable_entries);
@@ -277,7 +282,7 @@ impl Tasks {
             calls.push(
                 DependencyKey::for_known_rule(rule_id, output, explicit_args_arity)
                     .provided_params(inputs)
-                    .in_scope_params(vec![]),
+                    .in_scope_params(in_scope_types.clone()),
             );
         } else {
             calls.push(


### PR DESCRIPTION
The original implementation in #22375 incorrectly assumed
that call-by-name could ignore the `in_scope_types` 
of a `@union`, and instead compute the DependencyKey using
the types in the polymorphic rule signature, and just pass
an empty `in_scope_types` to the DependencyKey, to indicate
a reentry. 

However in some unusual cases where the in_scope_type isn't
explicitly provided, this causes the solver to fail. 

This change restores correct `in_scope_types` behavior.

There could be a way to get this to work, and it would be more
intuitive to do so (since it would more closely mirror the behavior
of virtual method signatures), but it would require more changes
that we want to make right now. So we can revisit this when we
are fully call-by-name.