### PR TITLE
re-sync generated github workflows

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -349,7 +349,7 @@ jobs:
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo
-      uses: benjyw/rust-cache@5ed697a6894712d2854c80635bb00a2496ea307a
+      uses: Swatinem/rust-cache@v2.8.1
       with:
         cache-bin: 'false'
         shared-key: engine


### PR DESCRIPTION
Both #22718 and #22717 made changes to the generated workflows, but not in a way that induced a merge conflict.

(This is FWIW the sort of thing that merge queues would catch.)