### PR TITLE
Switch several tests from mock gets to mock calls.

### DIFF
--- a/src/python/pants/backend/awslambda/python/rules_test.py
+++ b/src/python/pants/backend/awslambda/python/rules_test.py
@@ -55,7 +55,7 @@ from pants.engine.fs import DigestContents
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.target import FieldSet
 from pants.testutil.python_rule_runner import PythonRuleRunner
-from pants.testutil.rule_runner import MockGet, QueryRule, run_rule_with_mocks
+from pants.testutil.rule_runner import QueryRule, run_rule_with_mocks
 
 
 @pytest.fixture
@@ -451,11 +451,9 @@ def test_pex3_venv_create_extra_args_are_passed_through(
     run_rule_with_mocks(
         rule,
         rule_args=[field_set],
-        mock_gets=[
-            MockGet(
-                output_type=BuiltPackage, input_types=(BuildPythonFaaSRequest,), mock=mocked_build
-            )
-        ],
+        mock_calls={
+            "pants.backend.python.util_rules.faas.build_python_faas": mocked_build,
+        },
     )
 
     # Verify

--- a/src/python/pants/backend/javascript/subsystems/nodejs_test.py
+++ b/src/python/pants/backend/javascript/subsystems/nodejs_test.py
@@ -27,11 +27,7 @@ from pants.backend.javascript.subsystems.nodejs import (
 from pants.backend.javascript.target_types import JSSourcesGeneratorTarget
 from pants.backend.python import target_types_rules
 from pants.core.util_rules import config_files, source_files
-from pants.core.util_rules.external_tool import (
-    DownloadedExternalTool,
-    ExternalToolRequest,
-    ExternalToolVersion,
-)
+from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolVersion
 from pants.core.util_rules.search_paths import (
     VersionManagerSearchPaths,
     VersionManagerSearchPathsRequest,
@@ -55,7 +51,7 @@ from pants.engine.process import (
     ProcessResultMetadata,
 )
 from pants.testutil.option_util import create_subsystem
-from pants.testutil.rule_runner import MockGet, QueryRule, RuleRunner, run_rule_with_mocks
+from pants.testutil.rule_runner import QueryRule, RuleRunner, run_rule_with_mocks
 from pants.util.contextutil import temporary_dir
 
 
@@ -209,13 +205,6 @@ def test_node_version_from_semver_download(
     run_rule_with_mocks(
         determine_nodejs_binaries,
         rule_args=(nodejs_subsystem, Platform.linux_x86_64, _BinaryPathsPerVersion()),
-        mock_gets=[
-            MockGet(
-                DownloadedExternalTool,
-                (ExternalToolRequest,),
-                mock=lambda *_: DownloadedExternalTool(EMPTY_DIGEST, "myexe"),
-            ),
-        ],
     )
 
     nodejs_subsystem.download_known_version.assert_called_once_with(
@@ -260,9 +249,6 @@ def test_node_version_from_semver_bootstrap(
     result = run_rule_with_mocks(
         determine_nodejs_binaries,
         rule_args=(nodejs_subsystem, Platform.linux_x86_64, discoverable_versions),
-        mock_gets=[
-            MockGet(DownloadedExternalTool, (ExternalToolRequest,), mock=mock_download),
-        ],
     )
 
     assert result.binary_dir == expected_path
@@ -281,9 +267,6 @@ def test_finding_no_node_version_is_an_error(mock_nodejs_subsystem: Mock) -> Non
         run_rule_with_mocks(
             determine_nodejs_binaries,
             rule_args=(nodejs_subsystem, Platform.linux_x86_64, discoverable_versions),
-            mock_gets=[
-                MockGet(DownloadedExternalTool, (ExternalToolRequest,), mock=mock_download),
-            ],
         )
 
 
@@ -340,7 +323,9 @@ def test_get_nvm_root(env: dict[str, str], expected_directory: str | None) -> No
 
     result = run_rule_with_mocks(
         _get_nvm_root,
-        mock_gets=[MockGet(EnvironmentVars, (EnvironmentVarsRequest,), mock_environment_vars)],
+        mock_calls={
+            "pants.core.util_rules.env_vars.environment_vars_subset": mock_environment_vars,
+        },
     )
     assert result == expected_directory
 

--- a/src/python/pants/backend/python/subsystems/python_tool_base_test.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base_test.py
@@ -8,14 +8,13 @@ from pants.backend.python.util_rules.interpreter_constraints import InterpreterC
 from pants.backend.python.util_rules.lockfile_metadata import PythonLockfileMetadataV3
 from pants.backend.python.util_rules.pex_requirements import (
     LoadedLockfile,
-    LoadedLockfileRequest,
     Lockfile,
     PexRequirements,
     Resolve,
 )
 from pants.engine.internals.native_engine import EMPTY_DIGEST
 from pants.testutil.option_util import create_subsystem
-from pants.testutil.rule_runner import MockGet, run_rule_with_mocks
+from pants.testutil.rule_runner import run_rule_with_mocks
 from pants.util.ordered_set import FrozenOrderedSet
 
 
@@ -58,14 +57,12 @@ def test_get_lockfile_metadata() -> None:
         run_rule_with_mocks(
             get_lockfile_metadata,
             rule_args=[tool],
-            mock_gets=[
-                MockGet(Lockfile, (Resolve,), lambda x: lockfile),
-                MockGet(
-                    LoadedLockfile,
-                    (LoadedLockfileRequest,),
-                    lambda x: loaded_lockfile if x.lockfile == lockfile else None,
-                ),
-            ],
+            mock_calls={
+                "pants.backend.python.util_rules.pex_requirements.get_lockfile_for_resolve": lambda _: lockfile,
+                "pants.backend.python.util_rules.pex_requirements.load_lockfile": lambda x: loaded_lockfile
+                if x.lockfile == lockfile
+                else None,
+            },
         )
         == metadata
     )

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -46,12 +46,10 @@ from pants.backend.python.util_rules.pex_environment import PythonExecutable
 from pants.backend.python.util_rules.pex_requirements import (
     EntireLockfile,
     LoadedLockfile,
-    LoadedLockfileRequest,
     Lockfile,
     PexRequirements,
     Resolve,
     ResolvePexConfig,
-    ResolvePexConfigRequest,
 )
 from pants.backend.python.util_rules.pex_test_utils import (
     create_pex_and_get_all_data,
@@ -76,7 +74,6 @@ from pants.option.global_options import GlobalOptions
 from pants.testutil.option_util import create_subsystem
 from pants.testutil.rule_runner import (
     PYTHON_BOOTSTRAP_ENV,
-    MockGet,
     QueryRule,
     RuleRunner,
     engine_error,
@@ -646,13 +643,9 @@ def test_determine_pex_python_and_platforms() -> None:
         result = run_rule_with_mocks(
             _determine_pex_python_and_platforms,
             rule_args=[request],
-            mock_gets=[
-                MockGet(
-                    output_type=PythonExecutable,
-                    input_types=(InterpreterConstraints,),
-                    mock=lambda _: discovered_python,
-                )
-            ],
+            mock_calls={
+                "pants.backend.python.util_rules.pex.find_interpreter": lambda _: discovered_python
+            },
         )
         assert result == expected
 
@@ -728,50 +721,32 @@ def test_setup_pex_requirements() -> None:
         result = run_rule_with_mocks(
             _setup_pex_requirements,
             rule_args=[request, create_subsystem(PythonSetup)],
-            mock_gets=[
-                MockGet(
-                    output_type=Lockfile,
-                    input_types=(Resolve,),
-                    mock=lambda _: lockfile_obj,
+            mock_calls={
+                "pants.backend.python.util_rules.pex_requirements.determine_resolve_pex_config": lambda _: ResolvePexConfig(
+                    indexes=("custom-index",),
+                    find_links=("custom-find-links",),
+                    manylinux=None,
+                    constraints_file=None,
+                    only_binary=FrozenOrderedSet(),
+                    no_binary=FrozenOrderedSet(),
+                    path_mappings=(),
+                    excludes=FrozenOrderedSet(),
+                    overrides=FrozenOrderedSet(),
                 ),
-                MockGet(
-                    output_type=LoadedLockfile,
-                    input_types=(LoadedLockfileRequest,),
-                    mock=lambda _: create_loaded_lockfile(is_pex_lock),
-                ),
-                MockGet(
-                    output_type=PexRequirementsInfo,
-                    input_types=(PexRequirements,),
-                    mock=lambda _: PexRequirementsInfo(
-                        (
-                            tuple(str(x) for x in requirements.req_strings_or_addrs)
-                            if isinstance(requirements, PexRequirements)
-                            else tuple()
-                        ),
-                        ("imma/link",) if include_find_links else tuple(),
+                "pants.backend.python.util_rules.pex.get_req_strings": lambda _: PexRequirementsInfo(
+                    (
+                        tuple(str(x) for x in requirements.req_strings_or_addrs)
+                        if isinstance(requirements, PexRequirements)
+                        else tuple()
                     ),
+                    ("imma/link",) if include_find_links else tuple(),
                 ),
-                MockGet(
-                    output_type=ResolvePexConfig,
-                    input_types=(ResolvePexConfigRequest,),
-                    mock=lambda _: ResolvePexConfig(
-                        indexes=("custom-index",),
-                        find_links=("custom-find-links",),
-                        manylinux=None,
-                        constraints_file=None,
-                        only_binary=FrozenOrderedSet(),
-                        no_binary=FrozenOrderedSet(),
-                        path_mappings=(),
-                        excludes=FrozenOrderedSet(),
-                        overrides=FrozenOrderedSet(),
-                    ),
+                "pants.engine.intrinsics.create_digest": lambda _: constraints_digest,
+                "pants.backend.python.util_rules.pex_requirements.load_lockfile": lambda _: create_loaded_lockfile(
+                    is_pex_lock
                 ),
-                MockGet(
-                    output_type=Digest,
-                    input_types=(CreateDigest,),
-                    mock=lambda _: constraints_digest,
-                ),
-            ],
+                "pants.backend.python.util_rules.pex_requirements.get_lockfile_for_resolve": lambda _: lockfile_obj,
+            },
         )
         assert result == expected
 

--- a/src/python/pants/backend/python/util_rules/pex_venv_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_venv_test.py
@@ -25,10 +25,10 @@ from pants.backend.python.util_rules.pex_venv import (
 )
 from pants.backend.python.util_rules.pex_venv import rules as pex_venv_rules
 from pants.engine.fs import CreateDigest, DigestContents, FileContent
-from pants.engine.internals.native_engine import EMPTY_DIGEST, Digest, MergeDigests, Snapshot
+from pants.engine.internals.native_engine import EMPTY_DIGEST, Digest, Snapshot
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.process import ProcessResult
-from pants.testutil.rule_runner import MockGet, QueryRule, RuleRunner, run_rule_with_mocks
+from pants.testutil.rule_runner import QueryRule, RuleRunner, run_rule_with_mocks
 
 
 @pytest.fixture
@@ -256,14 +256,10 @@ def test_extra_args_should_be_passed_through(
     run_rule_with_mocks(
         pex_venv,
         rule_args=[request],
-        mock_gets=[
-            MockGet(output_type=Digest, input_types=(MergeDigests,), mock=lambda _: EMPTY_DIGEST),
-            MockGet(
-                output_type=ProcessResult,
-                input_types=(PexCliProcess,),
-                mock=mocked_run_pex_cli_process,
-            ),
-        ],
+        mock_calls={
+            "pants.engine.intrinsics.merge_digests": lambda _: EMPTY_DIGEST,
+            "pants.engine.process.fallible_to_exec_result_or_raise": mocked_run_pex_cli_process,
+        },
     )
 
     # Verify


### PR DESCRIPTION
The files under test were already using call-by-name,
but the tests were leaning on the temporary ability to
satisfy a call via a MockGet.