### PR TITLE
Go dependency download and analysis performance fix (Cherry-pick of #22726)

### DIFF
--- a/src/python/pants/backend/go/util_rules/third_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/third_party_pkg.py
@@ -37,7 +37,7 @@ from pants.engine.fs import (
     Snapshot,
 )
 from pants.engine.process import FallibleProcessResult, Process, ProcessResult
-from pants.engine.rules import Get, collect_rules, concurrently, rule
+from pants.engine.rules import Get, MultiGet, collect_rules, concurrently, rule
 from pants.util.dirutil import group_by_dir
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel

--- a/src/python/pants/backend/go/util_rules/third_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/third_party_pkg.py
@@ -37,7 +37,7 @@ from pants.engine.fs import (
     Snapshot,
 )
 from pants.engine.process import FallibleProcessResult, Process, ProcessResult
-from pants.engine.rules import collect_rules, concurrently, rule
+from pants.engine.rules import Get, collect_rules, concurrently, rule
 from pants.util.dirutil import group_by_dir
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel

--- a/src/python/pants/backend/go/util_rules/third_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/third_party_pkg.py
@@ -37,7 +37,7 @@ from pants.engine.fs import (
     Snapshot,
 )
 from pants.engine.process import FallibleProcessResult, Process, ProcessResult
-from pants.engine.rules import Get, MultiGet, collect_rules, concurrently, rule
+from pants.engine.rules import Get, MultiGet, collect_rules, concurrently, implicitly, rule
 from pants.util.dirutil import group_by_dir
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
@@ -599,6 +599,7 @@ async def download_and_analyze_third_party_packages(
                 minimum_go_version=mod.minimum_go_version,
                 build_opts=request.build_opts,
             ),
+            **implicitly(),
         )
         for mod in module_analysis.modules
     )


### PR DESCRIPTION
I have a setup with 468 third party Go modules, at that point the Go backend is not scaling well. One source is from downloading and analysing all the dependencies, which happens all the time since it is necessary for dependency inference, and thus affects the entire project even for non-go work. It is both slow, and uses **a lot** of memory.

After some digging for causes it seems like merging the output digest of the `go list` as input to each module download is causing a lot of overhead. And it doesn't seem like it is necessary since it is only used to determine which are the modules included, and then those are downloaded individually anyways, so it would seem like the `go_mod_digest` is enough for the input digest.

I'm not sure exactly why it's causing so much overhead, possibly a lot of additional data via that digest to shuffle around?

Here are some perf comparisons on the setup mentioned with and without this change:

|  Test case | Before  | After |
| - | - | - |
| No caches 10 parallelism | 1015 seconds / 6.1 GB max RSS | 135 seconds / 5.3 GB max RSS |
| No caches 1 parallelism | 860 seconds / 6.5 GB max RSS | 233 seconds / 5.2 GB max RSS |
| Local cache 10 parallelism | 18 seconds / 13.3 GB max RSS | 4 seconds / 6 GB max RSS |
| Local cache 1 parallelism | 15 seconds / 13.4 GB max RSS | 4 seconds / 6 GB max RSS |
| *Only* remote cache 10 parallelism | 31 seconds / 9.3 GB max RSS | 6 seconds / 6 GB max RSS |
| *Only* remote 1 parallelism | 15 seconds / 8.6 GB max RSS | 4 seconds / 6 GB max RSS |

Those tests are run on caches that are fully seeded with the work prior to testing. The test is running `pants check` in a project with a single `go_mod` target and no source files, thus is only doing the go module download and analysis.
