### PR TITLE
flag non-runnable targets used with `code_quality_tool`

### DIFF
--- a/src/python/pants/backend/adhoc/adhoc_tool.py
+++ b/src/python/pants/backend/adhoc/adhoc_tool.py
@@ -80,6 +80,7 @@ async def run_in_sandbox_request(
             execution_dependencies=target.get(AdhocToolExecutionDependenciesField).value or (),
             runnable_dependencies=target.get(AdhocToolRunnableDependenciesField).value or (),
             target=request.protocol_target,
+            runnable_address_field_alias=AdhocToolRunnableField.alias,
             named_caches=FrozenDict(target.get(AdhocToolNamedCachesField).value or {}),
         )
     )

--- a/src/python/pants/backend/adhoc/code_quality_tool.py
+++ b/src/python/pants/backend/adhoc/code_quality_tool.py
@@ -164,6 +164,7 @@ class CodeQualityTool:
     file_glob_include: tuple[str, ...]
     file_glob_exclude: tuple[str, ...]
     target: Target
+    runnable_address_field_alias: str
 
 
 @rule
@@ -195,6 +196,7 @@ async def find_code_quality_tool(request: CodeQualityToolAddressString) -> CodeQ
         file_glob_include=target[CodeQualityToolFileGlobIncludeField].value or (),
         file_glob_exclude=target[CodeQualityToolFileGlobExcludeField].value or (),
         target=target,
+        runnable_address_field_alias=CodeQualityToolRunnableField.alias,
     )
 
 
@@ -244,6 +246,7 @@ async def runner_request_for_code_quality_tool(
         execution_dependencies=cqt.execution_dependencies,
         runnable_dependencies=cqt.runnable_dependencies,
         target=cqt.target,
+        runnable_address_field_alias=cqt.runnable_address_field_alias,
     )
 
 

--- a/src/python/pants/core/util_rules/adhoc_process_support.py
+++ b/src/python/pants/core/util_rules/adhoc_process_support.py
@@ -75,6 +75,7 @@ from pants.engine.process import (
 from pants.engine.rules import collect_rules, concurrently, implicitly, rule
 from pants.engine.target import (
     FieldSetsPerTargetRequest,
+    InvalidFieldException,
     SourcesField,
     Target,
     TransitiveTargetsRequest,
@@ -157,6 +158,7 @@ class ToolRunnerRequest:
     execution_dependencies: tuple[str, ...]
     runnable_dependencies: tuple[str, ...]
     target: Target
+    runnable_address_field_alias: str
     named_caches: FrozenDict[str, str] | None = None
 
 
@@ -445,6 +447,16 @@ async def create_tool_runner(
         ),
     )
 
+    if not run_field_sets.field_sets:
+        raise InvalidFieldException(
+            f"The `{request.runnable_address_field_alias}` field in target `{request.target.address}` must be set to the "
+            f"address of a target which can be run by the `run` goal. Instead, the `{request.runnable_address_field_alias}` field is "
+            f"set to `{request.runnable_address_str}` which refers to the `{runnable_targets[0].alias}` target "
+            f"at `{runnable_targets[0].address}` that cannot be run by the `run` goal."
+        )
+
+    run_field_set: RunFieldSet = run_field_sets.field_sets[0]
+
     req = ResolveExecutionDependenciesRequest(
         address=request.target.address,
         execution_dependencies=request.execution_dependencies,
@@ -453,8 +465,6 @@ async def create_tool_runner(
     execution_environment = await resolve_execution_environment(
         **implicitly({req: ResolveExecutionDependenciesRequest, environment_name: EnvironmentName}),
     )
-
-    run_field_set: RunFieldSet = run_field_sets.field_sets[0]
 
     # Must be run in target environment so that the binaries/envvars match the execution
     # environment when we actually run the process.


### PR DESCRIPTION
Raise an exception when a non-runnable target is set as the `runnable` for `code_quality_tool` (and other similar uses). Otherise, the user sees an obtuse `IndexError`.

Before:

```
IndexError: tuple index out of range
```

After:

```
pants.engine.target.InvalidFieldException: The `runnable` field in target `pants-macros:gofmt_tool` must be set to the address of a target which can be run by the `run` goal. Instead, the `runnable` field is set to `:gofmt` which refers to the `adhoc_tool` target at `pants-macros:gofmt` that cannot be run by the `run` goal.
```

This particular error arose while I was trying to run `gofmt` as a `code_quality_tool`.