### PR TITLE
only set pex --override during lockfile generation (Cherry-pick of #22783)

### DIFF
--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -147,6 +147,10 @@ async def generate_lockfile(
                     *(f"--find-links={link}" for link in req.find_links),
                     *pip_args_setup.args,
                     *req.interpreter_constraints.generate_pex_arg_list(),
+                    *(
+                        f"--override={override}"
+                        for override in pip_args_setup.resolve_config.overrides
+                    ),
                     *req.requirements,
                 ),
                 additional_input_digest=pip_args_setup.digest,

--- a/src/python/pants/backend/python/util_rules/pex_requirements.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements.py
@@ -388,7 +388,6 @@ class ResolvePexConfig:
         yield from (f"--path-mapping={v}" for v in self.path_mappings)
 
         yield from (f"--exclude={exclude}" for exclude in self.excludes)
-        yield from (f"--override={override}" for override in self.overrides)
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
For many cli flags we tend towards a "belt and suspenders" approach and set them broadly -- and perhaps redundantly -- instead of only in the narrow case where we are sure they are needed.  This works fine in most cases but for --override Pex has an explicit check [1] so that in Pants terms one most override when generating a lockfile, not when using or subsetting it.

[1] https://github.com/pex-tool/pex/blob/682536efd427b07c571c5c5718a56ff9be1edf40/pex/bin/pex.py#L1012
