### PR TITLE
Use the sandboxer in our own CI.

### DIFF
--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -2,6 +2,7 @@
 colors = true
 plugins.add = ["shoalsoft-pants-opentelemetry-plugin==0.4.1"]
 backend_packages.add = ["shoalsoft.pants_opentelemetry_plugin"]
+sandboxer = true
 
 [test]
 report = true


### PR DESCRIPTION
This will help find any bugs or issues with sandboxer
before we start relying on it heavily.