### PR TITLE
filter out github-actions[bot] as a contributor

### DIFF
--- a/src/python/pants_release/common.py
+++ b/src/python/pants_release/common.py
@@ -52,5 +52,9 @@ def sorted_contributors(git_range: str) -> list[str]:
         .stdout.decode()
         .splitlines()
     )
-    contributors -= {"dependabot[bot]", "github-actions[bot]", "Worker Pants (Pantsbuild GitHub Automation Bot)"}
+    contributors -= {
+        "dependabot[bot]",
+        "github-actions[bot]",
+        "Worker Pants (Pantsbuild GitHub Automation Bot)",
+    }
     return sorted(contributors)


### PR DESCRIPTION
Filter out `github-actions[bot]` as a contributor. This is new and comes from the RunsOn AMI update workflow.