### PR TITLE
add a spiffy coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Pants Build System
 
+[![Coverage Status](https://coveralls.io/repos/github/pantsbuild/pants/badge.svg?branch=main)](https://coveralls.io/github/pantsbuild/pants?branch=main)
+
 Pants is a scalable build system for _monorepos_: codebases containing 
 multiple projects, often using multiple programming languages and frameworks, 
 in a single unified code repository.


### PR DESCRIPTION
The coverage.io reporting was restored in #22700.  It was run mostly successfully for a few weeks now, so let's add pretty coverage badge.

<img width="499" height="133" alt="image" src="https://github.com/user-attachments/assets/5a2d3e81-b9db-4fd2-a3c1-50912d68ecd0" />