### PR TITLE
make the sandboxer startup less chatty

### DIFF
--- a/src/rust/process_execution/sandboxer/src/lib.rs
+++ b/src/rust/process_execution/sandboxer/src/lib.rs
@@ -368,7 +368,7 @@ impl Sandboxer {
                 base.join(&workdir_hash)
             };
             let socket_path = run_dir.join("sandboxer.sock");
-            info!("Trying sandboxer socket path {}", socket_path.display());
+            debug!("Trying sandboxer socket path {}", socket_path.display());
 
             match SocketAddr::from_pathname(&socket_path) {
                 Ok(_) => (),
@@ -384,7 +384,7 @@ impl Sandboxer {
 
             let res = fs::create_dir_all(&run_dir);
             if res.is_err() {
-                warn!(
+                debug!(
                     "Failed to create dir for sandboxer socket at {}",
                     socket_path.display()
                 );


### PR DESCRIPTION
I currently see something along the lines of

```
10:23:05.68 [INFO] Trying sandboxer socket path /run/pants/5c204249d71d9b4f/sandboxer.sock
10:23:05.68 [WARN] Failed to create dir for sandboxer socket at /run/pants/5c204249d71d9b4f/sandboxer.sock
10:23:05.68 [INFO] Trying sandboxer socket path /var/run/pants/5c204249d71d9b4f/sandboxer.sock
10:23:05.68 [WARN] Failed to create dir for sandboxer socket at /var/run/pants/5c204249d71d9b4f/sandboxer.sock
10:23:05.68 [INFO] Trying sandboxer socket path /tmp/run/pants/5c204249d71d9b4f/sandboxer.sock
10:23:05.68 [INFO] Using sandboxer socket path /tmp/run/pants/5c204249d71d9b4f/sandboxer.sock
10:23:05.95 [INFO] Scheduler initialized.
```
But these WARNings are not actionable, it is expected that we need to check a few different paths. This cuts it down at INFO to:
```
15:02:49.05 [INFO] Using sandboxer socket path /run/user/1002/pants/5c204249d71d9b4f/sandboxer.sock
```