### PR TITLE
update the 2.28.x release notes on main to match the `2.28.x` branch

### DIFF
--- a/docs/notes/2.28.x.md
+++ b/docs/notes/2.28.x.md
@@ -29,9 +29,9 @@ Mitigates an issue where the sandboxer would fail to start up if the socket path
 
 #### Python
 
-The version of [Pex](https://github.com/pex-tool/pex) used by the Python backend has been upgraded to v2.40.1.
+The version of [Pex](https://github.com/pex-tool/pex) used by the Python backend has been upgraded to v2.45.2.
 
-The Python Build Standalone backend (`pants.backend.python.providers.experimental.python_build_standalone`) has release metadata current through PBS release `20250610`.
+The Python Build Standalone backend (`pants.backend.python.providers.experimental.python_build_standalone`) has release metadata current through PBS release `20250723`.
 
 Protobuf: See protobuf backend section for information about the new `[python-protobuf].generate_type_stubs` option.
 


### PR DESCRIPTION
Forward-port the changes to the 2.28.x release notes on the `2.28.x` branch forward to the `main` branch.