### PR TITLE
upgrade to go setup v6 action to use the right urls

### DIFF
--- a/.github/workflows/public_repos.yaml
+++ b/.github/workflows/public_repos.yaml
@@ -1071,11 +1071,11 @@ jobs:
       with:
         python-version: '3.10'
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@7bc60db215a8b16959b0b5cccfdc95950d697b25
       with:
         go-version: 1.25.3
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@7bc60db215a8b16959b0b5cccfdc95950d697b25
       with:
         go-version: 1.24.9
     - name: Pants on

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -163,11 +163,11 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         version: 23.x
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@7bc60db215a8b16959b0b5cccfdc95950d697b25
       with:
         go-version: 1.25.3
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@7bc60db215a8b16959b0b5cccfdc95950d697b25
       with:
         go-version: 1.24.9
     - env:
@@ -292,11 +292,11 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         version: 23.x
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@7bc60db215a8b16959b0b5cccfdc95950d697b25
       with:
         go-version: 1.25.3
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@7bc60db215a8b16959b0b5cccfdc95950d697b25
       with:
         go-version: 1.24.9
     - env:
@@ -416,11 +416,11 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         version: 23.x
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@7bc60db215a8b16959b0b5cccfdc95950d697b25
       with:
         go-version: 1.25.3
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@7bc60db215a8b16959b0b5cccfdc95950d697b25
       with:
         go-version: 1.24.9
     - env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -517,11 +517,11 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         version: 23.x
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@7bc60db215a8b16959b0b5cccfdc95950d697b25
       with:
         go-version: 1.25.3
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@7bc60db215a8b16959b0b5cccfdc95950d697b25
       with:
         go-version: 1.24.9
     - env:
@@ -594,11 +594,11 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         version: 23.x
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@7bc60db215a8b16959b0b5cccfdc95950d697b25
       with:
         go-version: 1.25.3
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@7bc60db215a8b16959b0b5cccfdc95950d697b25
       with:
         go-version: 1.24.9
     - env:
@@ -681,11 +681,11 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         version: 23.x
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@7bc60db215a8b16959b0b5cccfdc95950d697b25
       with:
         go-version: 1.25.3
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@7bc60db215a8b16959b0b5cccfdc95950d697b25
       with:
         go-version: 1.24.9
     - env:
@@ -987,11 +987,11 @@ jobs:
         distribution: adopt
         java-version: '11'
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@7bc60db215a8b16959b0b5cccfdc95950d697b25
       with:
         go-version: 1.25.3
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@7bc60db215a8b16959b0b5cccfdc95950d697b25
       with:
         go-version: 1.24.9
     - name: Download native binaries
@@ -1085,11 +1085,11 @@ jobs:
         distribution: adopt
         java-version: '11'
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@7bc60db215a8b16959b0b5cccfdc95950d697b25
       with:
         go-version: 1.25.3
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@7bc60db215a8b16959b0b5cccfdc95950d697b25
       with:
         go-version: 1.24.9
     - if: runner.os == 'Linux'
@@ -1201,11 +1201,11 @@ jobs:
         distribution: adopt
         java-version: '11'
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@7bc60db215a8b16959b0b5cccfdc95950d697b25
       with:
         go-version: 1.25.3
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@7bc60db215a8b16959b0b5cccfdc95950d697b25
       with:
         go-version: 1.24.9
     - if: runner.os == 'Linux'
@@ -1317,11 +1317,11 @@ jobs:
         distribution: adopt
         java-version: '11'
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@7bc60db215a8b16959b0b5cccfdc95950d697b25
       with:
         go-version: 1.25.3
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@7bc60db215a8b16959b0b5cccfdc95950d697b25
       with:
         go-version: 1.24.9
     - if: runner.os == 'Linux'
@@ -1433,11 +1433,11 @@ jobs:
         distribution: adopt
         java-version: '11'
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@7bc60db215a8b16959b0b5cccfdc95950d697b25
       with:
         go-version: 1.25.3
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@7bc60db215a8b16959b0b5cccfdc95950d697b25
       with:
         go-version: 1.24.9
     - if: runner.os == 'Linux'
@@ -1549,11 +1549,11 @@ jobs:
         distribution: adopt
         java-version: '11'
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@7bc60db215a8b16959b0b5cccfdc95950d697b25
       with:
         go-version: 1.25.3
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@7bc60db215a8b16959b0b5cccfdc95950d697b25
       with:
         go-version: 1.24.9
     - if: runner.os == 'Linux'
@@ -1665,11 +1665,11 @@ jobs:
         distribution: adopt
         java-version: '11'
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@7bc60db215a8b16959b0b5cccfdc95950d697b25
       with:
         go-version: 1.25.3
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@7bc60db215a8b16959b0b5cccfdc95950d697b25
       with:
         go-version: 1.24.9
     - if: runner.os == 'Linux'
@@ -1781,11 +1781,11 @@ jobs:
         distribution: adopt
         java-version: '11'
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@7bc60db215a8b16959b0b5cccfdc95950d697b25
       with:
         go-version: 1.25.3
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@7bc60db215a8b16959b0b5cccfdc95950d697b25
       with:
         go-version: 1.24.9
     - if: runner.os == 'Linux'
@@ -1897,11 +1897,11 @@ jobs:
         distribution: adopt
         java-version: '11'
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@7bc60db215a8b16959b0b5cccfdc95950d697b25
       with:
         go-version: 1.25.3
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@7bc60db215a8b16959b0b5cccfdc95950d697b25
       with:
         go-version: 1.24.9
     - if: runner.os == 'Linux'
@@ -2013,11 +2013,11 @@ jobs:
         distribution: adopt
         java-version: '11'
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@7bc60db215a8b16959b0b5cccfdc95950d697b25
       with:
         go-version: 1.25.3
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@7bc60db215a8b16959b0b5cccfdc95950d697b25
       with:
         go-version: 1.24.9
     - if: runner.os == 'Linux'
@@ -2129,11 +2129,11 @@ jobs:
         distribution: adopt
         java-version: '11'
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@7bc60db215a8b16959b0b5cccfdc95950d697b25
       with:
         go-version: 1.25.3
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@7bc60db215a8b16959b0b5cccfdc95950d697b25
       with:
         go-version: 1.24.9
     - if: runner.os == 'Linux'
@@ -2222,11 +2222,11 @@ jobs:
         distribution: adopt
         java-version: '11'
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@7bc60db215a8b16959b0b5cccfdc95950d697b25
       with:
         go-version: 1.25.3
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@7bc60db215a8b16959b0b5cccfdc95950d697b25
       with:
         go-version: 1.24.9
     - name: Download native binaries
@@ -2296,11 +2296,11 @@ jobs:
         distribution: adopt
         java-version: '11'
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@7bc60db215a8b16959b0b5cccfdc95950d697b25
       with:
         go-version: 1.25.3
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@7bc60db215a8b16959b0b5cccfdc95950d697b25
       with:
         go-version: 1.24.9
     - name: Set up Python 3.9, 3.10, 3.12, 3.13, 3.11

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -31,7 +31,8 @@ def action(name: str) -> str:
         "github-action-required-labels": "mheap/github-action-required-labels@v4.0.0",
         "msys2": "msys2/setup-msys2@v2",
         "rust-cache": "Swatinem/rust-cache@v2.8.1",
-        "setup-go": "actions/setup-go@v6",
+        # Switch to v6 once https://github.com/actions/setup-go/pull/665 is released
+        "setup-go": "actions/setup-go@7bc60db215a8b16959b0b5cccfdc95950d697b25",
         "setup-java": "actions/setup-java@v4",
         "setup-node": "actions/setup-node@v4",
         "setup-protoc": "arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9",


### PR DESCRIPTION
https://github.com/actions/setup-go/pull/665

Currently v6 is the only release series that has this fix.