### PR TITLE
Optionally panic if a Get is used.

### DIFF
--- a/src/python/pants/engine/internals/rule_visitor.py
+++ b/src/python/pants/engine/internals/rule_visitor.py
@@ -6,6 +6,7 @@ import ast
 import inspect
 import itertools
 import logging
+import os
 import sys
 from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager
@@ -369,6 +370,8 @@ class _AwaitableCollector(ast.NodeVisitor):
                 self.awaitables.append(
                     self._get_legacy_awaitable(call_node, is_effect=issubclass(func, Effect))
                 )
+                if os.environ.get("PANTS_DISABLE_GETS", "").lower() in {"1", "t", "true"}:
+                    raise Exception("Get() is disabled!")
             elif (inspect.isfunction(func) or isinstance(func, RuleDescriptor)) and (
                 rule_id := getattr(func, "rule_id", None)
             ) is not None:

--- a/src/python/pants/engine/internals/selectors_test.py
+++ b/src/python/pants/engine/internals/selectors_test.py
@@ -10,8 +10,6 @@ import pytest
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.unions import union
 
-pytestmark = pytest.mark.call_by_type
-
 
 class AClass:
     pass
@@ -22,6 +20,16 @@ class BClass:
     pass
 
 
+# A dummy test so that at least one test is collected when we exclude the call_by_type mark.
+# Otherwise pytest returns exit code 5 ("No tests were collected") which we interpret as failure.
+# See https://docs.pytest.org/en/stable/reference/exit-codes.html
+# TODO: Modify our test support to optionally accept exit code 5 as success. Seems generally
+#  useful to allow users to opt for this. See https://github.com/pantsbuild/pants/issues/22668
+def test_dummy() -> None:
+    pass
+
+
+@pytest.mark.call_by_type
 def test_create_get() -> None:
     get1 = Get(AClass)
     assert get1.output_type is AClass
@@ -52,6 +60,7 @@ def assert_invalid_get(create_get: Callable[[], Get], *, expected: str) -> None:
     assert str(exc.value) == expected
 
 
+@pytest.mark.call_by_type
 def test_invalid_get() -> None:
     # Bad output type.
     assert_invalid_get(
@@ -91,6 +100,7 @@ def test_invalid_get() -> None:
     )
 
 
+@pytest.mark.call_by_type
 def test_invalid_get_input_does_not_match_type() -> None:
     assert_invalid_get(
         lambda: Get(AClass, str, 1),
@@ -110,6 +120,7 @@ def test_invalid_get_input_does_not_match_type() -> None:
     assert union_get.inputs == [1]
 
 
+@pytest.mark.call_by_type
 def test_multiget_invalid_types() -> None:
     with pytest.raises(
         expected_exception=TypeError,
@@ -118,6 +129,7 @@ def test_multiget_invalid_types() -> None:
         next(MultiGet(Get(AClass, BClass()), "bob").__await__())  # type: ignore[call-overload]
 
 
+@pytest.mark.call_by_type
 def test_multiget_invalid_Nones() -> None:
     with pytest.raises(
         expected_exception=ValueError,
@@ -135,6 +147,7 @@ def test_multiget_invalid_Nones() -> None:
 #
 # Here we test that the runtime actually accepts 11 or more Gets. This is really just a regression
 # test that checks MultiGet retains a trailing *args slot.
+@pytest.mark.call_by_type
 @pytest.mark.parametrize("count", list(range(1, 20)))
 def test_homogenous(count) -> None:
     gets = tuple(Get(AClass, BClass()) for _ in range(count))

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -16,8 +16,8 @@ use pyo3::{create_exception, import_exception, intern};
 use smallvec::{SmallVec, smallvec};
 use std::collections::BTreeMap;
 use std::convert::TryInto;
-use std::fmt;
 use std::sync::LazyLock;
+use std::{env, fmt};
 
 use logging::PythonLogLevel;
 use rule_graph::RuleId;
@@ -648,6 +648,14 @@ impl PyGeneratorResponseGet {
         input_arg0: Option<Bound<'_, PyAny>>,
         input_arg1: Option<Bound<'_, PyAny>>,
     ) -> PyResult<Self> {
+        if ["1", "t", "true"].contains(
+            &env::var("PANTS_DISABLE_GETS")
+                .map(|s| s.to_lowercase())
+                .unwrap_or("".to_string())
+                .as_str(),
+        ) {
+            panic!("Get() is disabled!");
+        }
         let product = product.downcast::<PyType>().map_err(|_| {
             let actual_type = product.get_type();
             PyTypeError::new_err(format!(


### PR DESCRIPTION
The option is controlled by an env var directly, since some rule
processing happens before options are available.

We raise an exception in the RuleVisitor if a Get is seen in 
a rule, and we also panic in the rust-side Get constructor
if a Get is created without first having been visited by
RuleVisitor (e.g., in tests).

Currently the env var is not set. We will flip it in a branch
to see what breaks.

I have manually tested that when the env var is set on
the pants client cmd line, the expected things happen
if a Get is found.