### PR TITLE
use upstream rust-cache action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -287,7 +287,7 @@ jobs:
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo
-      uses: benjyw/rust-cache@5ed697a6894712d2854c80635bb00a2496ea307a
+      uses: Swatinem/rust-cache@v2.8.1
       with:
         cache-bin: 'false'
         shared-key: engine
@@ -407,7 +407,7 @@ jobs:
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo
-      uses: benjyw/rust-cache@5ed697a6894712d2854c80635bb00a2496ea307a
+      uses: Swatinem/rust-cache@v2.8.1
       with:
         cache-bin: 'false'
         shared-key: engine
@@ -526,7 +526,7 @@ jobs:
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo
-      uses: benjyw/rust-cache@5ed697a6894712d2854c80635bb00a2496ea307a
+      uses: Swatinem/rust-cache@v2.8.1
       with:
         cache-bin: 'false'
         shared-key: engine

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,7 +47,7 @@ jobs:
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo
-      uses: benjyw/rust-cache@5ed697a6894712d2854c80635bb00a2496ea307a
+      uses: Swatinem/rust-cache@v2.8.1
       with:
         cache-bin: 'false'
         shared-key: engine
@@ -145,7 +145,7 @@ jobs:
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo
-      uses: benjyw/rust-cache@5ed697a6894712d2854c80635bb00a2496ea307a
+      uses: Swatinem/rust-cache@v2.8.1
       with:
         cache-bin: 'false'
         shared-key: engine
@@ -253,7 +253,7 @@ jobs:
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo
-      uses: benjyw/rust-cache@5ed697a6894712d2854c80635bb00a2496ea307a
+      uses: Swatinem/rust-cache@v2.8.1
       with:
         cache-bin: 'false'
         shared-key: engine
@@ -503,7 +503,7 @@ jobs:
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo
-      uses: benjyw/rust-cache@5ed697a6894712d2854c80635bb00a2496ea307a
+      uses: Swatinem/rust-cache@v2.8.1
       with:
         cache-bin: 'false'
         shared-key: engine
@@ -586,7 +586,7 @@ jobs:
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo
-      uses: benjyw/rust-cache@5ed697a6894712d2854c80635bb00a2496ea307a
+      uses: Swatinem/rust-cache@v2.8.1
       with:
         cache-bin: 'false'
         shared-key: engine

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -28,7 +28,7 @@ def action(name: str) -> str:
         "coverallsapp": "coverallsapp/github-action@v2",
         "download-artifact": "actions/download-artifact@v4",
         "github-action-required-labels": "mheap/github-action-required-labels@v4.0.0",
-        "rust-cache": "benjyw/rust-cache@5ed697a6894712d2854c80635bb00a2496ea307a",
+        "rust-cache": "Swatinem/rust-cache@v2.8.1",
         "setup-go": "actions/setup-go@v5",
         "setup-java": "actions/setup-java@v4",
         "setup-node": "actions/setup-node@v4",


### PR DESCRIPTION
With https://github.com/Swatinem/rust-cache/pull/216 we should no longer need to diverge from upstream.