### PR TITLE
migrate `task_executor` crate to Rust 2024 Edition

### DIFF
--- a/src/rust/fs/src/lib.rs
+++ b/src/rust/fs/src/lib.rs
@@ -426,11 +426,9 @@ impl PosixFS {
     pub async fn scandir(&self, dir_relative_to_root: Dir) -> Result<DirectoryListing, io::Error> {
         let vfs = self.clone();
         self.executor
-            .spawn_blocking(
-                move || vfs.scandir_sync(&dir_relative_to_root),
-                |e| Err(io::Error::other(format!("Synchronous scandir failed: {e}"))),
-            )
-            .await
+            .native_spawn_blocking(move || vfs.scandir_sync(&dir_relative_to_root))
+            .await?
+            .map_err(|e| io::Error::other(format!("Synchronous scandir failed: {e}")))
     }
 
     fn scandir_sync(&self, dir_relative_to_root: &Dir) -> Result<DirectoryListing, io::Error> {

--- a/src/rust/fs/src/lib.rs
+++ b/src/rust/fs/src/lib.rs
@@ -426,7 +426,7 @@ impl PosixFS {
     pub async fn scandir(&self, dir_relative_to_root: Dir) -> Result<DirectoryListing, io::Error> {
         let vfs = self.clone();
         self.executor
-            .native_spawn_blocking(move || vfs.scandir_sync(&dir_relative_to_root))
+            .spawn_blocking(move || vfs.scandir_sync(&dir_relative_to_root))
             .await?
             .map_err(|e| io::Error::other(format!("Synchronous scandir failed: {e}")))
     }

--- a/src/rust/fs/store/src/local.rs
+++ b/src/rust/fs/store/src/local.rs
@@ -203,7 +203,7 @@ impl ShardedFSDB {
                 .map_err(|e| format!("Failed to create directory: {e}"))?;
             let (src_file, dst_dir) = fsdb
                 .executor
-                .native_spawn_blocking(move || {
+                .spawn_blocking(move || {
                     let src_file = Builder::new()
                         .suffix(".hardlink_canary")
                         .tempfile_in(&fsdb.root)
@@ -288,7 +288,7 @@ impl ShardedFSDB {
             // have to worry about parent dirs.
             let named_temp_file = self
                 .executor
-                .native_spawn_blocking(move || {
+                .spawn_blocking(move || {
                     Builder::new()
                         .suffix(".tmp")
                         .tempfile_in(dest_path2.parent().unwrap())
@@ -364,7 +364,7 @@ impl UnderlyingByteStore for ShardedFSDB {
     async fn lease(&self, fingerprint: Fingerprint) -> Result<(), String> {
         let path = self.get_path(fingerprint);
         self.executor
-            .native_spawn_blocking(move || {
+            .spawn_blocking(move || {
                 fs_set_times::set_mtime(&path, fs_set_times::SystemTimeSpec::SymbolicNow)
                     .map_err(|e| format!("Failed to extend mtime of {path:?}: {e}"))
             })
@@ -467,7 +467,7 @@ impl UnderlyingByteStore for ShardedFSDB {
         let root = self.root.clone();
         let expiration_time = SystemTime::now() - self.lease_time;
         self.executor
-            .native_spawn_blocking(move || {
+            .spawn_blocking(move || {
                 let maybe_shards = std::fs::read_dir(&root);
                 let mut fingerprints = vec![];
                 if let Ok(shards) = maybe_shards {

--- a/src/rust/nailgun/src/server.rs
+++ b/src/rust/nailgun/src/server.rs
@@ -242,7 +242,7 @@ impl Nail for RawFdNail {
         // output stream.
         let executor = self.executor.clone();
         let nail = self.clone();
-        let exit_code_join = executor.native_spawn_blocking(move || {
+        let exit_code_join = executor.spawn_blocking(move || {
             // NB: This closure captures the stdio handles, and will drop/close them when it completes.
             (nail.runner)(RawFdExecution {
                 cmd,

--- a/src/rust/process_execution/docker/src/docker.rs
+++ b/src/rust/process_execution/docker/src/docker.rs
@@ -279,7 +279,7 @@ async fn credentials_for_image(
     let server = server.to_owned();
 
     executor
-        .native_spawn_blocking(move || {
+        .spawn_blocking(move || {
             // Resolve the server as a DNS name to confirm that it is actually a registry.
             let Ok(_) = (server.as_ref(), 80)
                 .to_socket_addrs()

--- a/src/rust/process_execution/docker/src/docker.rs
+++ b/src/rust/process_execution/docker/src/docker.rs
@@ -279,50 +279,45 @@ async fn credentials_for_image(
     let server = server.to_owned();
 
     executor
-        .spawn_blocking(
-            move || {
-                // Resolve the server as a DNS name to confirm that it is actually a registry.
-                let Ok(_) = (server.as_ref(), 80)
-                    .to_socket_addrs()
-                    .or_else(|_| server.to_socket_addrs())
-                else {
+        .native_spawn_blocking(move || {
+            // Resolve the server as a DNS name to confirm that it is actually a registry.
+            let Ok(_) = (server.as_ref(), 80)
+                .to_socket_addrs()
+                .or_else(|_| server.to_socket_addrs())
+            else {
+                return Ok(None);
+            };
+
+            // TODO: https://github.com/keirlawson/docker_credential/issues/7 means that this will only
+            // work for credential helpers and credentials encoded directly in the docker config,
+            // rather than for general credStore implementations.
+            let credential = match docker_credential::get_credential(&server) {
+                Ok(credential) => credential,
+                Err(e) => {
+                    log::warn!("Failed to retrieve Docker credentials for server `{server}`: {e}");
                     return Ok(None);
-                };
+                }
+            };
 
-                // TODO: https://github.com/keirlawson/docker_credential/issues/7 means that this will only
-                // work for credential helpers and credentials encoded directly in the docker config,
-                // rather than for general credStore implementations.
-                let credential = match docker_credential::get_credential(&server) {
-                    Ok(credential) => credential,
-                    Err(e) => {
-                        log::warn!(
-                            "Failed to retrieve Docker credentials for server `{server}`: {e}"
-                        );
-                        return Ok(None);
+            let bollard_credentials = match credential {
+                docker_credential::DockerCredential::IdentityToken(token) => DockerCredentials {
+                    identitytoken: Some(token),
+                    ..DockerCredentials::default()
+                },
+                docker_credential::DockerCredential::UsernamePassword(username, password) => {
+                    DockerCredentials {
+                        username: Some(username),
+                        password: Some(password),
+                        ..DockerCredentials::default()
                     }
-                };
+                }
+            };
 
-                let bollard_credentials = match credential {
-                    docker_credential::DockerCredential::IdentityToken(token) => {
-                        DockerCredentials {
-                            identitytoken: Some(token),
-                            ..DockerCredentials::default()
-                        }
-                    }
-                    docker_credential::DockerCredential::UsernamePassword(username, password) => {
-                        DockerCredentials {
-                            username: Some(username),
-                            password: Some(password),
-                            ..DockerCredentials::default()
-                        }
-                    }
-                };
-
-                Ok(Some(bollard_credentials))
-            },
-            |e| Err(format!("Credentials task failed: {e}")),
-        )
+            Ok(Some(bollard_credentials))
+        })
         .await
+        .map_err(|e| format!("Failed to join Tokio task: {e}"))?
+        .map_err(|e: String| format!("Credentials task failed: {e}"))
 }
 
 /// Pull an image given its name and the image pull policy. This method is debounced by

--- a/src/rust/process_execution/pe_nailgun/src/nailgun_pool.rs
+++ b/src/rust/process_execution/pe_nailgun/src/nailgun_pool.rs
@@ -389,14 +389,13 @@ impl NailgunProcess {
 
         // Spawn the process and read its port from stdout.
         let (child, port) = executor
-            .spawn_blocking(
-                {
-                    let workdir = workdir.path().to_owned();
-                    move || spawn_and_read_port(startup_options, workdir)
-                },
-                |e| Err(format!("Nailgun spawn task failed: {e}")),
-            )
-            .await?;
+            .native_spawn_blocking({
+                let workdir = workdir.path().to_owned();
+                move || spawn_and_read_port(startup_options, workdir)
+            })
+            .await
+            .map_err(|e| format!("Failed to join Tokio task: {e}"))?
+            .map_err(|e| format!("Nailgun spawn task failed: {e}"))?;
         debug!(
             "Created nailgun server process with pid {} and port {}",
             child.id(),

--- a/src/rust/process_execution/pe_nailgun/src/nailgun_pool.rs
+++ b/src/rust/process_execution/pe_nailgun/src/nailgun_pool.rs
@@ -389,7 +389,7 @@ impl NailgunProcess {
 
         // Spawn the process and read its port from stdout.
         let (child, port) = executor
-            .native_spawn_blocking({
+            .spawn_blocking({
                 let workdir = workdir.path().to_owned();
                 move || spawn_and_read_port(startup_options, workdir)
             })
@@ -548,7 +548,7 @@ async fn clear_workdir(
     future::try_join_all(moves).await?;
 
     // And drop it in the background.
-    let fut = executor.native_spawn_blocking(move || std::mem::drop(garbage_dir));
+    let fut = executor.spawn_blocking(move || std::mem::drop(garbage_dir));
     drop(fut);
 
     Ok(())

--- a/src/rust/process_execution/src/local.rs
+++ b/src/rust/process_execution/src/local.rs
@@ -817,7 +817,7 @@ impl AsyncDropSandbox {
 impl Drop for AsyncDropSandbox {
     fn drop(&mut self) {
         if let Some(sandbox) = self.2.take() {
-            let _background_cleanup = self.0.native_spawn_blocking(|| std::mem::drop(sandbox));
+            let _background_cleanup = self.0.spawn_blocking(|| std::mem::drop(sandbox));
         }
     }
 }

--- a/src/rust/sharded_lmdb/src/lib.rs
+++ b/src/rust/sharded_lmdb/src/lib.rs
@@ -271,34 +271,33 @@ impl ShardedLmdb {
     pub async fn remove(&self, fingerprint: Fingerprint) -> Result<bool, String> {
         let store = self.clone();
         self.executor
-            .spawn_blocking(
-                move || {
-                    let effective_key =
-                        VersionedFingerprint::new(fingerprint, ShardedLmdb::SCHEMA_VERSION);
-                    let (env, db, lease_database) = store.get(&fingerprint);
-                    let del_res = env.begin_rw_txn().and_then(|mut txn| {
-                        txn.del(db, &effective_key, None)?;
-                        txn.del(lease_database, &effective_key, None)
-                            .or_else(|err| match err {
-                                lmdb::Error::NotFound => Ok(()),
-                                err => Err(err),
-                            })?;
-                        txn.commit()
-                    });
+            .native_spawn_blocking(move || {
+                let effective_key =
+                    VersionedFingerprint::new(fingerprint, ShardedLmdb::SCHEMA_VERSION);
+                let (env, db, lease_database) = store.get(&fingerprint);
+                let del_res = env.begin_rw_txn().and_then(|mut txn| {
+                    txn.del(db, &effective_key, None)?;
+                    txn.del(lease_database, &effective_key, None)
+                        .or_else(|err| match err {
+                            lmdb::Error::NotFound => Ok(()),
+                            err => Err(err),
+                        })?;
+                    txn.commit()
+                });
 
-                    match del_res {
-                        Ok(()) => Ok(true),
-                        Err(lmdb::Error::NotFound) => Ok(false),
-                        Err(err) => Err(format!(
-                            "Error removing versioned key {:?}: {}",
-                            effective_key.to_hex(),
-                            err
-                        )),
-                    }
-                },
-                |e| Err(format!("`remove` task failed: {e}")),
-            )
+                match del_res {
+                    Ok(()) => Ok(true),
+                    Err(lmdb::Error::NotFound) => Ok(false),
+                    Err(err) => Err(format!(
+                        "Error removing versioned key {:?}: {}",
+                        effective_key.to_hex(),
+                        err
+                    )),
+                }
+            })
             .await
+            .map_err(|e| format!("Failed to join Tokio task: {e}"))?
+            .map_err(|e| format!("`remove` task failed: {e}"))
     }
 
     ///
@@ -320,56 +319,55 @@ impl ShardedLmdb {
     ) -> Result<HashSet<Fingerprint>, String> {
         let store = self.clone();
         self.executor
-            .spawn_blocking(
-                move || {
-                    // Group the items by the Environment that they will be applied to.
-                    let mut items_by_env = HashMap::new();
-                    let mut exists = HashSet::new();
+            .native_spawn_blocking(move || {
+                // Group the items by the Environment that they will be applied to.
+                let mut items_by_env = HashMap::new();
+                let mut exists = HashSet::new();
 
-                    for fingerprint in &fingerprints {
-                        let effective_key =
-                            VersionedFingerprint::new(*fingerprint, ShardedLmdb::SCHEMA_VERSION);
-                        let (env_id, _, env, db, _) = store.get_raw(&fingerprint.0);
+                for fingerprint in &fingerprints {
+                    let effective_key =
+                        VersionedFingerprint::new(*fingerprint, ShardedLmdb::SCHEMA_VERSION);
+                    let (env_id, _, env, db, _) = store.get_raw(&fingerprint.0);
 
-                        let (_, _, batch) = items_by_env
-                            .entry(*env_id)
-                            .or_insert_with(|| (env.clone(), *db, vec![]));
-                        batch.push(effective_key);
-                    }
+                    let (_, _, batch) = items_by_env
+                        .entry(*env_id)
+                        .or_insert_with(|| (env.clone(), *db, vec![]));
+                    batch.push(effective_key);
+                }
 
-                    // Open and commit a Transaction per Environment. Since we never have more than one
-                    // Transaction open at a time, we don't have to worry about ordering.
-                    for (_, (env, db, batch)) in items_by_env {
-                        env.begin_ro_txn()
-                            .and_then(|txn| {
-                                for effective_key in &batch {
-                                    let get_res = txn.get(db, &effective_key);
-                                    match get_res {
-                                        Ok(_) => {
-                                            exists.insert(effective_key.get_fingerprint());
-                                        }
-                                        Err(lmdb::Error::NotFound) => (),
-                                        Err(err) => return Err(err),
-                                    };
-                                }
-                                txn.commit()
-                            })
-                            .map_err(|e| {
-                                format!(
-                                    "Error checking existence of fingerprints {:?}: {}",
-                                    batch
-                                        .iter()
-                                        .map(|key| key.get_fingerprint())
-                                        .collect::<Vec<_>>(),
-                                    e
-                                )
-                            })?;
-                    }
-                    Ok(exists)
-                },
-                |e| Err(format!("`exists_batch` task failed: {e}")),
-            )
+                // Open and commit a Transaction per Environment. Since we never have more than one
+                // Transaction open at a time, we don't have to worry about ordering.
+                for (_, (env, db, batch)) in items_by_env {
+                    env.begin_ro_txn()
+                        .and_then(|txn| {
+                            for effective_key in &batch {
+                                let get_res = txn.get(db, &effective_key);
+                                match get_res {
+                                    Ok(_) => {
+                                        exists.insert(effective_key.get_fingerprint());
+                                    }
+                                    Err(lmdb::Error::NotFound) => (),
+                                    Err(err) => return Err(err),
+                                };
+                            }
+                            txn.commit()
+                        })
+                        .map_err(|e| {
+                            format!(
+                                "Error checking existence of fingerprints {:?}: {}",
+                                batch
+                                    .iter()
+                                    .map(|key| key.get_fingerprint())
+                                    .collect::<Vec<_>>(),
+                                e
+                            )
+                        })?;
+                }
+                Ok(exists)
+            })
             .await
+            .map_err(|e| format!("Failed to join Tokio task: {e}"))?
+            .map_err(|e: String| format!("`exists_batch` task failed: {e}"))
     }
 
     ///
@@ -378,62 +376,58 @@ impl ShardedLmdb {
     pub async fn all_fingerprints(&self) -> Result<Vec<AgedFingerprint>, String> {
         let store = self.clone();
         self.executor
-            .spawn_blocking(
-                move || {
-                    let mut fingerprints = Vec::new();
-                    for (env, database, lease_database) in &store.all_lmdbs() {
-                        let txn = env.begin_ro_txn().map_err(|err| {
-                            format!("Error beginning transaction to garbage collect: {err}")
-                        })?;
-                        let mut cursor = txn
-                            .open_ro_cursor(*database)
-                            .map_err(|err| format!("Failed to open lmdb read cursor: {err}"))?;
-                        for key_res in cursor.iter() {
-                            let (key, bytes) = key_res.map_err(|err| {
-                                format!("Failed to advance lmdb read cursor: {err}")
-                            })?;
+            .native_spawn_blocking(move || {
+                let mut fingerprints = Vec::new();
+                for (env, database, lease_database) in &store.all_lmdbs() {
+                    let txn = env.begin_ro_txn().map_err(|err| {
+                        format!("Error beginning transaction to garbage collect: {err}")
+                    })?;
+                    let mut cursor = txn
+                        .open_ro_cursor(*database)
+                        .map_err(|err| format!("Failed to open lmdb read cursor: {err}"))?;
+                    for key_res in cursor.iter() {
+                        let (key, bytes) = key_res
+                            .map_err(|err| format!("Failed to advance lmdb read cursor: {err}"))?;
 
-                            // Random access into the lease_database is slower than iterating, but hopefully garbage
-                            // collection is rare enough that we can get away with this, rather than do two passes
-                            // here (either to populate leases into pre-populated AgedFingerprints, or to read sizes
-                            // when we delete from lmdb to track how much we've freed).
-                            let lease_until_unix_timestamp = txn
-                                .get(*lease_database, &key)
-                                .map(|b| {
-                                    let mut array = [0_u8; 8];
-                                    array.copy_from_slice(b);
-                                    u64::from_le_bytes(array)
-                                })
-                                .unwrap_or_else(|e| match e {
-                                    lmdb::Error::NotFound => 0,
-                                    e => panic!(
-                                        "Error reading lease, probable lmdb corruption: {e:?}"
-                                    ),
-                                });
-
-                            let leased_until =
-                                time::UNIX_EPOCH + Duration::from_secs(lease_until_unix_timestamp);
-
-                            let expired_seconds_ago = time::SystemTime::now()
-                                .duration_since(leased_until)
-                                .map(|t| t.as_secs())
-                                // 0 indicates unexpired.
-                                .unwrap_or(0);
-
-                            let v = VersionedFingerprint::from_bytes_unsafe(key);
-                            let fingerprint = v.get_fingerprint();
-                            fingerprints.push(AgedFingerprint {
-                                expired_seconds_ago,
-                                fingerprint,
-                                size_bytes: bytes.len(),
+                        // Random access into the lease_database is slower than iterating, but hopefully garbage
+                        // collection is rare enough that we can get away with this, rather than do two passes
+                        // here (either to populate leases into pre-populated AgedFingerprints, or to read sizes
+                        // when we delete from lmdb to track how much we've freed).
+                        let lease_until_unix_timestamp = txn
+                            .get(*lease_database, &key)
+                            .map(|b| {
+                                let mut array = [0_u8; 8];
+                                array.copy_from_slice(b);
+                                u64::from_le_bytes(array)
+                            })
+                            .unwrap_or_else(|e| match e {
+                                lmdb::Error::NotFound => 0,
+                                e => panic!("Error reading lease, probable lmdb corruption: {e:?}"),
                             });
-                        }
+
+                        let leased_until =
+                            time::UNIX_EPOCH + Duration::from_secs(lease_until_unix_timestamp);
+
+                        let expired_seconds_ago = time::SystemTime::now()
+                            .duration_since(leased_until)
+                            .map(|t| t.as_secs())
+                            // 0 indicates unexpired.
+                            .unwrap_or(0);
+
+                        let v = VersionedFingerprint::from_bytes_unsafe(key);
+                        let fingerprint = v.get_fingerprint();
+                        fingerprints.push(AgedFingerprint {
+                            expired_seconds_ago,
+                            fingerprint,
+                            size_bytes: bytes.len(),
+                        });
                     }
-                    Ok(fingerprints)
-                },
-                |e| Err(format!("`all_fingerprints` task failed: {e}")),
-            )
+                }
+                Ok(fingerprints)
+            })
             .await
+            .map_err(|e| format!("Failed to join Tokio task: {e}"))?
+            .map_err(|e: String| format!("`all_fingerprints` task failed: {e}"))
     }
 
     ///
@@ -464,68 +458,63 @@ impl ShardedLmdb {
     ) -> Result<(), String> {
         let store = self.clone();
         self.executor
-            .spawn_blocking(
-                move || {
-                    // Group the items by the Environment that they will be applied to.
-                    let mut items_by_env = HashMap::new();
-                    let mut fingerprints = Vec::new();
-                    for (fingerprint, bytes) in items {
-                        let effective_key =
-                            VersionedFingerprint::new(fingerprint, ShardedLmdb::SCHEMA_VERSION);
-                        let (env_id, _, env, db, lease_database) = store.get_raw(&fingerprint.0);
+            .native_spawn_blocking(move || {
+                // Group the items by the Environment that they will be applied to.
+                let mut items_by_env = HashMap::new();
+                let mut fingerprints = Vec::new();
+                for (fingerprint, bytes) in items {
+                    let effective_key =
+                        VersionedFingerprint::new(fingerprint, ShardedLmdb::SCHEMA_VERSION);
+                    let (env_id, _, env, db, lease_database) = store.get_raw(&fingerprint.0);
 
-                        let (_, _, _, batch) = items_by_env
-                            .entry(*env_id)
-                            .or_insert_with(|| (env.clone(), *db, *lease_database, vec![]));
-                        batch.push((effective_key, bytes));
-                        fingerprints.push(fingerprint);
-                    }
+                    let (_, _, _, batch) = items_by_env
+                        .entry(*env_id)
+                        .or_insert_with(|| (env.clone(), *db, *lease_database, vec![]));
+                    batch.push((effective_key, bytes));
+                    fingerprints.push(fingerprint);
+                }
 
-                    // Open and commit a Transaction per Environment. Since we never have more than one
-                    // Transaction open at a time, we don't have to worry about ordering.
-                    for (_, (env, db, lease_database, batch)) in items_by_env {
-                        env.begin_rw_txn()
-                            .and_then(|mut txn| {
-                                for (effective_key, bytes) in &batch {
-                                    let put_res = txn.put(
-                                        db,
-                                        &effective_key,
-                                        &bytes,
-                                        WriteFlags::NO_OVERWRITE,
-                                    );
-                                    match put_res {
-                                        Ok(()) => (),
-                                        Err(lmdb::Error::KeyExist) => continue,
-                                        Err(err) => return Err(err),
-                                    }
-                                    if initial_lease {
-                                        store.lease_inner(
-                                            lease_database,
-                                            effective_key,
-                                            store.lease_until_secs_since_epoch(),
-                                            &mut txn,
-                                        )?;
-                                    }
+                // Open and commit a Transaction per Environment. Since we never have more than one
+                // Transaction open at a time, we don't have to worry about ordering.
+                for (_, (env, db, lease_database, batch)) in items_by_env {
+                    env.begin_rw_txn()
+                        .and_then(|mut txn| {
+                            for (effective_key, bytes) in &batch {
+                                let put_res =
+                                    txn.put(db, &effective_key, &bytes, WriteFlags::NO_OVERWRITE);
+                                match put_res {
+                                    Ok(()) => (),
+                                    Err(lmdb::Error::KeyExist) => continue,
+                                    Err(err) => return Err(err),
                                 }
-                                txn.commit()
-                            })
-                            .map_err(|e| {
-                                format!(
-                                    "Error storing fingerprints {:?}: {}",
-                                    batch
-                                        .iter()
-                                        .map(|(key, _)| key.to_hex())
-                                        .collect::<Vec<_>>(),
-                                    e
-                                )
-                            })?;
-                    }
+                                if initial_lease {
+                                    store.lease_inner(
+                                        lease_database,
+                                        effective_key,
+                                        store.lease_until_secs_since_epoch(),
+                                        &mut txn,
+                                    )?;
+                                }
+                            }
+                            txn.commit()
+                        })
+                        .map_err(|e| {
+                            format!(
+                                "Error storing fingerprints {:?}: {}",
+                                batch
+                                    .iter()
+                                    .map(|(key, _)| key.to_hex())
+                                    .collect::<Vec<_>>(),
+                                e
+                            )
+                        })?;
+                }
 
-                    Ok(())
-                },
-                |e| Err(format!("`store_bytes_batch` task failed: {e}")),
-            )
+                Ok(())
+            })
             .await
+            .map_err(|e| format!("Failed to join Tokio task: {e}"))?
+            .map_err(|e: String| format!("`store_bytes_batch` task failed: {e}"))
     }
 
     ///
@@ -548,104 +537,103 @@ impl ShardedLmdb {
     {
         let store = self.clone();
         self.executor
-            .spawn_blocking(
-                move || {
-                    let mut attempts = 0;
-                    loop {
-                        let effective_key = VersionedFingerprint::new(
-                            expected_digest.hash,
-                            ShardedLmdb::SCHEMA_VERSION,
-                        );
-                        let (env, db, lease_database) = store.get(&expected_digest.hash);
-                        let put_res: Result<(), StoreError> =
-                            env.begin_rw_txn()
-                                .map_err(StoreError::Lmdb)
-                                .and_then(|mut txn| {
-                                    // Second pass: copy into the reserved memory.
-                                    let mut writer = txn
-                                        .reserve(
-                                            db,
-                                            &effective_key,
-                                            expected_digest.size_bytes,
-                                            WriteFlags::NO_OVERWRITE,
-                                        )?
-                                        .writer();
-                                    let mut read = data_provider()
-                                        .map_err(|e| format!("Failed to read: {e}"))?;
-                                    let should_retry =
-                  !sync_verified_copy(expected_digest, data_is_immutable, &mut read, &mut writer)
-                    .map_err(|e| {
-                    format!("Failed to copy from {read:?} or store in {env:?}: {e:?}")
-                  })?;
+            .native_spawn_blocking(move || {
+                let mut attempts = 0;
+                loop {
+                    let effective_key = VersionedFingerprint::new(
+                        expected_digest.hash,
+                        ShardedLmdb::SCHEMA_VERSION,
+                    );
+                    let (env, db, lease_database) = store.get(&expected_digest.hash);
+                    let put_res: Result<(), StoreError> = env
+                        .begin_rw_txn()
+                        .map_err(StoreError::Lmdb)
+                        .and_then(|mut txn| {
+                            // Second pass: copy into the reserved memory.
+                            let mut writer = txn
+                                .reserve(
+                                    db,
+                                    &effective_key,
+                                    expected_digest.size_bytes,
+                                    WriteFlags::NO_OVERWRITE,
+                                )?
+                                .writer();
+                            let mut read =
+                                data_provider().map_err(|e| format!("Failed to read: {e}"))?;
+                            let should_retry = !sync_verified_copy(
+                                expected_digest,
+                                data_is_immutable,
+                                &mut read,
+                                &mut writer,
+                            )
+                            .map_err(|e| {
+                                format!("Failed to copy from {read:?} or store in {env:?}: {e:?}")
+                            })?;
 
-                                    if should_retry {
-                                        let msg = format!("Input {read:?} changed while reading.");
-                                        log::debug!("{msg}");
-                                        return Err(StoreError::Retry(msg));
-                                    }
+                            if should_retry {
+                                let msg = format!("Input {read:?} changed while reading.");
+                                log::debug!("{msg}");
+                                return Err(StoreError::Retry(msg));
+                            }
 
-                                    if initial_lease {
-                                        store.lease_inner(
-                                            lease_database,
-                                            &effective_key,
-                                            store.lease_until_secs_since_epoch(),
-                                            &mut txn,
-                                        )?;
-                                    }
-                                    txn.commit()?;
-                                    Ok(())
-                                });
+                            if initial_lease {
+                                store.lease_inner(
+                                    lease_database,
+                                    &effective_key,
+                                    store.lease_until_secs_since_epoch(),
+                                    &mut txn,
+                                )?;
+                            }
+                            txn.commit()?;
+                            Ok(())
+                        });
 
-                        match put_res {
-                            Ok(()) => return Ok(()),
-                            Err(StoreError::Retry(msg)) => {
-                                // Input changed during reading: maybe retry.
-                                if attempts > 10 {
-                                    return Err(msg);
-                                } else {
-                                    attempts += 1;
-                                }
+                    match put_res {
+                        Ok(()) => return Ok(()),
+                        Err(StoreError::Retry(msg)) => {
+                            // Input changed during reading: maybe retry.
+                            if attempts > 10 {
+                                return Err(msg);
+                            } else {
+                                attempts += 1;
                             }
-                            Err(StoreError::Lmdb(lmdb::Error::KeyExist)) => return Ok(()),
-                            Err(StoreError::Lmdb(err)) => {
-                                return Err(format!("Error storing {expected_digest:?}: {err}"));
-                            }
-                            Err(StoreError::Io(err)) => {
-                                return Err(format!("Error storing {expected_digest:?}: {err}"));
-                            }
-                        };
-                    }
-                },
-                |e| Err(format!("`store` task failed: {e}")),
-            )
+                        }
+                        Err(StoreError::Lmdb(lmdb::Error::KeyExist)) => return Ok(()),
+                        Err(StoreError::Lmdb(err)) => {
+                            return Err(format!("Error storing {expected_digest:?}: {err}"));
+                        }
+                        Err(StoreError::Io(err)) => {
+                            return Err(format!("Error storing {expected_digest:?}: {err}"));
+                        }
+                    };
+                }
+            })
             .await
+            .map_err(|e| format!("Failed to join Tokio task: {e}"))?
+            .map_err(|e| format!("`store` task failed: {e}"))
     }
 
     pub async fn lease(&self, fingerprint: Fingerprint) -> Result<(), String> {
         let store = self.clone();
         self.executor
-            .spawn_blocking(
-                move || {
-                    let until_secs_since_epoch: u64 = store.lease_until_secs_since_epoch();
-                    let (env, _, lease_database) = store.get(&fingerprint);
-                    env.begin_rw_txn()
-                        .and_then(|mut txn| {
-                            store.lease_inner(
-                                lease_database,
-                                &VersionedFingerprint::new(
-                                    fingerprint,
-                                    ShardedLmdb::SCHEMA_VERSION,
-                                ),
-                                until_secs_since_epoch,
-                                &mut txn,
-                            )?;
-                            txn.commit()
-                        })
-                        .map_err(|e| format!("Error leasing {fingerprint:?}: {e}"))
-                },
-                |e| Err(format!("`lease` task failed: {e}")),
-            )
+            .native_spawn_blocking(move || {
+                let until_secs_since_epoch: u64 = store.lease_until_secs_since_epoch();
+                let (env, _, lease_database) = store.get(&fingerprint);
+                env.begin_rw_txn()
+                    .and_then(|mut txn| {
+                        store.lease_inner(
+                            lease_database,
+                            &VersionedFingerprint::new(fingerprint, ShardedLmdb::SCHEMA_VERSION),
+                            until_secs_since_epoch,
+                            &mut txn,
+                        )?;
+                        txn.commit()
+                    })
+                    .map_err(|e| format!("Error leasing {fingerprint:?}: {e}"))
+            })
             .await
+            .map_err(|e| format!("Failed to join Tokio task: {e}"))?
+            .map_err(|e| format!("`lease` task failed: {e}"))
     }
 
     fn lease_inner(
@@ -681,25 +669,24 @@ impl ShardedLmdb {
         let store = self.clone();
         let effective_key = VersionedFingerprint::new(fingerprint, ShardedLmdb::SCHEMA_VERSION);
         self.executor
-            .spawn_blocking(
-                move || {
-                    let (env, db, _) = store.get(&fingerprint);
-                    let ro_txn = env
-                        .begin_ro_txn()
-                        .map_err(|err| format!("Failed to begin read transaction: {err}"))?;
-                    match ro_txn.get(db, &effective_key) {
-                        Ok(bytes) => f(bytes).map(Some),
-                        Err(lmdb::Error::NotFound) => Ok(None),
-                        Err(err) => Err(format!(
-                            "Error loading versioned key {:?}: {}",
-                            effective_key.to_hex(),
-                            err,
-                        )),
-                    }
-                },
-                |e| Err(format!("`load_bytes_with` task failed: {e}")),
-            )
+            .native_spawn_blocking(move || {
+                let (env, db, _) = store.get(&fingerprint);
+                let ro_txn = env
+                    .begin_ro_txn()
+                    .map_err(|err| format!("Failed to begin read transaction: {err}"))?;
+                match ro_txn.get(db, &effective_key) {
+                    Ok(bytes) => f(bytes).map(Some),
+                    Err(lmdb::Error::NotFound) => Ok(None),
+                    Err(err) => Err(format!(
+                        "Error loading versioned key {:?}: {}",
+                        effective_key.to_hex(),
+                        err,
+                    )),
+                }
+            })
             .await
+            .map_err(|e| format!("Failed to join Tokio task: {e}"))?
+            .map_err(|e| format!("`load_bytes_with` task failed: {e}"))
     }
 
     #[allow(clippy::useless_conversion)] // False positive: https://github.com/rust-lang/rust-clippy/issues/3913

--- a/src/rust/sharded_lmdb/src/lib.rs
+++ b/src/rust/sharded_lmdb/src/lib.rs
@@ -271,7 +271,7 @@ impl ShardedLmdb {
     pub async fn remove(&self, fingerprint: Fingerprint) -> Result<bool, String> {
         let store = self.clone();
         self.executor
-            .native_spawn_blocking(move || {
+            .spawn_blocking(move || {
                 let effective_key =
                     VersionedFingerprint::new(fingerprint, ShardedLmdb::SCHEMA_VERSION);
                 let (env, db, lease_database) = store.get(&fingerprint);
@@ -319,7 +319,7 @@ impl ShardedLmdb {
     ) -> Result<HashSet<Fingerprint>, String> {
         let store = self.clone();
         self.executor
-            .native_spawn_blocking(move || {
+            .spawn_blocking(move || {
                 // Group the items by the Environment that they will be applied to.
                 let mut items_by_env = HashMap::new();
                 let mut exists = HashSet::new();
@@ -376,7 +376,7 @@ impl ShardedLmdb {
     pub async fn all_fingerprints(&self) -> Result<Vec<AgedFingerprint>, String> {
         let store = self.clone();
         self.executor
-            .native_spawn_blocking(move || {
+            .spawn_blocking(move || {
                 let mut fingerprints = Vec::new();
                 for (env, database, lease_database) in &store.all_lmdbs() {
                     let txn = env.begin_ro_txn().map_err(|err| {
@@ -458,7 +458,7 @@ impl ShardedLmdb {
     ) -> Result<(), String> {
         let store = self.clone();
         self.executor
-            .native_spawn_blocking(move || {
+            .spawn_blocking(move || {
                 // Group the items by the Environment that they will be applied to.
                 let mut items_by_env = HashMap::new();
                 let mut fingerprints = Vec::new();
@@ -537,7 +537,7 @@ impl ShardedLmdb {
     {
         let store = self.clone();
         self.executor
-            .native_spawn_blocking(move || {
+            .spawn_blocking(move || {
                 let mut attempts = 0;
                 loop {
                     let effective_key = VersionedFingerprint::new(
@@ -616,7 +616,7 @@ impl ShardedLmdb {
     pub async fn lease(&self, fingerprint: Fingerprint) -> Result<(), String> {
         let store = self.clone();
         self.executor
-            .native_spawn_blocking(move || {
+            .spawn_blocking(move || {
                 let until_secs_since_epoch: u64 = store.lease_until_secs_since_epoch();
                 let (env, _, lease_database) = store.get(&fingerprint);
                 env.begin_rw_txn()
@@ -669,7 +669,7 @@ impl ShardedLmdb {
         let store = self.clone();
         let effective_key = VersionedFingerprint::new(fingerprint, ShardedLmdb::SCHEMA_VERSION);
         self.executor
-            .native_spawn_blocking(move || {
+            .spawn_blocking(move || {
                 let (env, db, _) = store.get(&fingerprint);
                 let ro_txn = env
                     .begin_ro_txn()

--- a/src/rust/task_executor/Cargo.toml
+++ b/src/rust/task_executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.0.1"
-edition = "2021"
+edition = "2024"
 name = "task_executor"
 authors = ["Pants Build <pantsbuild@gmail.com>"]
 publish = false

--- a/src/rust/task_executor/src/lib.rs
+++ b/src/rust/task_executor/src/lib.rs
@@ -178,7 +178,7 @@ impl Executor {
     /// Spawn a Future on threads specifically reserved for I/O tasks which are allowed to be
     /// long-running and return a JoinHandle
     ///
-    pub fn native_spawn_blocking<F: FnOnce() -> R + Send + 'static, R: Send + 'static>(
+    pub fn spawn_blocking<F: FnOnce() -> R + Send + 'static, R: Send + 'static>(
         &self,
         f: F,
     ) -> JoinHandle<R> {

--- a/src/rust/task_executor/src/lib.rs
+++ b/src/rust/task_executor/src/lib.rs
@@ -175,27 +175,6 @@ impl Executor {
     }
 
     ///
-    /// Spawn a Future on a threadpool specifically reserved for I/O tasks which are allowed to be
-    /// long-running.
-    ///
-    /// If the background Task exits abnormally, the given closure will be called to recover: usually
-    /// it should convert the resulting Error to a relevant error type.
-    ///
-    /// If the returned Future is dropped, the computation will still continue to completion: see
-    /// <https://docs.rs/tokio/0.2.20/tokio/task/struct.JoinHandle.html>
-    ///
-    pub fn spawn_blocking<F: FnOnce() -> R + Send + 'static, R: Send + 'static>(
-        &self,
-        f: F,
-        rescue_join_error: impl FnOnce(JoinError) -> R,
-    ) -> impl Future<Output = R> {
-        self.native_spawn_blocking(f).map(|res| match res {
-            Ok(o) => o,
-            Err(e) => rescue_join_error(e),
-        })
-    }
-
-    ///
     /// Spawn a Future on threads specifically reserved for I/O tasks which are allowed to be
     /// long-running and return a JoinHandle
     ///

--- a/src/rust/ui/src/instance/prodash.rs
+++ b/src/rust/ui/src/instance/prodash.rs
@@ -77,7 +77,7 @@ impl ProdashInstance {
         // TODO: There is a shutdown race here, where if the UI is torn down before exclusive access is
         // dropped, we might drop stderr on the floor. That likely causes:
         //   https://github.com/pantsbuild/pants/issues/13276
-        let _stderr_task = executor.native_spawn_blocking({
+        let _stderr_task = executor.spawn_blocking({
             let mut tree = tree.clone();
             move || {
                 while let Ok(stderr) = stderr_receiver.recv() {
@@ -100,7 +100,7 @@ impl ProdashInstance {
         // empty Tree, which will clear the screen.
         self.tasks_to_display.clear();
         let executor = self.executor.clone();
-        let shutdown = executor.native_spawn_blocking(move || self.handle.shutdown_and_wait());
+        let shutdown = executor.spawn_blocking(move || self.handle.shutdown_and_wait());
         async move {
             if let Err(e) = shutdown.await {
                 fatal_log!("Failed to teardown UI: {e}");

--- a/src/rust/watch/src/lib.rs
+++ b/src/rust/watch/src/lib.rs
@@ -290,7 +290,7 @@ impl InvalidationWatcher {
 
         let watcher = self.clone();
         executor
-            .native_spawn_blocking(move || {
+            .spawn_blocking(move || {
                 let mut inner = watcher.0.lock();
                 inner
                     .watcher

--- a/src/rust/watch/src/lib.rs
+++ b/src/rust/watch/src/lib.rs
@@ -290,17 +290,16 @@ impl InvalidationWatcher {
 
         let watcher = self.clone();
         executor
-            .spawn_blocking(
-                move || {
-                    let mut inner = watcher.0.lock();
-                    inner
-                        .watcher
-                        .watch(&path, RecursiveMode::NonRecursive)
-                        .map_err(|e| maybe_enrich_notify_error(&path, e))
-                },
-                |e| Err(format!("Watch attempt failed: {e}")),
-            )
+            .native_spawn_blocking(move || {
+                let mut inner = watcher.0.lock();
+                inner
+                    .watcher
+                    .watch(&path, RecursiveMode::NonRecursive)
+                    .map_err(|e| maybe_enrich_notify_error(&path, e))
+            })
             .await
+            .map_err(|e| format!("Failed to join Tokio task: {e}"))?
+            .map_err(|e| format!("Watch attempt failed: {e}"))
     }
 }
 


### PR DESCRIPTION
Migrate the `task_executor` crate to Rust 2024 Edition.

The signature of `task_executor::Executor::spawn_blocking` was causing errors due to changes in the 2024 Edition around how lifetimes are captured for return-position `impl Trait`s. Since `spawn_blocking` called the existing `native_spawn_blocking` method in its implementation, it was easier to just migrate all callers to `native_spawn_blocking` which didn't have issues due to the edition change.

Finally, `spawn_blocking` could then be replaced entirely by `native_spawn_blocking` (which is renamed to `spawn_blocking`).

The main resulting change is that callers now have to account for the `JoinError` when `await`'ing the `JoinHandle` returned by `native_spawn_blocking` (e.g., with a `map_err(...)` instead of passing a second argument to `spawn_blocking` to do an implied `map_err`.