### PR TITLE
Port core/environments to call-by-name.

### DIFF
--- a/src/python/pants/core/environments/rules.py
+++ b/src/python/pants/core/environments/rules.py
@@ -47,7 +47,7 @@ from pants.engine.internals.scheduler import SchedulerSession
 from pants.engine.internals.selectors import Params
 from pants.engine.intrinsics import docker_resolve_image
 from pants.engine.platform import Platform
-from pants.engine.rules import Get, QueryRule, collect_rules, concurrently, implicitly, rule
+from pants.engine.rules import QueryRule, collect_rules, concurrently, implicitly, rule
 from pants.engine.target import (
     NO_VALUE,
     Field,
@@ -428,14 +428,14 @@ async def _apply_fallback_environment(env_tgt: Target, error_msg: str) -> Enviro
     if fallback_field.value is None:
         raise NoFallbackEnvironmentError(error_msg)
     # TODO: Requires call-by-name support for mutual @rule recursion.
-    return await Get(
-        EnvironmentName,
+    return await resolve_environment_name(
         EnvironmentNameRequest(
             fallback_field.value,
             description_of_origin=(
                 f"the `{fallback_field.alias}` field of the target {env_tgt.address}"
             ),
         ),
+        **implicitly(),
     )
 
 

--- a/src/python/pants/core/environments/rules.py
+++ b/src/python/pants/core/environments/rules.py
@@ -427,7 +427,6 @@ async def _apply_fallback_environment(env_tgt: Target, error_msg: str) -> Enviro
     fallback_field = env_tgt[FallbackEnvironmentField]
     if fallback_field.value is None:
         raise NoFallbackEnvironmentError(error_msg)
-    # TODO: Requires call-by-name support for mutual @rule recursion.
     return await resolve_environment_name(
         EnvironmentNameRequest(
             fallback_field.value,

--- a/src/python/pants/core/environments/rules_test.py
+++ b/src/python/pants/core/environments/rules_test.py
@@ -49,13 +49,7 @@ from pants.option.global_options import GlobalOptions, KeepSandboxes
 from pants.option.option_types import ShellStrListOption
 from pants.option.subsystem import Subsystem
 from pants.testutil.option_util import create_subsystem
-from pants.testutil.rule_runner import (
-    MockGet,
-    QueryRule,
-    RuleRunner,
-    engine_error,
-    run_rule_with_mocks,
-)
+from pants.testutil.rule_runner import QueryRule, RuleRunner, engine_error, run_rule_with_mocks
 
 
 @pytest.fixture
@@ -368,14 +362,10 @@ def test_resolve_environment_name_local_and_docker_fallbacks(monkeypatch) -> Non
                 "pants.core.environments.rules.determine_local_environment": mock_determine_local_environment,
                 "pants.core.environments.rules.determine_local_workspace_environment": mock_determine_local_workspace_environment,
                 "pants.core.environments.rules.get_target_for_environment_name": mock_get_target_for_environment_name,
-            },
-            mock_gets=[
-                MockGet(
-                    output_type=EnvironmentName,
-                    input_types=(EnvironmentNameRequest,),
-                    mock=lambda req: EnvironmentName(req.raw_value),
+                "pants.core.environments.rules.resolve_environment_name": lambda req: EnvironmentName(
+                    req.raw_value
                 ),
-            ],
+            },
         ).val
         return result
 


### PR DESCRIPTION
The remaining `Get` there was required because of mutual
recursion. As of #22648 we support mutual recursion
with call-by-name, so we can remove that last `Get`.