### PR TITLE
Finish porting backends to call-by-name.

### DIFF
--- a/src/python/pants/backend/project_info/list_targets_test.py
+++ b/src/python/pants/backend/project_info/list_targets_test.py
@@ -10,7 +10,7 @@ from pants.backend.project_info.list_targets import ListSubsystem, list_targets
 from pants.engine.addresses import Address, Addresses
 from pants.engine.target import DescriptionField, Target, UnexpandedTargets
 from pants.testutil.option_util import create_goal_subsystem, create_options_bootstrapper
-from pants.testutil.rule_runner import MockGet, mock_console, run_rule_with_mocks
+from pants.testutil.rule_runner import mock_console, run_rule_with_mocks
 
 
 class MockTarget(Target):
@@ -32,13 +32,11 @@ def run_goal(targets: list[MockTarget], *, show_documented: bool = False) -> tup
                 ),
                 console,
             ],
-            mock_gets=[
-                MockGet(
-                    output_type=UnexpandedTargets,
-                    input_types=(Addresses,),
-                    mock=lambda _: UnexpandedTargets(targets),
+            mock_calls={
+                "pants.engine.internals.graph.resolve_unexpanded_targets": lambda _: UnexpandedTargets(
+                    targets
                 )
-            ],
+            },
         )
         return stdio_reader.get_stdout(), stdio_reader.get_stderr()
 

--- a/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
@@ -43,9 +43,10 @@ from pants.core.goals.test import (
 from pants.core.util_rules import config_files, distdir
 from pants.core.util_rules.partitions import Partitions
 from pants.engine.addresses import Address
-from pants.engine.fs import CreateDigest, Digest, DigestContents, FileContent
+from pants.engine.fs import CreateDigest, DigestContents, FileContent
+from pants.engine.intrinsics import create_digest
 from pants.engine.process import InteractiveProcessResult
-from pants.engine.rules import Get, rule
+from pants.engine.rules import rule
 from pants.engine.target import Target
 from pants.engine.unions import UnionRule
 from pants.testutil.debug_adapter_util import debugadapter_port_for_testing
@@ -671,13 +672,13 @@ class UnusedPlugin(PytestPluginSetupRequest):
 
 @rule
 async def used_plugin(_: UsedPlugin) -> PytestPluginSetup:
-    digest = await Get(Digest, CreateDigest([FileContent("used.txt", b"")]))
+    digest = await create_digest(CreateDigest([FileContent("used.txt", b"")]))
     return PytestPluginSetup(digest=digest, extra_sys_path=("sys/path/used",))
 
 
 @rule
 async def unused_plugin(_: UnusedPlugin) -> PytestPluginSetup:
-    digest = await Get(Digest, CreateDigest([FileContent("unused.txt", b"")]))
+    digest = await create_digest(CreateDigest([FileContent("unused.txt", b"")]))
     return PytestPluginSetup(digest=digest, extra_sys_path=("sys/path/unused",))
 
 

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -79,7 +79,7 @@ from pants.engine.process import (
     ProcessResult,
     fallible_to_exec_result_or_raise,
 )
-from pants.engine.rules import Get, collect_rules, concurrently, implicitly, rule
+from pants.engine.rules import collect_rules, concurrently, implicitly, rule
 from pants.engine.target import HydrateSourcesRequest, SourcesField, TransitiveTargetsRequest
 from pants.engine.unions import UnionMembership, union
 from pants.util.frozendict import FrozenDict
@@ -98,6 +98,13 @@ class PythonProvider:
     """
 
     interpreter_constraints: InterpreterConstraints
+
+
+@rule(polymorphic=True)
+async def get_python_executable(
+    provider: PythonProvider, env_name: EnvironmentName
+) -> PythonExecutable:
+    raise NotImplementedError()
 
 
 class PexPlatforms(DeduplicatedCollection[str]):
@@ -358,8 +365,8 @@ async def find_interpreter(
         )
     if python_providers:
         python_provider = next(iter(python_providers))
-        python = await Get(
-            PythonExecutable, PythonProvider, python_provider(interpreter_constraints)
+        python = await get_python_executable(
+            **implicitly({python_provider(interpreter_constraints): PythonProvider})
         )
         return python
 


### PR DESCRIPTION
These are the last `Get`s in the backends, and possibly
in the entire codebase!

The next step will be to disable `Get` and see what breaks.