### PR TITLE
add default module mappings for confluent-kafka and discord.py

### DIFF
--- a/docs/notes/2.29.x.md
+++ b/docs/notes/2.29.x.md
@@ -36,6 +36,8 @@ The version of [Pex](https://github.com/pex-tool/pex) used by the Python backend
 
 The Python Build Standalone backend (`pants.backend.python.providers.experimental.python_build_standalone`) has release metadata current through PBS release `20250712`.
 
+Adds default module mappings for confluent-kafka and discord.py.
+
 #### Javascript
 
 Enable setting missing common fields e.g "tags" for the `node_build_script`-symbol and resulting `NodeBuildScriptTarget`.

--- a/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
+++ b/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
@@ -118,6 +118,7 @@ DEFAULT_MODULE_MAPPING: dict[str, tuple[str, ...]] = {
     "bitvector": ("BitVector",),
     "cattrs": ("cattr", "cattrs"),
     "cloud-sql-python-connector": ("google.cloud.sql.connector",),
+    "confluent-kafka": ("confluent_kafka",),
     "coolprop": ("CoolProp",),
     "databricks-sdk": ("databricks.sdk",),
     "databricks-sql-connector": (
@@ -125,6 +126,7 @@ DEFAULT_MODULE_MAPPING: dict[str, tuple[str, ...]] = {
         "databricks.sqlalchemy",
     ),
     "delta-spark": ("delta",),
+    "discord.py": ("discord",),
     "django-activity-stream": ("actstream",),
     "django-cors-headers": ("corsheaders",),
     "django-countries": ("django_countries",),

--- a/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
+++ b/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
@@ -126,7 +126,7 @@ DEFAULT_MODULE_MAPPING: dict[str, tuple[str, ...]] = {
         "databricks.sqlalchemy",
     ),
     "delta-spark": ("delta",),
-    "discord.py": ("discord",),
+    "discord-py": ("discord",),
     "django-activity-stream": ("actstream",),
     "django-cors-headers": ("corsheaders",),
     "django-countries": ("django_countries",),


### PR DESCRIPTION
add default module mappings for confluent-kafka and discord.py