### PR TITLE
upgrade to Rust v1.89.0

### DIFF
--- a/src/rust/address/src/lib.rs
+++ b/src/rust/address/src/lib.rs
@@ -65,6 +65,6 @@ peg::parser! {
     }
 }
 
-pub fn parse_address_spec(value: &str) -> Result<SpecInput, String> {
+pub fn parse_address_spec(value: &str) -> Result<SpecInput<'_>, String> {
     parsers::spec(value).map_err(|e| format!("Failed to parse address spec `{value}`: {e}"))
 }

--- a/src/rust/engine/src/externs/address.rs
+++ b/src/rust/engine/src/externs/address.rs
@@ -641,7 +641,7 @@ impl Address {
     }
 
     #[getter]
-    fn parameters_repr(&self) -> Cow<str> {
+    fn parameters_repr(&self) -> Cow<'_, str> {
         if self.parameters.is_empty() {
             return Cow::from("");
         }
@@ -878,7 +878,7 @@ type ParsedSpec<'a> = (ParsedAddress<'a>, Option<&'a str>);
 
 /// Parses an "address spec" from the CLI.
 #[pyfunction]
-fn address_spec_parse(spec_str: &str) -> PyResult<ParsedSpec> {
+fn address_spec_parse(spec_str: &str) -> PyResult<ParsedSpec<'_>> {
     let spec = address::parse_address_spec(spec_str).map_err(AddressParseException::new_err)?;
     Ok((
         (

--- a/src/rust/engine/src/externs/fs.rs
+++ b/src/rust/engine/src/externs/fs.rs
@@ -397,7 +397,8 @@ impl PyRemovePrefix {
 // PathGlobs
 // -----------------------------------------------------------------------------
 
-struct PyPathGlobs(#[allow(dead_code)] PathGlobs);
+#[allow(dead_code)]
+struct PyPathGlobs(PathGlobs);
 
 impl<'py> FromPyObject<'py> for PyPathGlobs {
     fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self> {

--- a/src/rust/engine/src/nodes/mod.rs
+++ b/src/rust/engine/src/nodes/mod.rs
@@ -193,7 +193,7 @@ fn select_reentry(
     context: Context,
     params: Params,
     query: &Query<TypeId>,
-) -> BoxFuture<NodeResult<Value>> {
+) -> BoxFuture<'_, NodeResult<Value>> {
     // TODO: Actually using the `RuleEdges` of this entry to compute inputs is not
     // implemented: doing so would involve doing something similar to what we do for
     // intrinsics above, and waiting to compute inputs before executing the query here.

--- a/src/rust/engine/src/nodes/task.rs
+++ b/src/rust/engine/src/nodes/task.rs
@@ -160,7 +160,7 @@ impl Task {
         params: Params,
         entry: Intern<rule_graph::Entry<Rule>>,
         gog: externs::GetOrGenerator,
-    ) -> BoxFuture<NodeResult<Value>> {
+    ) -> BoxFuture<'_, NodeResult<Value>> {
         async move {
             match gog {
                 externs::GetOrGenerator::Get(get) => {

--- a/src/rust/fs/store/src/local.rs
+++ b/src/rust/fs/store/src/local.rs
@@ -538,7 +538,7 @@ impl FileSource {
     async fn open_readonly(
         &self,
         path: &Path,
-    ) -> Result<(tokio::fs::File, SemaphorePermit), String> {
+    ) -> Result<(tokio::fs::File, SemaphorePermit<'_>), String> {
         let permit = self
             .open_files
             .acquire()

--- a/src/rust/graph/src/entry.rs
+++ b/src/rust/graph/src/entry.rs
@@ -465,7 +465,7 @@ impl<N: Node> Entry<N> {
         &self,
         context: &Context<N>,
         entry_id: EntryId,
-    ) -> BoxFuture<NodeResult<N>> {
+    ) -> BoxFuture<'_, NodeResult<N>> {
         let mut state = self.state.lock();
 
         // First check whether the Node is already complete, or is currently running: in both of these

--- a/src/rust/options/src/config.rs
+++ b/src/rust/options/src/config.rs
@@ -100,7 +100,7 @@ struct ValueConversionError<'a> {
 }
 
 trait FromValue: Parseable {
-    fn from_value(value: &Value) -> Result<Self, ValueConversionError>;
+    fn from_value(value: &Value) -> Result<Self, ValueConversionError<'_>>;
 
     fn from_config(config: &ConfigReader, id: &OptionId) -> Result<Option<Self>, String> {
         if let Some(value) = config.get_value(id) {
@@ -149,7 +149,7 @@ trait FromValue: Parseable {
 }
 
 impl FromValue for String {
-    fn from_value(value: &Value) -> Result<String, ValueConversionError> {
+    fn from_value(value: &Value) -> Result<String, ValueConversionError<'_>> {
         if let Some(string) = value.as_str() {
             Ok(string.to_owned())
         } else {
@@ -162,7 +162,7 @@ impl FromValue for String {
 }
 
 impl FromValue for bool {
-    fn from_value(value: &Value) -> Result<bool, ValueConversionError> {
+    fn from_value(value: &Value) -> Result<bool, ValueConversionError<'_>> {
         if let Some(boolean) = value.as_bool() {
             Ok(boolean)
         } else {
@@ -175,7 +175,7 @@ impl FromValue for bool {
 }
 
 impl FromValue for i64 {
-    fn from_value(value: &Value) -> Result<i64, ValueConversionError> {
+    fn from_value(value: &Value) -> Result<i64, ValueConversionError<'_>> {
         if let Some(int) = value.as_integer() {
             Ok(int)
         } else {
@@ -188,7 +188,7 @@ impl FromValue for i64 {
 }
 
 impl FromValue for f64 {
-    fn from_value(value: &Value) -> Result<f64, ValueConversionError> {
+    fn from_value(value: &Value) -> Result<f64, ValueConversionError<'_>> {
         if let Some(float) = value.as_float() {
             Ok(float)
         } else if let Some(int) = value.as_integer() {

--- a/src/rust/options/src/lib.rs
+++ b/src/rust/options/src/lib.rs
@@ -622,7 +622,7 @@ impl OptionParser {
         id: &OptionId,
         default: Option<&T>,
         getter: fn(&Arc<dyn OptionsSource>, &OptionId) -> Result<Option<T::Owned>, String>,
-    ) -> Result<OptionalOptionValue<T::Owned>, String> {
+    ) -> Result<OptionalOptionValue<'_, T::Owned>, String> {
         let mut derivation = None;
         if self.include_derivation {
             let mut derivations = vec![];
@@ -656,7 +656,7 @@ impl OptionParser {
         &self,
         id: &OptionId,
         default: Option<bool>,
-    ) -> Result<OptionalOptionValue<bool>, String> {
+    ) -> Result<OptionalOptionValue<'_, bool>, String> {
         self.parse_scalar(id, default.as_ref(), |source, id| source.get_bool(id))
     }
 
@@ -664,7 +664,7 @@ impl OptionParser {
         &self,
         id: &OptionId,
         default: Option<i64>,
-    ) -> Result<OptionalOptionValue<i64>, String> {
+    ) -> Result<OptionalOptionValue<'_, i64>, String> {
         self.parse_scalar(id, default.as_ref(), |source, id| source.get_int(id))
     }
 
@@ -672,7 +672,7 @@ impl OptionParser {
         &self,
         id: &OptionId,
         default: Option<f64>,
-    ) -> Result<OptionalOptionValue<f64>, String> {
+    ) -> Result<OptionalOptionValue<'_, f64>, String> {
         self.parse_scalar(id, default.as_ref(), |source, id| source.get_float(id))
     }
 
@@ -680,21 +680,25 @@ impl OptionParser {
         &self,
         id: &OptionId,
         default: Option<&str>,
-    ) -> Result<OptionalOptionValue<String>, String> {
+    ) -> Result<OptionalOptionValue<'_, String>, String> {
         self.parse_scalar(id, default, |source, id| source.get_string(id))
     }
 
-    pub fn parse_bool(&self, id: &OptionId, default: bool) -> Result<OptionValue<bool>, String> {
+    pub fn parse_bool(
+        &self,
+        id: &OptionId,
+        default: bool,
+    ) -> Result<OptionValue<'_, bool>, String> {
         self.parse_bool_optional(id, Some(default))
             .map(OptionalOptionValue::unwrap)
     }
 
-    pub fn parse_int(&self, id: &OptionId, default: i64) -> Result<OptionValue<i64>, String> {
+    pub fn parse_int(&self, id: &OptionId, default: i64) -> Result<OptionValue<'_, i64>, String> {
         self.parse_int_optional(id, Some(default))
             .map(OptionalOptionValue::unwrap)
     }
 
-    pub fn parse_float(&self, id: &OptionId, default: f64) -> Result<OptionValue<f64>, String> {
+    pub fn parse_float(&self, id: &OptionId, default: f64) -> Result<OptionValue<'_, f64>, String> {
         self.parse_float_optional(id, Some(default))
             .map(OptionalOptionValue::unwrap)
     }
@@ -703,7 +707,7 @@ impl OptionParser {
         &self,
         id: &OptionId,
         default: &str,
-    ) -> Result<OptionValue<String>, String> {
+    ) -> Result<OptionValue<'_, String>, String> {
         self.parse_string_optional(id, Some(default))
             .map(OptionalOptionValue::unwrap)
     }
@@ -715,7 +719,7 @@ impl OptionParser {
         default: Vec<T>,
         getter: fn(&Arc<dyn OptionsSource>, &OptionId) -> Result<Option<Vec<ListEdit<T>>>, String>,
         remover: fn(&mut Vec<T>, &[T]),
-    ) -> Result<ListOptionValue<T>, String> {
+    ) -> Result<ListOptionValue<'_, T>, String> {
         let mut derivation = None;
         if self.include_derivation {
             let mut derivations = vec![(
@@ -766,7 +770,7 @@ impl OptionParser {
         id: &OptionId,
         default: Vec<T>,
         getter: fn(&Arc<dyn OptionsSource>, &OptionId) -> Result<Option<Vec<ListEdit<T>>>, String>,
-    ) -> Result<ListOptionValue<T>, String> {
+    ) -> Result<ListOptionValue<'_, T>, String> {
         self.parse_list(id, default, getter, |list, remove| {
             let to_remove = remove.iter().collect::<HashSet<_>>();
             list.retain(|item| !to_remove.contains(item));
@@ -777,7 +781,7 @@ impl OptionParser {
         &self,
         id: &OptionId,
         default: Vec<bool>,
-    ) -> Result<ListOptionValue<bool>, String> {
+    ) -> Result<ListOptionValue<'_, bool>, String> {
         self.parse_list_hashable(id, default, |source, id| source.get_bool_list(id))
     }
 
@@ -785,7 +789,7 @@ impl OptionParser {
         &self,
         id: &OptionId,
         default: Vec<i64>,
-    ) -> Result<ListOptionValue<i64>, String> {
+    ) -> Result<ListOptionValue<'_, i64>, String> {
         self.parse_list_hashable(id, default, |source, id| source.get_int_list(id))
     }
 
@@ -794,7 +798,7 @@ impl OptionParser {
         &self,
         id: &OptionId,
         default: Vec<f64>,
-    ) -> Result<ListOptionValue<f64>, String> {
+    ) -> Result<ListOptionValue<'_, f64>, String> {
         self.parse_list(
             id,
             default,
@@ -809,7 +813,7 @@ impl OptionParser {
         &self,
         id: &OptionId,
         default: Vec<String>,
-    ) -> Result<ListOptionValue<String>, String> {
+    ) -> Result<ListOptionValue<'_, String>, String> {
         self.parse_list_hashable::<String>(id, default, |source, id| source.get_string_list(id))
     }
 
@@ -817,7 +821,7 @@ impl OptionParser {
         &self,
         id: &OptionId,
         default: HashMap<String, Val>,
-    ) -> Result<DictOptionValue, String> {
+    ) -> Result<DictOptionValue<'_>, String> {
         let mut derivation = None;
         if self.include_derivation {
             let mut derivations = vec![(

--- a/src/rust/rule_graph/src/builder.rs
+++ b/src/rust/rule_graph/src/builder.rs
@@ -1475,7 +1475,7 @@ impl<R: Rule> Builder<R> {
         include_deleted_dependencies: bool,
     ) -> BTreeMap<
         DependencyKey<R::TypeId>,
-        Vec<EdgeReference<MaybeDeleted<DependencyKey<R::TypeId>, EdgePrunedReason>, u32>>,
+        Vec<EdgeReference<'_, MaybeDeleted<DependencyKey<R::TypeId>, EdgePrunedReason>, u32>>,
     > {
         let node = &graph[node_id].0.node;
         let mut edges_by_dependency_key = node

--- a/src/rust/rust-toolchain
+++ b/src/rust/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.88.0"
+channel = "1.89.0"
 # NB: We don't list the components (namely `clippy` and `rustfmt`) and instead rely on either the
 #  the profile being "default" (by-and-large the default profile) or the nice error message from
 #  `cargo fmt` and `cargo clippy` if the required component isn't installed

--- a/src/rust/testutil/mock/src/cas_service.rs
+++ b/src/rust/testutil/mock/src/cas_service.rs
@@ -88,7 +88,7 @@ struct ParsedWriteResourceName<'a> {
 /// Parses a resource name of the form `{instance_name}/uploads/{uuid}/blobs/{hash}/{size}` into
 /// a struct with references to the individual components of the resource name. The
 /// `{instance_name}` may be blank (with no leading slash) as per REAPI specification.
-fn parse_write_resource_name(resource: &str) -> Result<ParsedWriteResourceName, String> {
+fn parse_write_resource_name(resource: &str) -> Result<ParsedWriteResourceName<'_>, String> {
     if resource.is_empty() {
         return Err("Missing resource name".to_owned());
     }
@@ -141,7 +141,7 @@ struct ParsedReadResourceName<'a> {
 }
 
 /// `"{instance_name}/blobs/{hash}/{size}"`
-fn parse_read_resource_name(resource: &str) -> Result<ParsedReadResourceName, String> {
+fn parse_read_resource_name(resource: &str) -> Result<ParsedReadResourceName<'_>, String> {
     if resource.is_empty() {
         return Err("Missing resource name".to_owned());
     }


### PR DESCRIPTION
Upgrade to Rust v1.89.0.

Major changes from the [release notes](https://blog.rust-lang.org/2025/08/07/Rust-1.89.0/):

- Explicitly inferred arguments to const generics
- Mismatched lifetime syntaxes lint is fixed and requires lifetime parameters to be specified in more places now.