### PR TITLE
migrate most remaining crates to Rust 2024 Edition

### DIFF
--- a/src/rust/engine/src/session.rs
+++ b/src/rust/engine/src/session.rs
@@ -366,7 +366,7 @@ impl Session {
                                 .into_iter()
                                 .map(|(duration, desc)| format!(
                                     "{}\t{}",
-                                    format_workunit_duration_ms!(duration.as_millis()),
+                                    format_workunit_duration_ms(duration),
                                     desc
                                 ))
                                 .collect::<Vec<_>>()

--- a/src/rust/nailgun/Cargo.toml
+++ b/src/rust/nailgun/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2021"
+edition = "2024"
 name = "nailgun"
 authors = ["Pants Build <pantsbuild@gmail.com>"]
 publish = false

--- a/src/rust/pantsd/Cargo.toml
+++ b/src/rust/pantsd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2021"
+edition = "2024"
 name = "pantsd"
 authors = ["Pants Build <pantsbuild@gmail.com>"]
 publish = false

--- a/src/rust/process_executor/Cargo.toml
+++ b/src/rust/process_executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2021"
+edition = "2024"
 name = "process_executor"
 authors = ["Pants Build <pantsbuild@gmail.com>"]
 publish = false

--- a/src/rust/protos/Cargo.toml
+++ b/src/rust/protos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2021"
+edition = "2024"
 name = "protos"
 authors = ["Pants Build <pantsbuild@gmail.com>"]
 publish = false

--- a/src/rust/protos/src/verification.rs
+++ b/src/rust/protos/src/verification.rs
@@ -56,14 +56,14 @@ where
                 "All children must have one path segment, but found {name}"
             ));
         }
-        if let Some(p) = prev {
-            if name <= get_name(p) {
-                return Err(format!(
-                    "Children must be sorted and unique, but {} was before {}",
-                    get_name(p),
-                    name,
-                ));
-            }
+        if let Some(p) = prev
+            && name <= get_name(p)
+        {
+            return Err(format!(
+                "Children must be sorted and unique, but {} was before {}",
+                get_name(p),
+                name,
+            ));
         }
         prev = Some(node);
     }

--- a/src/rust/sharded_lmdb/Cargo.toml
+++ b/src/rust/sharded_lmdb/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sharded_lmdb"
 version = "0.0.1"
 authors = ["Pants Build <pantsbuild@gmail.com>"]
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 bytes = { workspace = true }

--- a/src/rust/stdio/Cargo.toml
+++ b/src/rust/stdio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2021"
+edition = "2024"
 name = "stdio"
 authors = ["Pants Build <pantsbuild@gmail.com>"]
 publish = false

--- a/src/rust/task_executor/Cargo.toml
+++ b/src/rust/task_executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2024"
+edition = "2021"
 name = "task_executor"
 authors = ["Pants Build <pantsbuild@gmail.com>"]
 publish = false

--- a/src/rust/task_executor/Cargo.toml
+++ b/src/rust/task_executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2021"
+edition = "2024"
 name = "task_executor"
 authors = ["Pants Build <pantsbuild@gmail.com>"]
 publish = false

--- a/src/rust/testutil/Cargo.toml
+++ b/src/rust/testutil/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2021"
+edition = "2024"
 name = "testutil"
 authors = ["Pants Build <pantsbuild@gmail.com>"]
 publish = false

--- a/src/rust/testutil/local_cas/Cargo.toml
+++ b/src/rust/testutil/local_cas/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "local_cas"
 version = "0.0.1"
-edition = "2021"
+edition = "2024"
 authors = ["Pants Build <pantsbuild@gmail.com>"]
 publish = false
 

--- a/src/rust/testutil/local_execution_server/Cargo.toml
+++ b/src/rust/testutil/local_execution_server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "local_execution_server"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 authors = ["Pants Build <pantsbuild@gmail.com>"]
 publish = false
 

--- a/src/rust/testutil/mock/Cargo.toml
+++ b/src/rust/testutil/mock/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mock"
 version = "0.0.1"
-edition = "2021"
+edition = "2024"
 authors = ["Pants Build <pantsbuild@gmail.com>"]
 publish = false
 

--- a/src/rust/tryfuture/Cargo.toml
+++ b/src/rust/tryfuture/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2021"
+edition = "2024"
 name = "tryfuture"
 authors = ["Pants Build <pantsbuild@gmail.com>"]
 publish = false

--- a/src/rust/ui/Cargo.toml
+++ b/src/rust/ui/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ui"
 version = "0.0.1"
-edition = "2021"
+edition = "2024"
 authors = ["Pants Build <pantsbuild@gmail.com>"]
 
 [dependencies]

--- a/src/rust/ui/src/instance/indicatif.rs
+++ b/src/rust/ui/src/instance/indicatif.rs
@@ -98,9 +98,7 @@ impl IndicatifInstance {
                 let (label, start_time) = heavy_hitters.get(span_id).unwrap();
                 let duration_label = match now.duration_since(*start_time).ok() {
                     None => "(Waiting)".to_string(),
-                    Some(duration) => {
-                        format_workunit_duration_ms!((duration).as_millis()).to_string()
-                    }
+                    Some(duration) => format_workunit_duration_ms(duration),
                 };
                 format!("{duration_label} {label}")
             });

--- a/src/rust/ui/src/instance/prodash.rs
+++ b/src/rust/ui/src/instance/prodash.rs
@@ -166,8 +166,8 @@ impl prodash::unit::DisplayValue for MillisAsFloatingPointSecs {
     ) -> fmt::Result {
         // Convert back from millis-since-epoch to millis elapsed.
         let start_time = UNIX_EPOCH + Duration::from_millis(value as u64);
-        let elapsed_ms = start_time.elapsed().map(|d| d.as_millis()).unwrap_or(0);
-        w.write_fmt(format_workunit_duration_ms!(elapsed_ms))
+        let elapsed_ms = start_time.elapsed().unwrap_or_else(|_| Duration::new(0, 0));
+        w.write_str(&format_workunit_duration_ms(elapsed_ms))
     }
     fn display_unit(&self, _w: &mut dyn fmt::Write, _value: Step) -> fmt::Result {
         Ok(())

--- a/src/rust/watch/Cargo.toml
+++ b/src/rust/watch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2021"
+edition = "2024"
 name = "watch"
 authors = ["Pants Build <pantsbuild@gmail.com>"]
 publish = false

--- a/src/rust/workunit_store/Cargo.toml
+++ b/src/rust/workunit_store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2021"
+edition = "2024"
 name = "workunit_store"
 authors = ["Pants Build <pantsbuild@gmail.com>"]
 publish = false

--- a/src/rust/workunit_store/src/lib.rs
+++ b/src/rust/workunit_store/src/lib.rs
@@ -912,13 +912,12 @@ impl RunningWorkunit {
     where
         F: FnOnce(Option<(WorkunitMetadata, Level)>) -> Option<(WorkunitMetadata, Level)>,
     {
-        if let Some(ref mut workunit) = self.workunit {
-            if let Some((metadata, level)) =
+        if let Some(ref mut workunit) = self.workunit
+            && let Some((metadata, level)) =
                 f(workunit.metadata.clone().map(|m| (m, workunit.level)))
-            {
-                workunit.level = level;
-                workunit.metadata = Some(metadata);
-            }
+        {
+            workunit.level = level;
+            workunit.metadata = Some(metadata);
         }
     }
 
@@ -927,11 +926,11 @@ impl RunningWorkunit {
     ///
     pub fn blocking(&mut self) -> BlockingWorkunitToken {
         let mut token = BlockingWorkunitToken(None);
-        if let Some(ref mut workunit) = self.workunit {
-            if let WorkunitState::Started { blocked, .. } = &mut workunit.state {
-                blocked.store(true, atomic::Ordering::Relaxed);
-                token.0 = Some(blocked.clone());
-            }
+        if let Some(ref mut workunit) = self.workunit
+            && let WorkunitState::Started { blocked, .. } = &mut workunit.state
+        {
+            blocked.store(true, atomic::Ordering::Relaxed);
+            token.0 = Some(blocked.clone());
         }
         token
     }

--- a/src/rust/workunit_store/src/lib.rs
+++ b/src/rust/workunit_store/src/lib.rs
@@ -770,9 +770,8 @@ impl WorkunitStore {
     }
 }
 
-#[macro_export]
-macro_rules! format_workunit_duration_ms {
-    ($workunit_duration_ms:expr) => {{ format_args!("{:.2}s", ($workunit_duration_ms as f64) / 1000.0) }};
+pub fn format_workunit_duration_ms(duration: Duration) -> String {
+    format!("{:.2}s", (duration.as_millis() as f64) / 1000.0)
 }
 
 ///


### PR DESCRIPTION
Migrate most of the remaining crates to Rust 2024 Edition. Basically, `task_executor` is excluded from this PR due to `task_executor::Executor::spawn_blocking` needing some further thought.