### PR TITLE
migrate the `process_execution` crates to Rust 2024 Edition

### DIFF
--- a/src/rust/process_execution/Cargo.toml
+++ b/src/rust/process_execution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2021"
+edition = "2024"
 name = "process_execution"
 authors = ["Pants Build <pantsbuild@gmail.com>"]
 publish = false

--- a/src/rust/process_execution/children/Cargo.toml
+++ b/src/rust/process_execution/children/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2021"
+edition = "2024"
 name = "children"
 authors = ["Pants Build <pantsbuild@gmail.com>"]
 publish = false

--- a/src/rust/process_execution/docker/Cargo.toml
+++ b/src/rust/process_execution/docker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2021"
+edition = "2024"
 name = "docker"
 authors = ["Pants Build <pantsbuild@gmail.com>"]
 publish = false

--- a/src/rust/process_execution/pe_nailgun/Cargo.toml
+++ b/src/rust/process_execution/pe_nailgun/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2021"
+edition = "2024"
 name = "pe_nailgun"
 authors = ["Pants Build <pantsbuild@gmail.com>"]
 publish = false

--- a/src/rust/process_execution/pe_nailgun/src/nailgun_pool.rs
+++ b/src/rust/process_execution/pe_nailgun/src/nailgun_pool.rs
@@ -322,19 +322,19 @@ fn spawn_and_read_port(
         .and_then(|res| res.map_err(|e| format!("Failed to read stdout from nailgun: {e}")));
 
     // If we failed to read a port line and the child has exited, report that.
-    if port_line.is_err() {
-        if let Some(exit_status) = child.try_wait().map_err(|e| e.to_string())? {
-            let mut stderr = String::new();
-            child
-                .stderr
-                .take()
-                .unwrap()
-                .read_to_string(&mut stderr)
-                .map_err(|e| e.to_string())?;
-            return Err(format!(
-                "Nailgun failed to start: exited with {exit_status}, stderr:\n{stderr}"
-            ));
-        }
+    if port_line.is_err()
+        && let Some(exit_status) = child.try_wait().map_err(|e| e.to_string())?
+    {
+        let mut stderr = String::new();
+        child
+            .stderr
+            .take()
+            .unwrap()
+            .read_to_string(&mut stderr)
+            .map_err(|e| e.to_string())?;
+        return Err(format!(
+            "Nailgun failed to start: exited with {exit_status}, stderr:\n{stderr}"
+        ));
     }
     let port_line = port_line?;
 

--- a/src/rust/process_execution/remote/Cargo.toml
+++ b/src/rust/process_execution/remote/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2021"
+edition = "2024"
 name = "remote"
 authors = ["Pants Build <pantsbuild@gmail.com>"]
 publish = false

--- a/src/rust/process_execution/sandboxer/Cargo.toml
+++ b/src/rust/process_execution/sandboxer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2021"
+edition = "2024"
 name = "sandboxer"
 authors = ["Pants Build <pantsbuild@gmail.com>"]
 publish = false

--- a/src/rust/process_execution/src/lib.rs
+++ b/src/rust/process_execution/src/lib.rs
@@ -1150,12 +1150,12 @@ fn maybe_make_wrapper_script(
                 writeln!(&mut fragment, "/bin/mkdir -p {cache_path}",)
                     .map_err(|err| format!("write! failed: {err:?}"))?;
 
-                if let Some(parent) = path.parent() {
-                    if !parent.as_os_str().is_empty() {
-                        let parent_quoted = quote_path(parent)?;
-                        writeln!(&mut fragment, "/bin/mkdir -p {}", &parent_quoted)
-                            .map_err(|err| format!("write! failed: {err}"))?;
-                    }
+                if let Some(parent) = path.parent()
+                    && !parent.as_os_str().is_empty()
+                {
+                    let parent_quoted = quote_path(parent)?;
+                    writeln!(&mut fragment, "/bin/mkdir -p {}", &parent_quoted)
+                        .map_err(|err| format!("write! failed: {err}"))?;
                 }
                 writeln!(
                     &mut fragment,

--- a/src/rust/process_execution/src/local.rs
+++ b/src/rust/process_execution/src/local.rs
@@ -852,7 +852,7 @@ pub fn setup_run_sh_script(
     }
 
     let stringified_cwd = {
-        let cwd = if let Some(ref working_directory) = working_directory {
+        let cwd = if let Some(working_directory) = working_directory {
             workdir_path.join(working_directory)
         } else {
             workdir_path.to_owned()


### PR DESCRIPTION
Migrate the `process_execution` crates to Rust 2024 Edition. Fixed clippy lints which triggered for (1) combining `if let` statements with `if` statements and (2) not using `ref` when the binding mode in a pattern is already by reference.