### PR TITLE
remove plugin support for `pkg_resources`-style  namespace packages

### DIFF
--- a/docs/notes/2.31.x.md
+++ b/docs/notes/2.31.x.md
@@ -40,6 +40,8 @@ Go now compiles with trimpath to strip sandbox paths from output, allowing for r
 
 ### Plugin API changes
 
+Pants no longer supports loading `pkg_resources`-style namespace packages for plugins. Instead, just use ["native namespace packages"](https://packaging.python.org/en/latest/guides/packaging-namespace-packages/#native-namespace-packages) as per [PEP 420](https://peps.python.org/pep-0420/).
+
 ## Full Changelog
 
 For the full changelog, see the individual GitHub Releases for this series: <https://github.com/pantsbuild/pants/releases>

--- a/src/python/pants/init/options_initializer.py
+++ b/src/python/pants/init/options_initializer.py
@@ -11,8 +11,6 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 
-import pkg_resources
-
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.engine.env_vars import CompleteEnvironmentVars
 from pants.engine.internals.native_engine import PyExecutor
@@ -53,7 +51,6 @@ def _initialize_build_configuration(
     for path in bootstrap_options.pythonpath:
         if path not in sys.path:
             sys.path.append(path)
-            pkg_resources.fixup_namespace_packages(path)
 
     # Resolve the actual Python code for any plugins. `sys.path` is modified as a side effect if
     # plugins were configured.


### PR DESCRIPTION
Remove support for `pkg_resources`-style namespace packages for Pants plugins.

Given Pants rule code uses Python 3, plugins should instead just use ["native namespace packages"](https://packaging.python.org/en/latest/guides/packaging-namespace-packages/#native-namespace-packages) as per [PEP 420](https://peps.python.org/pep-0420/). This basically just means omitting the top-level `__int__.py` file.

This removes the final `pkg_resources` usage which also was causing a deprecation warning.