### PR TITLE
migrate `options` crate to Rust 2024 Edition

### DIFF
--- a/src/rust/options/Cargo.toml
+++ b/src/rust/options/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2021"
+edition = "2024"
 name = "options"
 authors = ["Pants Build <pantsbuild@gmail.com>"]
 publish = false

--- a/src/rust/options/src/cli_alias.rs
+++ b/src/rust/options/src/cli_alias.rs
@@ -109,11 +109,9 @@ pub fn expand_aliases<I: IntoIterator<Item = String>>(
             expand = false;
         }
         expanded_args.push(arg_str);
-        if expand {
-            if let Some(replacement) = alias_map.0.get(expanded_args.last().unwrap()) {
-                expanded_args.pop();
-                expanded_args.extend(replacement.clone())
-            }
+        if expand && let Some(replacement) = alias_map.0.get(expanded_args.last().unwrap()) {
+            expanded_args.pop();
+            expanded_args.extend(replacement.clone())
         }
     }
     expanded_args

--- a/src/rust/options/src/config.rs
+++ b/src/rust/options/src/config.rs
@@ -275,12 +275,12 @@ impl Config {
             mut imap: InterpolationMap,
             section: Option<&Value>,
         ) -> Result<InterpolationMap, String> {
-            if let Some(section) = section {
-                if let Some(table) = section.as_table() {
-                    for (key, value) in table.iter() {
-                        if let Value::String(s) = value {
-                            imap.insert(key.clone(), s.clone());
-                        }
+            if let Some(section) = section
+                && let Some(table) = section.as_table()
+            {
+                for (key, value) in table.iter() {
+                    if let Value::String(s) = value {
+                        imap.insert(key.clone(), s.clone());
                     }
                 }
             }
@@ -487,13 +487,14 @@ impl ConfigReader {
             if let Some(value) = table.get(&option_name) {
                 match value {
                     Value::Table(sub_table) => {
-                        if let Some(add) = sub_table.get("add") {
-                            if sub_table.len() == 1 && add.is_table() {
-                                return Ok(Some(vec![DictEdit {
-                                    action: DictEditAction::Add,
-                                    items: toml_table_to_dict(add),
-                                }]));
-                            }
+                        if let Some(add) = sub_table.get("add")
+                            && sub_table.len() == 1
+                            && add.is_table()
+                        {
+                            return Ok(Some(vec![DictEdit {
+                                action: DictEditAction::Add,
+                                items: toml_table_to_dict(add),
+                            }]));
                         }
                         return Ok(Some(vec![DictEdit {
                             action: DictEditAction::Replace,

--- a/src/rust/options/src/lib.rs
+++ b/src/rust/options/src/lib.rs
@@ -580,10 +580,10 @@ impl OptionParser {
         };
 
         // Apply the bin name set by the user, if any.
-        if let Ok(val) = parser.parse_string_optional(&option_id!("pants", "bin", "name"), None) {
-            if let Some(bin_name) = val.value {
-                *BIN_NAME.lock() = munge_bin_name(bin_name, &buildroot);
-            }
+        if let Ok(val) = parser.parse_string_optional(&option_id!("pants", "bin", "name"), None)
+            && let Some(bin_name) = val.value
+        {
+            *BIN_NAME.lock() = munge_bin_name(bin_name, &buildroot);
         }
 
         // Step #5: Return the final OptionParser, with any extra specs from spec_files added
@@ -730,10 +730,10 @@ impl OptionParser {
                 }],
             )];
             for (source_type, source) in self.sources.iter() {
-                if let Some(list_edits) = getter(source, id)? {
-                    if !list_edits.is_empty() {
-                        derivations.push((source_type, list_edits));
-                    }
+                if let Some(list_edits) = getter(source, id)?
+                    && !list_edits.is_empty()
+                {
+                    derivations.push((source_type, list_edits));
                 }
             }
             derivation = Some(derivations);
@@ -898,15 +898,15 @@ impl OptionParser {
     ) -> Vec<String> {
         let mut errors = vec![];
         for (source_type, source) in self.sources.iter() {
-            if let Source::Config { ordinal: _, path } = source_type {
-                if let Some(config_reader) = source.as_any().downcast_ref::<ConfigReader>() {
-                    errors.extend(
-                        config_reader
-                            .validate(section_to_valid_keys)
-                            .iter()
-                            .map(|err| format!("{err} in {path}")),
-                    );
-                }
+            if let Source::Config { ordinal: _, path } = source_type
+                && let Some(config_reader) = source.as_any().downcast_ref::<ConfigReader>()
+            {
+                errors.extend(
+                    config_reader
+                        .validate(section_to_valid_keys)
+                        .iter()
+                        .map(|err| format!("{err} in {path}")),
+                );
             }
         }
         errors

--- a/src/rust/options/src/parse.rs
+++ b/src/rust/options/src/parse.rs
@@ -66,7 +66,7 @@ peg::parser! {
         // NB: ##method(X) is an undocumented peg feature expression that calls input.method(pos, X)
         // (see https://github.com/kevinmehall/rust-peg/issues/283).
         rule quoted_character(quote_char: &'static str) -> char
-            = !(##parse_string_literal(quote_char) / "\\x") c:$([_]) { c.chars().next().unwrap() }
+            = !(#{|input, pos| input.parse_string_literal(pos, quote_char)} / "\\x") c:$([_]) { c.chars().next().unwrap() }
 
         // Python string literal escape sequences.
         // See https://docs.python.org/3/reference/lexical_analysis.html#escape-sequences.

--- a/src/rust/options/src/parse.rs
+++ b/src/rust/options/src/parse.rs
@@ -63,8 +63,6 @@ peg::parser! {
         rule single_quoted_character() -> char
             = escaped_character() / quoted_character("'")
 
-        // NB: ##method(X) is an undocumented peg feature expression that calls input.method(pos, X)
-        // (see https://github.com/kevinmehall/rust-peg/issues/283).
         rule quoted_character(quote_char: &'static str) -> char
             = !(#{|input, pos| input.parse_string_literal(pos, quote_char)} / "\\x") c:$([_]) { c.chars().next().unwrap() }
 


### PR DESCRIPTION
Migrate the `options` crate to Rust 2024 Edition. Changes:
- The `##` syntax is now reserved in Rust 2024 Edition and so the peg grammar cannot use it. The `peg` crate considers it undocumented and it is now deprecated and replaced. See https://github.com/kevinmehall/rust-peg/issues/391.
- Collapse some `if let` and `if` statements together.