### PR TITLE
remove obsolete "sparse" crate configuration

### DIFF
--- a/src/rust/.cargo/config.toml
+++ b/src/rust/.cargo/config.toml
@@ -2,8 +2,3 @@
 # See https://docs.rs/tokio/1.21.1/tokio/task/struct.JoinSet.html#method.join_next_with_id.
 [build]
 rustflags = ["--cfg", "tokio_unstable"]
-
-# Opt-in to the Cargo "sparse" protocol for index downloads.
-# Note: Remove once this becomes the default in Rust v1.70.0
-[registries.crates-io]
-protocol = "sparse"


### PR DESCRIPTION
This did indeed become the default in 1.70
https://blog.rust-lang.org/2023/06/01/Rust-1.70.0/