### PR TITLE
upgrade shoalsoft-pants-opentelemetry-plugin in CI to v0.5.0

### DIFF
--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -1,6 +1,6 @@
 [GLOBAL]
 colors = true
-plugins.add = ["shoalsoft-pants-opentelemetry-plugin==0.4.1"]
+plugins.add = ["shoalsoft-pants-opentelemetry-plugin==0.5.0"]
 backend_packages.add = ["shoalsoft.pants_opentelemetry_plugin"]
 sandboxer = true
 


### PR DESCRIPTION
Upgrade to [v0.5.0](https://github.com/shoalsoft/shoalsoft-pants-opentelemetry-plugin/releases/tag/v0.5.0) of the [shoalsoft-pants-opentelemetry-plugin](https://github.com/shoalsoft/shoalsoft-pants-opentelemetry-plugin). The main change is that the plugin uses call-by-name syntax now.