### PR TITLE
add macOS x86_64 support highlight to release notes

### DIFF
--- a/docs/notes/2.30.x.md
+++ b/docs/notes/2.30.x.md
@@ -14,6 +14,8 @@ Thank you to [Klaviyo](https://www.klaviyo.com/) for their Platinum tier support
 
 Python lockfile metadata can now be stored in a sibling file to the lockfile, instead of as a prepended header in the lockfile itself.
 
+Pants 2.30 is scheduled to be the last version to provide binaries for `x86_64` macOS.  This flows from the [reduced support](https://github.com/actions/runner-images/issues/13046) from GitHub and continued movement in the macOS ecosystem.  If you are interested in maintaining or supporting `x86_64` macOS binaries, please [reach out](https://github.com/pantsbuild/pants/discussions/22711).
+
 ### Deprecations
 
 The plugin API's `Get()` construct has been deprecated in favor of the call-by-name idiom. See [here](https://www.pantsbuild.org/2.30/docs/writing-plugins/the-rules-api/migrating-gets) for how to update your plugins.


### PR DESCRIPTION
At the last dev meeting it was felt that dropping support *in* 2.30 was too aggressive.

Disccusion ref: https://github.com/pantsbuild/pants/discussions/22711