### PR TITLE
migrate various crates to Rust 2024 Edition

### DIFF
--- a/src/rust/address/Cargo.toml
+++ b/src/rust/address/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2021"
+edition = "2024"
 name = "address"
 authors = ["Pants Build <pantsbuild@gmail.com>"]
 publish = false

--- a/src/rust/cache/Cargo.toml
+++ b/src/rust/cache/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cache"
 version = "0.0.1"
-edition = "2021"
+edition = "2024"
 authors = ["Pants Build <pantsbuild@gmail.com>"]
 publish = false
 

--- a/src/rust/client/Cargo.toml
+++ b/src/rust/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2021"
+edition = "2024"
 name = "client"
 authors = ["Pants Build <pantsbuild@gmail.com>"]
 publish = false

--- a/src/rust/client/src/client.rs
+++ b/src/rust/client/src/client.rs
@@ -42,13 +42,13 @@ pub async fn execute_command(
                 debug!("Failed to save terminal attributes for file descriptor {raw_fd}: {err}")
             }
         }
-        if connection_settings.dynamic_ui {
-            if let Ok(path) = nix::unistd::ttyname(*raw_fd) {
-                env.push((
-                    format!("NAILGUN_TTY_PATH_{raw_fd}"),
-                    path.display().to_string(),
-                ));
-            }
+        if connection_settings.dynamic_ui
+            && let Ok(path) = nix::unistd::ttyname(*raw_fd)
+        {
+            env.push((
+                format!("NAILGUN_TTY_PATH_{raw_fd}"),
+                path.display().to_string(),
+            ));
         }
     }
 

--- a/src/rust/concrete_time/Cargo.toml
+++ b/src/rust/concrete_time/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2021"
+edition = "2024"
 authors = ["Pants Build <pantsbuild@gmail.com>"]
 name = "concrete_time"
 publish = false

--- a/src/rust/hashing/Cargo.toml
+++ b/src/rust/hashing/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hashing"
 version = "0.0.1"
-edition = "2021"
+edition = "2024"
 authors = ["Pants Build <pantsbuild@gmail.com>"]
 publish = false
 

--- a/src/rust/logging/Cargo.toml
+++ b/src/rust/logging/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2021"
+edition = "2024"
 name = "logging"
 authors = ["Pants Build <pantsbuild@gmail.com>"]
 publish = false


### PR DESCRIPTION
Migrate the `address`, `cache`, `client`, `concrete_time`, `hashing`, and `logging` crates to Rust 2024 Edition. Only code change is collapsing an `if let` statement in one crate.