### PR TITLE
migrate `dep_inference` crate to Rust 2024 Edition

### DIFF
--- a/src/rust/dep_inference/Cargo.toml
+++ b/src/rust/dep_inference/Cargo.toml
@@ -9,7 +9,7 @@
 # (A "breaking change" is one that changes the behavior of dependency parsing. This version is
 # embedded in the local cache. Therefore if behavior changes, the cache should be busted)
 version = "2.18.0"
-edition = "2021"
+edition = "2024"
 name = "dep_inference"
 authors = ["Pants Build <pantsbuild@gmail.com>"]
 publish = false

--- a/src/rust/dep_inference/src/javascript/mod.rs
+++ b/src/rust/dep_inference/src/javascript/mod.rs
@@ -248,12 +248,12 @@ impl Visitor for ImportCollector<'_> {
     }
 
     fn visit_call_expression(&mut self, node: Node) -> ChildBehavior {
-        if let (Some(function), Some(args)) = (node.named_child(0), node.named_child(1)) {
-            if let "require" | "import" = self.code_at(function.range()) {
-                for arg in args.children(&mut args.walk()) {
-                    if KindID::STRING.contains(&arg.kind_id()) {
-                        self.insert_import(Some(arg))
-                    }
+        if let (Some(function), Some(args)) = (node.named_child(0), node.named_child(1))
+            && let "require" | "import" = self.code_at(function.range())
+        {
+            for arg in args.children(&mut args.walk()) {
+                if KindID::STRING.contains(&arg.kind_id()) {
+                    self.insert_import(Some(arg))
                 }
             }
         }

--- a/src/rust/dep_inference/src/python/mod.rs
+++ b/src/rust/dep_inference/src/python/mod.rs
@@ -171,19 +171,19 @@ impl ImportCollector<'_> {
 
     fn is_pragma_ignored_recursive(&self, node: tree_sitter::Node) -> bool {
         let node_end_point = node.range().end_point;
-        if let Some(sibling) = node.next_named_sibling() {
-            if self.is_pragma_ignored_at_row(sibling, node_end_point.row) {
-                return true;
-            }
+        if let Some(sibling) = node.next_named_sibling()
+            && self.is_pragma_ignored_at_row(sibling, node_end_point.row)
+        {
+            return true;
         }
 
         let mut current = node;
         loop {
             if let Some(parent) = current.parent() {
-                if let Some(sibling) = parent.next_named_sibling() {
-                    if self.is_pragma_ignored_at_row(sibling, node_end_point.row) {
-                        return true;
-                    }
+                if let Some(sibling) = parent.next_named_sibling()
+                    && self.is_pragma_ignored_at_row(sibling, node_end_point.row)
+                {
+                    return true;
                 }
                 current = parent;
                 continue;
@@ -257,13 +257,12 @@ impl ImportCollector<'_> {
     }
 
     fn handle_string_candidate(&mut self, node: tree_sitter::Node) {
-        if let Some(text) = self.extract_string(node) {
-            if !text.contains(|c: char| c.is_ascii_whitespace() || c == '\\')
-                && !self.is_pragma_ignored_recursive(node)
-            {
-                self.string_candidates
-                    .insert(text, (node.range().start_point.row + 1) as u64);
-            }
+        if let Some(text) = self.extract_string(node)
+            && !text.contains(|c: char| c.is_ascii_whitespace() || c == '\\')
+            && !self.is_pragma_ignored_recursive(node)
+        {
+            self.string_candidates
+                .insert(text, (node.range().start_point.row + 1) as u64);
         }
     }
 }
@@ -390,12 +389,11 @@ impl Visitor for ImportCollector<'_> {
         }
 
         let args = node.named_child(1).unwrap();
-        if let Some(arg) = args.named_child(0) {
-            if let Some(content) = self.extract_string(arg) {
-                if !self.is_pragma_ignored(node.parent().unwrap()) {
-                    self.insert_import(BaseNode::StringNode(content, arg), None);
-                }
-            }
+        if let Some(arg) = args.named_child(0)
+            && let Some(content) = self.extract_string(arg)
+            && !self.is_pragma_ignored(node.parent().unwrap())
+        {
+            self.insert_import(BaseNode::StringNode(content, arg), None);
         }
 
         // Do not descend below the `__import__` call statement.


### PR DESCRIPTION
Migrate the `dep_inference` crate to the Rust 2024 Edition. Code changes are because `if let` statements can now be combined with regular `if` statements. https://rust-lang.github.io/rust-clippy/master/index.html#collapsible_if