### PR TITLE
correct js/ts `check` release notes version

### DIFF
--- a/docs/notes/2.28.x.md
+++ b/docs/notes/2.28.x.md
@@ -48,7 +48,6 @@ Added internal support for executing a NodeJS tool where the executable name is 
 
 Added new build file alias `node_run_script` to allow generating node script targets that are not tied to packaging and can be executed via the `run` goal.
 
-Added support for typechecking typescript and javascript files with the `check` goal.
 
 #### Docker
 

--- a/docs/notes/2.30.x.md
+++ b/docs/notes/2.30.x.md
@@ -52,6 +52,8 @@ The version of [Pex](https://github.com/pex-tool/pex) used by the Python backend
 
 #### Javascript
 
+Added support for typechecking typescript and javascript files with the `check` goal.
+
 #### TypeScript
 
 #### Go


### PR DESCRIPTION
Move the releases notes from #22461 to the proper version.