### PR TITLE
Use self-hosted MacOS Intel runner

### DIFF
--- a/.github/workflows/clear_self_hosted_persistent_caches.yaml
+++ b/.github/workflows/clear_self_hosted_persistent_caches.yaml
@@ -26,6 +26,25 @@ jobs:
       run: du -sh ~/.pex || true; rm -rf ~/.pex || true
     - name: df after
       run: df -h
+  clean_macos13_x86_64:
+    runs-on:
+    - self-hosted
+    - macos-13
+    steps:
+    - name: df before
+      run: df -h
+    - name: Deleting ~/Library/Caches
+      run: du -sh ~/Library/Caches || true; rm -rf ~/Library/Caches || true
+    - name: Deleting ~/.cache
+      run: du -sh ~/.cache || true; rm -rf ~/.cache || true
+    - name: Deleting ~/.nce
+      run: du -sh ~/.nce || true; rm -rf ~/.nce || true
+    - name: Deleting ~/.rustup
+      run: du -sh ~/.rustup || true; rm -rf ~/.rustup || true
+    - name: Deleting ~/.pex
+      run: du -sh ~/.pex || true; rm -rf ~/.pex || true
+    - name: df after
+      run: df -h
 name: Clear persistent caches on long-lived self-hosted runners
 'on':
   workflow_dispatch: {}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -253,6 +253,7 @@ jobs:
       contents: write
       id-token: write
     runs-on:
+    - self-hosted
     - macos-13
     steps:
     - name: Check out code
@@ -260,17 +261,6 @@ jobs:
       with:
         fetch-depth: 10
         ref: ${{ needs.release_info.outputs.build-ref }}
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
-      uses: actions/setup-python@v5
-      with:
-        python-version: |-
-          3.7
-          3.8
-          3.9
-          3.10
-          3.12
-          3.13
-          3.11
     - name: Install Protoc
       uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
       with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -220,23 +220,13 @@ jobs:
     needs:
     - classify_changes
     runs-on:
+    - self-hosted
     - macos-13
     steps:
     - name: Check out code
       uses: actions/checkout@v4
       with:
         fetch-depth: 10
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
-      uses: actions/setup-python@v5
-      with:
-        python-version: |-
-          3.7
-          3.8
-          3.9
-          3.10
-          3.12
-          3.13
-          3.11
     - name: Install Protoc
       uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
       with:
@@ -566,23 +556,13 @@ jobs:
       contents: write
       id-token: write
     runs-on:
+    - self-hosted
     - macos-13
     steps:
     - name: Check out code
       uses: actions/checkout@v4
       with:
         fetch-depth: 10
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
-      uses: actions/setup-python@v5
-      with:
-        python-version: |-
-          3.7
-          3.8
-          3.9
-          3.10
-          3.12
-          3.13
-          3.11
     - name: Install Protoc
       uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
       with:
@@ -2173,6 +2153,7 @@ jobs:
     - bootstrap_pants_macos13_x86_64
     - classify_changes
     runs-on:
+    - self-hosted
     - macos-13
     steps:
     - name: Check out code
@@ -2188,17 +2169,6 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: 1.19.5
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
-      uses: actions/setup-python@v5
-      with:
-        python-version: |-
-          3.7
-          3.8
-          3.9
-          3.10
-          3.12
-          3.13
-          3.11
     - name: Download native binaries
       uses: actions/download-artifact@v4
       with:

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -72,8 +72,8 @@ class Platform(Enum):
     WINDOWS11_X86_64 = "Windows11-x86_64"
 
 
-GITHUB_HOSTED = {Platform.LINUX_X86_64, Platform.MACOS13_X86_64, Platform.MACOS14_ARM64}
-SELF_HOSTED = {Platform.LINUX_ARM64}
+GITHUB_HOSTED = {Platform.LINUX_X86_64, Platform.MACOS14_ARM64}
+SELF_HOSTED = {Platform.MACOS13_X86_64, Platform.LINUX_ARM64}
 CARGO_AUDIT_IGNORED_ADVISORY_IDS = (
     "RUSTSEC-2020-0128",  # returns a false positive on the cache crate, which is a local crate not a 3rd party crate
 )
@@ -85,10 +85,10 @@ _BASE_PYTHON_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.12", "3.13", "3.11"]
 
 PYTHON_VERSIONS_PER_PLATFORM = {
     Platform.LINUX_X86_64: _BASE_PYTHON_VERSIONS,
-    Platform.MACOS13_X86_64: _BASE_PYTHON_VERSIONS,
     # Python 3.7 or 3.8 aren't supported directly on arm64 macOS
     Platform.MACOS14_ARM64: [v for v in _BASE_PYTHON_VERSIONS if v not in ("3.7", "3.8")],
     # These runners have Python already installed
+    Platform.MACOS13_X86_64: None,
     Platform.LINUX_ARM64: None,
 }
 
@@ -479,6 +479,7 @@ class Helper:
             # macosx-10.9-universal2. Thus, without this env var, we tag our single-platform wheels
             # as universal2... this is a lie and understandably leads to installing the wrong wheel
             # and thus things do not work (see #21938 for an example).
+            # A similar issue may occur with the interpreters on self-hosted runners.
             ret["_PYTHON_HOST_PLATFORM"] = "macosx-13.0-x86_64"
         if self.platform in {Platform.MACOS14_ARM64}:
             ret["ARCHFLAGS"] = "-arch arm64"


### PR DESCRIPTION
Since Github hosted macos-13 x86 runners are going away Nov 14.

We could continue to support macos 15 on intel via GHA hosted runners
until August 2027: https://github.com/actions/runner-images/issues/13045