### PR TITLE
remove obsolete coverage directive

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,12 +19,6 @@ omit = [
   "BUILD",
 ]
 
-[tool.coverage.report]
-# We inject this file at test time (see src/python/pants/conftest.py), and so
-# coverage will gather stats for it, but it doesn't correspond to a real source file,
-# so reporting will fail, unless we omit it here.
-omit = ["src/python/pants/__init__.py"]
-
 [tool.mypy]
 namespace_packages = true
 explicit_package_bases = true


### PR DESCRIPTION
The file `src/python/pants/__init__.py` currently exists as a regular old file in the source tree.