### PR TITLE
test_shell_command: use correct default cache scope for a test's environment (Cherry-pick of #22804)

### DIFF
--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -509,6 +509,7 @@ class ShellCommandTestTarget(Target):
         ShellCommandOutputDirectoriesField,
         ShellCommandOutputRootDirField,
         ShellCommandOutputsMatchMode,
+        ShellCommandCacheScopeField,
     )
     help = help_text(
         """


### PR DESCRIPTION
Fix `test_shell_command` to use the correct default process cache scope for the environment in which the test is running. The existing code was always using the "success" cache scope.

For workspace environments (i.e., `experimental_workspace_environment`) however, the default is "session" scope and not the "success" scope used for other environments. "Session" scope is used for in-workspace execution because Pants does not know how underlying tools cache and invalidate their results. Thus always running a tool each session makes sure Pants does not inadvertently cache a result which the tool would have recomputed.

Also add `cache_scope` as a field on `test_shell_command` so users may override the caches scope as needed.
