### PR TITLE
update to Pex 2.47.0

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -12,7 +12,7 @@ hdrhistogram==0.10.3
 ijson==3.2.3
 libcst==1.4.0
 packaging==24.2
-pex==2.45.2
+pex==2.47.0
 psutil==5.9.8
 # This should be compatible with pytest.py, although it can be looser so that we don't
 # over-constrain pantsbuild.pants.testutil

--- a/3rdparty/python/user_reqs.lock
+++ b/3rdparty/python/user_reqs.lock
@@ -24,7 +24,7 @@
 //     "mypy-typing-asserts==0.1.1",
 //     "node-semver==0.9.0",
 //     "packaging==24.2",
-//     "pex==2.45.2",
+//     "pex==2.47.0",
 //     "psutil==5.9.8",
 //     "pydevd-pycharm==251.23536.40",
 //     "pytest<7.1.0,>=6.2.4",
@@ -1117,13 +1117,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "04d8b34591964da87a7053c1b2b9b04696fcb4fee4fed99bd660ed99795cb750",
-              "url": "https://files.pythonhosted.org/packages/41/1b/b6937bec553c678133f98fa93b3285fafb2354ab36eab316d4b191a29370/pex-2.45.2-py2.py3-none-any.whl"
+              "hash": "9cc9f67e5bd11adaafd1aa78b7eb4a918de08de843e92ecc994cd13097ef20b7",
+              "url": "https://files.pythonhosted.org/packages/23/36/8310ce8e92fa8cb30902155fb4dd24a20335fe8147b07652c3cd60e5efcc/pex-2.47.0-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d0475e72fc0a0632e2d1c6ec0a2a3ccb6e05ba7c1d4b4294417794867a7975c9",
-              "url": "https://files.pythonhosted.org/packages/88/48/d4533f831cd722eb27837fd38928f15345eba2a38e8934e1ea663c5e32eb/pex-2.45.2.tar.gz"
+              "hash": "75ace8a54827df63b1ba448523ed5bbb81fdc826f3e2f78e9d641c8432afcd4b",
+              "url": "https://files.pythonhosted.org/packages/bd/07/5df5b685385407149f4b9b1dd73252a58bd77f315a297eaefc2c5eb87714/pex-2.47.0.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -1131,8 +1131,8 @@
             "psutil>=5.3; extra == \"management\"",
             "subprocess32>=3.2.7; python_version < \"3\" and extra == \"subprocess\""
           ],
-          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.14,>=2.7",
-          "version": "2.45.2"
+          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.15,>=2.7",
+          "version": "2.47.0"
         },
         {
           "artifacts": [
@@ -2409,7 +2409,7 @@
   "only_wheels": [],
   "overridden": [],
   "path_mappings": {},
-  "pex_version": "2.45.2",
+  "pex_version": "2.47.0",
   "pip_version": "25.1.1",
   "prefer_older_binary": false,
   "requirements": [
@@ -2428,7 +2428,7 @@
     "mypy-typing-asserts==0.1.1",
     "node-semver==0.9.0",
     "packaging==24.2",
-    "pex==2.45.2",
+    "pex==2.47.0",
     "psutil==5.9.8",
     "pydevd-pycharm==251.23536.40",
     "pytest<7.1.0,>=6.2.4",

--- a/docs/notes/2.29.x.md
+++ b/docs/notes/2.29.x.md
@@ -24,7 +24,7 @@ Adds a label to `docker_environment` containers so pantsd can cleanup any old, d
 
 #### Python
 
-The version of [Pex](https://github.com/pex-tool/pex) used by the Python backend has been upgraded to v2.45.2.
+The version of [Pex](https://github.com/pex-tool/pex) used by the Python backend has been upgraded to v2.47.0.
 
 The Python Build Standalone backend (`pants.backend.python.providers.experimental.python_build_standalone`) has release metadata current through PBS release `20250712`.
 

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -42,7 +42,7 @@ class PexCli(TemplatedExternalTool):
     name = "pex"
     help = "The PEX (Python EXecutable) tool (https://github.com/pex-tool/pex)."
 
-    default_version = "v2.45.2"
+    default_version = "v2.47.0"
     default_url_template = "https://github.com/pex-tool/pex/releases/download/{version}/pex"
     version_constraints = ">=2.13.0,<3.0"
 
@@ -59,10 +59,10 @@ class PexCli(TemplatedExternalTool):
     )
 
     default_known_versions = [
-        "v2.45.2|macos_x86_64|570a3d5ca306a39aa3a180bd4cf3e2661b7c74b0579422b34659246daf122384|4833957",
-        "v2.45.2|macos_arm64|570a3d5ca306a39aa3a180bd4cf3e2661b7c74b0579422b34659246daf122384|4833957",
-        "v2.45.2|linux_x86_64|570a3d5ca306a39aa3a180bd4cf3e2661b7c74b0579422b34659246daf122384|4833957",
-        "v2.45.2|linux_arm64|570a3d5ca306a39aa3a180bd4cf3e2661b7c74b0579422b34659246daf122384|4833957",
+        "v2.47.0|macos_x86_64|e5166a60fe2617c0ff5fcd4f560cb4d85aa50e0013f4e1135e468139ec91e09a|4840635",
+        "v2.47.0|macos_arm64|e5166a60fe2617c0ff5fcd4f560cb4d85aa50e0013f4e1135e468139ec91e09a|4840635",
+        "v2.47.0|linux_x86_64|e5166a60fe2617c0ff5fcd4f560cb4d85aa50e0013f4e1135e468139ec91e09a|4840635",
+        "v2.47.0|linux_arm64|e5166a60fe2617c0ff5fcd4f560cb4d85aa50e0013f4e1135e468139ec91e09a|4840635",
     ]
 
 


### PR DESCRIPTION
Changelogs:
 * https://github.com/pex-tool/pex/releases/tag/v2.45.3
 * https://github.com/pex-tool/pex/releases/tag/v2.46.0
 * https://github.com/pex-tool/pex/releases/tag/v2.46.1
 * https://github.com/pex-tool/pex/releases/tag/v2.46.2
 * https://github.com/pex-tool/pex/releases/tag/v2.46.3
 * https://github.com/pex-tool/pex/releases/tag/v2.47.0

```
Lockfile diff: 3rdparty/python/user_reqs.lock [python-default]

==                    Upgraded dependencies                     ==

  pex                            2.45.2       -->   2.47.0
```