### PR TITLE
Port the engine to call-by-name

### DIFF
--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -76,13 +76,17 @@ from pants.engine.fs import EMPTY_FILE_DIGEST, AddPrefix, Digest, MergeDigests
 from pants.engine.internals.graph import resolve_targets
 from pants.engine.internals.native_engine import EMPTY_DIGEST, Snapshot
 from pants.engine.internals.platform_rules import environment_vars_subset
-from pants.engine.intrinsics import add_prefix, digest_to_snapshot, merge_digests
+from pants.engine.intrinsics import (
+    add_prefix,
+    digest_to_snapshot,
+    execute_process_with_retry,
+    merge_digests,
+)
 from pants.engine.process import (
     Process,
     ProcessCacheScope,
     ProcessWithRetries,
     execute_process_or_raise,
-    execute_process_with_retry,
 )
 from pants.engine.rules import collect_rules, concurrently, implicitly, rule
 from pants.engine.target import Dependencies, DependenciesRequest, SourcesField, Target

--- a/src/python/pants/backend/helm/test/unittest.py
+++ b/src/python/pants/backend/helm/test/unittest.py
@@ -44,13 +44,13 @@ from pants.engine.intrinsics import (
     add_prefix,
     digest_subset_to_digest,
     digest_to_snapshot,
+    execute_process_with_retry,
     merge_digests,
     remove_prefix,
 )
 from pants.engine.process import (
     ProcessCacheScope,
     ProcessWithRetries,
-    execute_process_with_retry,
     fallible_to_exec_result_or_raise,
 )
 from pants.engine.rules import collect_rules, concurrently, implicitly, rule

--- a/src/python/pants/backend/javascript/goals/test.py
+++ b/src/python/pants/backend/javascript/goals/test.py
@@ -55,8 +55,8 @@ from pants.engine.internals.graph import transitive_targets
 from pants.engine.internals.native_engine import MergeDigests, Snapshot
 from pants.engine.internals.platform_rules import environment_vars_subset
 from pants.engine.internals.selectors import concurrently
-from pants.engine.intrinsics import digest_to_snapshot, merge_digests
-from pants.engine.process import ProcessCacheScope, ProcessWithRetries, execute_process_with_retry
+from pants.engine.intrinsics import digest_to_snapshot, execute_process_with_retry, merge_digests
+from pants.engine.process import ProcessCacheScope, ProcessWithRetries
 from pants.engine.rules import Rule, collect_rules, implicitly, rule
 from pants.engine.target import Dependencies, SourcesField, Target, TransitiveTargetsRequest
 from pants.engine.unions import UnionRule

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -79,16 +79,11 @@ from pants.engine.intrinsics import (
     create_digest,
     digest_subset_to_digest,
     digest_to_snapshot,
+    execute_process_with_retry,
     get_digest_contents,
     merge_digests,
 )
-from pants.engine.process import (
-    InteractiveProcess,
-    Process,
-    ProcessCacheScope,
-    ProcessWithRetries,
-    execute_process_with_retry,
-)
+from pants.engine.process import InteractiveProcess, Process, ProcessCacheScope, ProcessWithRetries
 from pants.engine.rules import Get, collect_rules, concurrently, implicitly, rule
 from pants.engine.target import Target, TransitiveTargetsRequest, WrappedTargetRequest
 from pants.engine.unions import UnionMembership, UnionRule, union

--- a/src/python/pants/backend/scala/test/scalatest.py
+++ b/src/python/pants/backend/scala/test/scalatest.py
@@ -28,13 +28,13 @@ from pants.engine.env_vars import EnvironmentVarsRequest
 from pants.engine.fs import DigestSubset, MergeDigests, PathGlobs, RemovePrefix
 from pants.engine.internals.graph import transitive_targets
 from pants.engine.internals.platform_rules import environment_vars_subset
-from pants.engine.intrinsics import digest_subset_to_digest, digest_to_snapshot, merge_digests
-from pants.engine.process import (
-    InteractiveProcess,
-    ProcessCacheScope,
-    ProcessWithRetries,
+from pants.engine.intrinsics import (
+    digest_subset_to_digest,
+    digest_to_snapshot,
     execute_process_with_retry,
+    merge_digests,
 )
+from pants.engine.process import InteractiveProcess, ProcessCacheScope, ProcessWithRetries
 from pants.engine.rules import collect_rules, concurrently, implicitly, rule
 from pants.engine.target import SourcesField, TransitiveTargetsRequest
 from pants.engine.unions import UnionRule

--- a/src/python/pants/backend/shell/shunit2_test_runner.py
+++ b/src/python/pants/backend/shell/shunit2_test_runner.py
@@ -40,15 +40,14 @@ from pants.core.util_rules.system_binaries import (
 from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, FileContent, MergeDigests
 from pants.engine.internals.graph import transitive_targets as transitive_targets_get
-from pants.engine.intrinsics import create_digest, get_digest_contents, merge_digests
-from pants.engine.platform import Platform
-from pants.engine.process import (
-    InteractiveProcess,
-    Process,
-    ProcessCacheScope,
-    ProcessWithRetries,
+from pants.engine.intrinsics import (
+    create_digest,
     execute_process_with_retry,
+    get_digest_contents,
+    merge_digests,
 )
+from pants.engine.platform import Platform
+from pants.engine.process import InteractiveProcess, Process, ProcessCacheScope, ProcessWithRetries
 from pants.engine.rules import collect_rules, concurrently, implicitly, rule
 from pants.engine.target import SourcesField, Target, TransitiveTargetsRequest
 from pants.option.global_options import GlobalOptions

--- a/src/python/pants/engine/addresses.py
+++ b/src/python/pants/engine/addresses.py
@@ -41,13 +41,13 @@ class UnparsedAddressInputs:
 
     You can convert these into fully normalized `Addresses` and `Targets` like this:
 
-        await Get(Addresses, UnparsedAddressInputs(["//:tgt1", "//:tgt2"], owning_address=None)
-        await Get(Targets, UnparsedAddressInputs([...], owning_address=Address("original"))
+        await resolve_unparsed_address_inputs(UnparsedAddressInputs(["//:tgt1", "//:tgt2"], owning_address=None), **implicitly())
+        await resolve_targets(**implicitly(UnparsedAddressInputs([...], owning_address=Address("original")))
 
     This is intended for contexts where the user specifies addresses outside of the `dependencies`
     field, such as through an option or a special field on a target that is not normal
     `dependencies`. You should not use this to resolve the `dependencies` field; use
-    `await Get(Addresses, DependenciesRequest)` for that.
+    `await resolve_dependencies(DependenciesRequest(..), **implicitly())` for that.
 
     If the addresses are coming from a target's fields, set `owning_address` so that relative
     references like `:sibling` work properly.

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -45,11 +45,7 @@ class Paths:
 
 @dataclass(frozen=True)
 class FileContent:
-    """The content of a file.
-
-    This can be used to create a new Digest with `Get(Digest, CreateDigest)`. You can also get back
-    a list of `FileContent` objects by using `Get(DigestContents, Digest)`.
-    """
+    """The content of a file."""
 
     path: str
     content: bytes
@@ -70,11 +66,7 @@ class FileContent:
 
 @dataclass(frozen=True)
 class FileEntry:
-    """An indirect reference to the content of a file by digest.
-
-    This can be used to create a new Digest with `Get(Digest, CreateDigest)`. You can also get back
-    a list of `FileEntry` objects by using `Get(DigestEntries, Digest)`.
-    """
+    """An indirect reference to the content of a file by digest."""
 
     path: str
     file_digest: FileDigest
@@ -101,10 +93,7 @@ class SymlinkEntry:
 
 @dataclass(frozen=True)
 class Directory:
-    """The path to a directory.
-
-    This can be used to create empty directories with `Get(Digest, CreateDigest)`.
-    """
+    """The path to a directory."""
 
     path: str
 
@@ -230,12 +219,8 @@ class DigestSubset:
     """A request to get a subset of a digest.
 
     The digest will be traversed symlink-oblivious to match the provided globs. If you require a
-    symlink-aware subset, you can access the digest's entries `Get(DigestEntries, Digest, digest)`,
-    filter them out, and create a new digest: `Get(Digest, CreateDigest(...))`.
-
-    Example:
-
-        result = await Get(Digest, DigestSubset(original_digest, PathGlobs(["subdir1", "f.txt"]))
+    symlink-aware subset, you can access the digest's DigestEntries, filter them out, and create a
+    new digest.
     """
 
     digest: Digest
@@ -309,8 +294,8 @@ class Workspace(SideEffecting):
     ) -> None:
         """Write a digest to disk, relative to the build root.
 
-        You should not use this in a `for` loop due to slow performance. Instead, call `await
-        Get(Digest, MergeDigests)` beforehand.
+        You should not use this in a `for` loop due to slow performance. Instead, first merge
+        digests and then write the single merged digest.
 
         As an advanced use-case, if the digest is known to be written to a temporary or idempotent
         location, side_effecting=False may be passed to avoid tracking this write as a side effect.

--- a/src/python/pants/engine/internals/native_engine.pyi
+++ b/src/python/pants/engine/internals/native_engine.pyi
@@ -415,11 +415,7 @@ class Field:
 # ------------------------------------------------------------------------------
 
 class Digest:
-    """A Digest is a lightweight reference to a set of files known about by the engine.
-
-    You can use `await Get(Snapshot, Digest)` to see the file names referred to, or use `await
-    Get(DigestContents, Digest)` to see the actual file content.
-    """
+    """A Digest is a lightweight reference to a set of files known about by the engine."""
 
     def __init__(self, fingerprint: str, serialized_bytes_length: int) -> None: ...
     @property
@@ -446,11 +442,8 @@ class Snapshot:
     """A Snapshot is a collection of sorted file paths and dir paths fingerprinted by their
     names/content.
 
-    You can lift a `Digest` to a `Snapshot` with `await Get(Snapshot, Digest, my_digest)`.
-
     The `files` and `dirs` properties are symlink oblivious. If you require knowing about symlinks,
-    you can use the `digest` property to request the `DigestEntries`:
-    `await Get(DigestEntries, Digest, snapshot.digest)`.
+    you can use the `digest` property to request the `DigestEntries`.
     """
 
     @classmethod
@@ -478,12 +471,8 @@ class Snapshot:
 class MergeDigests:
     """A request to merge several digests into one single digest.
 
-    This will fail if there are any conflicting changes, such as two digests having the same
-    file but with different content.
-
-    Example:
-
-        result = await Get(Digest, MergeDigests([digest1, digest2])
+    This will fail if there are any conflicting changes, such as two digests having the same file
+    but with different content.
     """
 
     def __init__(self, digests: Iterable[Digest]) -> None: ...
@@ -492,12 +481,7 @@ class MergeDigests:
     def __repr__(self) -> str: ...
 
 class AddPrefix:
-    """A request to add the specified prefix path to every file and directory in the digest.
-
-    Example:
-
-        result = await Get(Digest, AddPrefix(input_digest, "my_dir")
-    """
+    """A request to add the specified prefix path to every file and directory in the digest."""
 
     def __init__(self, digest: Digest, prefix: str) -> None: ...
     def __eq__(self, other: AddPrefix | Any) -> bool: ...
@@ -509,10 +493,6 @@ class RemovePrefix:
 
     This will fail if there are any files or directories in the original input digest without the
     specified prefix.
-
-    Example:
-
-        result = await Get(Digest, RemovePrefix(input_digest, "my_dir")
     """
 
     def __init__(self, digest: Digest, prefix: str) -> None: ...
@@ -793,10 +773,6 @@ class NativeDependenciesRequest:
     * Depending on the implementation, a `metadata` structure
       can be passed. It will be supplied to the native parser, and
       it will be incorporated into the cache key.
-
-
-    Example:
-        result = await Get(NativeParsedPythonDependencies, NativeDependenciesRequest(input_digest, None)
     """
 
     def __init__(self, digest: Digest, metadata: InferenceMetadata | None = None) -> None: ...

--- a/src/python/pants/jvm/test/junit.py
+++ b/src/python/pants/jvm/test/junit.py
@@ -25,13 +25,13 @@ from pants.engine.env_vars import EnvironmentVarsRequest
 from pants.engine.fs import DigestSubset, MergeDigests, PathGlobs, RemovePrefix
 from pants.engine.internals.graph import transitive_targets
 from pants.engine.internals.platform_rules import environment_vars_subset
-from pants.engine.intrinsics import digest_subset_to_digest, digest_to_snapshot, merge_digests
-from pants.engine.process import (
-    InteractiveProcess,
-    ProcessCacheScope,
-    ProcessWithRetries,
+from pants.engine.intrinsics import (
+    digest_subset_to_digest,
+    digest_to_snapshot,
     execute_process_with_retry,
+    merge_digests,
 )
+from pants.engine.process import InteractiveProcess, ProcessCacheScope, ProcessWithRetries
 from pants.engine.rules import collect_rules, concurrently, implicitly, rule
 from pants.engine.target import SourcesField, TransitiveTargetsRequest
 from pants.engine.unions import UnionRule


### PR DESCRIPTION
The only remaining `Get`s in pants/engine are related
to the Get implementation itself, and its tests.