### PR TITLE
Fix crypto provider initialization in grpc_util tests.

### DIFF
--- a/src/rust/grpc_util/src/tls.rs
+++ b/src/rust/grpc_util/src/tls.rs
@@ -270,7 +270,7 @@ mod test {
 
     #[test]
     fn test_client_auth_cert_resolver_is_unconfigured_no_mtls() {
-        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+        crate::initialize().expect("init crate");
 
         let cert_pem = std::fs::read(
             PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -291,6 +291,8 @@ mod test {
 
     #[test]
     fn test_client_auth_cert_resolver_is_configured() {
+        crate::initialize().expect("init crate");
+
         let cert_pem = std::fs::read(
             PathBuf::from(env!("CARGO_MANIFEST_DIR"))
                 .join("test-certs")


### PR DESCRIPTION
The initialization is intended to happen exactly once per process.

One test neglected to initialize, and another
did not do so via the `Once` mechanism. This
was mostly masked by the fact that we run all
these tests in a single process, along with 
several other tests that initialized correctly
using `Once`, so correct initialization for that
process was a matter of race condition luck.

However the race is now being lost on the new
macos13 self-hosted runner. And the issue
can be reliably reproduced by running just the
affected test in isolation.

This change ensures that all relevant tests
initialize correctly.