### PR TITLE
support setting the working directory on interactive process

### DIFF
--- a/docs/notes/2.31.x.md
+++ b/docs/notes/2.31.x.md
@@ -87,6 +87,8 @@ Please provide feedback on this backend [here](https://github.com/pantsbuild/pan
 
 Pants no longer supports loading `pkg_resources`-style namespace packages for plugins. Instead, just use ["native namespace packages"](https://packaging.python.org/en/latest/guides/packaging-namespace-packages/#native-namespace-packages) as per [PEP 420](https://peps.python.org/pep-0420/).
 
+Allow `InteractiveProcess` to set the working directory relative to the sandbox or workspace. Existing usages of `InteractiveProcess.from_process` will now respect the working directory if its set on the Process, which may be a breaking change depending on the use case. Two existing rules `twine_upload` for python package uploads and `test_shell_command_interactively` for shell command testing with the `--debug` flag will now honor the working directory if set on the Process.
+
 #### nFPM backend
 
 Added a new rule to help in-repo plugins implement the `inject_nfpm_package_fields(InjectNfpmPackageFieldsRequest) -> InjectedNfpmPackageFields` polymorphic rule. The `get_package_field_sets_for_nfpm_content_file_deps` rule (in the `pants.backend.nfpm.util_rules.contents` module) collects selected `PackageFieldSet`s from the contents of an `nfpm_*_package` so that the packages can be analyzed to inject things like package requirements.

--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -441,6 +441,7 @@ class InteractiveProcess(SideEffecting):
         append_only_caches: Mapping[str, str] | None = None,
         immutable_input_digests: Mapping[str, Digest] | None = None,
         keep_sandboxes: KeepSandboxes = KeepSandboxes.never,
+        working_directory: str | None = None,
     ) -> None:
         """Request to run a subprocess in the foreground, similar to subprocess.run().
 
@@ -463,6 +464,7 @@ class InteractiveProcess(SideEffecting):
                 input_digest=input_digest,
                 append_only_caches=append_only_caches,
                 immutable_input_digests=immutable_input_digests,
+                working_directory=working_directory,
             ),
         )
         object.__setattr__(self, "run_in_workspace", run_in_workspace)
@@ -489,6 +491,7 @@ class InteractiveProcess(SideEffecting):
             append_only_caches=process.append_only_caches,
             immutable_input_digests=process.immutable_input_digests,
             keep_sandboxes=keep_sandboxes,
+            working_directory=process.working_directory,
         )
 
 

--- a/src/python/pants/engine/process_test.py
+++ b/src/python/pants/engine/process_test.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import os
 import textwrap
 from pathlib import Path
 
@@ -309,6 +310,55 @@ def test_interactive_process_inputs(rule_runner: RuleRunner, run_in_workspace: b
             "prefix1",
             "prefix2",
         }
+
+
+@pytest.mark.parametrize("working_directory", [None, "foo", "foo/bar"])
+@pytest.mark.parametrize("run_in_workspace", [True, False])
+def test_interactive_process_working_directory(
+    rule_runner: RuleRunner,
+    working_directory: str,
+    run_in_workspace: bool,
+) -> None:
+    # Test that interactive processes can run in a working directory, and that the
+    # working directory is correctly resolved relative to the sandbox root or workspace root.
+    rule_runner.write_files(
+        {
+            "test.txt": "workspace test.txt",
+            "foo/test.txt": "workspace foo/test.txt",
+            "foo/bar/test.txt": "workspace foo/bar/test.txt",
+        }
+    )
+    input_digest = rule_runner.make_snapshot(
+        {
+            "test.txt": "chroot test.txt",
+            "foo/test.txt": "chroot foo/test.txt",
+            "foo/bar/test.txt": "chroot foo/bar/test.txt",
+        }
+    ).digest
+
+    process = InteractiveProcess(
+        argv=["/bin/bash", "-c", "pwd && cat test.txt"],
+        input_digest=input_digest,
+        working_directory=working_directory,
+        run_in_workspace=run_in_workspace,
+    )
+
+    with mock_console(rule_runner.options_bootstrapper) as (_, stdio_reader):
+        result = rule_runner.run_interactive_process(process)
+        stdout = stdio_reader.get_stdout()
+        stderr = stdio_reader.get_stderr()
+        assert result.exit_code == 0, (
+            f"Process failed with exit code {result.exit_code}.\nstdout: {stdout}\nstderr: {stderr}"
+        )
+
+        lines = stdout.splitlines()
+        assert len(lines) == 2
+        if working_directory is not None:
+            assert lines[0].endswith(working_directory)
+
+        expected_prefix = "workspace" if run_in_workspace else "chroot"
+        expected_path = os.path.join(*(s for s in (working_directory, "test.txt") if s))
+        assert f"{expected_prefix} {expected_path}" in stdout
 
 
 def test_workspace_execution_support() -> None:


### PR DESCRIPTION
We've run into a few cases where setting the working directory on an InteractiveProcess would be useful, in particular for rules are tests (ie TestRequest). In order to support debugging we convert the setup process to InteractiveProcess but since that drops the working directory you're unable to utilize it currently.

As a workaround we currently write a bash script into the sandbox like 

```
cd ${DIR} && exec {COMMAND}
```

This will help clean that up

This is also a pre-requisite to supporting setting the working dir in the Run goal (small thread here https://pantsbuild.slack.com/archives/C01CQHVDMMW/p1707448457657149) I'll handle that in a separate pr though 