### PR TITLE
Add support for reading pylock.toml lockfiles

### DIFF
--- a/docs/notes/2.29.x.md
+++ b/docs/notes/2.29.x.md
@@ -28,6 +28,8 @@ The version of [Pex](https://github.com/pex-tool/pex) used by the Python backend
 
 The Python Build Standalone backend (`pants.backend.python.providers.experimental.python_build_standalone`) has release metadata current through PBS release `20250712`.
 
+Enable support for reading `pylock.toml` lock files.
+
 #### Javascript
 
 Enable setting missing common fields e.g "tags" for the `node_build_script`-symbol and resulting `NodeBuildScriptTarget`.

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -41,6 +41,11 @@ from pants.backend.python.util_rules.pex_requirements import (
     LoadedLockfile,
     LoadedLockfileRequest,
     Lockfile,
+)
+from pants.backend.python.util_rules.pex_requirements import (
+    PexRequirements as PexRequirements,  # Explicit re-export.
+)
+from pants.backend.python.util_rules.pex_requirements import (
     Resolve,
     ResolvePexConfigRequest,
     determine_resolve_pex_config,
@@ -49,14 +54,12 @@ from pants.backend.python.util_rules.pex_requirements import (
     load_lockfile,
     validate_metadata,
 )
-from pants.backend.python.util_rules.pex_requirements import (
-    PexRequirements as PexRequirements,  # Explicit re-export.
-)
 from pants.build_graph.address import Address
 from pants.core.environments.target_types import EnvironmentTarget
 from pants.core.target_types import FileSourceField, ResourceSourceField
-from pants.core.util_rules.stripped_source_files import StrippedFileNameRequest, strip_file_name
+from pants.core.util_rules.stripped_source_files import StrippedFileNameRequest
 from pants.core.util_rules.stripped_source_files import rules as stripped_source_rules
+from pants.core.util_rules.stripped_source_files import strip_file_name
 from pants.core.util_rules.system_binaries import BashBinary
 from pants.engine.addresses import UnparsedAddressInputs
 from pants.engine.collection import Collection, DeduplicatedCollection


### PR DESCRIPTION
# Summary
- This change add a new PEX-native lockfile: `pylock.toml`. 
- The reason for this change is to work towards being able to generate lock files with UV. See #22201
- Whether a lockfile is a `pylock.toml` is decided based on filename, which should be `pylock.toml`, `pylock.dev.toml` or similar.
- Note that this change does not include generating `pylock.toml` files with PEX, because the hope is to do this with UV. To that end, I filed a PR with UV (https://github.com/astral-sh/uv/pull/14783), to make its output sufficient for PEX.

Still todo:
- [x] Change the PEX CLI to version at least 2.43.0 (https://github.com/pex-tool/pex/releases/tag/v2.43.0). (done in #22539)