### PR TITLE
[Call-by-name] Candidate fix for error when using `migrate-call-by-name` outside of Pants main repo

### DIFF
--- a/src/python/pants/goal/migrate_call_by_name.py
+++ b/src/python/pants/goal/migrate_call_by_name.py
@@ -132,10 +132,15 @@ class MigrateCallByNameBuiltinGoal(BuiltinGoal):
 
             assert (spec := importlib.util.find_spec(rule.__module__)) is not None
             assert spec.origin is not None
-            spec_origin = PurePath(spec.origin)
+
+            try:
+                spec_origin = str(PurePath(spec.origin).relative_to(build_root))
+            except ValueError:
+                logger.debug(f"Ignoring migration plan item located outside of build_root ({build_root}) - file was located at {spec.origin}")
+                continue
 
             item: RuleGraphGet = {
-                "filepath": str(spec_origin.relative_to(build_root)),
+                "filepath": spec_origin,
                 "module": rule.__module__,
                 "function": rule.__name__,
                 "gets": [],

--- a/src/python/pants/goal/migrate_call_by_name.py
+++ b/src/python/pants/goal/migrate_call_by_name.py
@@ -136,7 +136,9 @@ class MigrateCallByNameBuiltinGoal(BuiltinGoal):
             try:
                 spec_origin = str(PurePath(spec.origin).relative_to(build_root))
             except ValueError:
-                logger.debug(f"Ignoring migration plan item located outside of build_root ({build_root}) - file was located at {spec.origin}")
+                logger.debug(
+                    f"Ignoring migration plan item located outside of build_root ({build_root}) - file was located at {spec.origin}"
+                )
                 continue
 
             item: RuleGraphGet = {


### PR DESCRIPTION
Depending on how this is called, there are different exceptions raised from the same segment of code which muddled everything up.

To attempt this fix, I went into the installed Pants 2.29rc0 venv on my machine and made these changes to ensure no exception pops up.

The cause was, actually, the rule graph was emitting Gets that needed to be fixed in Pants itself, not just the target repo. So, that was actually the root cause, so this problem may just disappear on it's own in Pants 2.30ish.

Either way, we should have this check.

Closes #21044 