### PR TITLE
Use sandboxer in this repo.

### DIFF
--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -2,7 +2,6 @@
 colors = true
 plugins.add = ["shoalsoft-pants-opentelemetry-plugin==0.5.0"]
 backend_packages.add = ["shoalsoft.pants_opentelemetry_plugin"]
-sandboxer = true
 
 [test]
 report = true

--- a/pants.toml
+++ b/pants.toml
@@ -1,5 +1,6 @@
 [GLOBAL]
 print_stacktrace = true
+sandboxer = true
 
 # Enable our custom loose-source plugins.
 pythonpath = ["%(buildroot)s/pants-plugins"]


### PR DESCRIPTION
Previously we turned it on for CI.
Now we turn it on for all usage.

This is so we can kick the tires on
it in desktop use before we enable it
by default for all users.