### PR TITLE
Fixed two sources of export_integration_test flakiness

### DIFF
--- a/src/python/pants/backend/python/goals/export_integration_test.py
+++ b/src/python/pants/backend/python/goals/export_integration_test.py
@@ -3,12 +3,12 @@
 
 from __future__ import annotations
 
-import os
 import platform
-import re
 import shutil
-from collections.abc import Mapping, MutableMapping
+from collections.abc import Mapping
+from pathlib import Path
 from textwrap import dedent
+from typing import Any
 
 import pytest
 
@@ -39,9 +39,9 @@ SOURCES = {
 
 
 def build_config(
-    tmpdir: str, py_resolve_format: PythonResolveExportFormat, py_hermetic_scripts: bool = True
-) -> Mapping:
-    cfg: MutableMapping = {
+    py_resolve_format: PythonResolveExportFormat, py_hermetic_scripts: bool = True
+) -> Mapping[str, Any]:
+    return {
         "GLOBAL": {
             "backend_packages": ["pants.backend.python"],
         },
@@ -49,8 +49,8 @@ def build_config(
             "enable_resolves": True,
             "interpreter_constraints": [f"=={platform.python_version()}"],
             "resolves": {
-                "a": f"{tmpdir}/3rdparty/a.lock",
-                "b": f"{tmpdir}/3rdparty/b.lock",
+                "a": "3rdparty/a.lock",
+                "b": "3rdparty/b.lock",
             },
         },
         "export": {
@@ -58,8 +58,6 @@ def build_config(
             "py_non_hermetic_scripts_in_resolve": [] if py_hermetic_scripts else ["a", "b"],
         },
     }
-
-    return cfg
 
 
 @pytest.mark.parametrize(
@@ -71,7 +69,7 @@ def build_config(
     ],
 )
 def test_export(py_resolve_format: PythonResolveExportFormat, py_hermetic_scripts: bool) -> None:
-    with setup_tmpdir(SOURCES) as tmpdir:
+    with setup_tmpdir(SOURCES):
         resolve_names = ["a", "b"]
         run_pants(
             [
@@ -81,85 +79,75 @@ def test_export(py_resolve_format: PythonResolveExportFormat, py_hermetic_script
                 *(f"--resolve={name}" for name in resolve_names),
                 "--export-py-editable-in-resolve=['a']",
             ],
-            config=build_config(tmpdir, py_resolve_format, py_hermetic_scripts),
+            config=build_config(py_resolve_format, py_hermetic_scripts),
         ).assert_success()
 
-    export_prefix = os.path.join("dist", "export", "python", "virtualenvs")
-    assert os.path.isdir(export_prefix), (
-        f"expected export prefix dir '{export_prefix}' does not exist"
-    )
+    export_prefix = Path("dist") / "export" / "python" / "virtualenvs"
+    assert export_prefix.is_dir(), f"export prefix dir '{export_prefix}' does not exist"
+
     py_minor_version = f"{platform.python_version_tuple()[0]}.{platform.python_version_tuple()[1]}"
     for resolve, ansicolors_version in [("a", "1.1.8"), ("b", "1.0.2")]:
-        export_resolve_dir = os.path.join(export_prefix, resolve)
-        assert os.path.isdir(export_resolve_dir), (
+        export_resolve_dir = export_prefix / resolve
+        assert export_resolve_dir.is_dir(), (
             f"expected export resolve dir '{export_resolve_dir}' does not exist"
         )
 
-        export_dir = os.path.join(export_resolve_dir, platform.python_version())
-        assert os.path.isdir(export_dir), f"expected export dir '{export_dir}' does not exist"
+        export_dir = export_resolve_dir / platform.python_version()
+        assert export_dir.is_dir(), f"expected export dir '{export_dir}' does not exist"
         if py_resolve_format == PythonResolveExportFormat.symlinked_immutable_virtualenv:
-            assert os.path.islink(export_dir), (
-                f"expected export dir '{export_dir}' is not a symlink"
-            )
+            assert export_dir.is_symlink(), f"expected export dir '{export_dir}' is not a symlink"
 
-        lib_dir = os.path.join(export_dir, "lib", f"python{py_minor_version}", "site-packages")
-        assert os.path.isdir(lib_dir), f"expected export lib dir '{lib_dir}' does not exist"
-        expected_ansicolors_dir = os.path.join(
-            lib_dir, f"ansicolors-{ansicolors_version}.dist-info"
-        )
-        assert os.path.isdir(expected_ansicolors_dir), (
+        lib_dir = export_dir / "lib" / f"python{py_minor_version}" / "site-packages"
+        assert lib_dir.is_dir(), f"expected export lib dir '{lib_dir}' does not exist"
+        expected_ansicolors_dir = lib_dir / f"ansicolors-{ansicolors_version}.dist-info"
+        assert expected_ansicolors_dir.is_dir(), (
             f"expected dist-info for ansicolors '{expected_ansicolors_dir}' does not exist"
         )
 
         if py_resolve_format == PythonResolveExportFormat.mutable_virtualenv:
-            activate_path = os.path.join(export_dir, "bin", "activate")
-            assert os.path.isfile(activate_path), "virtualenv's bin/activate is missing"
-            with open(activate_path) as activate_file:
-                activate_content = activate_file.read()
+            activate_path = export_dir / "bin" / "activate"
+            activate_contents = activate_path.read_text()
+            expected_version = f"{resolve}/{platform.python_version()}"
+            assert any(
+                line.strip().startswith("PS1=") and expected_version in line
+                for line in activate_contents.splitlines()
+            ), "Expected PS1 prompt not defined in bin/activate."
 
-            prompt_re = re.compile(rf"""PS1=('|")\({resolve}/{platform.python_version()}\) """)
-            assert prompt_re.search(activate_content) is not None, (
-                "Expected PS1 prompt not defined in bin/activate."
-            )
-
-            script_path = os.path.join(export_dir, "bin", "wheel")
-            assert os.path.isfile(script_path), (
-                "expected wheel to be installed, but bin/wheel is missing"
-            )
-            with open(script_path) as script_file:
+            script_path = export_dir / "bin" / "wheel"
+            with script_path.open() as script_file:
                 shebang = script_file.readline().strip()
-            if py_hermetic_scripts:
-                assert shebang.endswith(" -sE")
-            else:
-                assert not shebang.endswith(" -sE")
+                if py_hermetic_scripts:
+                    assert shebang.endswith(" -sE")
+                else:
+                    assert not shebang.endswith(" -sE")
 
-            expected_foo_dir = os.path.join(lib_dir, "foo_dist-1.2.3.dist-info")
+            expected_foo_dir = lib_dir / "foo_dist-1.2.3.dist-info"
             if resolve == "b":
-                assert not os.path.isdir(expected_foo_dir), (
+                assert not expected_foo_dir.is_dir(), (
                     f"unexpected dist-info for foo-dist '{expected_foo_dir}' exists"
                 )
             elif resolve == "a":
                 # make sure the editable wheel for the python_distribution is installed
-                assert os.path.isdir(expected_foo_dir), (
+                assert expected_foo_dir.is_dir(), (
                     f"expected dist-info for foo-dist '{expected_foo_dir}' does not exist"
                 )
+
                 # direct_url__pants__.json should be moved to direct_url.json
-                expected_foo_direct_url_pants = os.path.join(
-                    expected_foo_dir, "direct_url__pants__.json"
-                )
-                assert not os.path.isfile(expected_foo_direct_url_pants), (
+                expected_foo_direct_url_pants = expected_foo_dir / "direct_url__pants__.json"
+                assert not expected_foo_direct_url_pants.is_file(), (
                     f"expected direct_url__pants__.json for foo-dist '{expected_foo_direct_url_pants}' was not removed"
                 )
-                expected_foo_direct_url = os.path.join(expected_foo_dir, "direct_url.json")
-                assert os.path.isfile(expected_foo_direct_url), (
+
+                expected_foo_direct_url = expected_foo_dir / "direct_url.json"
+                assert expected_foo_direct_url.is_file(), (
                     f"expected direct_url.json for foo-dist '{expected_foo_direct_url}' does not exist"
                 )
 
 
 def test_symlinked_venv_resilience() -> None:
     with temporary_dir() as named_caches:
-        pex_root = os.path.join(os.path.realpath(named_caches), "pex_root")
-        with setup_tmpdir(SOURCES) as tmpdir:
+        pex_root = Path(named_caches).resolve() / "pex_root"
+        with setup_tmpdir(SOURCES):
             run_pants(
                 [
                     f"--named-caches-dir={named_caches}",
@@ -167,19 +155,16 @@ def test_symlinked_venv_resilience() -> None:
                     "export",
                     "--resolve=a",
                 ],
-                config=build_config(
-                    tmpdir, PythonResolveExportFormat.symlinked_immutable_virtualenv
-                ),
+                config=build_config(PythonResolveExportFormat.symlinked_immutable_virtualenv),
             ).assert_success()
 
             def check():
-                export_dir = os.path.join(
-                    "dist", "export", "python", "virtualenvs", "a", platform.python_version()
-                )
-                assert os.path.islink(export_dir)
-                export_dir_tgt = os.readlink(export_dir)
-                assert os.path.isdir(export_dir_tgt)
-                assert os.path.commonpath([pex_root, export_dir_tgt]) == pex_root
+                py = platform.python_version()
+                export_dir = Path("dist") / "export" / "python" / "virtualenvs" / "a" / py
+                assert export_dir.is_symlink()
+                export_dir_tgt = export_dir.readlink()
+                assert export_dir_tgt.is_dir()
+                assert export_dir_tgt.is_relative_to(pex_root)
 
             check()
 
@@ -187,9 +172,7 @@ def test_symlinked_venv_resilience() -> None:
 
             run_pants(
                 [f"--named-caches-dir={named_caches}", "export", "--resolve=a"],
-                config=build_config(
-                    tmpdir, PythonResolveExportFormat.symlinked_immutable_virtualenv
-                ),
+                config=build_config(PythonResolveExportFormat.symlinked_immutable_virtualenv),
             ).assert_success()
 
             check()


### PR DESCRIPTION
Discovered these during the Python 3.14 migration, but they're not explicitly related to that.

1. Putting a `tmpdir` in the "build_config resolves" reliably failed this test on my machine (MacOS 15.7.2). Python 3.14 or 3.11, I could not ever get this to succeed for the mutable environments (received `native_engine.IntrinsicError: Unmatched glob from the resolve `b`: "tmpvt7ijaj_/3rdparty/b.lock"`.
2. PS1 in the activation script changed between 3.11 and 3.14, but as per #21756 - we can see this regex wasn't strictly reliable

Also replaced `os` with `pathlib` to help reduce vertical line count