### PR TITLE
Make Trivy external tool compatible with upgrade tool

### DIFF
--- a/src/python/pants/backend/tools/trivy/subsystem.py
+++ b/src/python/pants/backend/tools/trivy/subsystem.py
@@ -24,7 +24,7 @@ class Trivy(TemplatedExternalTool):
         "0.57.0|macos_x86_64|e7955b6d38d8125d4aa8936e6af51b0de2b0e0840b4feb90b44002bf7f47bf13|41286618",
         "0.57.0|linux_arm64|29012fdb5ba18da506d1c8b6f389c2ec9d113db965c254971f35267ebb45dd64|37315561",
         "0.57.0|linux_x86_64|cf08a8cd861e5192631fc03bb21efde27c1d93e4407ab70bab32e572bafcbf07|40466119",
-     ]
+    ]
 
     default_url_template = "https://github.com/aquasecurity/trivy/releases/download/v{version}/trivy_{version}_{platform}.tar.gz"
     default_url_platform_mapping = {


### PR DESCRIPTION
Dynamic code doesn't work with [the upgrade tool](https://github.com/pantsbuild/pants/pull/22064)