### PR TITLE
try and fix dependabot builds

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -96,6 +96,8 @@ jobs:
           src/python/pants/engine/internals/native_engine.so
           src/python/pants/engine/internals/native_engine.so.metadata
     - env:
+        HONEYCOMB_API_KEY: --DISABLED--
+        PANTS_SHOALSOFT_OPENTELEMETRY_ENABLED: 'False'
         TMPDIR: ${{ runner.temp }}
       if: needs.classify_changes.outputs.rust == 'true'
       name: Test Rust
@@ -200,6 +202,8 @@ jobs:
       run: |
         ./pants run src/python/pants_release/generate_github_workflows.py -- --check
     - env:
+        HONEYCOMB_API_KEY: --DISABLED--
+        PANTS_SHOALSOFT_OPENTELEMETRY_ENABLED: 'False'
         TMPDIR: ${{ runner.temp }}
       if: needs.classify_changes.outputs.rust == 'true'
       name: Test and lint Rust
@@ -302,6 +306,8 @@ jobs:
           src/python/pants/engine/internals/native_engine.so
           src/python/pants/engine/internals/native_engine.so.metadata
     - env:
+        HONEYCOMB_API_KEY: --DISABLED--
+        PANTS_SHOALSOFT_OPENTELEMETRY_ENABLED: 'False'
         TMPDIR: ${{ runner.temp }}
       if: needs.classify_changes.outputs.rust == 'true'
       name: Test Rust

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -1704,7 +1704,8 @@ def add_telemetry_secret_env(workflow: dict[str, Any]) -> dict[str, Any]:
     """Inject the Honeycomb telemetry configuration into any job/step which runs Pants."""
     for job_config in workflow.get("jobs", {}).values():
         for step_config in job_config.get("steps", []):
-            if "./pants" in step_config.get("run", ""):
+            run_config = step_config.get("run", "")
+            if "./pants" in run_config:
                 if "env" not in step_config:
                     step_config["env"] = {}
 
@@ -1715,6 +1716,12 @@ def add_telemetry_secret_env(workflow: dict[str, Any]) -> dict[str, Any]:
                 step_config["env"]["HONEYCOMB_API_KEY"] = gha_expr(
                     "secrets.HONEYCOMB_API_KEY || '--DISABLED--'"
                 )
+            elif "./cargo test" in run_config:
+                if "env" not in step_config:
+                    step_config["env"] = {}
+                step_config["env"]["PANTS_SHOALSOFT_OPENTELEMETRY_ENABLED"] = "False"
+                step_config["env"]["HONEYCOMB_API_KEY"] = "--DISABLED--"
+
     return workflow
 
 


### PR DESCRIPTION
Depend-a-bot builds are broken due to the `HONEYCOMB_API_KEY` secret not having a value when the Rust code is being tested and the Rust code invokes Pants for Integration tests.