### PR TITLE
Fix the RunsOn AMI building action.

### DIFF
--- a/.github/workflows/build_runson_ami.yaml
+++ b/.github/workflows/build_runson_ami.yaml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 10
       - name: Run packer
         env:
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -24,22 +26,11 @@ jobs:
         run: |
           set -ex
 
-          wget -O - https://apt.releases.hashicorp.com/gpg | \
-            sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
-          echo "deb [arch=$(dpkg --print-architecture) \
-            signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] \
-            https://apt.releases.hashicorp.com \
-            $(grep -oP '(?<=UBUNTU_CODENAME=).*' /etc/os-release || lsb_release -cs) main" | \
-            sudo tee /etc/apt/sources.list.d/hashicorp.list
-          sudo apt update && sudo apt install -y packer gh
-
           git config --local user.email "pantsbuild+github-automation@gmail.com"
           git config --local user.name "Worker Pants (Pantsbuild GitHub Automation Bot)"
 
-          # Don't xtrace GITHUB_TOKEN.
-          set +x
-          git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}"
-          set -x
+          # In case we're running from a branch that isn't main (e.g., for debugging this workflow).
+          git fetch origin main
 
           packer init build-support/packer/runson/runson.pkr.hcl
           packer build build-support/packer/runson/runson.pkr.hcl

--- a/.github/workflows/build_runson_ami.yaml
+++ b/.github/workflows/build_runson_ami.yaml
@@ -56,5 +56,4 @@ jobs:
             --head ${BRANCH_NAME} \
             --fill \
             --label "release-notes:not-required" \
-            --reviewer "pantsbuild/maintainers"
-
+            --reviewer "benjyw,tdyas"

--- a/.github/workflows/build_runson_ami.yaml
+++ b/.github/workflows/build_runson_ami.yaml
@@ -45,6 +45,7 @@ jobs:
           gh pr create \
             --base main \
             --head ${BRANCH_NAME} \
-            --fill \
+            --title "Upgrade RunsOn AMI to ${AMI_ID}" \
+            --body "" \
             --label "release-notes:not-required" \
             --reviewer "benjyw,tdyas"


### PR DESCRIPTION
Setting a team as a reviewer requires permissions that the 
GITHUB_TOKEN doesn't have. Rather than start messing 
around with creating and managing custom tokens, we just
use individual reviewers instead.

Also got rid of unnecessary setup, since
Packer is already installed on the image.