### PR TITLE
upgrade PyO3 to v0.26.0

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -3254,9 +3254,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8970a78afe0628a3e3430376fc5fd76b6b45c4d43360ffd6cdd40bdde72b682a"
+checksum = "7ba0117f4212101ee6544044dae45abe1083d30ce7b29c4b5cbdfa2354e07383"
 dependencies = [
  "indoc",
  "libc",
@@ -3271,19 +3271,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458eb0c55e7ece017adeba38f2248ff3ac615e53660d7c71a238d7d2a01c7598"
+checksum = "4fc6ddaf24947d12a9aa31ac65431fb1b851b8f4365426e182901eabfb87df5f"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7114fe5457c61b276ab77c5055f206295b812608083644a5c5b2640c3102565c"
+checksum = "025474d3928738efb38ac36d4744a74a400c901c7596199e20e45d98eb194105"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -3291,9 +3290,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8725c0a622b374d6cb051d11a0983786448f7785336139c3c94f5aa6bef7e50"
+checksum = "2e64eb489f22fe1c95911b77c44cc41e7c19f3082fc81cce90f657cdc42ffded"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -3303,9 +3302,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4109984c22491085343c05b0dbc54ddc405c3cf7b4374fc533f5c3313a572ccc"
+checksum = "100246c0ecf400b475341b8455a9213344569af29a3c841d29270e53102e0fcf"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -3260,8 +3260,10 @@ checksum = "7ba0117f4212101ee6544044dae45abe1083d30ce7b29c4b5cbdfa2354e07383"
 dependencies = [
  "indoc",
  "libc",
+ "lock_api",
  "memoffset 0.9.1",
  "once_cell",
+ "parking_lot 0.12.4",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -202,8 +202,8 @@ prodash = { git = "https://github.com/stuhood/prodash", rev = "stuhood/raw-messa
 prost = "0.13"
 prost-build = "0.13"
 prost-types = "0.13"
-pyo3 = "0.25.1"
-pyo3-build-config = "0.25.1"
+pyo3 = "0.26.0"
+pyo3-build-config = "0.26.0"
 rand = "0.9"
 regex = "1"
 reqwest = { version = "0.12", default-features = false }

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -202,7 +202,7 @@ prodash = { git = "https://github.com/stuhood/prodash", rev = "stuhood/raw-messa
 prost = "0.13"
 prost-build = "0.13"
 prost-types = "0.13"
-pyo3 = "0.26.0"
+pyo3 = { version = "0.26.0", features = ["parking_lot"] }
 pyo3-build-config = "0.26.0"
 rand = "0.9"
 regex = "1"

--- a/src/rust/engine/src/externs/address.rs
+++ b/src/rust/engine/src/externs/address.rs
@@ -768,7 +768,7 @@ impl Address {
         }
     }
 
-    fn maybe_convert_to_target_generator(self_: PyRef<Self>, py: Python) -> PyResult<PyObject> {
+    fn maybe_convert_to_target_generator(self_: PyRef<Self>, py: Python) -> PyResult<Py<PyAny>> {
         if !self_.is_generated_target() && !self_.is_parametrized() {
             return Ok(self_.into_pyobject(py)?.into_any().unbind());
         }

--- a/src/rust/engine/src/externs/fs.rs
+++ b/src/rust/engine/src/externs/fs.rs
@@ -445,10 +445,9 @@ impl PyFilespecMatcher {
     #[new]
     fn __new__(includes: Vec<String>, excludes: Vec<String>, py: Python) -> PyResult<Self> {
         // Parsing the globs has shown up in benchmarks
-        // (https://github.com/pantsbuild/pants/issues/16122), so we use py.allow_threads().
-        let matcher = py.allow_threads(|| {
-            FilespecMatcher::new(includes, excludes).map_err(PyValueError::new_err)
-        })?;
+        // (https://github.com/pantsbuild/pants/issues/16122), so we use py.detach().
+        let matcher =
+            py.detach(|| FilespecMatcher::new(includes, excludes).map_err(PyValueError::new_err))?;
         Ok(Self(matcher))
     }
 
@@ -486,7 +485,7 @@ impl PyFilespecMatcher {
     }
 
     fn matches(&self, paths: Vec<String>, py: Python) -> PyResult<Vec<String>> {
-        py.allow_threads(|| {
+        py.detach(|| {
             Ok(paths
                 .into_iter()
                 .filter(|p| self.0.matches(Path::new(p)))

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -1175,6 +1175,7 @@ fn scheduler_metrics<'py>(
     })
 }
 
+#[allow(clippy::type_complexity)]
 #[pyfunction]
 fn scheduler_live_items<'py>(
     py: Python<'py>,

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -187,7 +187,7 @@ where
 }
 
 ///
-/// Collect the Values contained within an outer Python Iterable PyObject.
+/// Collect the Values contained within an outer Python Iterable Py<PyAny>.
 ///
 pub fn collect_iterable<'py>(value: &Bound<'py, PyAny>) -> Result<Vec<Bound<'py, PyAny>>, String> {
     match value.try_iter() {
@@ -517,7 +517,7 @@ impl PyGeneratorResponseNativeCall {
         Some(self_)
     }
 
-    fn send(&self, py: Python<'_>, value: PyObject) -> PyResult<()> {
+    fn send(&self, py: Python<'_>, value: Py<PyAny>) -> PyResult<()> {
         let args = PyTuple::new(py, [value])?.into_pyobject(py)?.unbind();
         Err(PyStopIteration::new_err(args))
     }
@@ -597,9 +597,9 @@ impl PyGeneratorResponseCall {
     }
 
     #[getter]
-    fn inputs(&self, py: Python<'_>) -> PyResult<Vec<PyObject>> {
+    fn inputs(&self, py: Python<'_>) -> PyResult<Vec<Py<PyAny>>> {
         let inner = self.borrow_inner(py)?;
-        let args: Vec<PyObject> = inner.args.as_ref().map_or_else(
+        let args: Vec<Py<PyAny>> = inner.args.as_ref().map_or_else(
             || Ok(Vec::default()),
             |args| args.to_py_object().extract(py),
         )?;
@@ -697,7 +697,7 @@ impl PyGeneratorResponseGet {
     }
 
     #[getter]
-    fn inputs(&self, py: Python<'_>) -> PyResult<Vec<PyObject>> {
+    fn inputs(&self, py: Python<'_>) -> PyResult<Vec<Py<PyAny>>> {
         Ok(self
             .0
             .get(py)

--- a/src/rust/engine/src/externs/nailgun.rs
+++ b/src/rust/engine/src/externs/nailgun.rs
@@ -59,7 +59,7 @@ impl PyNailgunClient {
             .map(|kv_pair| kv_pair.extract::<(String, String)>())
             .collect::<Result<Vec<_>, _>>()?;
 
-        py.allow_threads(|| {
+        py.detach(|| {
             self.executor
                 .block_on(nailgun::client_execute(self.port, command, args, env_list))
                 .map_err(|e| match e {

--- a/src/rust/engine/src/externs/options.rs
+++ b/src/rust/engine/src/externs/options.rs
@@ -33,7 +33,7 @@ pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
 // The (nested) values of a dict-valued option are represented by Val.
 // This function converts them to equivalent Python types.
-fn val_to_py_object(py: Python, val: &Val) -> PyResult<PyObject> {
+fn val_to_py_object(py: Python, val: &Val) -> PyResult<Py<PyAny>> {
     let res = match val {
         Val::Bool(b) => b.into_pyobject(py)?.into_any().unbind(),
         Val::Int(i) => i.into_pyobject(py)?.into_any().unbind(),
@@ -64,7 +64,7 @@ fn dict_into_py(py: Python, vals: HashMap<String, Val>) -> PyResult<PyDictVal> {
             Ok(pyobj) => Ok((k, pyobj)),
             Err(err) => Err(err),
         })
-        .collect::<PyResult<HashMap<String, PyObject>>>()
+        .collect::<PyResult<HashMap<String, Py<PyAny>>>>()
 }
 
 // Converts a Python object into a Val, which is necessary for receiving
@@ -218,7 +218,7 @@ impl PyConfigSource {
 struct PyOptionParser(OptionParser);
 
 // The pythonic value of a dict-typed option.
-type PyDictVal = HashMap<String, PyObject>;
+type PyDictVal = HashMap<String, Py<PyAny>>;
 
 // The derivation of the option value, as a vec of (value, rank, details string) tuples.
 type OptionValueDerivation<'py, T> = Vec<(T, isize, Option<Bound<'py, PyString>>)>;
@@ -580,7 +580,7 @@ impl PyOptionParser {
     fn validate_config(
         &self,
         py: Python<'_>,
-        py_valid_keys: HashMap<String, PyObject>,
+        py_valid_keys: HashMap<String, Py<PyAny>>,
     ) -> PyResult<Vec<String>> {
         let mut valid_keys = HashMap::new();
 

--- a/src/rust/engine/src/externs/scheduler.rs
+++ b/src/rust/engine/src/externs/scheduler.rs
@@ -36,8 +36,8 @@ impl PyExecutor {
             // thread, and the Python runtime won't wipe the trace function between calls.
             // See https://github.com/PyO3/pyo3/issues/2495
             let _ =
-                unsafe { ffi::PyThreadState_New(Python::with_gil(|_| PyInterpreterState_Main())) };
-            Python::with_gil(|py| {
+                unsafe { ffi::PyThreadState_New(Python::attach(|_| PyInterpreterState_Main())) };
+            Python::attach(|py| {
                 let _ = py.eval(c"__import__('debugpy').debug_this_thread()", None, None);
             });
         })

--- a/src/rust/engine/src/externs/scheduler.rs
+++ b/src/rust/engine/src/externs/scheduler.rs
@@ -54,7 +54,7 @@ impl PyExecutor {
     /// Shut down this executor, waiting for all tasks to exit. Any tasks which have not exited at
     /// the end of the timeout will be leaked.
     fn shutdown(&self, py: Python, duration_secs: f64) {
-        py.allow_threads(|| self.0.shutdown(Duration::from_secs_f64(duration_secs)))
+        py.detach(|| self.0.shutdown(Duration::from_secs_f64(duration_secs)))
     }
 }
 

--- a/src/rust/engine/src/externs/stdio.rs
+++ b/src/rust/engine/src/externs/stdio.rs
@@ -29,7 +29,7 @@ impl PyStdioRead {
         let py_buffer = PyBuffer::get(obj)?;
         let mut buffer = vec![0; py_buffer.len_bytes()];
         let read = py
-            .allow_threads(|| stdio::get_destination().read_stdin(&mut buffer))
+            .detach(|| stdio::get_destination().read_stdin(&mut buffer))
             .map_err(|e| PyException::new_err(e.to_string()))?;
         // NB: `as_mut_slice` exposes a `&[Cell<u8>]`, which we can't use directly in `read`. We use
         // `copy_from_slice` instead, which unfortunately involves some extra copying.
@@ -60,7 +60,7 @@ pub struct PyStdioWrite {
 #[pymethods]
 impl PyStdioWrite {
     fn write(&self, payload: &str, py: Python) {
-        py.allow_threads(|| {
+        py.detach(|| {
             let destination = stdio::get_destination();
             if self.is_stdout {
                 destination.write_stdout(payload.as_bytes());

--- a/src/rust/engine/src/externs/target.rs
+++ b/src/rust/engine/src/externs/target.rs
@@ -38,7 +38,7 @@ impl NoFieldValue {
 
 #[pyclass(subclass)]
 pub struct Field {
-    value: PyObject,
+    value: Py<PyAny>,
 }
 
 #[pymethods]

--- a/src/rust/engine/src/interning.rs
+++ b/src/rust/engine/src/interning.rs
@@ -45,7 +45,7 @@ pub struct Interns {
 impl Interns {
     pub fn new() -> Self {
         Self {
-            keys: Python::with_gil(|py| PyDict::new(py).unbind()),
+            keys: Python::attach(|py| PyDict::new(py).unbind()),
             id_generator: atomic::AtomicU64::default(),
         }
     }

--- a/src/rust/engine/src/interning.rs
+++ b/src/rust/engine/src/interning.rs
@@ -50,7 +50,7 @@ impl Interns {
         }
     }
 
-    pub fn key_insert(&self, py: Python, v: PyObject) -> PyResult<Key> {
+    pub fn key_insert(&self, py: Python, v: Py<PyAny>) -> PyResult<Key> {
         let (id, type_id): (u64, TypeId) = {
             let v = v.bind(py);
             let keys = self.keys.bind(py);

--- a/src/rust/engine/src/intrinsics/dep_inference.rs
+++ b/src/rust/engine/src/intrinsics/dep_inference.rs
@@ -55,7 +55,7 @@ impl PreparedInferenceRequest {
         let PyNativeDependenciesRequest {
             directory_digest,
             metadata,
-        } = Python::with_gil(|py| deps_request.bind(py).extract())?;
+        } = Python::attach(|py| deps_request.bind(py).extract())?;
 
         let (path, digest) = Self::find_one_file(directory_digest, store, backend).await?;
         let str_path = path.display().to_string();
@@ -146,7 +146,7 @@ fn parse_dockerfile_info(deps_request: Value) -> PyGeneratorResponseNativeCall {
                 )
                 .await?;
 
-                let result = Python::with_gil(|py| -> Result<_, PyErr> {
+                let result = Python::attach(|py| -> Result<_, PyErr> {
                     Ok(externs::unsafe_call(
                         py,
                         core.types.parsed_dockerfile_info_result,
@@ -227,7 +227,7 @@ fn parse_python_deps(deps_request: Value) -> PyGeneratorResponseNativeCall {
                 )
                 .await?;
 
-                let result = Python::with_gil(|py| -> Result<_, PyErr> {
+                let result = Python::attach(|py| -> Result<_, PyErr> {
                     Ok(externs::unsafe_call(
                         py,
                         core.types.parsed_python_deps_result,
@@ -295,7 +295,7 @@ fn parse_javascript_deps(deps_request: Value) -> PyGeneratorResponseNativeCall {
                 )
                 .await?;
 
-                Python::with_gil(|py| -> Result<_, Failure> {
+                Python::attach(|py| -> Result<_, Failure> {
                     let import_items = result
                         .imports
                         .into_iter()

--- a/src/rust/engine/src/intrinsics/digests.rs
+++ b/src/rust/engine/src/intrinsics/digests.rs
@@ -257,7 +257,7 @@ enum CreateDigestItem {
 
 #[pyfunction]
 fn create_digest(py: Python, create_digest: Value) -> PyResult<PyGeneratorResponseNativeCall> {
-    let (items_to_store, trie) = py.allow_threads(|| -> Result<_, Failure> {
+    let (items_to_store, trie) = py.detach(|| -> Result<_, Failure> {
         let mut new_file_count = 0;
 
         let items: Vec<CreateDigestItem> = {

--- a/src/rust/engine/src/intrinsics/docker.rs
+++ b/src/rust/engine/src/intrinsics/docker.rs
@@ -25,7 +25,7 @@ fn docker_resolve_image(docker_request: Value) -> PyGeneratorResponseNativeCall 
         let types = &context.core.types;
         let docker_resolve_image_result = types.docker_resolve_image_result;
 
-        let (image_name, platform) = Python::with_gil(|py| {
+        let (image_name, platform) = Python::attach(|py| {
             let py_docker_request = docker_request.bind(py);
             let image_name: String = externs::getattr(py_docker_request, "image_name").unwrap();
             let platform: String = externs::getattr(py_docker_request, "platform").unwrap();
@@ -60,7 +60,7 @@ fn docker_resolve_image(docker_request: Value) -> PyGeneratorResponseNativeCall 
             .id
             .ok_or_else(|| format!("Image does not exist: `{}`", &image_name))?;
 
-        Ok::<_, Failure>(Python::with_gil(|py| {
+        Ok::<_, Failure>(Python::attach(|py| {
             externs::unsafe_call(
                 py,
                 docker_resolve_image_result,

--- a/src/rust/engine/src/intrinsics/interactive_process.rs
+++ b/src/rust/engine/src/intrinsics/interactive_process.rs
@@ -56,7 +56,7 @@ pub async fn interactive_process_inner(
         Value,
         Value,
         externs::process::PyProcessExecutionEnvironment,
-    ) = Python::with_gil(|py| {
+    ) = Python::attach(|py| {
         let py_interactive_process = interactive_process.bind(py);
         let py_process: Value = externs::getattr(py_interactive_process, "process").unwrap();
         let process_config = process_config.bind(py).extract().unwrap();
@@ -81,7 +81,7 @@ pub async fn interactive_process_inner(
     let mut process = ExecuteProcess::lift(&context.core.store(), py_process, process_config)
         .await?
         .process;
-    let (run_in_workspace, keep_sandboxes) = Python::with_gil(|py| {
+    let (run_in_workspace, keep_sandboxes) = Python::attach(|py| {
         let py_interactive_process = py_interactive_process.bind(py);
         let run_in_workspace: bool =
             externs::getattr(py_interactive_process, "run_in_workspace").unwrap();
@@ -215,7 +215,7 @@ pub async fn interactive_process_inner(
             do_setup_run_sh_script(tempdir.path())?;
         }
     }
-    Ok::<_, Failure>(Python::with_gil(|py| {
+    Ok::<_, Failure>(Python::attach(|py| {
         externs::unsafe_call(
             py,
             interactive_process_result,

--- a/src/rust/engine/src/intrinsics/process.rs
+++ b/src/rust/engine/src/intrinsics/process.rs
@@ -24,7 +24,7 @@ fn execute_process(process: Value, process_config: Value) -> PyGeneratorResponse
         let context = task_get_context();
 
         let process_config: externs::process::PyProcessExecutionEnvironment =
-            Python::with_gil(|py| process_config.bind(py).extract()).map_err(|e| format!("{e}"))?;
+            Python::attach(|py| process_config.bind(py).extract()).map_err(|e| format!("{e}"))?;
         let process_request = ExecuteProcess::lift(&context.core.store(), process, process_config)
             .map_err(|e| e.enrich("Error lifting Process"))
             .await?;
@@ -41,7 +41,7 @@ fn execute_process(process: Value, process_config: Value) -> PyGeneratorResponse
                 .map_err(|e| e.enrich("Bytes from stderr"))
         )?;
 
-        Python::with_gil(|py| -> NodeResult<Value> {
+        Python::attach(|py| -> NodeResult<Value> {
             Ok(externs::unsafe_call(
                 py,
                 context.core.types.process_result,

--- a/src/rust/engine/src/nodes/downloaded_file.rs
+++ b/src/rust/engine/src/nodes/downloaded_file.rs
@@ -96,7 +96,7 @@ impl DownloadedFile {
 
     pub(super) async fn run_node(self, context: Context) -> NodeResult<store::Snapshot> {
         let (url_str, expected_digest, auth_headers, retry_delay_duration, max_attempts) =
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 let py_download_file_val = self.0.to_value();
                 let py_download_file = py_download_file_val.bind(py);
                 let url_str: String = externs::getattr(py_download_file, "url")

--- a/src/rust/engine/src/nodes/execute_process.rs
+++ b/src/rust/engine/src/nodes/execute_process.rs
@@ -37,7 +37,7 @@ impl ExecuteProcess {
         store: &Store,
         value: &Value,
     ) -> Result<InputDigests, StoreError> {
-        let input_digests_fut: Result<_, String> = Python::with_gil(|py| {
+        let input_digests_fut: Result<_, String> = Python::attach(|py| {
             let value = value.bind(py);
             let input_files = {
                 let input_files_py_value: Bound<'_, PyAny> =
@@ -188,7 +188,7 @@ impl ExecuteProcess {
         process_config: externs::process::PyProcessExecutionEnvironment,
     ) -> Result<Self, StoreError> {
         let input_digests = Self::lift_process_input_digests(store, &value).await?;
-        let process = Python::with_gil(|py| {
+        let process = Python::attach(|py| {
             Self::lift_process_fields(value.bind(py), input_digests, process_config)
         })?;
         Ok(Self { process })

--- a/src/rust/engine/src/nodes/mod.rs
+++ b/src/rust/engine/src/nodes/mod.rs
@@ -230,7 +230,7 @@ pub fn lift_file_digest(digest: &Bound<'_, PyAny>) -> Result<hashing::Digest, St
 }
 
 pub fn unmatched_globs_additional_context() -> Option<String> {
-    let url = Python::with_gil(|py| {
+    let url = Python::attach(|py| {
         externs::doc_url(
             py,
             "troubleshooting#pants-cannot-find-a-file-in-your-project",
@@ -395,7 +395,7 @@ impl NodeKey {
             NodeKey::Task(ref task) => {
                 let task_desc = task.task.display_info.desc.as_ref().map(|s| s.to_owned())?;
 
-                let displayable_param_names: Vec<_> = Python::with_gil(|py| {
+                let displayable_param_names: Vec<_> = Python::attach(|py| {
                     Self::engine_aware_params(context, py, &task.params)
                         .filter_map(|k| EngineAwareParameter::debug_hint(k.value.bind(py)))
                         .collect()
@@ -501,7 +501,7 @@ impl Node for NodeKey {
             desc = workunit_desc.clone(),
             user_metadata = {
                 if let Some(params) = maybe_params {
-                    Python::with_gil(|py| {
+                    Python::attach(|py| {
                         Self::engine_aware_params(&context, py, params)
                             .flat_map(|k| EngineAwareParameter::metadata(k.value.bind(py)))
                             .collect()
@@ -601,9 +601,7 @@ impl Node for NodeKey {
                 }
             }
             (NodeKey::Task(ref t), NodeOutput::Value(ref v)) if t.task.engine_aware_return_type => {
-                Python::with_gil(|py| {
-                    EngineAwareReturnType::is_cacheable(v.bind(py)).unwrap_or(true)
-                })
+                Python::attach(|py| EngineAwareReturnType::is_cacheable(v.bind(py)).unwrap_or(true))
             }
             _ => true,
         }
@@ -615,7 +613,7 @@ impl Node for NodeKey {
             path[0] += " <-";
             path.push(path[0].clone());
         }
-        let url = Python::with_gil(|py| {
+        let url = Python::attach(|py| {
             externs::doc_url(
                 py,
                 "docs/using-pants/key-concepts/targets-and-build-files#dependencies-and-dependency-inference",
@@ -651,7 +649,7 @@ impl Display for NodeKey {
             NodeKey::Root(s) => write!(f, "{}", s.product),
             NodeKey::Task(task) => {
                 let params = {
-                    Python::with_gil(|py| {
+                    Python::attach(|py| {
                         task.params
                             .keys()
                             .filter_map(|k| EngineAwareParameter::debug_hint(k.to_value().bind(py)))

--- a/src/rust/engine/src/nodes/run_id.rs
+++ b/src/rust/engine/src/nodes/run_id.rs
@@ -15,7 +15,7 @@ pub struct RunId;
 
 impl RunId {
     pub(super) async fn run_node(self, context: Context) -> NodeResult<Value> {
-        Ok(Python::with_gil(|py| {
+        Ok(Python::attach(|py| {
             externs::unsafe_call(
                 py,
                 context.core.types.run_id,

--- a/src/rust/engine/src/nodes/task.rs
+++ b/src/rust/engine/src/nodes/task.rs
@@ -196,7 +196,7 @@ impl Task {
     ) -> NodeResult<(Value, TypeId)> {
         let mut input = GeneratorInput::Initial;
         loop {
-            let response = Python::with_gil(|py| {
+            let response = Python::attach(|py| {
                 externs::generator_send(py, &context.core.types.coroutine, &generator, input)
             })?;
             match response {
@@ -248,7 +248,7 @@ impl Task {
                     match future::try_join_all(get_futures).await {
                         Ok(values) => {
                             let values_tuple_result =
-                                Python::with_gil(|py| externs::store_tuple(py, values));
+                                Python::attach(|py| externs::store_tuple(py, values));
                             input = match values_tuple_result {
                                 Ok(t) => GeneratorInput::Arg(t),
                                 Err(err) => GeneratorInput::Err(err),
@@ -307,7 +307,7 @@ impl Task {
             self.task.side_effecting,
             &self.side_effected,
             async move {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let func = self.task.func.0.value.bind(py);
 
                     // If there are explicit positional arguments, apply any computed arguments as
@@ -367,7 +367,7 @@ impl Task {
         }
 
         if self.task.engine_aware_return_type {
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 EngineAwareReturnType::update_workunit(workunit, result_val.bind(py))
             })
         };

--- a/src/rust/engine/src/session.rs
+++ b/src/rust/engine/src/session.rs
@@ -146,7 +146,7 @@ impl Session {
         ui_use_prodash: bool,
         mut max_workunit_level: log::Level,
         build_id: String,
-        session_values: PyObject,
+        session_values: Py<PyAny>,
         cancelled: AsyncLatch,
     ) -> Result<Session, String> {
         // We record workunits with the maximum level of:


### PR DESCRIPTION
Upgrade the `pyo3` crate to v0.26.0. There are several deprecations:

- The `PyObject` type alias is removed. Switched to its expansion `Py<PyAny>`.
- "GIL" is removed as a legacy name since the free-threaded Python in Python 3.13+ has no GIL. Threads still "attach" to the interpreter though so `Python::with_gil` becomes `Python::attach` and  `Python::allow_threads` becomes `Python::detach`.
- The `GILProtected` wrapper is removed in favor of just using normal `Mutex` or `RwLock` locks. The various usages have been switched to `Mutex` and `RwLock`. There is a very small chance of acquiring a lock deadlocking with the GIL so PyO3 provides a helper `lock_py_attached` method to detach, acquire the lock, and reattach. For the `RwLock` used in `PyGeneratorResponseCall`, equivalent `read_py_attached` and `write_py_attached` methods won't be available until my PR https://github.com/PyO3/pyo3/pull/5435 lands upstrea.