### PR TITLE
migrate `fs` crates to Rust 2024 Edition

### DIFF
--- a/src/rust/fs/Cargo.toml
+++ b/src/rust/fs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2021"
+edition = "2024"
 name = "fs"
 authors = ["Pants Build <pantsbuild@gmail.com>"]
 publish = false

--- a/src/rust/fs/brfs/Cargo.toml
+++ b/src/rust/fs/brfs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "brfs"
 version = "0.0.1"
-edition = "2021"
+edition = "2024"
 authors = ["Pants Build <pantsbuild@gmail.com>"]
 publish = false
 

--- a/src/rust/fs/fs_util/Cargo.toml
+++ b/src/rust/fs/fs_util/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fs_util"
 version = "0.0.1"
-edition = "2021"
+edition = "2024"
 authors = ["Pants Build <pantsbuild@gmail.com>"]
 publish = false
 

--- a/src/rust/fs/store/Cargo.toml
+++ b/src/rust/fs/store/Cargo.toml
@@ -2,7 +2,7 @@
 name = "store"
 version = "0.1.0"
 authors = ["Daniel Wagner-Hall <dwagnerhall@twitter.com>"]
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 async-stream = { workspace = true }

--- a/src/rust/fs/store/src/cli_options.rs
+++ b/src/rust/fs/store/src/cli_options.rs
@@ -176,7 +176,7 @@ impl StoreCliOpt {
         oauth_bearer_token_path: &Option<PathBuf>,
     ) -> Result<BTreeMap<String, String>, String> {
         let mut headers: BTreeMap<String, String> = collection_from_keyvalues(self.header.iter());
-        if let Some(ref oauth_path) = oauth_bearer_token_path {
+        if let Some(oauth_path) = oauth_bearer_token_path {
             let token = std::fs::read_to_string(oauth_path)
                 .map_err(|e| format!("Error reading oauth bearer token file: {e}"))?;
             headers.insert(


### PR DESCRIPTION
Migrate the `fs` crates to the Rust 2024 Edition. Fix a now collapsible `if` statement and a pattern binding mode issue.