### PR TITLE
golang: fix Go SDK version check for coverage experiment (Cherry-pick of #22809)

### DIFF
--- a/src/python/pants/backend/go/util_rules/sdk.py
+++ b/src/python/pants/backend/go/util_rules/sdk.py
@@ -154,7 +154,7 @@ async def setup_go_sdk_process(
         env[GoSdkRunSetup.SANDBOX_ROOT_ENV] = "1"
 
     # Disable the "coverage redesign" experiment on Go v1.20+ for now since Pants does not yet support it.
-    if goroot.is_compatible_version("1.20"):
+    if goroot.is_compatible_version("1.20") and not goroot.is_compatible_version("1.25"):
         exp_str = env.get("GOEXPERIMENT", "")
         exp_fields = exp_str.split(",") if exp_str != "" else []
         exp_fields = [exp for exp in exp_fields if exp != "coverageredesign"]


### PR DESCRIPTION
In the Go backend, limit disabling the "coverage redesign" experiment to those Go versions where that experiment was actually included. The `coverageredesign` experiment was removed in Go 1.25, and so an existing version check needs to account for that change.

## Background

In Go 1.20, Go introduced a new coverage implementation called the "coverage redesign." Pants did not implement support at the time nor subsequently. Instead, https://github.com/pantsbuild/pants/pull/18205 disabled the `coverageredesign` experiment so that the "old" coverage implementation was always used.

In Go 1.25, the coverage redesign implementation is the only implementation and the old coverage implementation has been removed. The [relevant conditional in Pants](https://github.com/pantsbuild/pants/blob/main/src/python/pants/backend/go/util_rules/sdk.py#L162) needs to account for that fact.

## Testing

Tested by running tests in the https://github.com/pantsbuild/example-golang repository. Before the fix, the tests fail; after the fix, they pass. Not sure how to test with different Go versions being available in Pants CI though. We might need to update to Go 1.25.x in CI just to make sure the backend generally works with the latest versions.
