### PR TITLE
Go: compile with trimpath for reproducible output (Cherry-pick of #22749)

### DIFF
--- a/src/python/pants/backend/go/util_rules/build_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg.py
@@ -377,7 +377,7 @@ async def setup_golang_asm_check_binary() -> SetupAsmCheckBinary:
     compile_result = await execute_process_or_raise(
         **implicitly(
             GoSdkProcess(
-                command=("build", "-o", binary_name, src_file),
+                command=("build", "-trimpath", "-o", binary_name, src_file),
                 input_digest=sources_digest,
                 output_files=(binary_name,),
                 env={"CGO_ENABLED": "0"},
@@ -777,6 +777,8 @@ async def build_go_package(
         request.import_path,
         "-importcfg",
         import_config.CONFIG_PATH,
+        "-trimpath",
+        "__PANTS_SANDBOX_ROOT__",
     ]
 
     # See https://github.com/golang/go/blob/f229e7031a6efb2f23241b5da000c3b3203081d6/src/cmd/go/internal/work/gc.go#L79-L100
@@ -892,6 +894,7 @@ async def build_go_package(
                 description=f"Compile Go package: {request.import_path}",
                 output_files=("__pkg__.a", *([asm_header_path] if asm_header_path else [])),
                 env={"__PANTS_GO_COMPILE_ACTION_ID": action_id_result.action_id},
+                replace_sandbox_root_in_args=True,
             )
         )
     )

--- a/src/python/pants/backend/go/util_rules/cgo.py
+++ b/src/python/pants/backend/go/util_rules/cgo.py
@@ -567,6 +567,8 @@ async def _dynimport(
                     "cgo",
                     # record path to dynamic linker
                     *(["-dynlinker"] if import_path == "runtime/cgo" else []),
+                    "-trimpath",
+                    "__PANTS_SANDBOX_ROOT__",
                     "-dynpackage",
                     pkg_name,
                     "-dynimport",
@@ -578,6 +580,7 @@ async def _dynimport(
                 env={"TERM": "dumb"},
                 input_digest=cgo_binary_link_result.output_digest,
                 output_files=(import_go_path,),
+                replace_sandbox_root_in_args=True,
             ),
         )
     )
@@ -813,8 +816,8 @@ async def cgo_compile_request(
                     "-importpath",
                     request.import_path,
                     *maybe_disable_imports_flags,
-                    # TODO(#16835): Add -trimpath option to remove sandbox paths from source paths embedded in files.
-                    # This means using `__PANTS_SANDBOX_ROOT__` support of `GoSdkProcess`.
+                    "-trimpath",
+                    "__PANTS_SANDBOX_ROOT__",
                     "--",
                     *flags.cppflags,
                     *flags.cflags,


### PR DESCRIPTION
Adds `-trimpath` on go compilation to strip sandbox paths from the output binary.

It would be great to cherry-pick this as currently builds are not reproducible which impacts cache and downstream.

Fixes #16835
