### PR TITLE
Support **implicitly() in the RuleRunner

### DIFF
--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -389,7 +389,7 @@ def run_lint_rule(
                 ),
             ],
             mock_calls={
-                "pants.engine.internals.graph.filter_targets": lambda: FilteredTargets(
+                "pants.engine.internals.graph.filter_targets": lambda __implicitly: FilteredTargets(
                     tuple(targets)
                 ),
                 "pants.engine.internals.specs_rules.resolve_specs_paths": lambda _: SpecsPaths(

--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -82,7 +82,7 @@ def test_parse_address_family_empty() -> None:
             SessionValues({CompleteEnvironmentVars: CompleteEnvironmentVars({})}),
         ],
         mock_calls={
-            "pants.engine.intrinsics.get_digest_contents": lambda: DigestContents(
+            "pants.engine.intrinsics.get_digest_contents": lambda __implicitly: DigestContents(
                 [FileContent(path="/dev/null/BUILD", content=b"")]
             ),
             "pants.engine.internals.synthetic_targets.get_synthetic_address_maps": lambda _: SyntheticAddressMaps(),
@@ -121,7 +121,7 @@ def test_extend_synthetic_target() -> None:
             SessionValues({CompleteEnvironmentVars: CompleteEnvironmentVars({})}),
         ],
         mock_calls={
-            "pants.engine.intrinsics.get_digest_contents": lambda: DigestContents(
+            "pants.engine.intrinsics.get_digest_contents": lambda __implicitly: DigestContents(
                 [
                     FileContent(
                         path="/foo/BUILD.1", content=b"resource(name='aaa', description='a')"
@@ -132,7 +132,7 @@ def test_extend_synthetic_target() -> None:
                     ),
                 ]
             ),
-            "pants.engine.internals.synthetic_targets.get_synthetic_address_maps": lambda _: SyntheticAddressMaps(
+            "pants.engine.internals.synthetic_targets.get_synthetic_address_maps": lambda __implicitly: SyntheticAddressMaps(
                 [
                     SyntheticAddressMap.create(
                         "/foo/synthetic1",
@@ -149,7 +149,7 @@ def test_extend_synthetic_target() -> None:
                     ),
                 ]
             ),
-            "pants.engine.internals.build_files.parse_address_family": lambda _: OptionalAddressFamily(
+            "pants.engine.internals.build_files.parse_address_family": lambda __implicitly: OptionalAddressFamily(
                 "/",
                 address_family=AddressFamily.create(
                     "/",
@@ -198,15 +198,11 @@ def run_prelude_parsing_rule(prelude_content: str) -> BuildFilePreludeSymbols:
                 ignore_unrecognized_symbols=False,
             ),
         ],
-        mock_gets=[
-            MockGet(
-                output_type=DigestContents,
-                input_types=(PathGlobs,),
-                mock=lambda _: DigestContents(
-                    [FileContent(path="/dev/null/prelude", content=prelude_content.encode())]
-                ),
-            ),
-        ],
+        mock_calls={
+            "pants.engine.intrinsics.get_digest_contents": lambda __implicitly: DigestContents(
+                [FileContent(path="/dev/null/prelude", content=prelude_content.encode())]
+            )
+        },
     )
     return symbols
 

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -758,13 +758,17 @@ def run_rule_with_mocks(
             assert locals is not None
             rule_id = locals["rule_id"]
             args = locals["args"]
+            kwargs = dict(locals["kwargs"])
+            __implicitly = locals.get("__implicitly")
+            if __implicitly:
+                kwargs["__implicitly"] = __implicitly
             mock_call = mock_calls.get(rule_id)
             if mock_call:
                 unconsumed_mock_calls.discard(rule_id)
                 # Close the original, unmocked, coroutine, to prevent the "was never awaited"
                 # warning polluting stderr data that the test may examine.
                 res.close()
-                return mock_call(*args)
+                return mock_call(*args, **kwargs)
             raise AssertionError(f"No mock_call provided for {rule_id}.")
         elif isinstance(res, Call):
             mock_call = mock_calls.get(res.rule_id)


### PR DESCRIPTION
The RuleRunner is used to run mock rules in tests.
Previously we only supported positional args passed
to mock by-name calls in a concurrently().

This PR adds support for kwargs, but more specifically
for implicit args (which are passed via the `__implicitly`
kwarg). 

Mocks often don't care about their input, so the ripple 
effects of this change have been minimal. But some
mocks might want to inspect their input, and even those
that ignore their input have to at least have a matching
kwarg name if their inputs are passed **implicitly(). 
Hence the fix up of a couple of tests here.