### PR TITLE
deprecate experimental rust backend

### DIFF
--- a/docs/notes/2.30.x.md
+++ b/docs/notes/2.30.x.md
@@ -16,6 +16,8 @@ Thank you to [Klaviyo](https://www.klaviyo.com/) for their Platinum tier support
 
 The deprecation period for the `experimental_test_shell_command` alias has expired, use `test_shell_command` going forward.
 
+Since 2023 Pants has included a rudimentary experimental backend for Rust.  The functionality was mostly limited to running `rustfmt` and no further development has occurred.  This backend is deprecated in 2.30 and will be removed in 2.31.  Sustained support for Rust would be very much welcome in Pants.  If you are interested in contributing see  https://github.com/pantsbuild/pants/discussions/20119 for a recent effort.
+
 ### General
 
 Add support for custom resource definitions to the k8s-parser. This allows users to define custom Kubernetes resources in their codebase, which can then be parsed and used by Pants.

--- a/docs/notes/2.30.x.md
+++ b/docs/notes/2.30.x.md
@@ -16,7 +16,9 @@ Thank you to [Klaviyo](https://www.klaviyo.com/) for their Platinum tier support
 
 The deprecation period for the `experimental_test_shell_command` alias has expired, use `test_shell_command` going forward.
 
-Since 2023 Pants has included a rudimentary experimental backend for Rust.  The functionality was mostly limited to running `rustfmt` and no further development has occurred.  This backend is deprecated in 2.30 and will be removed in 2.31.  Sustained support for Rust would be very much welcome in Pants.  If you are interested in contributing see  https://github.com/pantsbuild/pants/discussions/20119 for a recent effort.
+Since 2023 Pants has included a rudimentary experimental backend for Rust.  The functionality was mostly limited to running `rustfmt` and no further development has occurred.  This backend is deprecated in 2.30 and will be removed in 2.31.
+
+We would love to see sustained support for Rust in Pants! If you're interested in contributing, please read through and comment onhttps://github.com/pantsbuild/pants/discussions/20119.
 
 ### General
 

--- a/src/python/pants/backend/rust/subsystems/rust.py
+++ b/src/python/pants/backend/rust/subsystems/rust.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 
+from pants.base.deprecated import warn_or_error
 from pants.option.option_types import StrListOption, StrOption
 from pants.option.subsystem import Subsystem
 from pants.util.ordered_set import OrderedSet
@@ -13,6 +14,15 @@ from pants.util.strutil import softwrap
 class RustSubsystem(Subsystem):
     options_scope = "rust"
     help = "Options for Rust support."
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        warn_or_error(
+            removal_version="2.31.0.dev1",
+            entity="The Experimental Rust Backend",
+            hint="See 2.30.0 release notes for more information",
+            start_version="2.30.0.dev0",
+        )
 
     toolchain = StrOption(
         "--toolchain",


### PR DESCRIPTION
This backend has had no meaningful development since the initial commit, not used by any contributor, what it does could likely be replaced by adhoc_tool and friends, and there is an out-of-tree plugin that is a more plausible path forward.

Recent breakage has revealed that our CI setup is not currently #22704 equipped to test this plugin.

I tired to highlight in the note that this this was a good attempt and more Rust support would also be welcome.  Wordsmiths welcome.