### PR TITLE
Get rid of TestCase classes in rules_test.py.

### DIFF
--- a/src/python/pants/engine/rules_test.py
+++ b/src/python/pants/engine/rules_test.py
@@ -278,32 +278,35 @@ async def a_goal_rule_generator(console: Console) -> Example:
     return Example(exit_code=0)
 
 
-class TestRule:
-    def test_run_rule_goal_rule_generator(self) -> None:
-        res = run_rule_with_mocks(
-            a_goal_rule_generator,
-            rule_args=[Console()],
-            mock_calls={"pants.engine.rules_test.str_to_a": lambda _: A()},
-        )
-        assert res == Example(0)
+# Rule tests
 
-    def test_side_effecting_inputs(self) -> None:
-        @goal_rule
-        async def valid_rule(console: Console, b: str) -> Example:
-            return Example(exit_code=0)
 
-        with pytest.raises(ValueError) as cm:
+def test_run_rule_goal_rule_generator() -> None:
+    res = run_rule_with_mocks(
+        a_goal_rule_generator,
+        rule_args=[Console()],
+        mock_calls={"pants.engine.rules_test.str_to_a": lambda _: A()},
+    )
+    assert res == Example(0)
 
-            @rule
-            async def invalid_rule(console: Console, b: str) -> bool:
-                return False
 
-        error_str = str(cm.value)
-        assert (
-            "(@rule pants.engine.rules_test:invalid_rule) may not have a side-effecting parameter"
-            in error_str
-        )
-        assert "pants.engine.console.Console" in error_str
+def test_side_effecting_inputs() -> None:
+    @goal_rule
+    async def valid_rule(console: Console, b: str) -> Example:
+        return Example(exit_code=0)
+
+    with pytest.raises(ValueError) as cm:
+
+        @rule
+        async def invalid_rule(console: Console, b: str) -> bool:
+            return False
+
+    error_str = str(cm.value)
+    assert (
+        "(@rule pants.engine.rules_test:invalid_rule) may not have a side-effecting parameter"
+        in error_str
+    )
+    assert "pants.engine.console.Console" in error_str
 
 
 def test_rule_index_creation_fails_with_bad_declaration_type():
@@ -315,87 +318,96 @@ def test_rule_index_creation_fails_with_bad_declaration_type():
     )
 
 
-class TestRuleArgumentAnnotation:
-    def test_annotations_kwargs(self) -> None:
-        @rule(level=LogLevel.INFO)
+# Rule argument annotation tests
+def test_annotations_kwargs() -> None:
+    @rule(level=LogLevel.INFO)
+    async def a_named_rule(a: int, b: str) -> bool:
+        return False
+
+    assert a_named_rule.rule is not None  # type: ignore[attr-defined]
+    assert (
+        a_named_rule.rule.canonical_name  # type: ignore[attr-defined]
+        == "pants.engine.rules_test.test_annotations_kwargs.a_named_rule"
+    )
+    assert a_named_rule.rule.desc is None  # type: ignore[attr-defined]
+    assert a_named_rule.rule.level == LogLevel.INFO  # type: ignore[attr-defined]
+
+    @rule(canonical_name="something_different", desc="Human readable desc")
+    async def another_named_rule(a: int, b: str) -> bool:
+        return False
+
+    assert a_named_rule.rule is not None  # type: ignore[attr-defined]
+    assert another_named_rule.rule.canonical_name == "something_different"  # type: ignore[attr-defined]
+    assert another_named_rule.rule.desc == "Human readable desc"  # type: ignore[attr-defined]
+    assert another_named_rule.rule.level == LogLevel.TRACE  # type: ignore[attr-defined]
+
+
+def test_bogus_rules() -> None:
+    with pytest.raises(UnrecognizedRuleArgument):
+
+        @rule(bogus_kwarg="TOTALLY BOGUS!!!!!!")  # type: ignore
         async def a_named_rule(a: int, b: str) -> bool:
             return False
 
-        assert a_named_rule.rule is not None  # type: ignore[attr-defined]
-        assert (
-            a_named_rule.rule.canonical_name  # type: ignore[attr-defined]
-            == "pants.engine.rules_test.TestRuleArgumentAnnotation.test_annotations_kwargs.a_named_rule"
-        )
-        assert a_named_rule.rule.desc is None  # type: ignore[attr-defined]
-        assert a_named_rule.rule.level == LogLevel.INFO  # type: ignore[attr-defined]
 
-        @rule(canonical_name="something_different", desc="Human readable desc")
-        async def another_named_rule(a: int, b: str) -> bool:
-            return False
+def test_goal_rule_automatically_gets_desc_from_goal():
+    @goal_rule
+    async def some_goal_rule() -> Example:
+        return Example(exit_code=0)
 
-        assert a_named_rule.rule is not None  # type: ignore[attr-defined]
-        assert another_named_rule.rule.canonical_name == "something_different"  # type: ignore[attr-defined]
-        assert another_named_rule.rule.desc == "Human readable desc"  # type: ignore[attr-defined]
-        assert another_named_rule.rule.level == LogLevel.TRACE  # type: ignore[attr-defined]
-
-    def test_bogus_rules(self) -> None:
-        with pytest.raises(UnrecognizedRuleArgument):
-
-            @rule(bogus_kwarg="TOTALLY BOGUS!!!!!!")  # type: ignore
-            async def a_named_rule(a: int, b: str) -> bool:
-                return False
-
-    def test_goal_rule_automatically_gets_desc_from_goal(self):
-        @goal_rule
-        async def some_goal_rule() -> Example:
-            return Example(exit_code=0)
-
-        assert some_goal_rule.rule.desc == "`example` goal"
-
-    def test_can_override_goal_rule_name(self) -> None:
-        @goal_rule(canonical_name="some_other_name")
-        async def some_goal_rule() -> Example:
-            return Example(exit_code=0)
-
-        name = some_goal_rule.rule.canonical_name  # type: ignore[attr-defined]
-        assert name == "some_other_name"
+    assert some_goal_rule.rule.desc == "`example` goal"
 
 
-class TestGraphVertexTypeAnnotation:
-    def test_nominal(self):
+def test_can_override_goal_rule_name() -> None:
+    @goal_rule(canonical_name="some_other_name")
+    async def some_goal_rule() -> Example:
+        return Example(exit_code=0)
+
+    name = some_goal_rule.rule.canonical_name  # type: ignore[attr-defined]
+    assert name == "some_other_name"
+
+
+# Graph vertex type annotation tests
+
+
+def test_nominal():
+    @rule
+    async def dry(a: int, b: str, c: float) -> bool:
+        return False
+
+    assert dry.rule is not None
+
+
+def test_missing_return_annotation() -> None:
+    with pytest.raises(MissingReturnTypeAnnotation):
+
         @rule
-        async def dry(a: int, b: str, c: float) -> bool:
+        async def dry(a: int, b: str, c: float):
             return False
 
-        assert dry.rule is not None
 
-    def test_missing_return_annotation(self) -> None:
-        with pytest.raises(MissingReturnTypeAnnotation):
+def test_bad_return_annotation():
+    with pytest.raises(MissingReturnTypeAnnotation):
 
-            @rule
-            async def dry(a: int, b: str, c: float):
-                return False
+        @rule
+        async def dry(a: int, b: str, c: float) -> 42:
+            return False
 
-    def test_bad_return_annotation(self):
-        with pytest.raises(MissingReturnTypeAnnotation):
 
-            @rule
-            async def dry(a: int, b: str, c: float) -> 42:
-                return False
+def test_missing_parameter_annotation() -> None:
+    with pytest.raises(MissingParameterTypeAnnotation):
 
-    def test_missing_parameter_annotation(self) -> None:
-        with pytest.raises(MissingParameterTypeAnnotation):
+        @rule
+        async def dry(a: int, b, c: float) -> bool:
+            return False
 
-            @rule
-            async def dry(a: int, b, c: float) -> bool:
-                return False
 
-    def test_bad_parameter_annotation(self):
-        with pytest.raises(MissingParameterTypeAnnotation):
+def test_bad_parameter_annotation():
+    with pytest.raises(MissingParameterTypeAnnotation):
 
-            @rule
-            async def dry(a: int, b: 42, c: float) -> bool:
-                return False
+        @rule
+        async def dry(a: int, b: 42, c: float) -> bool:
+            return False
 
 
 def test_goal_rule_not_properly_marked_goal_rule() -> None:
@@ -421,471 +433,489 @@ def test_goal_rule_not_returning_a_goal() -> None:
     assert str(exc.value) == "An `@goal_rule` must return a subclass of `engine.goal.Goal`."
 
 
-class TestRuleGraph:
-    def test_ruleset_with_ambiguity(self) -> None:
-        @rule
-        async def a_from_b_and_c(b: B, c: C) -> A:
-            return A()
+# Rule graph tests
 
-        @rule
-        async def a_from_c_and_b(c: C, b: B) -> A:
-            return A()
 
-        rules = [a_from_b_and_c, a_from_c_and_b, QueryRule(A, (B, C))]
-        with pytest.raises(Exception) as cm:
-            create_scheduler(rules)
+def test_ruleset_with_ambiguity() -> None:
+    @rule
+    async def a_from_b_and_c(b: B, c: C) -> A:
+        return A()
 
-        assert_equal_graph_output(
-            dedent(
-                f"""\
-                Encountered 1 rule graph error:
-                  Too many sources of dependency A for Query(A for (B, C)): [
-                        "{fmt_rule(a_from_c_and_b)} (for (B, C))",
-                        "{fmt_rule(a_from_b_and_c)} (for (B, C))",
-                    ]
-                """
-            ),
-            str(cm.value),
-        )
+    @rule
+    async def a_from_c_and_b(c: C, b: B) -> A:
+        return A()
 
-    def test_ruleset_with_valid_root(self) -> None:
-        @rule
-        async def a_from_b(b: B) -> A:
-            return A()
-
-        rules = [a_from_b, QueryRule(A, (B,))]
+    rules = [a_from_b_and_c, a_from_c_and_b, QueryRule(A, (B, C))]
+    with pytest.raises(Exception) as cm:
         create_scheduler(rules)
 
-    def test_ruleset_with_unreachable_root(self) -> None:
-        @rule
-        async def a_from_b(b: B) -> A:
-            return A()
+    assert_equal_graph_output(
+        dedent(
+            f"""\
+            Encountered 1 rule graph error:
+                Too many sources of dependency A for Query(A for (B, C)): [
+                    "{fmt_rule(a_from_c_and_b)} (for (B, C))",
+                    "{fmt_rule(a_from_b_and_c)} (for (B, C))",
+                ]
+            """
+        ),
+        str(cm.value),
+    )
 
-        rules = [a_from_b, QueryRule(A, ())]
-        with pytest.raises(Exception) as cm:
-            create_scheduler(rules)
-        assert (
-            "No installed rules return the type B, and it was not provided by potential callers of "
-        ) in str(cm.value)
-        assert (
-            "If that type should be computed by a rule, ensure that that rule is installed."
-        ) in str(cm.value)
-        assert (
-            "If it should be provided by a caller, ensure that it is included in any relevant "
-            "Query or Get."
-        ) in str(cm.value)
 
-    def test_smallest_full_test(self) -> None:
-        @rule
-        async def a_from_suba(suba: SubA) -> A:
-            return A()
+def test_ruleset_with_valid_root() -> None:
+    @rule
+    async def a_from_b(b: B) -> A:
+        return A()
 
-        rules = [a_from_suba, QueryRule(A, (SubA,))]
-        fullgraph = self.create_full_graph(rules)
-        assert_equal_graph_output(
-            dedent(
-                f"""\
-                digraph {{
-                  /*
-                  queries:
-                       Query(A for SubA)
-                  */
-                  // root entries
-                {fmt_non_param_edge(A, SubA)}
-                {fmt_non_param_edge(A, SubA, RuleFormatRequest(a_from_suba))}
-                  // internal entries
-                {fmt_param_edge(SubA, SubA, RuleFormatRequest(a_from_suba))}
-                }}"""
-            ).strip(),
-            fullgraph,
-        )
+    rules = [a_from_b, QueryRule(A, (B,))]
+    create_scheduler(rules)
 
-    def test_smallest_full_test_multiple_root_subject_types(self) -> None:
-        @rule
-        async def a_from_suba(suba: SubA) -> A:
-            return A()
 
-        @rule
-        async def b_from_a(a: A) -> B:
-            return B()
+def test_ruleset_with_unreachable_root() -> None:
+    @rule
+    async def a_from_b(b: B) -> A:
+        return A()
 
-        rules = [a_from_suba, QueryRule(A, (SubA,)), b_from_a, QueryRule(B, (A,))]
-        fullgraph = self.create_full_graph(rules)
-        assert_equal_graph_output(
-            dedent(
-                f"""\
-                digraph {{
-                  /*
-                  queries:
-                    Query(A for SubA),
-                    Query(B for A)
-                  */
-                  // root entries
-                {fmt_non_param_edge(A, SubA)}
-                {fmt_non_param_edge(A, SubA, RuleFormatRequest(a_from_suba))}
-                {fmt_non_param_edge(B, A)}
-                {fmt_non_param_edge(B, A, RuleFormatRequest(b_from_a))}
-                  // internal entries
-                {fmt_param_edge(A, A, RuleFormatRequest(b_from_a))}
-                {fmt_param_edge(SubA, SubA, RuleFormatRequest(a_from_suba))}
-                }}"""
-            ).strip(),
-            fullgraph,
-        )
+    rules = [a_from_b, QueryRule(A, ())]
+    with pytest.raises(Exception) as cm:
+        create_scheduler(rules)
+    assert (
+        "No installed rules return the type B, and it was not provided by potential callers of "
+    ) in str(cm.value)
+    assert (
+        "If that type should be computed by a rule, ensure that that rule is installed."
+    ) in str(cm.value)
+    assert (
+        "If it should be provided by a caller, ensure that it is included in any relevant "
+        "Query or Get."
+    ) in str(cm.value)
 
-    def test_single_rule_depending_on_subject_selection(self) -> None:
-        @rule
-        async def a_from_suba(suba: SubA) -> A:
-            return A()
 
-        rules = [a_from_suba, QueryRule(A, (SubA,))]
-        subgraph = self.create_subgraph(A, rules, SubA())
-        assert_equal_graph_output(
-            dedent(
-                f"""\
-                digraph {{
-                  /*
-                  queries:
+def test_smallest_full_test() -> None:
+    @rule
+    async def a_from_suba(suba: SubA) -> A:
+        return A()
+
+    rules = [a_from_suba, QueryRule(A, (SubA,))]
+    fullgraph = create_full_graph(rules)
+    assert_equal_graph_output(
+        dedent(
+            f"""\
+            digraph {{
+                /*
+                queries:
                     Query(A for SubA)
-                  */
-                  // root entries
-                {fmt_non_param_edge(A, SubA)}
-                {fmt_non_param_edge(A, SubA, RuleFormatRequest(a_from_suba))}
-                  // internal entries
-                {fmt_param_edge(SubA, SubA, RuleFormatRequest(a_from_suba))}
-                }}"""
-            ).strip(),
-            subgraph,
-        )
+                */
+                // root entries
+            {fmt_non_param_edge(A, SubA)}
+            {fmt_non_param_edge(A, SubA, RuleFormatRequest(a_from_suba))}
+                // internal entries
+            {fmt_param_edge(SubA, SubA, RuleFormatRequest(a_from_suba))}
+            }}"""
+        ).strip(),
+        fullgraph,
+    )
 
-    def test_multiple_selects(self) -> None:
-        @rule
-        async def a_from_suba_and_b(suba: SubA, b: B) -> A:
-            return A()
 
-        @rule
-        async def b() -> B:
-            return B()
+def test_smallest_full_test_multiple_root_subject_types() -> None:
+    @rule
+    async def a_from_suba(suba: SubA) -> A:
+        return A()
 
-        rules = [a_from_suba_and_b, b, QueryRule(A, (SubA,))]
-        subgraph = self.create_subgraph(A, rules, SubA())
-        assert_equal_graph_output(
-            dedent(
-                f"""\
-                digraph {{
-                  /*
-                  queries:
-                    Query(A for SubA)
-                  */
-                  // root entries
-                {fmt_non_param_edge(A, SubA)}
-                {fmt_non_param_edge(A, SubA, RuleFormatRequest(a_from_suba_and_b))}
-                  // internal entries
-                {fmt_non_param_edge(b, (), rule_type=GraphVertexType.inner)}
-                {fmt_non_param_edge(b, (), rule_type=GraphVertexType.singleton)}
-                {fmt_param_edge(SubA, SubA, RuleFormatRequest(a_from_suba_and_b), RuleFormatRequest(b, ()))}
-                }}"""
-            ).strip(),
-            subgraph,
-        )
+    @rule
+    async def b_from_a(a: A) -> B:
+        return B()
 
-    def test_one_level_of_recursion(self) -> None:
-        @rule
-        async def a_from_b(b: B) -> A:
-            return A()
+    rules = [a_from_suba, QueryRule(A, (SubA,)), b_from_a, QueryRule(B, (A,))]
+    fullgraph = create_full_graph(rules)
+    assert_equal_graph_output(
+        dedent(
+            f"""\
+            digraph {{
+                /*
+                queries:
+                Query(A for SubA),
+                Query(B for A)
+                */
+                // root entries
+            {fmt_non_param_edge(A, SubA)}
+            {fmt_non_param_edge(A, SubA, RuleFormatRequest(a_from_suba))}
+            {fmt_non_param_edge(B, A)}
+            {fmt_non_param_edge(B, A, RuleFormatRequest(b_from_a))}
+                // internal entries
+            {fmt_param_edge(A, A, RuleFormatRequest(b_from_a))}
+            {fmt_param_edge(SubA, SubA, RuleFormatRequest(a_from_suba))}
+            }}"""
+        ).strip(),
+        fullgraph,
+    )
 
-        @rule
-        async def b_from_suba(suba: SubA) -> B:
-            return B()
 
-        rules = [a_from_b, b_from_suba, QueryRule(A, (SubA,))]
-        subgraph = self.create_subgraph(A, rules, SubA())
-        assert_equal_graph_output(
-            dedent(
-                f"""\
-                digraph {{
-                  /*
-                  queries:
-                    Query(A for SubA)
-                  */
-                  // root entries
-                {fmt_non_param_edge(A, SubA)}
-                {fmt_non_param_edge(A, SubA, RuleFormatRequest(a_from_b))}
-                  // internal entries
-                {fmt_non_param_edge(a_from_b, SubA, RuleFormatRequest(b_from_suba))}
-                {fmt_param_edge(SubA, SubA, via_func=RuleFormatRequest(b_from_suba))}
-                }}"""
-            ).strip(),
-            subgraph,
-        )
+def test_single_rule_depending_on_subject_selection() -> None:
+    @rule
+    async def a_from_suba(suba: SubA) -> A:
+        return A()
 
-    @pytest.mark.skip(reason="TODO(#10649): figure out if this tests is still relevant.")
-    @pytest.mark.no_error_if_skipped
-    def test_noop_removal_in_subgraph(self) -> None:
-        @rule
-        async def a_from_c(c: C) -> A:
-            return A()
+    rules = [a_from_suba, QueryRule(A, (SubA,))]
+    subgraph = create_subgraph(A, rules, SubA())
+    assert_equal_graph_output(
+        dedent(
+            f"""\
+            digraph {{
+                /*
+                queries:
+                Query(A for SubA)
+                */
+                // root entries
+            {fmt_non_param_edge(A, SubA)}
+            {fmt_non_param_edge(A, SubA, RuleFormatRequest(a_from_suba))}
+                // internal entries
+            {fmt_param_edge(SubA, SubA, RuleFormatRequest(a_from_suba))}
+            }}"""
+        ).strip(),
+        subgraph,
+    )
 
-        @rule
-        async def a() -> A:
-            return A()
 
-        @rule
-        async def b_singleton() -> B:
-            return B()
+def test_multiple_selects() -> None:
+    @rule
+    async def a_from_suba_and_b(suba: SubA, b: B) -> A:
+        return A()
 
-        rules = [a_from_c, a, b_singleton, QueryRule(A, (SubA,))]
-        subgraph = self.create_subgraph(A, rules, SubA(), validate=False)
-        assert_equal_graph_output(
-            dedent(
-                f"""\
-                digraph {{
-                  /*
-                  queries:
-                    Query(A for SubA)
-                  */
-                  // root entries
-                {fmt_non_param_edge(A, ())}
-                {fmt_non_param_edge(a, (), rule_type=GraphVertexType.singleton)}
-                {fmt_non_param_edge(A, (), RuleFormatRequest(a))}
-                  // internal entries
-                {fmt_non_param_edge(a, (), rule_type=GraphVertexType.inner)}
-                }}"""
-            ).strip(),
-            subgraph,
-        )
+    @rule
+    async def b() -> B:
+        return B()
 
-    @pytest.mark.skip(reason="TODO(#10649): figure out if this tests is still relevant.")
-    @pytest.mark.no_error_if_skipped
-    def test_noop_removal_full_single_subject_type(self) -> None:
-        @rule
-        async def a_from_c(c: C) -> A:
-            return A()
+    rules = [a_from_suba_and_b, b, QueryRule(A, (SubA,))]
+    subgraph = create_subgraph(A, rules, SubA())
+    assert_equal_graph_output(
+        dedent(
+            f"""\
+            digraph {{
+                /*
+                queries:
+                Query(A for SubA)
+                */
+                // root entries
+            {fmt_non_param_edge(A, SubA)}
+            {fmt_non_param_edge(A, SubA, RuleFormatRequest(a_from_suba_and_b))}
+                // internal entries
+            {fmt_non_param_edge(b, (), rule_type=GraphVertexType.inner)}
+            {fmt_non_param_edge(b, (), rule_type=GraphVertexType.singleton)}
+            {fmt_param_edge(SubA, SubA, RuleFormatRequest(a_from_suba_and_b), RuleFormatRequest(b, ()))}
+            }}"""
+        ).strip(),
+        subgraph,
+    )
 
-        @rule
-        async def a() -> A:
-            return A()
 
-        rules = [a_from_c, a, QueryRule(A, (SubA,))]
-        fullgraph = self.create_full_graph(rules, validate=False)
-        assert_equal_graph_output(
-            dedent(
-                f"""\
-                digraph {{
-                  /*
-                  queries:
-                    Query(A for SubA)
-                  */
-                  // root entries
-                {fmt_non_param_edge(A, ())}
-                {fmt_non_param_edge(a, (), rule_type=GraphVertexType.singleton)}
-                {fmt_non_param_edge(A, (), RuleFormatRequest(a))}
-                  // internal entries
-                {fmt_non_param_edge(a, (), rule_type=GraphVertexType.inner)}
-                }}"""
-            ).strip(),
-            fullgraph,
-        )
+def test_one_level_of_recursion() -> None:
+    @rule
+    async def a_from_b(b: B) -> A:
+        return A()
 
-    @pytest.mark.skip(reason="TODO(#10649): figure out if this tests is still relevant.")
-    @pytest.mark.no_error_if_skipped
-    def test_root_tuple_removed_when_no_matches(self) -> None:
-        @rule
-        async def a_from_c(c: C) -> A:
-            return A()
+    @rule
+    async def b_from_suba(suba: SubA) -> B:
+        return B()
 
-        @rule
-        async def b_from_d_and_a(d: D, a: A) -> B:
-            return B()
+    rules = [a_from_b, b_from_suba, QueryRule(A, (SubA,))]
+    subgraph = create_subgraph(A, rules, SubA())
+    assert_equal_graph_output(
+        dedent(
+            f"""\
+            digraph {{
+                /*
+                queries:
+                Query(A for SubA)
+                */
+                // root entries
+            {fmt_non_param_edge(A, SubA)}
+            {fmt_non_param_edge(A, SubA, RuleFormatRequest(a_from_b))}
+                // internal entries
+            {fmt_non_param_edge(a_from_b, SubA, RuleFormatRequest(b_from_suba))}
+            {fmt_param_edge(SubA, SubA, via_func=RuleFormatRequest(b_from_suba))}
+            }}"""
+        ).strip(),
+        subgraph,
+    )
 
-        rules = [
-            a_from_c,
-            b_from_d_and_a,
-        ]
 
-        fullgraph = self.create_full_graph(rules, validate=False)
+@pytest.mark.skip(reason="TODO(#10649): figure out if this tests is still relevant.")
+@pytest.mark.no_error_if_skipped
+def test_noop_removal_in_subgraph() -> None:
+    @rule
+    async def a_from_c(c: C) -> A:
+        return A()
 
-        assert_equal_graph_output(
-            dedent(
-                f"""\
-                digraph {{
-                  // root subject types: C, D
-                  // root entries
-                {fmt_non_param_edge(A, C)}
-                {fmt_non_param_edge(A, C, RuleFormatRequest(a_from_c))}
-                {fmt_non_param_edge(B, (C, D))}
-                {fmt_non_param_edge(B, (C, D), RuleFormatRequest(b_from_d_and_a))}
-                  // internal entries
-                {fmt_param_edge(C, C, RuleFormatRequest(a_from_c))}
-                {fmt_param_edge(D, (C, D), RuleFormatRequest(b_from_d_and_a), return_func=RuleFormatRequest(a_from_c, C))}
-                }}"""
-            ).strip(),
-            fullgraph,
-        )
+    @rule
+    async def a() -> A:
+        return A()
 
-    @pytest.mark.skip(reason="TODO(#10649): figure out if this tests is still relevant.")
-    @pytest.mark.no_error_if_skipped
-    def test_noop_removal_transitive(self) -> None:
-        # If a noop-able rule has rules that depend on it,
-        # they should be removed from the graph.
+    @rule
+    async def b_singleton() -> B:
+        return B()
 
-        @rule
-        async def b_from_c(c: C) -> B:
-            return B()
+    rules = [a_from_c, a, b_singleton, QueryRule(A, (SubA,))]
+    subgraph = create_subgraph(A, rules, SubA(), validate=False)
+    assert_equal_graph_output(
+        dedent(
+            f"""\
+            digraph {{
+                /*
+                queries:
+                Query(A for SubA)
+                */
+                // root entries
+            {fmt_non_param_edge(A, ())}
+            {fmt_non_param_edge(a, (), rule_type=GraphVertexType.singleton)}
+            {fmt_non_param_edge(A, (), RuleFormatRequest(a))}
+                // internal entries
+            {fmt_non_param_edge(a, (), rule_type=GraphVertexType.inner)}
+            }}"""
+        ).strip(),
+        subgraph,
+    )
 
-        @rule
-        async def a_from_b(b: B) -> A:
-            return A()
 
-        @rule
-        async def a() -> A:
-            return A()
+@pytest.mark.skip(reason="TODO(#10649): figure out if this tests is still relevant.")
+@pytest.mark.no_error_if_skipped
+def test_noop_removal_full_single_subject_type() -> None:
+    @rule
+    async def a_from_c(c: C) -> A:
+        return A()
 
-        rules = [
-            b_from_c,
-            a_from_b,
-            a,
-        ]
-        subgraph = self.create_subgraph(A, rules, SubA(), validate=False)
+    @rule
+    async def a() -> A:
+        return A()
 
-        assert_equal_graph_output(
-            dedent(
-                f"""\
-                digraph {{
-                  // root subject types: SubA
-                  // root entries
-                {fmt_non_param_edge(A, ())}
-                {fmt_non_param_edge(a, (), rule_type=GraphVertexType.singleton)}
-                {fmt_non_param_edge(A, (), RuleFormatRequest(a))}
-                  // internal entries
-                {fmt_non_param_edge(a, (), rule_type=GraphVertexType.inner)}
-                }}"""
-            ).strip(),
-            subgraph,
-        )
+    rules = [a_from_c, a, QueryRule(A, (SubA,))]
+    fullgraph = create_full_graph(rules, validate=False)
+    assert_equal_graph_output(
+        dedent(
+            f"""\
+            digraph {{
+                /*
+                queries:
+                Query(A for SubA)
+                */
+                // root entries
+            {fmt_non_param_edge(A, ())}
+            {fmt_non_param_edge(a, (), rule_type=GraphVertexType.singleton)}
+            {fmt_non_param_edge(A, (), RuleFormatRequest(a))}
+                // internal entries
+            {fmt_non_param_edge(a, (), rule_type=GraphVertexType.inner)}
+            }}"""
+        ).strip(),
+        fullgraph,
+    )
 
-    def test_matching_singleton(self) -> None:
-        @rule
-        async def a_from_suba(suba: SubA, b: B) -> A:
-            return A()
 
-        @rule
-        async def b_singleton() -> B:
-            return B()
+@pytest.mark.skip(reason="TODO(#10649): figure out if this tests is still relevant.")
+@pytest.mark.no_error_if_skipped
+def test_root_tuple_removed_when_no_matches() -> None:
+    @rule
+    async def a_from_c(c: C) -> A:
+        return A()
 
-        rules = [a_from_suba, b_singleton, QueryRule(A, (SubA,))]
-        subgraph = self.create_subgraph(A, rules, SubA())
-        assert_equal_graph_output(
-            dedent(
-                f"""\
-                digraph {{
-                  /*
-                  queries:
-                    Query(A for SubA)
-                  */
-                  // root entries
-                {fmt_non_param_edge(A, SubA)}
-                {fmt_non_param_edge(A, SubA, RuleFormatRequest(a_from_suba))}
-                  // internal entries
-                {fmt_non_param_edge(b_singleton, (), rule_type=GraphVertexType.inner)}
-                {fmt_non_param_edge(b_singleton, (), rule_type=GraphVertexType.singleton)}
-                {fmt_param_edge(SubA, SubA, via_func=RuleFormatRequest(a_from_suba), return_func=RuleFormatRequest(b_singleton, ()))}
-                }}"""
-            ).strip(),
-            subgraph,
-        )
+    @rule
+    async def b_from_d_and_a(d: D, a: A) -> B:
+        return B()
 
-    @pytest.mark.skip(reason="TODO(#10649): figure out if this tests is still relevant.")
-    @pytest.mark.no_error_if_skipped
-    def test_depends_on_multiple_one_noop(self) -> None:
-        @rule
-        async def a_from_c(c: C) -> A:
-            return A()
+    rules = [
+        a_from_c,
+        b_from_d_and_a,
+    ]
 
-        @rule
-        async def a_from_suba(suba: SubA) -> A:
-            return A()
+    fullgraph = create_full_graph(rules, validate=False)
 
-        @rule
-        async def b_from_a(a: A) -> B:
-            return B()
+    assert_equal_graph_output(
+        dedent(
+            f"""\
+            digraph {{
+                // root subject types: C, D
+                // root entries
+            {fmt_non_param_edge(A, C)}
+            {fmt_non_param_edge(A, C, RuleFormatRequest(a_from_c))}
+            {fmt_non_param_edge(B, (C, D))}
+            {fmt_non_param_edge(B, (C, D), RuleFormatRequest(b_from_d_and_a))}
+                // internal entries
+            {fmt_param_edge(C, C, RuleFormatRequest(a_from_c))}
+            {fmt_param_edge(D, (C, D), RuleFormatRequest(b_from_d_and_a), return_func=RuleFormatRequest(a_from_c, C))}
+            }}"""
+        ).strip(),
+        fullgraph,
+    )
 
-        rules = [a_from_c, a_from_suba, b_from_a, QueryRule(A, (SubA,))]
-        subgraph = self.create_subgraph(B, rules, SubA(), validate=False)
-        assert_equal_graph_output(
-            dedent(
-                f"""\
-                digraph {{
-                  /*
-                  queries:
-                    Query(A for SubA)
-                  */
-                  // root entries
-                {fmt_non_param_edge(B, SubA)}
-                {fmt_non_param_edge(B, SubA, RuleFormatRequest(b_from_a))}
-                  // internal entries
-                {fmt_non_param_edge(RuleFormatRequest(b_from_a), SubA, RuleFormatRequest(a_from_suba))}
-                {fmt_param_edge(SubA, SubA, RuleFormatRequest(a_from_suba))}
-                }}"""
-            ).strip(),
-            subgraph,
-        )
 
-    def test_multiple_depend_on_same_rule(self) -> None:
-        @rule
-        async def a_from_suba(suba: SubA) -> A:
-            return A()
+@pytest.mark.skip(reason="TODO(#10649): figure out if this tests is still relevant.")
+@pytest.mark.no_error_if_skipped
+def test_noop_removal_transitive() -> None:
+    # If a noop-able rule has rules that depend on it,
+    # they should be removed from the graph.
 
-        @rule
-        async def b_from_a(a: A) -> B:
-            return B()
+    @rule
+    async def b_from_c(c: C) -> B:
+        return B()
 
-        @rule
-        async def c_from_a(a: A) -> C:
-            return C()
+    @rule
+    async def a_from_b(b: B) -> A:
+        return A()
 
-        rules = [
-            a_from_suba,
-            b_from_a,
-            c_from_a,
-            QueryRule(A, (SubA,)),
-            QueryRule(B, (SubA,)),
-            QueryRule(C, (SubA,)),
-        ]
-        fullgraph = self.create_full_graph(rules)
-        assert_equal_graph_output(
-            dedent(
-                f"""\
-                digraph {{
-                  /*
-                  queries:
-                    Query(A for SubA),
-                    Query(B for SubA),
-                    Query(C for SubA)
-                  */
-                  // root entries
-                {fmt_non_param_edge(A, SubA)}
-                {fmt_non_param_edge(A, SubA, RuleFormatRequest(a_from_suba))}
-                {fmt_non_param_edge(B, SubA)}
-                {fmt_non_param_edge(B, SubA, RuleFormatRequest(b_from_a))}
-                {fmt_non_param_edge(C, SubA)}
-                {fmt_non_param_edge(C, SubA, RuleFormatRequest(c_from_a))}
-                  // internal entries
-                {fmt_non_param_edge(b_from_a, SubA, RuleFormatRequest(a_from_suba))}
-                {fmt_non_param_edge(c_from_a, SubA, RuleFormatRequest(a_from_suba))}
-                {fmt_param_edge(SubA, SubA, RuleFormatRequest(a_from_suba))}
-                }}"""
-            ).strip(),
-            fullgraph,
-        )
+    @rule
+    async def a() -> A:
+        return A()
 
-    def create_full_graph(self, rules, validate=True):
-        scheduler = create_scheduler(rules, validate=validate)
-        return "\n".join(scheduler.rule_graph_visualization())
+    rules = [
+        b_from_c,
+        a_from_b,
+        a,
+    ]
+    subgraph = create_subgraph(A, rules, SubA(), validate=False)
 
-    def create_subgraph(self, requested_product, rules, subject, validate=True):
-        scheduler = create_scheduler(rules, validate=validate)
-        return "\n".join(scheduler.rule_subgraph_visualization([type(subject)], requested_product))
+    assert_equal_graph_output(
+        dedent(
+            f"""\
+            digraph {{
+                // root subject types: SubA
+                // root entries
+            {fmt_non_param_edge(A, ())}
+            {fmt_non_param_edge(a, (), rule_type=GraphVertexType.singleton)}
+            {fmt_non_param_edge(A, (), RuleFormatRequest(a))}
+                // internal entries
+            {fmt_non_param_edge(a, (), rule_type=GraphVertexType.inner)}
+            }}"""
+        ).strip(),
+        subgraph,
+    )
+
+
+def test_matching_singleton() -> None:
+    @rule
+    async def a_from_suba(suba: SubA, b: B) -> A:
+        return A()
+
+    @rule
+    async def b_singleton() -> B:
+        return B()
+
+    rules = [a_from_suba, b_singleton, QueryRule(A, (SubA,))]
+    subgraph = create_subgraph(A, rules, SubA())
+    assert_equal_graph_output(
+        dedent(
+            f"""\
+            digraph {{
+                /*
+                queries:
+                Query(A for SubA)
+                */
+                // root entries
+            {fmt_non_param_edge(A, SubA)}
+            {fmt_non_param_edge(A, SubA, RuleFormatRequest(a_from_suba))}
+                // internal entries
+            {fmt_non_param_edge(b_singleton, (), rule_type=GraphVertexType.inner)}
+            {fmt_non_param_edge(b_singleton, (), rule_type=GraphVertexType.singleton)}
+            {fmt_param_edge(SubA, SubA, via_func=RuleFormatRequest(a_from_suba), return_func=RuleFormatRequest(b_singleton, ()))}
+            }}"""
+        ).strip(),
+        subgraph,
+    )
+
+
+@pytest.mark.skip(reason="TODO(#10649): figure out if this tests is still relevant.")
+@pytest.mark.no_error_if_skipped
+def test_depends_on_multiple_one_noop() -> None:
+    @rule
+    async def a_from_c(c: C) -> A:
+        return A()
+
+    @rule
+    async def a_from_suba(suba: SubA) -> A:
+        return A()
+
+    @rule
+    async def b_from_a(a: A) -> B:
+        return B()
+
+    rules = [a_from_c, a_from_suba, b_from_a, QueryRule(A, (SubA,))]
+    subgraph = create_subgraph(B, rules, SubA(), validate=False)
+    assert_equal_graph_output(
+        dedent(
+            f"""\
+            digraph {{
+                /*
+                queries:
+                Query(A for SubA)
+                */
+                // root entries
+            {fmt_non_param_edge(B, SubA)}
+            {fmt_non_param_edge(B, SubA, RuleFormatRequest(b_from_a))}
+                // internal entries
+            {fmt_non_param_edge(RuleFormatRequest(b_from_a), SubA, RuleFormatRequest(a_from_suba))}
+            {fmt_param_edge(SubA, SubA, RuleFormatRequest(a_from_suba))}
+            }}"""
+        ).strip(),
+        subgraph,
+    )
+
+
+def test_multiple_depend_on_same_rule() -> None:
+    @rule
+    async def a_from_suba(suba: SubA) -> A:
+        return A()
+
+    @rule
+    async def b_from_a(a: A) -> B:
+        return B()
+
+    @rule
+    async def c_from_a(a: A) -> C:
+        return C()
+
+    rules = [
+        a_from_suba,
+        b_from_a,
+        c_from_a,
+        QueryRule(A, (SubA,)),
+        QueryRule(B, (SubA,)),
+        QueryRule(C, (SubA,)),
+    ]
+    fullgraph = create_full_graph(rules)
+    assert_equal_graph_output(
+        dedent(
+            f"""\
+            digraph {{
+                /*
+                queries:
+                Query(A for SubA),
+                Query(B for SubA),
+                Query(C for SubA)
+                */
+                // root entries
+            {fmt_non_param_edge(A, SubA)}
+            {fmt_non_param_edge(A, SubA, RuleFormatRequest(a_from_suba))}
+            {fmt_non_param_edge(B, SubA)}
+            {fmt_non_param_edge(B, SubA, RuleFormatRequest(b_from_a))}
+            {fmt_non_param_edge(C, SubA)}
+            {fmt_non_param_edge(C, SubA, RuleFormatRequest(c_from_a))}
+                // internal entries
+            {fmt_non_param_edge(b_from_a, SubA, RuleFormatRequest(a_from_suba))}
+            {fmt_non_param_edge(c_from_a, SubA, RuleFormatRequest(a_from_suba))}
+            {fmt_param_edge(SubA, SubA, RuleFormatRequest(a_from_suba))}
+            }}"""
+        ).strip(),
+        fullgraph,
+    )
+
+
+def create_full_graph(rules, validate=True):
+    scheduler = create_scheduler(rules, validate=validate)
+    return "\n".join(scheduler.rule_graph_visualization())
+
+
+def create_subgraph(requested_product, rules, subject, validate=True):
+    scheduler = create_scheduler(rules, validate=validate)
+    return "\n".join(scheduler.rule_subgraph_visualization([type(subject)], requested_product))
 
 
 def test_duplicated_rules() -> None:


### PR DESCRIPTION
Current style (in pytest and specifically in our codebase) is for tests to be standalone functions.