### PR TITLE
Use pipes and avoid wrapping in generated CI yaml, for easier human introspection

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -13,11 +13,9 @@ jobs:
       with:
         fetch-depth: 10
     - name: Cargo audit (for security vulnerabilities)
-      run: './cargo install cargo-audit --locked
-
+      run: |
+        ./cargo install cargo-audit --locked
         ./cargo audit --ignore RUSTSEC-2020-0128
-
-        '
 name: Cargo Audit
 'on':
   schedule:

--- a/.github/workflows/cache_comparison.yaml
+++ b/.github/workflows/cache_comparison.yaml
@@ -14,19 +14,14 @@ jobs:
     - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7
-
+        python-version: |-
+          3.7
           3.8
-
           3.9
-
           3.10
-
           3.12
-
           3.13
-
-          3.11'
+          3.11
     - env:
         BASE_REF: ${{ github.event.inputs.base_ref }}
         BUILD_COMMIT: ${{ github.event.inputs.build_commit }}
@@ -34,11 +29,9 @@ jobs:
         SOURCE_DIFFSPEC: ${{ github.event.inputs.source_diffspec }}
         SOURCE_DIFFSPEC_STEP: ${{ github.event.inputs.source_diffspec_step }}
       name: Prepare cache comparison
-      run: 'MODE=debug ./pants package build-support/bin/cache_comparison.py
-
+      run: |
+        MODE=debug ./pants package build-support/bin/cache_comparison.py
         git fetch --no-tags --depth=1024 origin "$BASE_REF"
-
-        '
     - env:
         BASE_REF: ${{ github.event.inputs.base_ref }}
         BUILD_COMMIT: ${{ github.event.inputs.build_commit }}
@@ -46,9 +39,12 @@ jobs:
         SOURCE_DIFFSPEC: ${{ github.event.inputs.source_diffspec }}
         SOURCE_DIFFSPEC_STEP: ${{ github.event.inputs.source_diffspec_step }}
       name: Run cache comparison
-      run: "dist/build-support.bin/cache_comparison_py.pex \\\n  --args=\"$PANTS_ARGS\"\
-        \ \\\n  --build-commit=\"$BUILD_COMMIT\" \\\n  --source-diffspec=\"$SOURCE_DIFFSPEC\"\
-        \ \\\n  --source-diffspec-step=$SOURCE_DIFFSPEC_STEP\n"
+      run: |
+        dist/build-support.bin/cache_comparison_py.pex \
+          --args="$PANTS_ARGS" \
+          --build-commit="$BUILD_COMMIT" \
+          --source-diffspec="$SOURCE_DIFFSPEC" \
+          --source-diffspec-step=$SOURCE_DIFFSPEC_STEP
     timeout-minutes: 90
 name: Cache Comparison
 'on':

--- a/.github/workflows/public_repos.yaml
+++ b/.github/workflows/public_repos.yaml
@@ -40,8 +40,7 @@ jobs:
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
-      name: Run `tailor --check update-build-files --check ::` with repo-default version
-        (baseline)
+      name: Run `tailor --check update-build-files --check ::` with repo-default version (baseline)
       run: ' pants tailor --check update-build-files --check ::'
     - env:
         PANTS_VERSION: ''
@@ -69,10 +68,8 @@ jobs:
     - env:
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
-      name: Run `tailor --check update-build-files --check ::` with ${{ github.event.inputs.pants_version
-        }}
-      run: '${{ github.event.inputs.extra_env }} pants tailor --check update-build-files
-        --check ::'
+      name: Run `tailor --check update-build-files --check ::` with ${{ github.event.inputs.pants_version }}
+      run: '${{ github.event.inputs.extra_env }} pants tailor --check update-build-files --check ::'
     - env:
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
@@ -175,8 +172,7 @@ jobs:
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
-      name: Run `tailor --check update-build-files --check ::` with repo-default version
-        (baseline)
+      name: Run `tailor --check update-build-files --check ::` with repo-default version (baseline)
       run: ' pants tailor --check update-build-files --check ::'
     - env:
         PANTS_VERSION: ''
@@ -204,10 +200,8 @@ jobs:
     - env:
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
-      name: Run `tailor --check update-build-files --check ::` with ${{ github.event.inputs.pants_version
-        }}
-      run: '${{ github.event.inputs.extra_env }} pants tailor --check update-build-files
-        --check ::'
+      name: Run `tailor --check update-build-files --check ::` with ${{ github.event.inputs.pants_version }}
+      run: '${{ github.event.inputs.extra_env }} pants tailor --check update-build-files --check ::'
     - env:
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
@@ -266,8 +260,7 @@ jobs:
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
-      name: Run `tailor --check update-build-files --check ::` with repo-default version
-        (baseline)
+      name: Run `tailor --check update-build-files --check ::` with repo-default version (baseline)
       run: ' pants tailor --check update-build-files --check ::'
     - env:
         PANTS_VERSION: ''
@@ -295,10 +288,8 @@ jobs:
     - env:
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
-      name: Run `tailor --check update-build-files --check ::` with ${{ github.event.inputs.pants_version
-        }}
-      run: '${{ github.event.inputs.extra_env }} pants tailor --check update-build-files
-        --check ::'
+      name: Run `tailor --check update-build-files --check ::` with ${{ github.event.inputs.pants_version }}
+      run: '${{ github.event.inputs.extra_env }} pants tailor --check update-build-files --check ::'
     - env:
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
@@ -536,8 +527,7 @@ jobs:
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
-      name: Run `tailor --check update-build-files --check ::` with repo-default version
-        (baseline)
+      name: Run `tailor --check update-build-files --check ::` with repo-default version (baseline)
       run: ' pants tailor --check update-build-files --check ::'
     - env:
         PANTS_VERSION: ''
@@ -547,8 +537,7 @@ jobs:
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
-      name: 'Run `test :: -tests/agent/docker:: -tests/client/integration:: -tests/common/redis_helper::`
-        with repo-default version (baseline)'
+      name: 'Run `test :: -tests/agent/docker:: -tests/client/integration:: -tests/common/redis_helper::` with repo-default version (baseline)'
       run: ' pants test :: -tests/agent/docker:: -tests/client/integration:: -tests/common/redis_helper::'
     - env:
         PANTS_VERSION: ''
@@ -566,10 +555,8 @@ jobs:
     - env:
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
-      name: Run `tailor --check update-build-files --check ::` with ${{ github.event.inputs.pants_version
-        }}
-      run: '${{ github.event.inputs.extra_env }} pants tailor --check update-build-files
-        --check ::'
+      name: Run `tailor --check update-build-files --check ::` with ${{ github.event.inputs.pants_version }}
+      run: '${{ github.event.inputs.extra_env }} pants tailor --check update-build-files --check ::'
     - env:
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
@@ -578,10 +565,8 @@ jobs:
     - env:
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
-      name: 'Run `test :: -tests/agent/docker:: -tests/client/integration:: -tests/common/redis_helper::`
-        with ${{ github.event.inputs.pants_version }}'
-      run: '${{ github.event.inputs.extra_env }} pants test :: -tests/agent/docker::
-        -tests/client/integration:: -tests/common/redis_helper::'
+      name: 'Run `test :: -tests/agent/docker:: -tests/client/integration:: -tests/common/redis_helper::` with ${{ github.event.inputs.pants_version }}'
+      run: '${{ github.event.inputs.extra_env }} pants test :: -tests/agent/docker:: -tests/client/integration:: -tests/common/redis_helper::'
     - env:
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
@@ -750,8 +735,7 @@ jobs:
     - env:
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
-      name: 'Run `package :: -directory_pull::` with ${{ github.event.inputs.pants_version
-        }}'
+      name: 'Run `package :: -directory_pull::` with ${{ github.event.inputs.pants_version }}'
       run: '${{ github.event.inputs.extra_env }} pants package :: -directory_pull::'
   pantsbuild_example-adhoc:
     env:
@@ -861,8 +845,7 @@ jobs:
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
-      name: Run `tailor --check update-build-files --check ::` with repo-default version
-        (baseline)
+      name: Run `tailor --check update-build-files --check ::` with repo-default version (baseline)
       run: ' pants tailor --check update-build-files --check ::'
     - env:
         PANTS_VERSION: ''
@@ -890,10 +873,8 @@ jobs:
     - env:
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
-      name: Run `tailor --check update-build-files --check ::` with ${{ github.event.inputs.pants_version
-        }}
-      run: '${{ github.event.inputs.extra_env }} pants tailor --check update-build-files
-        --check ::'
+      name: Run `tailor --check update-build-files --check ::` with ${{ github.event.inputs.pants_version }}
+      run: '${{ github.event.inputs.extra_env }} pants tailor --check update-build-files --check ::'
     - env:
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
@@ -945,8 +926,7 @@ jobs:
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
-      name: Run `tailor --check update-build-files --check ::` with repo-default version
-        (baseline)
+      name: Run `tailor --check update-build-files --check ::` with repo-default version (baseline)
       run: ' pants tailor --check update-build-files --check ::'
     - env:
         PANTS_VERSION: ''
@@ -974,10 +954,8 @@ jobs:
     - env:
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
-      name: Run `tailor --check update-build-files --check ::` with ${{ github.event.inputs.pants_version
-        }}
-      run: '${{ github.event.inputs.extra_env }} pants tailor --check update-build-files
-        --check ::'
+      name: Run `tailor --check update-build-files --check ::` with ${{ github.event.inputs.pants_version }}
+      run: '${{ github.event.inputs.extra_env }} pants tailor --check update-build-files --check ::'
     - env:
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
@@ -1030,8 +1008,7 @@ jobs:
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
-      name: Run `tailor --check update-build-files --check ::` with repo-default version
-        (baseline)
+      name: Run `tailor --check update-build-files --check ::` with repo-default version (baseline)
       run: ' pants tailor --check update-build-files --check ::'
     - env:
         PANTS_VERSION: ''
@@ -1059,10 +1036,8 @@ jobs:
     - env:
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
-      name: Run `tailor --check update-build-files --check ::` with ${{ github.event.inputs.pants_version
-        }}
-      run: '${{ github.event.inputs.extra_env }} pants tailor --check update-build-files
-        --check ::'
+      name: Run `tailor --check update-build-files --check ::` with ${{ github.event.inputs.pants_version }}
+      run: '${{ github.event.inputs.extra_env }} pants tailor --check update-build-files --check ::'
     - env:
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
@@ -1118,8 +1093,7 @@ jobs:
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
-      name: Run `tailor --check update-build-files --check ::` with repo-default version
-        (baseline)
+      name: Run `tailor --check update-build-files --check ::` with repo-default version (baseline)
       run: ' pants tailor --check update-build-files --check ::'
     - env:
         PANTS_VERSION: ''
@@ -1147,10 +1121,8 @@ jobs:
     - env:
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
-      name: Run `tailor --check update-build-files --check ::` with ${{ github.event.inputs.pants_version
-        }}
-      run: '${{ github.event.inputs.extra_env }} pants tailor --check update-build-files
-        --check ::'
+      name: Run `tailor --check update-build-files --check ::` with ${{ github.event.inputs.pants_version }}
+      run: '${{ github.event.inputs.extra_env }} pants tailor --check update-build-files --check ::'
     - env:
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
@@ -1202,8 +1174,7 @@ jobs:
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
-      name: Run `tailor --check update-build-files --check ::` with repo-default version
-        (baseline)
+      name: Run `tailor --check update-build-files --check ::` with repo-default version (baseline)
       run: ' pants tailor --check update-build-files --check ::'
     - env:
         PANTS_VERSION: ''
@@ -1231,10 +1202,8 @@ jobs:
     - env:
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
-      name: Run `tailor --check update-build-files --check ::` with ${{ github.event.inputs.pants_version
-        }}
-      run: '${{ github.event.inputs.extra_env }} pants tailor --check update-build-files
-        --check ::'
+      name: Run `tailor --check update-build-files --check ::` with ${{ github.event.inputs.pants_version }}
+      run: '${{ github.event.inputs.extra_env }} pants tailor --check update-build-files --check ::'
     - env:
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
@@ -1286,8 +1255,7 @@ jobs:
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
-      name: Run `tailor --check update-build-files --check ::` with repo-default version
-        (baseline)
+      name: Run `tailor --check update-build-files --check ::` with repo-default version (baseline)
       run: ' pants tailor --check update-build-files --check ::'
     - env:
         PANTS_VERSION: ''
@@ -1315,10 +1283,8 @@ jobs:
     - env:
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
-      name: Run `tailor --check update-build-files --check ::` with ${{ github.event.inputs.pants_version
-        }}
-      run: '${{ github.event.inputs.extra_env }} pants tailor --check update-build-files
-        --check ::'
+      name: Run `tailor --check update-build-files --check ::` with ${{ github.event.inputs.pants_version }}
+      run: '${{ github.event.inputs.extra_env }} pants tailor --check update-build-files --check ::'
     - env:
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
@@ -1370,8 +1336,7 @@ jobs:
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
-      name: Run `tailor --check update-build-files --check ::` with repo-default version
-        (baseline)
+      name: Run `tailor --check update-build-files --check ::` with repo-default version (baseline)
       run: ' pants tailor --check update-build-files --check ::'
     - env:
         PANTS_VERSION: ''
@@ -1399,10 +1364,8 @@ jobs:
     - env:
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
-      name: Run `tailor --check update-build-files --check ::` with ${{ github.event.inputs.pants_version
-        }}
-      run: '${{ github.event.inputs.extra_env }} pants tailor --check update-build-files
-        --check ::'
+      name: Run `tailor --check update-build-files --check ::` with ${{ github.event.inputs.pants_version }}
+      run: '${{ github.event.inputs.extra_env }} pants tailor --check update-build-files --check ::'
     - env:
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
@@ -1454,8 +1417,7 @@ jobs:
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
-      name: Run `tailor --check update-build-files --check ::` with repo-default version
-        (baseline)
+      name: Run `tailor --check update-build-files --check ::` with repo-default version (baseline)
       run: ' pants tailor --check update-build-files --check ::'
     - env:
         PANTS_VERSION: ''
@@ -1478,10 +1440,8 @@ jobs:
     - env:
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
-      name: Run `tailor --check update-build-files --check ::` with ${{ github.event.inputs.pants_version
-        }}
-      run: '${{ github.event.inputs.extra_env }} pants tailor --check update-build-files
-        --check ::'
+      name: Run `tailor --check update-build-files --check ::` with ${{ github.event.inputs.pants_version }}
+      run: '${{ github.event.inputs.extra_env }} pants tailor --check update-build-files --check ::'
     - env:
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
@@ -1528,8 +1488,7 @@ jobs:
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
-      name: Run `tailor --check update-build-files --check ::` with repo-default version
-        (baseline)
+      name: Run `tailor --check update-build-files --check ::` with repo-default version (baseline)
       run: ' pants tailor --check update-build-files --check ::'
     - env:
         PANTS_VERSION: ''
@@ -1557,10 +1516,8 @@ jobs:
     - env:
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
-      name: Run `tailor --check update-build-files --check ::` with ${{ github.event.inputs.pants_version
-        }}
-      run: '${{ github.event.inputs.extra_env }} pants tailor --check update-build-files
-        --check ::'
+      name: Run `tailor --check update-build-files --check ::` with ${{ github.event.inputs.pants_version }}
+      run: '${{ github.event.inputs.extra_env }} pants tailor --check update-build-files --check ::'
     - env:
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
@@ -1589,5 +1546,4 @@ name: Public repos tests
         description: Pants version (for example, `2.16.0`, `2.18.0.dev1`)
         required: true
         type: string
-run-name: 'Public repos test: version ${{ github.event.inputs.pants_version }} ${{
-  github.event.inputs.extra_env }}'
+run-name: 'Public repos test: version ${{ github.event.inputs.pants_version }} ${{ github.event.inputs.extra_env }}'

--- a/.github/workflows/public_repos.yaml
+++ b/.github/workflows/public_repos.yaml
@@ -22,17 +22,16 @@ jobs:
       with:
         python-version: '3.9'
     - name: Pants on
-      run: '
+      run: |2
 
-        curl --proto ''=https'' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh
-        | bash -
-
+        curl --proto '=https' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh | bash -
         echo "$HOME/bin" | tee -a $GITHUB_PATH
-
-        '
     - name: Check for pants.ci.toml
-      run: "\nif [[ -f pants.ci.toml ]]; then\n    echo \"PANTS_CONFIG_FILES=pants.ci.toml\"\
-        \ | tee -a $GITHUB_ENV\nfi\n"
+      run: |2
+
+        if [[ -f pants.ci.toml ]]; then
+            echo "PANTS_CONFIG_FILES=pants.ci.toml" | tee -a $GITHUB_ENV
+        fi
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
@@ -107,17 +106,16 @@ jobs:
       with:
         python-version: '3.10'
     - name: Pants on
-      run: '
+      run: |2
 
-        curl --proto ''=https'' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh
-        | bash -
-
+        curl --proto '=https' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh | bash -
         echo "$HOME/bin" | tee -a $GITHUB_PATH
-
-        '
     - name: Check for pants.ci.toml
-      run: "\nif [[ -f pants.ci.toml ]]; then\n    echo \"PANTS_CONFIG_FILES=pants.ci.toml\"\
-        \ | tee -a $GITHUB_ENV\nfi\n"
+      run: |2
+
+        if [[ -f pants.ci.toml ]]; then
+            echo "PANTS_CONFIG_FILES=pants.ci.toml" | tee -a $GITHUB_ENV
+        fi
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
@@ -159,17 +157,16 @@ jobs:
       with:
         python-version: 3.9.15
     - name: Pants on
-      run: '
+      run: |2
 
-        curl --proto ''=https'' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh
-        | bash -
-
+        curl --proto '=https' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh | bash -
         echo "$HOME/bin" | tee -a $GITHUB_PATH
-
-        '
     - name: Check for pants.ci.toml
-      run: "\nif [[ -f pants.ci.toml ]]; then\n    echo \"PANTS_CONFIG_FILES=pants.ci.toml\"\
-        \ | tee -a $GITHUB_ENV\nfi\n"
+      run: |2
+
+        if [[ -f pants.ci.toml ]]; then
+            echo "PANTS_CONFIG_FILES=pants.ci.toml" | tee -a $GITHUB_ENV
+        fi
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
@@ -245,28 +242,22 @@ jobs:
       with:
         python-version: '3.8'
     - name: Pants on
-      run: '
+      run: |2
 
-        curl --proto ''=https'' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh
-        | bash -
-
+        curl --proto '=https' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh | bash -
         echo "$HOME/bin" | tee -a $GITHUB_PATH
-
-        '
     - name: Check for pants.ci.toml
-      run: "\nif [[ -f pants.ci.toml ]]; then\n    echo \"PANTS_CONFIG_FILES=pants.ci.toml\"\
-        \ | tee -a $GITHUB_ENV\nfi\n"
+      run: |2
+
+        if [[ -f pants.ci.toml ]]; then
+            echo "PANTS_CONFIG_FILES=pants.ci.toml" | tee -a $GITHUB_ENV
+        fi
     - name: Run set-up
-      run: '
+      run: |2
 
-        sudo apt-get install gcc git make screen libffi-dev libssl-dev python3.8-dev
-        libldap2-dev libsasl2-dev
-
+        sudo apt-get install gcc git make screen libffi-dev libssl-dev python3.8-dev libldap2-dev libsasl2-dev
         # sudo apt-get install mongodb mongodb-server
-
         sudo apt-get install rabbitmq-server
-
-        '
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
@@ -342,17 +333,16 @@ jobs:
       with:
         python-version: '3.10'
     - name: Pants on
-      run: '
+      run: |2
 
-        curl --proto ''=https'' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh
-        | bash -
-
+        curl --proto '=https' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh | bash -
         echo "$HOME/bin" | tee -a $GITHUB_PATH
-
-        '
     - name: Check for pants.ci.toml
-      run: "\nif [[ -f pants.ci.toml ]]; then\n    echo \"PANTS_CONFIG_FILES=pants.ci.toml\"\
-        \ | tee -a $GITHUB_ENV\nfi\n"
+      run: |2
+
+        if [[ -f pants.ci.toml ]]; then
+            echo "PANTS_CONFIG_FILES=pants.ci.toml" | tee -a $GITHUB_ENV
+        fi
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
@@ -414,17 +404,16 @@ jobs:
       with:
         python-version: '3.10'
     - name: Pants on
-      run: '
+      run: |2
 
-        curl --proto ''=https'' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh
-        | bash -
-
+        curl --proto '=https' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh | bash -
         echo "$HOME/bin" | tee -a $GITHUB_PATH
-
-        '
     - name: Check for pants.ci.toml
-      run: "\nif [[ -f pants.ci.toml ]]; then\n    echo \"PANTS_CONFIG_FILES=pants.ci.toml\"\
-        \ | tee -a $GITHUB_ENV\nfi\n"
+      run: |2
+
+        if [[ -f pants.ci.toml ]]; then
+            echo "PANTS_CONFIG_FILES=pants.ci.toml" | tee -a $GITHUB_ENV
+        fi
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
@@ -476,17 +465,16 @@ jobs:
       with:
         python-version: '3.9'
     - name: Pants on
-      run: '
+      run: |2
 
-        curl --proto ''=https'' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh
-        | bash -
-
+        curl --proto '=https' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh | bash -
         echo "$HOME/bin" | tee -a $GITHUB_PATH
-
-        '
     - name: Check for pants.ci.toml
-      run: "\nif [[ -f pants.ci.toml ]]; then\n    echo \"PANTS_CONFIG_FILES=pants.ci.toml\"\
-        \ | tee -a $GITHUB_ENV\nfi\n"
+      run: |2
+
+        if [[ -f pants.ci.toml ]]; then
+            echo "PANTS_CONFIG_FILES=pants.ci.toml" | tee -a $GITHUB_ENV
+        fi
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
@@ -528,17 +516,16 @@ jobs:
       with:
         python-version: 3.11.4
     - name: Pants on
-      run: '
+      run: |2
 
-        curl --proto ''=https'' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh
-        | bash -
-
+        curl --proto '=https' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh | bash -
         echo "$HOME/bin" | tee -a $GITHUB_PATH
-
-        '
     - name: Check for pants.ci.toml
-      run: "\nif [[ -f pants.ci.toml ]]; then\n    echo \"PANTS_CONFIG_FILES=pants.ci.toml\"\
-        \ | tee -a $GITHUB_ENV\nfi\n"
+      run: |2
+
+        if [[ -f pants.ci.toml ]]; then
+            echo "PANTS_CONFIG_FILES=pants.ci.toml" | tee -a $GITHUB_ENV
+        fi
     - name: Run set-up
       run: mkdir .tmp
     - env:
@@ -618,17 +605,16 @@ jobs:
       with:
         python-version: '3.10'
     - name: Pants on
-      run: '
+      run: |2
 
-        curl --proto ''=https'' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh
-        | bash -
-
+        curl --proto '=https' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh | bash -
         echo "$HOME/bin" | tee -a $GITHUB_PATH
-
-        '
     - name: Check for pants.ci.toml
-      run: "\nif [[ -f pants.ci.toml ]]; then\n    echo \"PANTS_CONFIG_FILES=pants.ci.toml\"\
-        \ | tee -a $GITHUB_ENV\nfi\n"
+      run: |2
+
+        if [[ -f pants.ci.toml ]]; then
+            echo "PANTS_CONFIG_FILES=pants.ci.toml" | tee -a $GITHUB_ENV
+        fi
     - name: Run set-up
       run: sudo apt-get install pkg-config libxml2-dev libxmlsec1-dev libxmlsec1-openssl
     - env:
@@ -672,17 +658,16 @@ jobs:
       with:
         python-version: '3.10'
     - name: Pants on
-      run: '
+      run: |2
 
-        curl --proto ''=https'' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh
-        | bash -
-
+        curl --proto '=https' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh | bash -
         echo "$HOME/bin" | tee -a $GITHUB_PATH
-
-        '
     - name: Check for pants.ci.toml
-      run: "\nif [[ -f pants.ci.toml ]]; then\n    echo \"PANTS_CONFIG_FILES=pants.ci.toml\"\
-        \ | tee -a $GITHUB_ENV\nfi\n"
+      run: |2
+
+        if [[ -f pants.ci.toml ]]; then
+            echo "PANTS_CONFIG_FILES=pants.ci.toml" | tee -a $GITHUB_ENV
+        fi
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
@@ -724,17 +709,16 @@ jobs:
       with:
         python-version: '3.10'
     - name: Pants on
-      run: '
+      run: |2
 
-        curl --proto ''=https'' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh
-        | bash -
-
+        curl --proto '=https' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh | bash -
         echo "$HOME/bin" | tee -a $GITHUB_PATH
-
-        '
     - name: Check for pants.ci.toml
-      run: "\nif [[ -f pants.ci.toml ]]; then\n    echo \"PANTS_CONFIG_FILES=pants.ci.toml\"\
-        \ | tee -a $GITHUB_ENV\nfi\n"
+      run: |2
+
+        if [[ -f pants.ci.toml ]]; then
+            echo "PANTS_CONFIG_FILES=pants.ci.toml" | tee -a $GITHUB_ENV
+        fi
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
@@ -791,17 +775,16 @@ jobs:
       with:
         node-version: '20'
     - name: Pants on
-      run: '
+      run: |2
 
-        curl --proto ''=https'' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh
-        | bash -
-
+        curl --proto '=https' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh | bash -
         echo "$HOME/bin" | tee -a $GITHUB_PATH
-
-        '
     - name: Check for pants.ci.toml
-      run: "\nif [[ -f pants.ci.toml ]]; then\n    echo \"PANTS_CONFIG_FILES=pants.ci.toml\"\
-        \ | tee -a $GITHUB_ENV\nfi\n"
+      run: |2
+
+        if [[ -f pants.ci.toml ]]; then
+            echo "PANTS_CONFIG_FILES=pants.ci.toml" | tee -a $GITHUB_ENV
+        fi
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
@@ -854,28 +837,22 @@ jobs:
         python-version: '3.10'
     - if: runner.os == 'Linux'
       name: Download Apache `thrift` binary (Linux)
-      run: 'mkdir -p "${HOME}/.thrift"
-
-        curl --fail -L https://binaries.pantsbuild.org/bin/thrift/linux/x86_64/0.15.0/thrift
-        -o "${HOME}/.thrift/thrift"
-
+      run: |
+        mkdir -p "${HOME}/.thrift"
+        curl --fail -L https://binaries.pantsbuild.org/bin/thrift/linux/x86_64/0.15.0/thrift -o "${HOME}/.thrift/thrift"
         chmod +x "${HOME}/.thrift/thrift"
-
         echo "${HOME}/.thrift" >> $GITHUB_PATH
-
-        '
     - name: Pants on
-      run: '
+      run: |2
 
-        curl --proto ''=https'' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh
-        | bash -
-
+        curl --proto '=https' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh | bash -
         echo "$HOME/bin" | tee -a $GITHUB_PATH
-
-        '
     - name: Check for pants.ci.toml
-      run: "\nif [[ -f pants.ci.toml ]]; then\n    echo \"PANTS_CONFIG_FILES=pants.ci.toml\"\
-        \ | tee -a $GITHUB_ENV\nfi\n"
+      run: |2
+
+        if [[ -f pants.ci.toml ]]; then
+            echo "PANTS_CONFIG_FILES=pants.ci.toml" | tee -a $GITHUB_ENV
+        fi
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
@@ -950,17 +927,16 @@ jobs:
       with:
         python-version: '3.9'
     - name: Pants on
-      run: '
+      run: |2
 
-        curl --proto ''=https'' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh
-        | bash -
-
+        curl --proto '=https' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh | bash -
         echo "$HOME/bin" | tee -a $GITHUB_PATH
-
-        '
     - name: Check for pants.ci.toml
-      run: "\nif [[ -f pants.ci.toml ]]; then\n    echo \"PANTS_CONFIG_FILES=pants.ci.toml\"\
-        \ | tee -a $GITHUB_ENV\nfi\n"
+      run: |2
+
+        if [[ -f pants.ci.toml ]]; then
+            echo "PANTS_CONFIG_FILES=pants.ci.toml" | tee -a $GITHUB_ENV
+        fi
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
@@ -1036,17 +1012,16 @@ jobs:
       with:
         python-version: '3.8'
     - name: Pants on
-      run: '
+      run: |2
 
-        curl --proto ''=https'' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh
-        | bash -
-
+        curl --proto '=https' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh | bash -
         echo "$HOME/bin" | tee -a $GITHUB_PATH
-
-        '
     - name: Check for pants.ci.toml
-      run: "\nif [[ -f pants.ci.toml ]]; then\n    echo \"PANTS_CONFIG_FILES=pants.ci.toml\"\
-        \ | tee -a $GITHUB_ENV\nfi\n"
+      run: |2
+
+        if [[ -f pants.ci.toml ]]; then
+            echo "PANTS_CONFIG_FILES=pants.ci.toml" | tee -a $GITHUB_ENV
+        fi
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
@@ -1125,17 +1100,16 @@ jobs:
       with:
         go-version: 1.19.5
     - name: Pants on
-      run: '
+      run: |2
 
-        curl --proto ''=https'' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh
-        | bash -
-
+        curl --proto '=https' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh | bash -
         echo "$HOME/bin" | tee -a $GITHUB_PATH
-
-        '
     - name: Check for pants.ci.toml
-      run: "\nif [[ -f pants.ci.toml ]]; then\n    echo \"PANTS_CONFIG_FILES=pants.ci.toml\"\
-        \ | tee -a $GITHUB_ENV\nfi\n"
+      run: |2
+
+        if [[ -f pants.ci.toml ]]; then
+            echo "PANTS_CONFIG_FILES=pants.ci.toml" | tee -a $GITHUB_ENV
+        fi
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
@@ -1210,17 +1184,16 @@ jobs:
       with:
         python-version: '3.10'
     - name: Pants on
-      run: '
+      run: |2
 
-        curl --proto ''=https'' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh
-        | bash -
-
+        curl --proto '=https' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh | bash -
         echo "$HOME/bin" | tee -a $GITHUB_PATH
-
-        '
     - name: Check for pants.ci.toml
-      run: "\nif [[ -f pants.ci.toml ]]; then\n    echo \"PANTS_CONFIG_FILES=pants.ci.toml\"\
-        \ | tee -a $GITHUB_ENV\nfi\n"
+      run: |2
+
+        if [[ -f pants.ci.toml ]]; then
+            echo "PANTS_CONFIG_FILES=pants.ci.toml" | tee -a $GITHUB_ENV
+        fi
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
@@ -1295,17 +1268,16 @@ jobs:
       with:
         python-version: '3.10'
     - name: Pants on
-      run: '
+      run: |2
 
-        curl --proto ''=https'' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh
-        | bash -
-
+        curl --proto '=https' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh | bash -
         echo "$HOME/bin" | tee -a $GITHUB_PATH
-
-        '
     - name: Check for pants.ci.toml
-      run: "\nif [[ -f pants.ci.toml ]]; then\n    echo \"PANTS_CONFIG_FILES=pants.ci.toml\"\
-        \ | tee -a $GITHUB_ENV\nfi\n"
+      run: |2
+
+        if [[ -f pants.ci.toml ]]; then
+            echo "PANTS_CONFIG_FILES=pants.ci.toml" | tee -a $GITHUB_ENV
+        fi
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
@@ -1380,17 +1352,16 @@ jobs:
       with:
         python-version: '3.9'
     - name: Pants on
-      run: '
+      run: |2
 
-        curl --proto ''=https'' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh
-        | bash -
-
+        curl --proto '=https' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh | bash -
         echo "$HOME/bin" | tee -a $GITHUB_PATH
-
-        '
     - name: Check for pants.ci.toml
-      run: "\nif [[ -f pants.ci.toml ]]; then\n    echo \"PANTS_CONFIG_FILES=pants.ci.toml\"\
-        \ | tee -a $GITHUB_ENV\nfi\n"
+      run: |2
+
+        if [[ -f pants.ci.toml ]]; then
+            echo "PANTS_CONFIG_FILES=pants.ci.toml" | tee -a $GITHUB_ENV
+        fi
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
@@ -1465,17 +1436,16 @@ jobs:
       with:
         python-version: '3.9'
     - name: Pants on
-      run: '
+      run: |2
 
-        curl --proto ''=https'' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh
-        | bash -
-
+        curl --proto '=https' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh | bash -
         echo "$HOME/bin" | tee -a $GITHUB_PATH
-
-        '
     - name: Check for pants.ci.toml
-      run: "\nif [[ -f pants.ci.toml ]]; then\n    echo \"PANTS_CONFIG_FILES=pants.ci.toml\"\
-        \ | tee -a $GITHUB_ENV\nfi\n"
+      run: |2
+
+        if [[ -f pants.ci.toml ]]; then
+            echo "PANTS_CONFIG_FILES=pants.ci.toml" | tee -a $GITHUB_ENV
+        fi
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
@@ -1540,17 +1510,16 @@ jobs:
       with:
         python-version: '3.9'
     - name: Pants on
-      run: '
+      run: |2
 
-        curl --proto ''=https'' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh
-        | bash -
-
+        curl --proto '=https' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh | bash -
         echo "$HOME/bin" | tee -a $GITHUB_PATH
-
-        '
     - name: Check for pants.ci.toml
-      run: "\nif [[ -f pants.ci.toml ]]; then\n    echo \"PANTS_CONFIG_FILES=pants.ci.toml\"\
-        \ | tee -a $GITHUB_ENV\nfi\n"
+      run: |2
+
+        if [[ -f pants.ci.toml ]]; then
+            echo "PANTS_CONFIG_FILES=pants.ci.toml" | tee -a $GITHUB_ENV
+        fi
     - env:
         PANTS_VERSION: ''
       if: success() || failure()

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,37 +34,23 @@ jobs:
     - name: Configure Git
       run: git config --global safe.directory "$GITHUB_WORKSPACE"
     - name: Install rustup
-      run: 'curl --proto ''=https'' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s --
-        -v -y --default-toolchain none
-
+      run: |
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -v -y --default-toolchain none
         echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
-
-        '
     - name: Install Rust toolchain
-      run: '# Set the default toolchain. Installs the toolchain if it is not already
-        installed.
-
+      run: |
+        # Set the default toolchain. Installs the toolchain if it is not already installed.
         rustup default 1.88.0
-
         cargo version
-
-        '
     - name: Expose Pythons
-      run: 'echo "/opt/python/cp37-cp37m/bin" >> $GITHUB_PATH
-
+      run: |
+        echo "/opt/python/cp37-cp37m/bin" >> $GITHUB_PATH
         echo "/opt/python/cp38-cp38/bin" >> $GITHUB_PATH
-
         echo "/opt/python/cp39-cp39/bin" >> $GITHUB_PATH
-
         echo "/opt/python/cp310-cp310/bin" >> $GITHUB_PATH
-
         echo "/opt/python/cp311-cp311/bin" >> $GITHUB_PATH
-
         echo "/opt/python/cp312-cp312/bin" >> $GITHUB_PATH
-
         echo "/opt/python/cp313-cp313/bin" >> $GITHUB_PATH
-
-        '
     - name: Install Protoc
       uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
       with:
@@ -93,22 +79,14 @@ jobs:
         subject-path: dist/deploy/wheels/pantsbuild.pants/**/pantsbuild.pants-*.whl
     - if: needs.release_info.outputs.is-release == 'true'
       name: Rename the Pants Pex to its final name for upload
-      run: 'PANTS_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import
-        pants.version;print(pants.version.VERSION)")
-
-        PY_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import
-        sys;print(f''cp{sys.version_info[0]}{sys.version_info[1]}'')")
-
-        PLAT=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import os;print(f''{os.uname().sysname.lower()}_{os.uname().machine.lower()}'')")
-
+      run: |
+        PANTS_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import pants.version;print(pants.version.VERSION)")
+        PY_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import sys;print(f'cp{sys.version_info[0]}{sys.version_info[1]}')")
+        PLAT=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import os;print(f'{os.uname().sysname.lower()}_{os.uname().machine.lower()}')")
         PEX_FILENAME=pants.$PANTS_VER-$PY_VER-$PLAT.pex
 
-
         mv dist/src.python.pants/pants-pex.pex dist/src.python.pants/$PEX_FILENAME
-
         echo "PEX_FILENAME=$PEX_FILENAME" | tee -a "$GITHUB_ENV"
-
-        '
     - if: needs.release_info.outputs.is-release == 'true'
       name: Attest the Pants Pex artifact
       uses: actions/attest-build-provenance@v2
@@ -116,15 +94,21 @@ jobs:
         subject-path: dist/src.python.pants/*.pex
     - if: needs.release_info.outputs.is-release == 'true'
       name: Upload Wheel and Pex
-      run: "curl -L --fail \\\n    -X POST \\\n    -H \"Authorization: Bearer ${{\
-        \ github.token }}\" \\\n    -H \"Content-Type: application/octet-stream\"\
-        \ \\\n    ${{ needs.release_info.outputs.release-asset-upload-url }}?name=$PEX_FILENAME\
-        \ \\\n    --data-binary \"@dist/src.python.pants/$PEX_FILENAME\"\n\nWHL=$(find\
-        \ dist/deploy/wheels/pantsbuild.pants -type f -name \"pantsbuild.pants-*.whl\"\
-        )\ncurl -L --fail \\\n    -X POST \\\n    -H \"Authorization: Bearer ${{ github.token\
-        \ }}\" \\\n    -H \"Content-Type: application/octet-stream\" \\\n    \"${{\
-        \ needs.release_info.outputs.release-asset-upload-url }}?name=$(basename $WHL)\"\
-        \ \\\n    --data-binary \"@$WHL\";\n"
+      run: |
+        curl -L --fail \
+            -X POST \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            -H "Content-Type: application/octet-stream" \
+            ${{ needs.release_info.outputs.release-asset-upload-url }}?name=$PEX_FILENAME \
+            --data-binary "@dist/src.python.pants/$PEX_FILENAME"
+
+        WHL=$(find dist/deploy/wheels/pantsbuild.pants -type f -name "pantsbuild.pants-*.whl")
+        curl -L --fail \
+            -X POST \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            -H "Content-Type: application/octet-stream" \
+            "${{ needs.release_info.outputs.release-asset-upload-url }}?name=$(basename $WHL)" \
+            --data-binary "@$WHL";
     timeout-minutes: 90
   build_wheels_linux_x86_64:
     container:
@@ -152,37 +136,23 @@ jobs:
     - name: Configure Git
       run: git config --global safe.directory "$GITHUB_WORKSPACE"
     - name: Install rustup
-      run: 'curl --proto ''=https'' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s --
-        -v -y --default-toolchain none
-
+      run: |
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -v -y --default-toolchain none
         echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
-
-        '
     - name: Install Rust toolchain
-      run: '# Set the default toolchain. Installs the toolchain if it is not already
-        installed.
-
+      run: |
+        # Set the default toolchain. Installs the toolchain if it is not already installed.
         rustup default 1.88.0
-
         cargo version
-
-        '
     - name: Expose Pythons
-      run: 'echo "/opt/python/cp37-cp37m/bin" >> $GITHUB_PATH
-
+      run: |
+        echo "/opt/python/cp37-cp37m/bin" >> $GITHUB_PATH
         echo "/opt/python/cp38-cp38/bin" >> $GITHUB_PATH
-
         echo "/opt/python/cp39-cp39/bin" >> $GITHUB_PATH
-
         echo "/opt/python/cp310-cp310/bin" >> $GITHUB_PATH
-
         echo "/opt/python/cp311-cp311/bin" >> $GITHUB_PATH
-
         echo "/opt/python/cp312-cp312/bin" >> $GITHUB_PATH
-
         echo "/opt/python/cp313-cp313/bin" >> $GITHUB_PATH
-
-        '
     - name: Install Protoc
       uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
       with:
@@ -215,22 +185,14 @@ jobs:
         subject-path: dist/deploy/wheels/pantsbuild.pants/**/pantsbuild.pants-*.whl
     - if: needs.release_info.outputs.is-release == 'true'
       name: Rename the Pants Pex to its final name for upload
-      run: 'PANTS_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import
-        pants.version;print(pants.version.VERSION)")
-
-        PY_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import
-        sys;print(f''cp{sys.version_info[0]}{sys.version_info[1]}'')")
-
-        PLAT=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import os;print(f''{os.uname().sysname.lower()}_{os.uname().machine.lower()}'')")
-
+      run: |
+        PANTS_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import pants.version;print(pants.version.VERSION)")
+        PY_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import sys;print(f'cp{sys.version_info[0]}{sys.version_info[1]}')")
+        PLAT=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import os;print(f'{os.uname().sysname.lower()}_{os.uname().machine.lower()}')")
         PEX_FILENAME=pants.$PANTS_VER-$PY_VER-$PLAT.pex
 
-
         mv dist/src.python.pants/pants-pex.pex dist/src.python.pants/$PEX_FILENAME
-
         echo "PEX_FILENAME=$PEX_FILENAME" | tee -a "$GITHUB_ENV"
-
-        '
     - if: needs.release_info.outputs.is-release == 'true'
       name: Attest the Pants Pex artifact
       uses: actions/attest-build-provenance@v2
@@ -238,15 +200,21 @@ jobs:
         subject-path: dist/src.python.pants/*.pex
     - if: needs.release_info.outputs.is-release == 'true'
       name: Upload Wheel and Pex
-      run: "curl -L --fail \\\n    -X POST \\\n    -H \"Authorization: Bearer ${{\
-        \ github.token }}\" \\\n    -H \"Content-Type: application/octet-stream\"\
-        \ \\\n    ${{ needs.release_info.outputs.release-asset-upload-url }}?name=$PEX_FILENAME\
-        \ \\\n    --data-binary \"@dist/src.python.pants/$PEX_FILENAME\"\n\nWHL=$(find\
-        \ dist/deploy/wheels/pantsbuild.pants -type f -name \"pantsbuild.pants-*.whl\"\
-        )\ncurl -L --fail \\\n    -X POST \\\n    -H \"Authorization: Bearer ${{ github.token\
-        \ }}\" \\\n    -H \"Content-Type: application/octet-stream\" \\\n    \"${{\
-        \ needs.release_info.outputs.release-asset-upload-url }}?name=$(basename $WHL)\"\
-        \ \\\n    --data-binary \"@$WHL\";\n"
+      run: |
+        curl -L --fail \
+            -X POST \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            -H "Content-Type: application/octet-stream" \
+            ${{ needs.release_info.outputs.release-asset-upload-url }}?name=$PEX_FILENAME \
+            --data-binary "@dist/src.python.pants/$PEX_FILENAME"
+
+        WHL=$(find dist/deploy/wheels/pantsbuild.pants -type f -name "pantsbuild.pants-*.whl")
+        curl -L --fail \
+            -X POST \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            -H "Content-Type: application/octet-stream" \
+            "${{ needs.release_info.outputs.release-asset-upload-url }}?name=$(basename $WHL)" \
+            --data-binary "@$WHL";
     - if: needs.release_info.outputs.is-release == 'true'
       name: Attest the pantsbuild.pants.testutil wheel
       uses: actions/attest-build-provenance@v2
@@ -254,11 +222,14 @@ jobs:
         subject-path: dist/deploy/wheels/pantsbuild.pants/**/pantsbuild.pants.testutil*.whl
     - if: needs.release_info.outputs.is-release == 'true'
       name: Upload testutil Wheel
-      run: "WHL=$(find dist/deploy/wheels/pantsbuild.pants -type f -name \"pantsbuild.pants.testutil*.whl\"\
-        )\ncurl -L --fail \\\n    -X POST \\\n    -H \"Authorization: Bearer ${{ github.token\
-        \ }}\" \\\n    -H \"Content-Type: application/octet-stream\" \\\n    \"${{\
-        \ needs.release_info.outputs.release-asset-upload-url }}?name=$(basename $WHL)\"\
-        \ \\\n    --data-binary \"@$WHL\";\n"
+      run: |
+        WHL=$(find dist/deploy/wheels/pantsbuild.pants -type f -name "pantsbuild.pants.testutil*.whl")
+        curl -L --fail \
+            -X POST \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            -H "Content-Type: application/octet-stream" \
+            "${{ needs.release_info.outputs.release-asset-upload-url }}?name=$(basename $WHL)" \
+            --data-binary "@$WHL";
     timeout-minutes: 90
   build_wheels_macos13_x86_64:
     env:
@@ -284,19 +255,14 @@ jobs:
     - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7
-
+        python-version: |-
+          3.7
           3.8
-
           3.9
-
           3.10
-
           3.12
-
           3.13
-
-          3.11'
+          3.11
     - name: Install Protoc
       uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
       with:
@@ -308,13 +274,10 @@ jobs:
       uses: actions/cache@v4
       with:
         key: macOS13-x86_64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.88.0-*
-
+        path: |
+          ~/.rustup/toolchains/1.88.0-*
           ~/.rustup/update-hashes
-
           ~/.rustup/settings.toml
-
-          '
     - name: Cache Cargo
       uses: benjyw/rust-cache@5ed697a6894712d2854c80635bb00a2496ea307a
       with:
@@ -355,22 +318,14 @@ jobs:
         subject-path: dist/deploy/wheels/pantsbuild.pants/**/pantsbuild.pants-*.whl
     - if: needs.release_info.outputs.is-release == 'true'
       name: Rename the Pants Pex to its final name for upload
-      run: 'PANTS_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import
-        pants.version;print(pants.version.VERSION)")
-
-        PY_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import
-        sys;print(f''cp{sys.version_info[0]}{sys.version_info[1]}'')")
-
-        PLAT=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import os;print(f''{os.uname().sysname.lower()}_{os.uname().machine.lower()}'')")
-
+      run: |
+        PANTS_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import pants.version;print(pants.version.VERSION)")
+        PY_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import sys;print(f'cp{sys.version_info[0]}{sys.version_info[1]}')")
+        PLAT=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import os;print(f'{os.uname().sysname.lower()}_{os.uname().machine.lower()}')")
         PEX_FILENAME=pants.$PANTS_VER-$PY_VER-$PLAT.pex
 
-
         mv dist/src.python.pants/pants-pex.pex dist/src.python.pants/$PEX_FILENAME
-
         echo "PEX_FILENAME=$PEX_FILENAME" | tee -a "$GITHUB_ENV"
-
-        '
     - if: needs.release_info.outputs.is-release == 'true'
       name: Attest the Pants Pex artifact
       uses: actions/attest-build-provenance@v2
@@ -378,15 +333,21 @@ jobs:
         subject-path: dist/src.python.pants/*.pex
     - if: needs.release_info.outputs.is-release == 'true'
       name: Upload Wheel and Pex
-      run: "curl -L --fail \\\n    -X POST \\\n    -H \"Authorization: Bearer ${{\
-        \ github.token }}\" \\\n    -H \"Content-Type: application/octet-stream\"\
-        \ \\\n    ${{ needs.release_info.outputs.release-asset-upload-url }}?name=$PEX_FILENAME\
-        \ \\\n    --data-binary \"@dist/src.python.pants/$PEX_FILENAME\"\n\nWHL=$(find\
-        \ dist/deploy/wheels/pantsbuild.pants -type f -name \"pantsbuild.pants-*.whl\"\
-        )\ncurl -L --fail \\\n    -X POST \\\n    -H \"Authorization: Bearer ${{ github.token\
-        \ }}\" \\\n    -H \"Content-Type: application/octet-stream\" \\\n    \"${{\
-        \ needs.release_info.outputs.release-asset-upload-url }}?name=$(basename $WHL)\"\
-        \ \\\n    --data-binary \"@$WHL\";\n"
+      run: |
+        curl -L --fail \
+            -X POST \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            -H "Content-Type: application/octet-stream" \
+            ${{ needs.release_info.outputs.release-asset-upload-url }}?name=$PEX_FILENAME \
+            --data-binary "@dist/src.python.pants/$PEX_FILENAME"
+
+        WHL=$(find dist/deploy/wheels/pantsbuild.pants -type f -name "pantsbuild.pants-*.whl")
+        curl -L --fail \
+            -X POST \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            -H "Content-Type: application/octet-stream" \
+            "${{ needs.release_info.outputs.release-asset-upload-url }}?name=$(basename $WHL)" \
+            --data-binary "@$WHL";
     timeout-minutes: 90
   build_wheels_macos14_arm64:
     env:
@@ -412,15 +373,12 @@ jobs:
     - name: Set up Python 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9
-
+        python-version: |-
+          3.9
           3.10
-
           3.12
-
           3.13
-
-          3.11'
+          3.11
     - name: Install Protoc
       uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
       with:
@@ -432,13 +390,10 @@ jobs:
       uses: actions/cache@v4
       with:
         key: macOS14-ARM64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.88.0-*
-
+        path: |
+          ~/.rustup/toolchains/1.88.0-*
           ~/.rustup/update-hashes
-
           ~/.rustup/settings.toml
-
-          '
     - name: Cache Cargo
       uses: benjyw/rust-cache@5ed697a6894712d2854c80635bb00a2496ea307a
       with:
@@ -479,22 +434,14 @@ jobs:
         subject-path: dist/deploy/wheels/pantsbuild.pants/**/pantsbuild.pants-*.whl
     - if: needs.release_info.outputs.is-release == 'true'
       name: Rename the Pants Pex to its final name for upload
-      run: 'PANTS_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import
-        pants.version;print(pants.version.VERSION)")
-
-        PY_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import
-        sys;print(f''cp{sys.version_info[0]}{sys.version_info[1]}'')")
-
-        PLAT=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import os;print(f''{os.uname().sysname.lower()}_{os.uname().machine.lower()}'')")
-
+      run: |
+        PANTS_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import pants.version;print(pants.version.VERSION)")
+        PY_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import sys;print(f'cp{sys.version_info[0]}{sys.version_info[1]}')")
+        PLAT=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import os;print(f'{os.uname().sysname.lower()}_{os.uname().machine.lower()}')")
         PEX_FILENAME=pants.$PANTS_VER-$PY_VER-$PLAT.pex
 
-
         mv dist/src.python.pants/pants-pex.pex dist/src.python.pants/$PEX_FILENAME
-
         echo "PEX_FILENAME=$PEX_FILENAME" | tee -a "$GITHUB_ENV"
-
-        '
     - if: needs.release_info.outputs.is-release == 'true'
       name: Attest the Pants Pex artifact
       uses: actions/attest-build-provenance@v2
@@ -502,15 +449,21 @@ jobs:
         subject-path: dist/src.python.pants/*.pex
     - if: needs.release_info.outputs.is-release == 'true'
       name: Upload Wheel and Pex
-      run: "curl -L --fail \\\n    -X POST \\\n    -H \"Authorization: Bearer ${{\
-        \ github.token }}\" \\\n    -H \"Content-Type: application/octet-stream\"\
-        \ \\\n    ${{ needs.release_info.outputs.release-asset-upload-url }}?name=$PEX_FILENAME\
-        \ \\\n    --data-binary \"@dist/src.python.pants/$PEX_FILENAME\"\n\nWHL=$(find\
-        \ dist/deploy/wheels/pantsbuild.pants -type f -name \"pantsbuild.pants-*.whl\"\
-        )\ncurl -L --fail \\\n    -X POST \\\n    -H \"Authorization: Bearer ${{ github.token\
-        \ }}\" \\\n    -H \"Content-Type: application/octet-stream\" \\\n    \"${{\
-        \ needs.release_info.outputs.release-asset-upload-url }}?name=$(basename $WHL)\"\
-        \ \\\n    --data-binary \"@$WHL\";\n"
+      run: |
+        curl -L --fail \
+            -X POST \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            -H "Content-Type: application/octet-stream" \
+            ${{ needs.release_info.outputs.release-asset-upload-url }}?name=$PEX_FILENAME \
+            --data-binary "@dist/src.python.pants/$PEX_FILENAME"
+
+        WHL=$(find dist/deploy/wheels/pantsbuild.pants -type f -name "pantsbuild.pants-*.whl")
+        curl -L --fail \
+            -X POST \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            -H "Content-Type: application/octet-stream" \
+            "${{ needs.release_info.outputs.release-asset-upload-url }}?name=$(basename $WHL)" \
+            --data-binary "@$WHL";
     timeout-minutes: 90
   publish:
     env:
@@ -534,19 +487,14 @@ jobs:
     - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7
-
+        python-version: |-
+          3.7
           3.8
-
           3.9
-
           3.10
-
           3.12
-
           3.13
-
-          3.11'
+          3.11
     - name: Install Protoc
       uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
       with:
@@ -558,13 +506,10 @@ jobs:
       uses: actions/cache@v4
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.88.0-*
-
+        path: |
+          ~/.rustup/toolchains/1.88.0-*
           ~/.rustup/update-hashes
-
           ~/.rustup/settings.toml
-
-          '
     - name: Cache Cargo
       uses: benjyw/rust-cache@5ed697a6894712d2854c80635bb00a2496ea307a
       with:
@@ -579,18 +524,14 @@ jobs:
       uses: actions/cache@v4
       with:
         key: Linux-x86_64-engine-${{ steps.get-engine-hash.outputs.hash }}-v1
-        path: 'src/python/pants/bin/native_client
-
+        path: |-
+          src/python/pants/bin/native_client
           src/python/pants/bin/sandboxer
-
           src/python/pants/engine/internals/native_engine.so
-
-          src/python/pants/engine/internals/native_engine.so.metadata'
+          src/python/pants/engine/internals/native_engine.so.metadata
     - name: Generate announcement
-      run: './pants run src/python/pants_release/generate_release_announcement.py                         --
-        --output-dir=${{ runner.temp }}
-
-        '
+      run: |
+        ./pants run src/python/pants_release/generate_release_announcement.py                         -- --output-dir=${{ runner.temp }}
     - env:
         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       name: Announce to Slack
@@ -612,37 +553,27 @@ jobs:
         GH_REPO: ${{ github.repository }}
         GH_TOKEN: ${{ github.token }}
       name: Get release notes
-      run: './pants run src/python/pants_release/changelog.py -- "${{ needs.release_info.outputs.build-ref
-        }}" > notes.txt
-
-        '
+      run: |
+        ./pants run src/python/pants_release/changelog.py -- "${{ needs.release_info.outputs.build-ref }}" > notes.txt
     - env:
         GH_REPO: ${{ github.repository }}
         GH_TOKEN: ${{ github.token }}
       name: Publish GitHub Release
-      run: 'gh release edit ${{ needs.release_info.outputs.build-ref }} --draft=false
-        --notes-file notes.txt
-
-        '
+      run: |
+        gh release edit ${{ needs.release_info.outputs.build-ref }} --draft=false --notes-file notes.txt
     - env:
         GH_TOKEN: ${{ secrets.WORKER_PANTS_CHEESESHOP_TRIGGER_PAT }}
       name: Trigger cheeseshop build
-      run: 'gh api -X POST "/repos/pantsbuild/wheels.pantsbuild.org/dispatches" -F
-        event_type=github-pages
-
-        '
+      run: |
+        gh api -X POST "/repos/pantsbuild/wheels.pantsbuild.org/dispatches" -F event_type=github-pages
     - env:
         GH_TOKEN: ${{ secrets.WORKER_PANTS_PANTSBUILD_ORG_TRIGGER_PAT }}
       if: needs.release_info.outputs.is-release == 'true'
       name: Trigger docs sync
-      run: 'RELEASE_TAG=${{ needs.release_info.outputs.build-ref }}
-
+      run: |
+        RELEASE_TAG=${{ needs.release_info.outputs.build-ref }}
         RELEASE_VERSION="${RELEASE_TAG#release_}"
-
-        gh workflow run sync_docs.yml -F "version=$RELEASE_VERSION" -F "reviewer=${{
-        github.actor }}" -R pantsbuild/pantsbuild.org
-
-        '
+        gh workflow run sync_docs.yml -F "version=$RELEASE_VERSION" -F "reviewer=${{ github.actor }}" -R pantsbuild/pantsbuild.org
   release_info:
     if: github.repository_owner == 'pantsbuild'
     name: Create draft release and output info
@@ -657,9 +588,16 @@ jobs:
         REF: ${{ github.event.inputs.ref }}
       id: get_info
       name: Determine ref to build
-      run: "if [[ -n \"$REF\" ]]; then\n    ref=\"$REF\"\nelse\n    ref=\"${GITHUB_REF#refs/tags/}\"\
-        \nfi\necho \"build-ref=${ref}\" >> $GITHUB_OUTPUT\nif [[ \"${ref}\" =~ ^release_.+$\
-        \ ]]; then\n    echo \"is-release=true\" >> $GITHUB_OUTPUT\nfi\n"
+      run: |
+        if [[ -n "$REF" ]]; then
+            ref="$REF"
+        else
+            ref="${GITHUB_REF#refs/tags/}"
+        fi
+        echo "build-ref=${ref}" >> $GITHUB_OUTPUT
+        if [[ "${ref}" =~ ^release_.+$ ]]; then
+            echo "is-release=true" >> $GITHUB_OUTPUT
+        fi
     - env:
         GH_REPO: ${{ github.repository }}
         GH_TOKEN: ${{ github.token }}
@@ -667,22 +605,32 @@ jobs:
       if: github.repository_owner == 'pantsbuild' && steps.get_info.outputs.is-release
         == 'true'
       name: Make GitHub Release
-      run: "RELEASE_TAG=${{ steps.get_info.outputs.build-ref }}\nRELEASE_VERSION=\"\
-        ${RELEASE_TAG#release_}\"\n\n# NB: This could be a re-run of a release, in\
-        \ the event a job/step failed.\nif ! gh release view $RELEASE_TAG ; then\n\
-        \    GH_RELEASE_ARGS=(\"--notes\" \"\")\n    GH_RELEASE_ARGS+=(\"--title\"\
-        \ \"$RELEASE_TAG\")\n    if [[ $RELEASE_VERSION =~ [[:alpha:]] ]]; then\n\
-        \        GH_RELEASE_ARGS+=(\"--prerelease\")\n        GH_RELEASE_ARGS+=(\"\
-        --latest=false\")\n    else\n        STABLE_RELEASE_TAGS=$(gh api -X GET -F\
-        \ per_page=100 /repos/{owner}/{repo}/releases --jq '.[].tag_name | sub(\"\
-        ^release_\"; \"\") | select(test(\"^[0-9.]+$\"))')\n        LATEST_TAG=$(echo\
-        \ \"$STABLE_RELEASE_TAGS $RELEASE_TAG\" | tr ' ' '\\n' | sort --version-sort\
-        \ | tail -n 1)\n        if [[ $RELEASE_TAG == $LATEST_TAG ]]; then\n     \
-        \       GH_RELEASE_ARGS+=(\"--latest=true\")\n        else\n            GH_RELEASE_ARGS+=(\"\
-        --latest=false\")\n        fi\n    fi\n\n    gh release create \"$RELEASE_TAG\"\
-        \ \"${GH_RELEASE_ARGS[@]}\" --draft\nfi\n\nASSET_UPLOAD_URL=$(gh release view\
-        \ \"$RELEASE_TAG\" --json uploadUrl --jq '.uploadUrl | sub(\"\\\\{\\\\?.*$\"\
-        ; \"\")')\necho \"release-asset-upload-url=$ASSET_UPLOAD_URL\" >> $GITHUB_OUTPUT\n"
+      run: |
+        RELEASE_TAG=${{ steps.get_info.outputs.build-ref }}
+        RELEASE_VERSION="${RELEASE_TAG#release_}"
+
+        # NB: This could be a re-run of a release, in the event a job/step failed.
+        if ! gh release view $RELEASE_TAG ; then
+            GH_RELEASE_ARGS=("--notes" "")
+            GH_RELEASE_ARGS+=("--title" "$RELEASE_TAG")
+            if [[ $RELEASE_VERSION =~ [[:alpha:]] ]]; then
+                GH_RELEASE_ARGS+=("--prerelease")
+                GH_RELEASE_ARGS+=("--latest=false")
+            else
+                STABLE_RELEASE_TAGS=$(gh api -X GET -F per_page=100 /repos/{owner}/{repo}/releases --jq '.[].tag_name | sub("^release_"; "") | select(test("^[0-9.]+$"))')
+                LATEST_TAG=$(echo "$STABLE_RELEASE_TAGS $RELEASE_TAG" | tr ' ' '\n' | sort --version-sort | tail -n 1)
+                if [[ $RELEASE_TAG == $LATEST_TAG ]]; then
+                    GH_RELEASE_ARGS+=("--latest=true")
+                else
+                    GH_RELEASE_ARGS+=("--latest=false")
+                fi
+            fi
+
+            gh release create "$RELEASE_TAG" "${GH_RELEASE_ARGS[@]}" --draft
+        fi
+
+        ASSET_UPLOAD_URL=$(gh release view "$RELEASE_TAG" --json uploadUrl --jq '.uploadUrl | sub("\\{\\?.*$"; "")')
+        echo "release-asset-upload-url=$ASSET_UPLOAD_URL" >> $GITHUB_OUTPUT
 name: Release
 'on':
   push:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -468,8 +468,7 @@ jobs:
   publish:
     env:
       MODE: debug
-    if: github.repository_owner == 'pantsbuild' && needs.release_info.outputs.is-release
-      == 'true'
+    if: github.repository_owner == 'pantsbuild' && needs.release_info.outputs.is-release == 'true'
     needs:
     - build_wheels_linux_x86_64
     - build_wheels_linux_arm64
@@ -580,8 +579,7 @@ jobs:
     outputs:
       build-ref: ${{ steps.get_info.outputs.build-ref }}
       is-release: ${{ steps.get_info.outputs.is-release }}
-      release-asset-upload-url: ${{ steps.make_draft_release.outputs.release-asset-upload-url
-        }}
+      release-asset-upload-url: ${{ steps.make_draft_release.outputs.release-asset-upload-url }}
     runs-on: ubuntu-22.04
     steps:
     - env:
@@ -602,8 +600,7 @@ jobs:
         GH_REPO: ${{ github.repository }}
         GH_TOKEN: ${{ github.token }}
       id: make_draft_release
-      if: github.repository_owner == 'pantsbuild' && steps.get_info.outputs.is-release
-        == 'true'
+      if: github.repository_owner == 'pantsbuild' && steps.get_info.outputs.is-release == 'true'
       name: Make GitHub Release
       run: |
         RELEASE_TAG=${{ steps.get_info.outputs.build-ref }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,13 +40,10 @@ jobs:
       uses: actions/cache@v4
       with:
         key: Linux-ARM64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.88.0-*
-
+        path: |
+          ~/.rustup/toolchains/1.88.0-*
           ~/.rustup/update-hashes
-
           ~/.rustup/settings.toml
-
-          '
     - name: Cache Cargo
       uses: benjyw/rust-cache@5ed697a6894712d2854c80635bb00a2496ea307a
       with:
@@ -61,27 +58,20 @@ jobs:
       uses: actions/cache@v4
       with:
         key: Linux-ARM64-engine-${{ steps.get-engine-hash.outputs.hash }}-v1
-        path: 'src/python/pants/bin/native_client
-
+        path: |-
+          src/python/pants/bin/native_client
           src/python/pants/bin/sandboxer
-
           src/python/pants/engine/internals/native_engine.so
-
-          src/python/pants/engine/internals/native_engine.so.metadata'
+          src/python/pants/engine/internals/native_engine.so.metadata
     - name: Bootstrap Pants
       run: ./pants version > ${{ runner.temp }}/_pants_version.stdout && [[ -s ${{ runner.temp }}/_pants_version.stdout ]]
     - name: Run smoke tests
-      run: './pants list ::
-
+      run: |
+        ./pants list ::
         ./pants roots
-
         ./pants help goals
-
         ./pants help targets
-
         ./pants help subsystems
-
-        '
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -94,13 +84,11 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: native_binaries.${{ matrix.python-version }}.Linux-ARM64
-        path: 'src/python/pants/bin/native_client
-
+        path: |-
+          src/python/pants/bin/native_client
           src/python/pants/bin/sandboxer
-
           src/python/pants/engine/internals/native_engine.so
-
-          src/python/pants/engine/internals/native_engine.so.metadata'
+          src/python/pants/engine/internals/native_engine.so.metadata
     - env:
         TMPDIR: ${{ runner.temp }}
       if: needs.classify_changes.outputs.rust == 'true'
@@ -125,19 +113,14 @@ jobs:
     - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7
-
+        python-version: |-
+          3.7
           3.8
-
           3.9
-
           3.10
-
           3.12
-
           3.13
-
-          3.11'
+          3.11
     - name: Install Protoc
       uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
       with:
@@ -149,13 +132,10 @@ jobs:
       uses: actions/cache@v4
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.88.0-*
-
+        path: |
+          ~/.rustup/toolchains/1.88.0-*
           ~/.rustup/update-hashes
-
           ~/.rustup/settings.toml
-
-          '
     - name: Cache Cargo
       uses: benjyw/rust-cache@5ed697a6894712d2854c80635bb00a2496ea307a
       with:
@@ -170,27 +150,20 @@ jobs:
       uses: actions/cache@v4
       with:
         key: Linux-x86_64-engine-${{ steps.get-engine-hash.outputs.hash }}-v1
-        path: 'src/python/pants/bin/native_client
-
+        path: |-
+          src/python/pants/bin/native_client
           src/python/pants/bin/sandboxer
-
           src/python/pants/engine/internals/native_engine.so
-
-          src/python/pants/engine/internals/native_engine.so.metadata'
+          src/python/pants/engine/internals/native_engine.so.metadata
     - name: Bootstrap Pants
       run: ./pants version > ${{ runner.temp }}/_pants_version.stdout && [[ -s ${{ runner.temp }}/_pants_version.stdout ]]
     - name: Run smoke tests
-      run: './pants list ::
-
+      run: |
+        ./pants list ::
         ./pants roots
-
         ./pants help goals
-
         ./pants help targets
-
         ./pants help subsystems
-
-        '
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -203,28 +176,23 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: native_binaries.${{ matrix.python-version }}.Linux-x86_64
-        path: 'src/python/pants/bin/native_client
-
+        path: |-
+          src/python/pants/bin/native_client
           src/python/pants/bin/sandboxer
-
           src/python/pants/engine/internals/native_engine.so
-
-          src/python/pants/engine/internals/native_engine.so.metadata'
+          src/python/pants/engine/internals/native_engine.so.metadata
     - name: Validate CI config
-      run: './pants run src/python/pants_release/generate_github_workflows.py -- --check
-
-        '
+      run: |
+        ./pants run src/python/pants_release/generate_github_workflows.py -- --check
     - env:
         TMPDIR: ${{ runner.temp }}
       if: needs.classify_changes.outputs.rust == 'true'
       name: Test and lint Rust
-      run: 'sudo apt-get install -y pkg-config fuse libfuse-dev
-
+      run: |-
+        sudo apt-get install -y pkg-config fuse libfuse-dev
         ./build-support/bin/check_rust_pre_commit.sh
-
         ./cargo test --locked --all --tests --benches -- --nocapture
-
-        ./cargo doc'
+        ./cargo doc
     timeout-minutes: 60
   bootstrap_pants_macos13_x86_64:
     env:
@@ -244,19 +212,14 @@ jobs:
     - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7
-
+        python-version: |-
+          3.7
           3.8
-
           3.9
-
           3.10
-
           3.12
-
           3.13
-
-          3.11'
+          3.11
     - name: Install Protoc
       uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
       with:
@@ -268,13 +231,10 @@ jobs:
       uses: actions/cache@v4
       with:
         key: macOS13-x86_64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.88.0-*
-
+        path: |
+          ~/.rustup/toolchains/1.88.0-*
           ~/.rustup/update-hashes
-
           ~/.rustup/settings.toml
-
-          '
     - name: Cache Cargo
       uses: benjyw/rust-cache@5ed697a6894712d2854c80635bb00a2496ea307a
       with:
@@ -289,27 +249,20 @@ jobs:
       uses: actions/cache@v4
       with:
         key: macOS13-x86_64-engine-${{ steps.get-engine-hash.outputs.hash }}-v1
-        path: 'src/python/pants/bin/native_client
-
+        path: |-
+          src/python/pants/bin/native_client
           src/python/pants/bin/sandboxer
-
           src/python/pants/engine/internals/native_engine.so
-
-          src/python/pants/engine/internals/native_engine.so.metadata'
+          src/python/pants/engine/internals/native_engine.so.metadata
     - name: Bootstrap Pants
       run: ./pants version > ${{ runner.temp }}/_pants_version.stdout && [[ -s ${{ runner.temp }}/_pants_version.stdout ]]
     - name: Run smoke tests
-      run: './pants list ::
-
+      run: |
+        ./pants list ::
         ./pants roots
-
         ./pants help goals
-
         ./pants help targets
-
         ./pants help subsystems
-
-        '
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -322,13 +275,11 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: native_binaries.${{ matrix.python-version }}.macOS13-x86_64
-        path: 'src/python/pants/bin/native_client
-
+        path: |-
+          src/python/pants/bin/native_client
           src/python/pants/bin/sandboxer
-
           src/python/pants/engine/internals/native_engine.so
-
-          src/python/pants/engine/internals/native_engine.so.metadata'
+          src/python/pants/engine/internals/native_engine.so.metadata
     - env:
         TMPDIR: ${{ runner.temp }}
       if: needs.classify_changes.outputs.rust == 'true'
@@ -366,35 +317,23 @@ jobs:
     - name: Configure Git
       run: git config --global safe.directory "$GITHUB_WORKSPACE"
     - name: Install rustup
-      run: 'curl --proto ''=https'' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -v -y --default-toolchain none
-
+      run: |
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -v -y --default-toolchain none
         echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
-
-        '
     - name: Install Rust toolchain
-      run: '# Set the default toolchain. Installs the toolchain if it is not already installed.
-
+      run: |
+        # Set the default toolchain. Installs the toolchain if it is not already installed.
         rustup default 1.88.0
-
         cargo version
-
-        '
     - name: Expose Pythons
-      run: 'echo "/opt/python/cp37-cp37m/bin" >> $GITHUB_PATH
-
+      run: |
+        echo "/opt/python/cp37-cp37m/bin" >> $GITHUB_PATH
         echo "/opt/python/cp38-cp38/bin" >> $GITHUB_PATH
-
         echo "/opt/python/cp39-cp39/bin" >> $GITHUB_PATH
-
         echo "/opt/python/cp310-cp310/bin" >> $GITHUB_PATH
-
         echo "/opt/python/cp311-cp311/bin" >> $GITHUB_PATH
-
         echo "/opt/python/cp312-cp312/bin" >> $GITHUB_PATH
-
         echo "/opt/python/cp313-cp313/bin" >> $GITHUB_PATH
-
-        '
     - name: Install Protoc
       uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
       with:
@@ -444,35 +383,23 @@ jobs:
     - name: Configure Git
       run: git config --global safe.directory "$GITHUB_WORKSPACE"
     - name: Install rustup
-      run: 'curl --proto ''=https'' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -v -y --default-toolchain none
-
+      run: |
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -v -y --default-toolchain none
         echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
-
-        '
     - name: Install Rust toolchain
-      run: '# Set the default toolchain. Installs the toolchain if it is not already installed.
-
+      run: |
+        # Set the default toolchain. Installs the toolchain if it is not already installed.
         rustup default 1.88.0
-
         cargo version
-
-        '
     - name: Expose Pythons
-      run: 'echo "/opt/python/cp37-cp37m/bin" >> $GITHUB_PATH
-
+      run: |
+        echo "/opt/python/cp37-cp37m/bin" >> $GITHUB_PATH
         echo "/opt/python/cp38-cp38/bin" >> $GITHUB_PATH
-
         echo "/opt/python/cp39-cp39/bin" >> $GITHUB_PATH
-
         echo "/opt/python/cp310-cp310/bin" >> $GITHUB_PATH
-
         echo "/opt/python/cp311-cp311/bin" >> $GITHUB_PATH
-
         echo "/opt/python/cp312-cp312/bin" >> $GITHUB_PATH
-
         echo "/opt/python/cp313-cp313/bin" >> $GITHUB_PATH
-
-        '
     - name: Install Protoc
       uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
       with:
@@ -524,19 +451,14 @@ jobs:
     - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7
-
+        python-version: |-
+          3.7
           3.8
-
           3.9
-
           3.10
-
           3.12
-
           3.13
-
-          3.11'
+          3.11
     - name: Install Protoc
       uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
       with:
@@ -548,13 +470,10 @@ jobs:
       uses: actions/cache@v4
       with:
         key: macOS13-x86_64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.88.0-*
-
+        path: |
+          ~/.rustup/toolchains/1.88.0-*
           ~/.rustup/update-hashes
-
           ~/.rustup/settings.toml
-
-          '
     - name: Cache Cargo
       uses: benjyw/rust-cache@5ed697a6894712d2854c80635bb00a2496ea307a
       with:
@@ -614,15 +533,12 @@ jobs:
     - name: Set up Python 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9
-
+        python-version: |-
+          3.9
           3.10
-
           3.12
-
           3.13
-
-          3.11'
+          3.11
     - name: Install Protoc
       uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
       with:
@@ -634,13 +550,10 @@ jobs:
       uses: actions/cache@v4
       with:
         key: macOS14-ARM64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.88.0-*
-
+        path: |
+          ~/.rustup/toolchains/1.88.0-*
           ~/.rustup/update-hashes
-
           ~/.rustup/settings.toml
-
-          '
     - name: Cache Cargo
       uses: benjyw/rust-cache@5ed697a6894712d2854c80635bb00a2496ea307a
       with:
@@ -691,10 +604,18 @@ jobs:
       with:
         count: 1
         labels: release-notes:not-required, category:internal
-        message: "\nPlease do one of:\n\n- add release notes to the appropriate file in `docs/notes`\n\n- label this PR with\
-          \ `release-notes:not-required` if it does not need them (for\n  instance, if this is fixing a minor typo in documentation)\n\
-          \n- label this PR with `category:internal` if it's an internal change\n\nFeel free to ask a maintainer for help\
-          \ if you are not sure what is appropriate!\n"
+        message: |2
+
+          Please do one of:
+
+          - add release notes to the appropriate file in `docs/notes`
+
+          - label this PR with `release-notes:not-required` if it does not need them (for
+            instance, if this is fixing a minor typo in documentation)
+
+          - label this PR with `category:internal` if it's an internal change
+
+          Feel free to ask a maintainer for help if you are not sure what is appropriate!
         mode: minimum
   classify_changes:
     if: github.repository_owner == 'pantsbuild'
@@ -717,12 +638,23 @@ jobs:
         fetch-depth: 10
     - id: classify
       name: Classify changed files
-      run: "if [[ -z $GITHUB_EVENT_PULL_REQUEST_BASE_SHA ]]; then\n  # push: compare to the immediate parent, which should\
-        \ already be fetched\n  # (checkout's fetch_depth defaults to 10)\n  comparison_sha=$(git rev-parse HEAD^)\nelse\n\
-        \  # pull request: compare to the base branch, ensuring that commit exists\n  git fetch --depth=1 \"$GITHUB_EVENT_PULL_REQUEST_BASE_SHA\"\
-        \n  comparison_sha=\"$GITHUB_EVENT_PULL_REQUEST_BASE_SHA\"\nfi\necho \"comparison_sha=$comparison_sha\"\n\nchange_labels=$(git\
-        \ diff --name-only \"$comparison_sha\" HEAD | python build-support/bin/classify_changed_files.py)\necho \"Change Labels:\"\
-        \nfor i in ${change_labels}; do\n  echo \"${i}=true\" | tee -a $GITHUB_OUTPUT\ndone\n"
+      run: |
+        if [[ -z $GITHUB_EVENT_PULL_REQUEST_BASE_SHA ]]; then
+          # push: compare to the immediate parent, which should already be fetched
+          # (checkout's fetch_depth defaults to 10)
+          comparison_sha=$(git rev-parse HEAD^)
+        else
+          # pull request: compare to the base branch, ensuring that commit exists
+          git fetch --depth=1 "$GITHUB_EVENT_PULL_REQUEST_BASE_SHA"
+          comparison_sha="$GITHUB_EVENT_PULL_REQUEST_BASE_SHA"
+        fi
+        echo "comparison_sha=$comparison_sha"
+
+        change_labels=$(git diff --name-only "$comparison_sha" HEAD | python build-support/bin/classify_changed_files.py)
+        echo "Change Labels:"
+        for i in ${change_labels}; do
+          echo "${i}=true" | tee -a $GITHUB_OUTPUT
+        done
   lint_python:
     if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.no_code != 'true')
     name: Lint Python and Shell
@@ -740,36 +672,38 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       name: Launch bazel-remote
-      run: "mkdir -p ~/bazel-remote\nif [[ -z \"${AWS_ACCESS_KEY_ID}\" ]]; then\n  CACHE_WRITE=false\n  # If no secret read/write\
-        \ creds, use hard-coded read-only creds, so that\n  # cross-fork PRs can at least read from the cache.\n  # These\
-        \ creds are hard-coded here in this public repo, which makes the bucket\n  # world-readable. But since putting raw\
-        \ AWS tokens in a public repo, even\n  # deliberately, is icky, we base64-them. This will at least help hide from\n\
-        \  # automated scanners that look for checked in AWS keys.\n  # Not that it would be terrible if we were scanned,\
-        \ since this is public\n  # on purpose, but it's best not to draw attention.\n  AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK'\
-        \ | base64 -d)\n  AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo=' | base64\
-        \ -d)\nelse\n  CACHE_WRITE=true\nfi\ndocker run --detach -u 1001:1000                   -v ~/bazel-remote:/data  \
-        \                 -p 9092:9092                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key\
-        \                   --s3.access_key_id=\"${AWS_ACCESS_KEY_ID}\"                   --s3.secret_access_key=\"${AWS_SECRET_ACCESS_KEY}\"\
-        \                   --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com  \
-        \                 --max_size 30\necho \"PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092\" >> \"$GITHUB_ENV\"\necho\
-        \ \"PANTS_REMOTE_CACHE_READ=true\" >> \"$GITHUB_ENV\"\necho \"PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}\" >> \"$GITHUB_ENV\"\
-        \n"
+      run: |
+        mkdir -p ~/bazel-remote
+        if [[ -z "${AWS_ACCESS_KEY_ID}" ]]; then
+          CACHE_WRITE=false
+          # If no secret read/write creds, use hard-coded read-only creds, so that
+          # cross-fork PRs can at least read from the cache.
+          # These creds are hard-coded here in this public repo, which makes the bucket
+          # world-readable. But since putting raw AWS tokens in a public repo, even
+          # deliberately, is icky, we base64-them. This will at least help hide from
+          # automated scanners that look for checked in AWS keys.
+          # Not that it would be terrible if we were scanned, since this is public
+          # on purpose, but it's best not to draw attention.
+          AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK' | base64 -d)
+          AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo=' | base64 -d)
+        else
+          CACHE_WRITE=true
+        fi
+        docker run --detach -u 1001:1000                   -v ~/bazel-remote:/data                   -p 9092:9092                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key                   --s3.access_key_id="${AWS_ACCESS_KEY_ID}"                   --s3.secret_access_key="${AWS_SECRET_ACCESS_KEY}"                   --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com                   --max_size 30
+        echo "PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092" >> "$GITHUB_ENV"
+        echo "PANTS_REMOTE_CACHE_READ=true" >> "$GITHUB_ENV"
+        echo "PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}" >> "$GITHUB_ENV"
     - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7
-
+        python-version: |-
+          3.7
           3.8
-
           3.9
-
           3.10
-
           3.12
-
           3.13
-
-          3.11'
+          3.11
     - name: Download native binaries
       uses: actions/download-artifact@v4
       with:
@@ -778,9 +712,8 @@ jobs:
     - name: Make native-client runnable
       run: chmod +x src/python/pants/bin/native_client
     - name: Lint
-      run: './pants lint check ::
-
-        '
+      run: |
+        ./pants lint check ::
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -798,8 +731,15 @@ jobs:
     runs-on:
     - ubuntu-22.04
     steps:
-    - run: "merge_ok=\"${{ needs.set_merge_ok.outputs.merge_ok }}\"\nif [[ \"${merge_ok}\" == \"true\" ]]; then\n    echo\
-        \ \"Merge OK\"\n    exit 0\nelse\n    echo \"Merge NOT OK\"\n    exit 1\nfi\n"
+    - run: |
+        merge_ok="${{ needs.set_merge_ok.outputs.merge_ok }}"
+        if [[ "${merge_ok}" == "true" ]]; then
+            echo "Merge OK"
+            exit 0
+        else
+            echo "Merge NOT OK"
+            exit 1
+        fi
   set_merge_ok:
     if: always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
     name: Set Merge OK
@@ -870,22 +810,18 @@ jobs:
     - name: Make native-client runnable
       run: chmod +x src/python/pants/bin/native_client
     - name: Run Python tests
-      run: './pants --tag=+platform_specific_behavior test :: -- -m platform_specific_behavior
-
-        '
+      run: |
+        ./pants --tag=+platform_specific_behavior test :: -- -m platform_specific_behavior
     - continue-on-error: true
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: 'export S3_DST=s3://logs.pantsbuild.org/test/reports/Linux-ARM64/$(git show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}
-
+      run: |
+        export S3_DST=s3://logs.pantsbuild.org/test/reports/Linux-ARM64/$(git show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}
         echo "Uploading test reports to ${S3_DST}"
-
         ./pants run ./src/python/pants_release/copy_to_s3.py                   --                   --src-prefix=dist/test/reports                   --dst-prefix=${S3_DST}                   --path=""
-
-        '
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -914,20 +850,27 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       name: Launch bazel-remote
-      run: "mkdir -p ~/bazel-remote\nif [[ -z \"${AWS_ACCESS_KEY_ID}\" ]]; then\n  CACHE_WRITE=false\n  # If no secret read/write\
-        \ creds, use hard-coded read-only creds, so that\n  # cross-fork PRs can at least read from the cache.\n  # These\
-        \ creds are hard-coded here in this public repo, which makes the bucket\n  # world-readable. But since putting raw\
-        \ AWS tokens in a public repo, even\n  # deliberately, is icky, we base64-them. This will at least help hide from\n\
-        \  # automated scanners that look for checked in AWS keys.\n  # Not that it would be terrible if we were scanned,\
-        \ since this is public\n  # on purpose, but it's best not to draw attention.\n  AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK'\
-        \ | base64 -d)\n  AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo=' | base64\
-        \ -d)\nelse\n  CACHE_WRITE=true\nfi\ndocker run --detach -u 1001:1000                   -v ~/bazel-remote:/data  \
-        \                 -p 9092:9092                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key\
-        \                   --s3.access_key_id=\"${AWS_ACCESS_KEY_ID}\"                   --s3.secret_access_key=\"${AWS_SECRET_ACCESS_KEY}\"\
-        \                   --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com  \
-        \                 --max_size 30\necho \"PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092\" >> \"$GITHUB_ENV\"\necho\
-        \ \"PANTS_REMOTE_CACHE_READ=true\" >> \"$GITHUB_ENV\"\necho \"PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}\" >> \"$GITHUB_ENV\"\
-        \n"
+      run: |
+        mkdir -p ~/bazel-remote
+        if [[ -z "${AWS_ACCESS_KEY_ID}" ]]; then
+          CACHE_WRITE=false
+          # If no secret read/write creds, use hard-coded read-only creds, so that
+          # cross-fork PRs can at least read from the cache.
+          # These creds are hard-coded here in this public repo, which makes the bucket
+          # world-readable. But since putting raw AWS tokens in a public repo, even
+          # deliberately, is icky, we base64-them. This will at least help hide from
+          # automated scanners that look for checked in AWS keys.
+          # Not that it would be terrible if we were scanned, since this is public
+          # on purpose, but it's best not to draw attention.
+          AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK' | base64 -d)
+          AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo=' | base64 -d)
+        else
+          CACHE_WRITE=true
+        fi
+        docker run --detach -u 1001:1000                   -v ~/bazel-remote:/data                   -p 9092:9092                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key                   --s3.access_key_id="${AWS_ACCESS_KEY_ID}"                   --s3.secret_access_key="${AWS_SECRET_ACCESS_KEY}"                   --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com                   --max_size 30
+        echo "PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092" >> "$GITHUB_ENV"
+        echo "PANTS_REMOTE_CACHE_READ=true" >> "$GITHUB_ENV"
+        echo "PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}" >> "$GITHUB_ENV"
     - name: Install AdoptJDK
       uses: actions/setup-java@v4
       with:
@@ -939,31 +882,22 @@ jobs:
         go-version: 1.19.5
     - if: runner.os == 'Linux'
       name: Download Apache `thrift` binary (Linux)
-      run: 'mkdir -p "${HOME}/.thrift"
-
+      run: |
+        mkdir -p "${HOME}/.thrift"
         curl --fail -L https://binaries.pantsbuild.org/bin/thrift/linux/x86_64/0.15.0/thrift -o "${HOME}/.thrift/thrift"
-
         chmod +x "${HOME}/.thrift/thrift"
-
         echo "${HOME}/.thrift" >> $GITHUB_PATH
-
-        '
     - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7
-
+        python-version: |-
+          3.7
           3.8
-
           3.9
-
           3.10
-
           3.12
-
           3.13
-
-          3.11'
+          3.11
     - name: Download native binaries
       uses: actions/download-artifact@v4
       with:
@@ -972,22 +906,18 @@ jobs:
     - name: Make native-client runnable
       run: chmod +x src/python/pants/bin/native_client
     - name: Run Python test shard 0/10
-      run: './pants test --shard=0/10 ::
-
-        '
+      run: |
+        ./pants test --shard=0/10 ::
     - continue-on-error: true
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: 'export S3_DST=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}
-
+      run: |
+        export S3_DST=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}
         echo "Uploading test reports to ${S3_DST}"
-
         ./pants run ./src/python/pants_release/copy_to_s3.py                   --                   --src-prefix=dist/test/reports                   --dst-prefix=${S3_DST}                   --path=""
-
-        '
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -1016,20 +946,27 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       name: Launch bazel-remote
-      run: "mkdir -p ~/bazel-remote\nif [[ -z \"${AWS_ACCESS_KEY_ID}\" ]]; then\n  CACHE_WRITE=false\n  # If no secret read/write\
-        \ creds, use hard-coded read-only creds, so that\n  # cross-fork PRs can at least read from the cache.\n  # These\
-        \ creds are hard-coded here in this public repo, which makes the bucket\n  # world-readable. But since putting raw\
-        \ AWS tokens in a public repo, even\n  # deliberately, is icky, we base64-them. This will at least help hide from\n\
-        \  # automated scanners that look for checked in AWS keys.\n  # Not that it would be terrible if we were scanned,\
-        \ since this is public\n  # on purpose, but it's best not to draw attention.\n  AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK'\
-        \ | base64 -d)\n  AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo=' | base64\
-        \ -d)\nelse\n  CACHE_WRITE=true\nfi\ndocker run --detach -u 1001:1000                   -v ~/bazel-remote:/data  \
-        \                 -p 9092:9092                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key\
-        \                   --s3.access_key_id=\"${AWS_ACCESS_KEY_ID}\"                   --s3.secret_access_key=\"${AWS_SECRET_ACCESS_KEY}\"\
-        \                   --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com  \
-        \                 --max_size 30\necho \"PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092\" >> \"$GITHUB_ENV\"\necho\
-        \ \"PANTS_REMOTE_CACHE_READ=true\" >> \"$GITHUB_ENV\"\necho \"PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}\" >> \"$GITHUB_ENV\"\
-        \n"
+      run: |
+        mkdir -p ~/bazel-remote
+        if [[ -z "${AWS_ACCESS_KEY_ID}" ]]; then
+          CACHE_WRITE=false
+          # If no secret read/write creds, use hard-coded read-only creds, so that
+          # cross-fork PRs can at least read from the cache.
+          # These creds are hard-coded here in this public repo, which makes the bucket
+          # world-readable. But since putting raw AWS tokens in a public repo, even
+          # deliberately, is icky, we base64-them. This will at least help hide from
+          # automated scanners that look for checked in AWS keys.
+          # Not that it would be terrible if we were scanned, since this is public
+          # on purpose, but it's best not to draw attention.
+          AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK' | base64 -d)
+          AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo=' | base64 -d)
+        else
+          CACHE_WRITE=true
+        fi
+        docker run --detach -u 1001:1000                   -v ~/bazel-remote:/data                   -p 9092:9092                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key                   --s3.access_key_id="${AWS_ACCESS_KEY_ID}"                   --s3.secret_access_key="${AWS_SECRET_ACCESS_KEY}"                   --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com                   --max_size 30
+        echo "PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092" >> "$GITHUB_ENV"
+        echo "PANTS_REMOTE_CACHE_READ=true" >> "$GITHUB_ENV"
+        echo "PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}" >> "$GITHUB_ENV"
     - name: Install AdoptJDK
       uses: actions/setup-java@v4
       with:
@@ -1041,31 +978,22 @@ jobs:
         go-version: 1.19.5
     - if: runner.os == 'Linux'
       name: Download Apache `thrift` binary (Linux)
-      run: 'mkdir -p "${HOME}/.thrift"
-
+      run: |
+        mkdir -p "${HOME}/.thrift"
         curl --fail -L https://binaries.pantsbuild.org/bin/thrift/linux/x86_64/0.15.0/thrift -o "${HOME}/.thrift/thrift"
-
         chmod +x "${HOME}/.thrift/thrift"
-
         echo "${HOME}/.thrift" >> $GITHUB_PATH
-
-        '
     - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7
-
+        python-version: |-
+          3.7
           3.8
-
           3.9
-
           3.10
-
           3.12
-
           3.13
-
-          3.11'
+          3.11
     - name: Download native binaries
       uses: actions/download-artifact@v4
       with:
@@ -1074,22 +1002,18 @@ jobs:
     - name: Make native-client runnable
       run: chmod +x src/python/pants/bin/native_client
     - name: Run Python test shard 1/10
-      run: './pants test --shard=1/10 ::
-
-        '
+      run: |
+        ./pants test --shard=1/10 ::
     - continue-on-error: true
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: 'export S3_DST=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}
-
+      run: |
+        export S3_DST=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}
         echo "Uploading test reports to ${S3_DST}"
-
         ./pants run ./src/python/pants_release/copy_to_s3.py                   --                   --src-prefix=dist/test/reports                   --dst-prefix=${S3_DST}                   --path=""
-
-        '
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -1118,20 +1042,27 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       name: Launch bazel-remote
-      run: "mkdir -p ~/bazel-remote\nif [[ -z \"${AWS_ACCESS_KEY_ID}\" ]]; then\n  CACHE_WRITE=false\n  # If no secret read/write\
-        \ creds, use hard-coded read-only creds, so that\n  # cross-fork PRs can at least read from the cache.\n  # These\
-        \ creds are hard-coded here in this public repo, which makes the bucket\n  # world-readable. But since putting raw\
-        \ AWS tokens in a public repo, even\n  # deliberately, is icky, we base64-them. This will at least help hide from\n\
-        \  # automated scanners that look for checked in AWS keys.\n  # Not that it would be terrible if we were scanned,\
-        \ since this is public\n  # on purpose, but it's best not to draw attention.\n  AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK'\
-        \ | base64 -d)\n  AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo=' | base64\
-        \ -d)\nelse\n  CACHE_WRITE=true\nfi\ndocker run --detach -u 1001:1000                   -v ~/bazel-remote:/data  \
-        \                 -p 9092:9092                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key\
-        \                   --s3.access_key_id=\"${AWS_ACCESS_KEY_ID}\"                   --s3.secret_access_key=\"${AWS_SECRET_ACCESS_KEY}\"\
-        \                   --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com  \
-        \                 --max_size 30\necho \"PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092\" >> \"$GITHUB_ENV\"\necho\
-        \ \"PANTS_REMOTE_CACHE_READ=true\" >> \"$GITHUB_ENV\"\necho \"PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}\" >> \"$GITHUB_ENV\"\
-        \n"
+      run: |
+        mkdir -p ~/bazel-remote
+        if [[ -z "${AWS_ACCESS_KEY_ID}" ]]; then
+          CACHE_WRITE=false
+          # If no secret read/write creds, use hard-coded read-only creds, so that
+          # cross-fork PRs can at least read from the cache.
+          # These creds are hard-coded here in this public repo, which makes the bucket
+          # world-readable. But since putting raw AWS tokens in a public repo, even
+          # deliberately, is icky, we base64-them. This will at least help hide from
+          # automated scanners that look for checked in AWS keys.
+          # Not that it would be terrible if we were scanned, since this is public
+          # on purpose, but it's best not to draw attention.
+          AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK' | base64 -d)
+          AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo=' | base64 -d)
+        else
+          CACHE_WRITE=true
+        fi
+        docker run --detach -u 1001:1000                   -v ~/bazel-remote:/data                   -p 9092:9092                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key                   --s3.access_key_id="${AWS_ACCESS_KEY_ID}"                   --s3.secret_access_key="${AWS_SECRET_ACCESS_KEY}"                   --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com                   --max_size 30
+        echo "PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092" >> "$GITHUB_ENV"
+        echo "PANTS_REMOTE_CACHE_READ=true" >> "$GITHUB_ENV"
+        echo "PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}" >> "$GITHUB_ENV"
     - name: Install AdoptJDK
       uses: actions/setup-java@v4
       with:
@@ -1143,31 +1074,22 @@ jobs:
         go-version: 1.19.5
     - if: runner.os == 'Linux'
       name: Download Apache `thrift` binary (Linux)
-      run: 'mkdir -p "${HOME}/.thrift"
-
+      run: |
+        mkdir -p "${HOME}/.thrift"
         curl --fail -L https://binaries.pantsbuild.org/bin/thrift/linux/x86_64/0.15.0/thrift -o "${HOME}/.thrift/thrift"
-
         chmod +x "${HOME}/.thrift/thrift"
-
         echo "${HOME}/.thrift" >> $GITHUB_PATH
-
-        '
     - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7
-
+        python-version: |-
+          3.7
           3.8
-
           3.9
-
           3.10
-
           3.12
-
           3.13
-
-          3.11'
+          3.11
     - name: Download native binaries
       uses: actions/download-artifact@v4
       with:
@@ -1176,22 +1098,18 @@ jobs:
     - name: Make native-client runnable
       run: chmod +x src/python/pants/bin/native_client
     - name: Run Python test shard 2/10
-      run: './pants test --shard=2/10 ::
-
-        '
+      run: |
+        ./pants test --shard=2/10 ::
     - continue-on-error: true
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: 'export S3_DST=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}
-
+      run: |
+        export S3_DST=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}
         echo "Uploading test reports to ${S3_DST}"
-
         ./pants run ./src/python/pants_release/copy_to_s3.py                   --                   --src-prefix=dist/test/reports                   --dst-prefix=${S3_DST}                   --path=""
-
-        '
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -1220,20 +1138,27 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       name: Launch bazel-remote
-      run: "mkdir -p ~/bazel-remote\nif [[ -z \"${AWS_ACCESS_KEY_ID}\" ]]; then\n  CACHE_WRITE=false\n  # If no secret read/write\
-        \ creds, use hard-coded read-only creds, so that\n  # cross-fork PRs can at least read from the cache.\n  # These\
-        \ creds are hard-coded here in this public repo, which makes the bucket\n  # world-readable. But since putting raw\
-        \ AWS tokens in a public repo, even\n  # deliberately, is icky, we base64-them. This will at least help hide from\n\
-        \  # automated scanners that look for checked in AWS keys.\n  # Not that it would be terrible if we were scanned,\
-        \ since this is public\n  # on purpose, but it's best not to draw attention.\n  AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK'\
-        \ | base64 -d)\n  AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo=' | base64\
-        \ -d)\nelse\n  CACHE_WRITE=true\nfi\ndocker run --detach -u 1001:1000                   -v ~/bazel-remote:/data  \
-        \                 -p 9092:9092                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key\
-        \                   --s3.access_key_id=\"${AWS_ACCESS_KEY_ID}\"                   --s3.secret_access_key=\"${AWS_SECRET_ACCESS_KEY}\"\
-        \                   --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com  \
-        \                 --max_size 30\necho \"PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092\" >> \"$GITHUB_ENV\"\necho\
-        \ \"PANTS_REMOTE_CACHE_READ=true\" >> \"$GITHUB_ENV\"\necho \"PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}\" >> \"$GITHUB_ENV\"\
-        \n"
+      run: |
+        mkdir -p ~/bazel-remote
+        if [[ -z "${AWS_ACCESS_KEY_ID}" ]]; then
+          CACHE_WRITE=false
+          # If no secret read/write creds, use hard-coded read-only creds, so that
+          # cross-fork PRs can at least read from the cache.
+          # These creds are hard-coded here in this public repo, which makes the bucket
+          # world-readable. But since putting raw AWS tokens in a public repo, even
+          # deliberately, is icky, we base64-them. This will at least help hide from
+          # automated scanners that look for checked in AWS keys.
+          # Not that it would be terrible if we were scanned, since this is public
+          # on purpose, but it's best not to draw attention.
+          AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK' | base64 -d)
+          AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo=' | base64 -d)
+        else
+          CACHE_WRITE=true
+        fi
+        docker run --detach -u 1001:1000                   -v ~/bazel-remote:/data                   -p 9092:9092                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key                   --s3.access_key_id="${AWS_ACCESS_KEY_ID}"                   --s3.secret_access_key="${AWS_SECRET_ACCESS_KEY}"                   --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com                   --max_size 30
+        echo "PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092" >> "$GITHUB_ENV"
+        echo "PANTS_REMOTE_CACHE_READ=true" >> "$GITHUB_ENV"
+        echo "PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}" >> "$GITHUB_ENV"
     - name: Install AdoptJDK
       uses: actions/setup-java@v4
       with:
@@ -1245,31 +1170,22 @@ jobs:
         go-version: 1.19.5
     - if: runner.os == 'Linux'
       name: Download Apache `thrift` binary (Linux)
-      run: 'mkdir -p "${HOME}/.thrift"
-
+      run: |
+        mkdir -p "${HOME}/.thrift"
         curl --fail -L https://binaries.pantsbuild.org/bin/thrift/linux/x86_64/0.15.0/thrift -o "${HOME}/.thrift/thrift"
-
         chmod +x "${HOME}/.thrift/thrift"
-
         echo "${HOME}/.thrift" >> $GITHUB_PATH
-
-        '
     - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7
-
+        python-version: |-
+          3.7
           3.8
-
           3.9
-
           3.10
-
           3.12
-
           3.13
-
-          3.11'
+          3.11
     - name: Download native binaries
       uses: actions/download-artifact@v4
       with:
@@ -1278,22 +1194,18 @@ jobs:
     - name: Make native-client runnable
       run: chmod +x src/python/pants/bin/native_client
     - name: Run Python test shard 3/10
-      run: './pants test --shard=3/10 ::
-
-        '
+      run: |
+        ./pants test --shard=3/10 ::
     - continue-on-error: true
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: 'export S3_DST=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}
-
+      run: |
+        export S3_DST=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}
         echo "Uploading test reports to ${S3_DST}"
-
         ./pants run ./src/python/pants_release/copy_to_s3.py                   --                   --src-prefix=dist/test/reports                   --dst-prefix=${S3_DST}                   --path=""
-
-        '
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -1322,20 +1234,27 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       name: Launch bazel-remote
-      run: "mkdir -p ~/bazel-remote\nif [[ -z \"${AWS_ACCESS_KEY_ID}\" ]]; then\n  CACHE_WRITE=false\n  # If no secret read/write\
-        \ creds, use hard-coded read-only creds, so that\n  # cross-fork PRs can at least read from the cache.\n  # These\
-        \ creds are hard-coded here in this public repo, which makes the bucket\n  # world-readable. But since putting raw\
-        \ AWS tokens in a public repo, even\n  # deliberately, is icky, we base64-them. This will at least help hide from\n\
-        \  # automated scanners that look for checked in AWS keys.\n  # Not that it would be terrible if we were scanned,\
-        \ since this is public\n  # on purpose, but it's best not to draw attention.\n  AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK'\
-        \ | base64 -d)\n  AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo=' | base64\
-        \ -d)\nelse\n  CACHE_WRITE=true\nfi\ndocker run --detach -u 1001:1000                   -v ~/bazel-remote:/data  \
-        \                 -p 9092:9092                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key\
-        \                   --s3.access_key_id=\"${AWS_ACCESS_KEY_ID}\"                   --s3.secret_access_key=\"${AWS_SECRET_ACCESS_KEY}\"\
-        \                   --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com  \
-        \                 --max_size 30\necho \"PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092\" >> \"$GITHUB_ENV\"\necho\
-        \ \"PANTS_REMOTE_CACHE_READ=true\" >> \"$GITHUB_ENV\"\necho \"PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}\" >> \"$GITHUB_ENV\"\
-        \n"
+      run: |
+        mkdir -p ~/bazel-remote
+        if [[ -z "${AWS_ACCESS_KEY_ID}" ]]; then
+          CACHE_WRITE=false
+          # If no secret read/write creds, use hard-coded read-only creds, so that
+          # cross-fork PRs can at least read from the cache.
+          # These creds are hard-coded here in this public repo, which makes the bucket
+          # world-readable. But since putting raw AWS tokens in a public repo, even
+          # deliberately, is icky, we base64-them. This will at least help hide from
+          # automated scanners that look for checked in AWS keys.
+          # Not that it would be terrible if we were scanned, since this is public
+          # on purpose, but it's best not to draw attention.
+          AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK' | base64 -d)
+          AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo=' | base64 -d)
+        else
+          CACHE_WRITE=true
+        fi
+        docker run --detach -u 1001:1000                   -v ~/bazel-remote:/data                   -p 9092:9092                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key                   --s3.access_key_id="${AWS_ACCESS_KEY_ID}"                   --s3.secret_access_key="${AWS_SECRET_ACCESS_KEY}"                   --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com                   --max_size 30
+        echo "PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092" >> "$GITHUB_ENV"
+        echo "PANTS_REMOTE_CACHE_READ=true" >> "$GITHUB_ENV"
+        echo "PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}" >> "$GITHUB_ENV"
     - name: Install AdoptJDK
       uses: actions/setup-java@v4
       with:
@@ -1347,31 +1266,22 @@ jobs:
         go-version: 1.19.5
     - if: runner.os == 'Linux'
       name: Download Apache `thrift` binary (Linux)
-      run: 'mkdir -p "${HOME}/.thrift"
-
+      run: |
+        mkdir -p "${HOME}/.thrift"
         curl --fail -L https://binaries.pantsbuild.org/bin/thrift/linux/x86_64/0.15.0/thrift -o "${HOME}/.thrift/thrift"
-
         chmod +x "${HOME}/.thrift/thrift"
-
         echo "${HOME}/.thrift" >> $GITHUB_PATH
-
-        '
     - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7
-
+        python-version: |-
+          3.7
           3.8
-
           3.9
-
           3.10
-
           3.12
-
           3.13
-
-          3.11'
+          3.11
     - name: Download native binaries
       uses: actions/download-artifact@v4
       with:
@@ -1380,22 +1290,18 @@ jobs:
     - name: Make native-client runnable
       run: chmod +x src/python/pants/bin/native_client
     - name: Run Python test shard 4/10
-      run: './pants test --shard=4/10 ::
-
-        '
+      run: |
+        ./pants test --shard=4/10 ::
     - continue-on-error: true
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: 'export S3_DST=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}
-
+      run: |
+        export S3_DST=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}
         echo "Uploading test reports to ${S3_DST}"
-
         ./pants run ./src/python/pants_release/copy_to_s3.py                   --                   --src-prefix=dist/test/reports                   --dst-prefix=${S3_DST}                   --path=""
-
-        '
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -1424,20 +1330,27 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       name: Launch bazel-remote
-      run: "mkdir -p ~/bazel-remote\nif [[ -z \"${AWS_ACCESS_KEY_ID}\" ]]; then\n  CACHE_WRITE=false\n  # If no secret read/write\
-        \ creds, use hard-coded read-only creds, so that\n  # cross-fork PRs can at least read from the cache.\n  # These\
-        \ creds are hard-coded here in this public repo, which makes the bucket\n  # world-readable. But since putting raw\
-        \ AWS tokens in a public repo, even\n  # deliberately, is icky, we base64-them. This will at least help hide from\n\
-        \  # automated scanners that look for checked in AWS keys.\n  # Not that it would be terrible if we were scanned,\
-        \ since this is public\n  # on purpose, but it's best not to draw attention.\n  AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK'\
-        \ | base64 -d)\n  AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo=' | base64\
-        \ -d)\nelse\n  CACHE_WRITE=true\nfi\ndocker run --detach -u 1001:1000                   -v ~/bazel-remote:/data  \
-        \                 -p 9092:9092                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key\
-        \                   --s3.access_key_id=\"${AWS_ACCESS_KEY_ID}\"                   --s3.secret_access_key=\"${AWS_SECRET_ACCESS_KEY}\"\
-        \                   --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com  \
-        \                 --max_size 30\necho \"PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092\" >> \"$GITHUB_ENV\"\necho\
-        \ \"PANTS_REMOTE_CACHE_READ=true\" >> \"$GITHUB_ENV\"\necho \"PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}\" >> \"$GITHUB_ENV\"\
-        \n"
+      run: |
+        mkdir -p ~/bazel-remote
+        if [[ -z "${AWS_ACCESS_KEY_ID}" ]]; then
+          CACHE_WRITE=false
+          # If no secret read/write creds, use hard-coded read-only creds, so that
+          # cross-fork PRs can at least read from the cache.
+          # These creds are hard-coded here in this public repo, which makes the bucket
+          # world-readable. But since putting raw AWS tokens in a public repo, even
+          # deliberately, is icky, we base64-them. This will at least help hide from
+          # automated scanners that look for checked in AWS keys.
+          # Not that it would be terrible if we were scanned, since this is public
+          # on purpose, but it's best not to draw attention.
+          AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK' | base64 -d)
+          AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo=' | base64 -d)
+        else
+          CACHE_WRITE=true
+        fi
+        docker run --detach -u 1001:1000                   -v ~/bazel-remote:/data                   -p 9092:9092                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key                   --s3.access_key_id="${AWS_ACCESS_KEY_ID}"                   --s3.secret_access_key="${AWS_SECRET_ACCESS_KEY}"                   --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com                   --max_size 30
+        echo "PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092" >> "$GITHUB_ENV"
+        echo "PANTS_REMOTE_CACHE_READ=true" >> "$GITHUB_ENV"
+        echo "PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}" >> "$GITHUB_ENV"
     - name: Install AdoptJDK
       uses: actions/setup-java@v4
       with:
@@ -1449,31 +1362,22 @@ jobs:
         go-version: 1.19.5
     - if: runner.os == 'Linux'
       name: Download Apache `thrift` binary (Linux)
-      run: 'mkdir -p "${HOME}/.thrift"
-
+      run: |
+        mkdir -p "${HOME}/.thrift"
         curl --fail -L https://binaries.pantsbuild.org/bin/thrift/linux/x86_64/0.15.0/thrift -o "${HOME}/.thrift/thrift"
-
         chmod +x "${HOME}/.thrift/thrift"
-
         echo "${HOME}/.thrift" >> $GITHUB_PATH
-
-        '
     - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7
-
+        python-version: |-
+          3.7
           3.8
-
           3.9
-
           3.10
-
           3.12
-
           3.13
-
-          3.11'
+          3.11
     - name: Download native binaries
       uses: actions/download-artifact@v4
       with:
@@ -1482,22 +1386,18 @@ jobs:
     - name: Make native-client runnable
       run: chmod +x src/python/pants/bin/native_client
     - name: Run Python test shard 5/10
-      run: './pants test --shard=5/10 ::
-
-        '
+      run: |
+        ./pants test --shard=5/10 ::
     - continue-on-error: true
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: 'export S3_DST=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}
-
+      run: |
+        export S3_DST=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}
         echo "Uploading test reports to ${S3_DST}"
-
         ./pants run ./src/python/pants_release/copy_to_s3.py                   --                   --src-prefix=dist/test/reports                   --dst-prefix=${S3_DST}                   --path=""
-
-        '
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -1526,20 +1426,27 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       name: Launch bazel-remote
-      run: "mkdir -p ~/bazel-remote\nif [[ -z \"${AWS_ACCESS_KEY_ID}\" ]]; then\n  CACHE_WRITE=false\n  # If no secret read/write\
-        \ creds, use hard-coded read-only creds, so that\n  # cross-fork PRs can at least read from the cache.\n  # These\
-        \ creds are hard-coded here in this public repo, which makes the bucket\n  # world-readable. But since putting raw\
-        \ AWS tokens in a public repo, even\n  # deliberately, is icky, we base64-them. This will at least help hide from\n\
-        \  # automated scanners that look for checked in AWS keys.\n  # Not that it would be terrible if we were scanned,\
-        \ since this is public\n  # on purpose, but it's best not to draw attention.\n  AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK'\
-        \ | base64 -d)\n  AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo=' | base64\
-        \ -d)\nelse\n  CACHE_WRITE=true\nfi\ndocker run --detach -u 1001:1000                   -v ~/bazel-remote:/data  \
-        \                 -p 9092:9092                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key\
-        \                   --s3.access_key_id=\"${AWS_ACCESS_KEY_ID}\"                   --s3.secret_access_key=\"${AWS_SECRET_ACCESS_KEY}\"\
-        \                   --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com  \
-        \                 --max_size 30\necho \"PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092\" >> \"$GITHUB_ENV\"\necho\
-        \ \"PANTS_REMOTE_CACHE_READ=true\" >> \"$GITHUB_ENV\"\necho \"PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}\" >> \"$GITHUB_ENV\"\
-        \n"
+      run: |
+        mkdir -p ~/bazel-remote
+        if [[ -z "${AWS_ACCESS_KEY_ID}" ]]; then
+          CACHE_WRITE=false
+          # If no secret read/write creds, use hard-coded read-only creds, so that
+          # cross-fork PRs can at least read from the cache.
+          # These creds are hard-coded here in this public repo, which makes the bucket
+          # world-readable. But since putting raw AWS tokens in a public repo, even
+          # deliberately, is icky, we base64-them. This will at least help hide from
+          # automated scanners that look for checked in AWS keys.
+          # Not that it would be terrible if we were scanned, since this is public
+          # on purpose, but it's best not to draw attention.
+          AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK' | base64 -d)
+          AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo=' | base64 -d)
+        else
+          CACHE_WRITE=true
+        fi
+        docker run --detach -u 1001:1000                   -v ~/bazel-remote:/data                   -p 9092:9092                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key                   --s3.access_key_id="${AWS_ACCESS_KEY_ID}"                   --s3.secret_access_key="${AWS_SECRET_ACCESS_KEY}"                   --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com                   --max_size 30
+        echo "PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092" >> "$GITHUB_ENV"
+        echo "PANTS_REMOTE_CACHE_READ=true" >> "$GITHUB_ENV"
+        echo "PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}" >> "$GITHUB_ENV"
     - name: Install AdoptJDK
       uses: actions/setup-java@v4
       with:
@@ -1551,31 +1458,22 @@ jobs:
         go-version: 1.19.5
     - if: runner.os == 'Linux'
       name: Download Apache `thrift` binary (Linux)
-      run: 'mkdir -p "${HOME}/.thrift"
-
+      run: |
+        mkdir -p "${HOME}/.thrift"
         curl --fail -L https://binaries.pantsbuild.org/bin/thrift/linux/x86_64/0.15.0/thrift -o "${HOME}/.thrift/thrift"
-
         chmod +x "${HOME}/.thrift/thrift"
-
         echo "${HOME}/.thrift" >> $GITHUB_PATH
-
-        '
     - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7
-
+        python-version: |-
+          3.7
           3.8
-
           3.9
-
           3.10
-
           3.12
-
           3.13
-
-          3.11'
+          3.11
     - name: Download native binaries
       uses: actions/download-artifact@v4
       with:
@@ -1584,22 +1482,18 @@ jobs:
     - name: Make native-client runnable
       run: chmod +x src/python/pants/bin/native_client
     - name: Run Python test shard 6/10
-      run: './pants test --shard=6/10 ::
-
-        '
+      run: |
+        ./pants test --shard=6/10 ::
     - continue-on-error: true
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: 'export S3_DST=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}
-
+      run: |
+        export S3_DST=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}
         echo "Uploading test reports to ${S3_DST}"
-
         ./pants run ./src/python/pants_release/copy_to_s3.py                   --                   --src-prefix=dist/test/reports                   --dst-prefix=${S3_DST}                   --path=""
-
-        '
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -1628,20 +1522,27 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       name: Launch bazel-remote
-      run: "mkdir -p ~/bazel-remote\nif [[ -z \"${AWS_ACCESS_KEY_ID}\" ]]; then\n  CACHE_WRITE=false\n  # If no secret read/write\
-        \ creds, use hard-coded read-only creds, so that\n  # cross-fork PRs can at least read from the cache.\n  # These\
-        \ creds are hard-coded here in this public repo, which makes the bucket\n  # world-readable. But since putting raw\
-        \ AWS tokens in a public repo, even\n  # deliberately, is icky, we base64-them. This will at least help hide from\n\
-        \  # automated scanners that look for checked in AWS keys.\n  # Not that it would be terrible if we were scanned,\
-        \ since this is public\n  # on purpose, but it's best not to draw attention.\n  AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK'\
-        \ | base64 -d)\n  AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo=' | base64\
-        \ -d)\nelse\n  CACHE_WRITE=true\nfi\ndocker run --detach -u 1001:1000                   -v ~/bazel-remote:/data  \
-        \                 -p 9092:9092                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key\
-        \                   --s3.access_key_id=\"${AWS_ACCESS_KEY_ID}\"                   --s3.secret_access_key=\"${AWS_SECRET_ACCESS_KEY}\"\
-        \                   --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com  \
-        \                 --max_size 30\necho \"PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092\" >> \"$GITHUB_ENV\"\necho\
-        \ \"PANTS_REMOTE_CACHE_READ=true\" >> \"$GITHUB_ENV\"\necho \"PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}\" >> \"$GITHUB_ENV\"\
-        \n"
+      run: |
+        mkdir -p ~/bazel-remote
+        if [[ -z "${AWS_ACCESS_KEY_ID}" ]]; then
+          CACHE_WRITE=false
+          # If no secret read/write creds, use hard-coded read-only creds, so that
+          # cross-fork PRs can at least read from the cache.
+          # These creds are hard-coded here in this public repo, which makes the bucket
+          # world-readable. But since putting raw AWS tokens in a public repo, even
+          # deliberately, is icky, we base64-them. This will at least help hide from
+          # automated scanners that look for checked in AWS keys.
+          # Not that it would be terrible if we were scanned, since this is public
+          # on purpose, but it's best not to draw attention.
+          AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK' | base64 -d)
+          AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo=' | base64 -d)
+        else
+          CACHE_WRITE=true
+        fi
+        docker run --detach -u 1001:1000                   -v ~/bazel-remote:/data                   -p 9092:9092                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key                   --s3.access_key_id="${AWS_ACCESS_KEY_ID}"                   --s3.secret_access_key="${AWS_SECRET_ACCESS_KEY}"                   --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com                   --max_size 30
+        echo "PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092" >> "$GITHUB_ENV"
+        echo "PANTS_REMOTE_CACHE_READ=true" >> "$GITHUB_ENV"
+        echo "PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}" >> "$GITHUB_ENV"
     - name: Install AdoptJDK
       uses: actions/setup-java@v4
       with:
@@ -1653,31 +1554,22 @@ jobs:
         go-version: 1.19.5
     - if: runner.os == 'Linux'
       name: Download Apache `thrift` binary (Linux)
-      run: 'mkdir -p "${HOME}/.thrift"
-
+      run: |
+        mkdir -p "${HOME}/.thrift"
         curl --fail -L https://binaries.pantsbuild.org/bin/thrift/linux/x86_64/0.15.0/thrift -o "${HOME}/.thrift/thrift"
-
         chmod +x "${HOME}/.thrift/thrift"
-
         echo "${HOME}/.thrift" >> $GITHUB_PATH
-
-        '
     - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7
-
+        python-version: |-
+          3.7
           3.8
-
           3.9
-
           3.10
-
           3.12
-
           3.13
-
-          3.11'
+          3.11
     - name: Download native binaries
       uses: actions/download-artifact@v4
       with:
@@ -1686,22 +1578,18 @@ jobs:
     - name: Make native-client runnable
       run: chmod +x src/python/pants/bin/native_client
     - name: Run Python test shard 7/10
-      run: './pants test --shard=7/10 ::
-
-        '
+      run: |
+        ./pants test --shard=7/10 ::
     - continue-on-error: true
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: 'export S3_DST=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}
-
+      run: |
+        export S3_DST=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}
         echo "Uploading test reports to ${S3_DST}"
-
         ./pants run ./src/python/pants_release/copy_to_s3.py                   --                   --src-prefix=dist/test/reports                   --dst-prefix=${S3_DST}                   --path=""
-
-        '
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -1730,20 +1618,27 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       name: Launch bazel-remote
-      run: "mkdir -p ~/bazel-remote\nif [[ -z \"${AWS_ACCESS_KEY_ID}\" ]]; then\n  CACHE_WRITE=false\n  # If no secret read/write\
-        \ creds, use hard-coded read-only creds, so that\n  # cross-fork PRs can at least read from the cache.\n  # These\
-        \ creds are hard-coded here in this public repo, which makes the bucket\n  # world-readable. But since putting raw\
-        \ AWS tokens in a public repo, even\n  # deliberately, is icky, we base64-them. This will at least help hide from\n\
-        \  # automated scanners that look for checked in AWS keys.\n  # Not that it would be terrible if we were scanned,\
-        \ since this is public\n  # on purpose, but it's best not to draw attention.\n  AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK'\
-        \ | base64 -d)\n  AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo=' | base64\
-        \ -d)\nelse\n  CACHE_WRITE=true\nfi\ndocker run --detach -u 1001:1000                   -v ~/bazel-remote:/data  \
-        \                 -p 9092:9092                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key\
-        \                   --s3.access_key_id=\"${AWS_ACCESS_KEY_ID}\"                   --s3.secret_access_key=\"${AWS_SECRET_ACCESS_KEY}\"\
-        \                   --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com  \
-        \                 --max_size 30\necho \"PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092\" >> \"$GITHUB_ENV\"\necho\
-        \ \"PANTS_REMOTE_CACHE_READ=true\" >> \"$GITHUB_ENV\"\necho \"PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}\" >> \"$GITHUB_ENV\"\
-        \n"
+      run: |
+        mkdir -p ~/bazel-remote
+        if [[ -z "${AWS_ACCESS_KEY_ID}" ]]; then
+          CACHE_WRITE=false
+          # If no secret read/write creds, use hard-coded read-only creds, so that
+          # cross-fork PRs can at least read from the cache.
+          # These creds are hard-coded here in this public repo, which makes the bucket
+          # world-readable. But since putting raw AWS tokens in a public repo, even
+          # deliberately, is icky, we base64-them. This will at least help hide from
+          # automated scanners that look for checked in AWS keys.
+          # Not that it would be terrible if we were scanned, since this is public
+          # on purpose, but it's best not to draw attention.
+          AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK' | base64 -d)
+          AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo=' | base64 -d)
+        else
+          CACHE_WRITE=true
+        fi
+        docker run --detach -u 1001:1000                   -v ~/bazel-remote:/data                   -p 9092:9092                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key                   --s3.access_key_id="${AWS_ACCESS_KEY_ID}"                   --s3.secret_access_key="${AWS_SECRET_ACCESS_KEY}"                   --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com                   --max_size 30
+        echo "PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092" >> "$GITHUB_ENV"
+        echo "PANTS_REMOTE_CACHE_READ=true" >> "$GITHUB_ENV"
+        echo "PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}" >> "$GITHUB_ENV"
     - name: Install AdoptJDK
       uses: actions/setup-java@v4
       with:
@@ -1755,31 +1650,22 @@ jobs:
         go-version: 1.19.5
     - if: runner.os == 'Linux'
       name: Download Apache `thrift` binary (Linux)
-      run: 'mkdir -p "${HOME}/.thrift"
-
+      run: |
+        mkdir -p "${HOME}/.thrift"
         curl --fail -L https://binaries.pantsbuild.org/bin/thrift/linux/x86_64/0.15.0/thrift -o "${HOME}/.thrift/thrift"
-
         chmod +x "${HOME}/.thrift/thrift"
-
         echo "${HOME}/.thrift" >> $GITHUB_PATH
-
-        '
     - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7
-
+        python-version: |-
+          3.7
           3.8
-
           3.9
-
           3.10
-
           3.12
-
           3.13
-
-          3.11'
+          3.11
     - name: Download native binaries
       uses: actions/download-artifact@v4
       with:
@@ -1788,22 +1674,18 @@ jobs:
     - name: Make native-client runnable
       run: chmod +x src/python/pants/bin/native_client
     - name: Run Python test shard 8/10
-      run: './pants test --shard=8/10 ::
-
-        '
+      run: |
+        ./pants test --shard=8/10 ::
     - continue-on-error: true
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: 'export S3_DST=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}
-
+      run: |
+        export S3_DST=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}
         echo "Uploading test reports to ${S3_DST}"
-
         ./pants run ./src/python/pants_release/copy_to_s3.py                   --                   --src-prefix=dist/test/reports                   --dst-prefix=${S3_DST}                   --path=""
-
-        '
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -1832,20 +1714,27 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       name: Launch bazel-remote
-      run: "mkdir -p ~/bazel-remote\nif [[ -z \"${AWS_ACCESS_KEY_ID}\" ]]; then\n  CACHE_WRITE=false\n  # If no secret read/write\
-        \ creds, use hard-coded read-only creds, so that\n  # cross-fork PRs can at least read from the cache.\n  # These\
-        \ creds are hard-coded here in this public repo, which makes the bucket\n  # world-readable. But since putting raw\
-        \ AWS tokens in a public repo, even\n  # deliberately, is icky, we base64-them. This will at least help hide from\n\
-        \  # automated scanners that look for checked in AWS keys.\n  # Not that it would be terrible if we were scanned,\
-        \ since this is public\n  # on purpose, but it's best not to draw attention.\n  AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK'\
-        \ | base64 -d)\n  AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo=' | base64\
-        \ -d)\nelse\n  CACHE_WRITE=true\nfi\ndocker run --detach -u 1001:1000                   -v ~/bazel-remote:/data  \
-        \                 -p 9092:9092                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key\
-        \                   --s3.access_key_id=\"${AWS_ACCESS_KEY_ID}\"                   --s3.secret_access_key=\"${AWS_SECRET_ACCESS_KEY}\"\
-        \                   --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com  \
-        \                 --max_size 30\necho \"PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092\" >> \"$GITHUB_ENV\"\necho\
-        \ \"PANTS_REMOTE_CACHE_READ=true\" >> \"$GITHUB_ENV\"\necho \"PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}\" >> \"$GITHUB_ENV\"\
-        \n"
+      run: |
+        mkdir -p ~/bazel-remote
+        if [[ -z "${AWS_ACCESS_KEY_ID}" ]]; then
+          CACHE_WRITE=false
+          # If no secret read/write creds, use hard-coded read-only creds, so that
+          # cross-fork PRs can at least read from the cache.
+          # These creds are hard-coded here in this public repo, which makes the bucket
+          # world-readable. But since putting raw AWS tokens in a public repo, even
+          # deliberately, is icky, we base64-them. This will at least help hide from
+          # automated scanners that look for checked in AWS keys.
+          # Not that it would be terrible if we were scanned, since this is public
+          # on purpose, but it's best not to draw attention.
+          AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK' | base64 -d)
+          AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo=' | base64 -d)
+        else
+          CACHE_WRITE=true
+        fi
+        docker run --detach -u 1001:1000                   -v ~/bazel-remote:/data                   -p 9092:9092                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key                   --s3.access_key_id="${AWS_ACCESS_KEY_ID}"                   --s3.secret_access_key="${AWS_SECRET_ACCESS_KEY}"                   --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com                   --max_size 30
+        echo "PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092" >> "$GITHUB_ENV"
+        echo "PANTS_REMOTE_CACHE_READ=true" >> "$GITHUB_ENV"
+        echo "PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}" >> "$GITHUB_ENV"
     - name: Install AdoptJDK
       uses: actions/setup-java@v4
       with:
@@ -1857,31 +1746,22 @@ jobs:
         go-version: 1.19.5
     - if: runner.os == 'Linux'
       name: Download Apache `thrift` binary (Linux)
-      run: 'mkdir -p "${HOME}/.thrift"
-
+      run: |
+        mkdir -p "${HOME}/.thrift"
         curl --fail -L https://binaries.pantsbuild.org/bin/thrift/linux/x86_64/0.15.0/thrift -o "${HOME}/.thrift/thrift"
-
         chmod +x "${HOME}/.thrift/thrift"
-
         echo "${HOME}/.thrift" >> $GITHUB_PATH
-
-        '
     - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7
-
+        python-version: |-
+          3.7
           3.8
-
           3.9
-
           3.10
-
           3.12
-
           3.13
-
-          3.11'
+          3.11
     - name: Download native binaries
       uses: actions/download-artifact@v4
       with:
@@ -1890,22 +1770,18 @@ jobs:
     - name: Make native-client runnable
       run: chmod +x src/python/pants/bin/native_client
     - name: Run Python test shard 9/10
-      run: './pants test --shard=9/10 ::
-
-        '
+      run: |
+        ./pants test --shard=9/10 ::
     - continue-on-error: true
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: 'export S3_DST=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}
-
+      run: |
+        export S3_DST=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}
         echo "Uploading test reports to ${S3_DST}"
-
         ./pants run ./src/python/pants_release/copy_to_s3.py                   --                   --src-prefix=dist/test/reports                   --dst-prefix=${S3_DST}                   --path=""
-
-        '
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -1943,19 +1819,14 @@ jobs:
     - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.7
-
+        python-version: |-
+          3.7
           3.8
-
           3.9
-
           3.10
-
           3.12
-
           3.13
-
-          3.11'
+          3.11
     - name: Download native binaries
       uses: actions/download-artifact@v4
       with:
@@ -1964,22 +1835,18 @@ jobs:
     - name: Make native-client runnable
       run: chmod +x src/python/pants/bin/native_client
     - name: Run Python tests
-      run: './pants --tag=+platform_specific_behavior test :: -- -m platform_specific_behavior
-
-        '
+      run: |
+        ./pants --tag=+platform_specific_behavior test :: -- -m platform_specific_behavior
     - continue-on-error: true
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: 'export S3_DST=s3://logs.pantsbuild.org/test/reports/macOS13-x86_64/$(git show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}
-
+      run: |
+        export S3_DST=s3://logs.pantsbuild.org/test/reports/macOS13-x86_64/$(git show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}
         echo "Uploading test reports to ${S3_DST}"
-
         ./pants run ./src/python/pants_release/copy_to_s3.py                   --                   --src-prefix=dist/test/reports                   --dst-prefix=${S3_DST}                   --path=""
-
-        '
     - continue-on-error: true
       if: always()
       name: Upload pants.log

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -294,8 +294,7 @@ jobs:
       MODE: debug
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
-    if: ((github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.release == 'true' || needs.classify_changes.outputs.ci_config
-      == 'true')) && (needs.classify_changes.outputs.no_code != 'true')
+    if: ((github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.release == 'true' || needs.classify_changes.outputs.ci_config == 'true')) && (needs.classify_changes.outputs.no_code != 'true')
     name: Build wheels (Linux-ARM64)
     needs:
     - classify_changes
@@ -364,8 +363,7 @@ jobs:
       MODE: debug
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
-    if: ((github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.release == 'true' || needs.classify_changes.outputs.ci_config
-      == 'true')) && (needs.classify_changes.outputs.no_code != 'true')
+    if: ((github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.release == 'true' || needs.classify_changes.outputs.ci_config == 'true')) && (needs.classify_changes.outputs.no_code != 'true')
     name: Build wheels (Linux-x86_64)
     needs:
     - classify_changes
@@ -432,8 +430,7 @@ jobs:
       MODE: debug
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
-    if: ((github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.release == 'true' || needs.classify_changes.outputs.ci_config
-      == 'true')) && (needs.classify_changes.outputs.no_code != 'true')
+    if: ((github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.release == 'true' || needs.classify_changes.outputs.ci_config == 'true')) && (needs.classify_changes.outputs.no_code != 'true')
     name: Build wheels (macOS13-x86_64)
     needs:
     - classify_changes
@@ -514,8 +511,7 @@ jobs:
       MODE: debug
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
-    if: ((github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.release == 'true' || needs.classify_changes.outputs.ci_config
-      == 'true')) && (needs.classify_changes.outputs.no_code != 'true')
+    if: ((github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.release == 'true' || needs.classify_changes.outputs.ci_config == 'true')) && (needs.classify_changes.outputs.no_code != 'true')
     name: Build wheels (macOS14-ARM64)
     needs:
     - classify_changes

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -1717,6 +1717,17 @@ class NoAliasDumper(yaml.SafeDumper):
         return True
 
 
+# Forcibly use | string literals for multi-line strings, much better than seeing a bunch of \n, or
+# empty lines, if a human need to read the generated file.
+def _yaml_representer_pipes_if_multiline(dumper: NoAliasDumper, data: str) -> yaml.Node:
+    if "\n" in data:
+        return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
+    return dumper.represent_str(data)
+
+
+NoAliasDumper.add_representer(str, _yaml_representer_pipes_if_multiline)
+
+
 def merge_ok(pr_jobs: list[str]) -> Jobs:
     # Generate the "Merge OK" job that branch protection can monitor.
     # Note: A job skipped due to an "if" condition, or due to a failed dependency, counts as

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -1713,7 +1713,7 @@ def create_parser() -> argparse.ArgumentParser:
 # PyYAML will try by default to use anchors to deduplicate certain code. The alias
 # names are cryptic, though, like `&id002`, so we turn this feature off.
 class NoAliasDumper(yaml.SafeDumper):
-    def __init__(self, stream, width = None, **kwargs):
+    def __init__(self, stream, width=None, **kwargs):
         # set a very wide width to effectively disable wrapping, which is generally distracting
         if width is None:
             width = 999999

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -1713,6 +1713,12 @@ def create_parser() -> argparse.ArgumentParser:
 # PyYAML will try by default to use anchors to deduplicate certain code. The alias
 # names are cryptic, though, like `&id002`, so we turn this feature off.
 class NoAliasDumper(yaml.SafeDumper):
+    def __init__(self, stream, width = None, **kwargs):
+        # set a very wide width to effectively disable wrapping, which is generally distracting
+        if width is None:
+            width = 999999
+        super().__init__(stream, width=width, **kwargs)
+
     def ignore_aliases(self, data):
         return True
 
@@ -1809,7 +1815,6 @@ def generate() -> dict[Path, str]:
             "jobs": pr_jobs,
             "env": global_env(),
         },
-        width=120,
         Dumper=NoAliasDumper,
     )
 


### PR DESCRIPTION
This makes a few minor tweaks to the CI yaml that's generated by `src/python/pants_release/generate_github_workflows.py`, to make it slightly easier for a human to read in the occasional case that it's useful:

- use `|` syntax for strings, to avoid inline `\n` escapes (`"abc\ndef"`) and/or multiline `'` strings with blank lines
- disable wrapping entirely by setting the target width to something huge, to avoid long single-line strings being broken mid-string, which is usually a distraction
- consistently use the `PantsDumper` that powers the above (previously called `NoAliasDumper`) via a helper function

The commits are individually sensible, alternating between "change the codegen in one way" and "regenerate the codegen".

This is no-functional-change: doesn't change the result of parsing the files, just how they're saved on disk. Verification using https://github.com/TomWright/dasel : the `diff` prints nothing (i.e. no differences):
```
git checkout 468dbd1044ca433e438b8cad07793258cf7d8b1a
dasel -f .github/workflows/test.yaml -w json  > /tmp/after.json 

git checkout 68bdc29ec21fd703660b179d39990691133ef459
dasel -f .github/workflows/test.yaml -w json  > /tmp/before.json 

diff /tmp/before.json /tmp/after.json
```

(468dbd1044ca433e438b8cad07793258cf7d8b1a is the current HEAD of this PR, 68bdc29ec21fd703660b179d39990691133ef459 is the merge base on develop)
