### PR TITLE
Simplify Scheduler.product_request to only take a single subject.

### DIFF
--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -207,7 +207,7 @@ class LocalPantsRunner:
             determine_bootstrap_environment(self.graph_session.scheduler_session),
         )
         (workunits_callback_factories,) = self.graph_session.scheduler_session.product_request(
-            WorkunitsCallbackFactories, [params]
+            WorkunitsCallbackFactories, params
         )
         return tuple(filter(bool, (wcf.callback_factory() for wcf in workunits_callback_factories)))
 

--- a/src/python/pants/core/environments/rules.py
+++ b/src/python/pants/core/environments/rules.py
@@ -150,7 +150,7 @@ async def _warn_on_non_local_environments(specified_targets: Iterable[Target], s
 def determine_bootstrap_environment(session: SchedulerSession) -> EnvironmentName:
     local_env = cast(
         ChosenLocalEnvironmentName,
-        session.product_request(ChosenLocalEnvironmentName, [Params()])[0],
+        session.product_request(ChosenLocalEnvironmentName, Params())[0],
     )
     return local_env.val
 

--- a/src/python/pants/engine/explorer.py
+++ b/src/python/pants/engine/explorer.py
@@ -62,7 +62,7 @@ class RequestState:
     ) -> T:
         result = self.scheduler_session.product_request(
             product,
-            [Params(*subjects, self.env_name)],
+            Params(*subjects, self.env_name),
             poll=poll,
             timeout=timeout,
         )

--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -222,7 +222,7 @@ def mk_scheduler(
 def test_recursive_multi_get(tmp_path: Path) -> None:
     # Tests that a rule that "uses itself" multiple times per invoke works.
     rules = [fib, QueryRule(Fib, (int,))]
-    (fib_10,) = mk_scheduler(tmp_path, rules=rules).product_request(Fib, subjects=[10])
+    (fib_10,) = mk_scheduler(tmp_path, rules=rules).product_request(Fib, subject=10)
     assert 55 == fib_10.val
 
 
@@ -230,28 +230,9 @@ def test_no_include_trace_error_raises_boring_error(tmp_path: Path) -> None:
     rules = [nested_raise, QueryRule(A, (B,))]
     scheduler = mk_scheduler(tmp_path, rules, include_trace_on_error=False)
     with pytest.raises(ExecutionError) as cm:
-        list(scheduler.product_request(A, subjects=[(B())]))
+        list(scheduler.product_request(A, subject=B()))
     assert_equal_with_printing(
         "1 Exception encountered:\n\nException: An exception for B\n", str(cm.value)
-    )
-
-
-def test_no_include_trace_error_multiple_paths_raises_executionerror(tmp_path: Path) -> None:
-    rules = [nested_raise, QueryRule(A, (B,))]
-    scheduler = mk_scheduler(tmp_path, rules, include_trace_on_error=False)
-    with pytest.raises(ExecutionError) as cm:
-        list(scheduler.product_request(A, subjects=[B(), B()]))
-    assert_equal_with_printing(
-        dedent(
-            """
-            2 Exceptions encountered:
-
-            Exception: An exception for B
-
-            (and 1 more)
-            """
-        ).lstrip(),
-        str(cm.value),
     )
 
 
@@ -259,7 +240,7 @@ def test_include_trace_error_raises_error_with_trace(tmp_path: Path) -> None:
     rules = [nested_raise, QueryRule(A, (B,))]
     scheduler = mk_scheduler(tmp_path, rules, include_trace_on_error=True)
     with pytest.raises(ExecutionError) as cm:
-        list(scheduler.product_request(A, subjects=[(B())]))
+        list(scheduler.product_request(A, subject=(B())))
     assert_equal_with_printing(
         dedent(
             """
@@ -299,7 +280,7 @@ def test_missing_query_rule(tmp_path: Path) -> None:
     # for the graph to work when making a synchronous call via `Scheduler.product_request`.
     scheduler = mk_scheduler(tmp_path, rules=[upcast], include_trace_on_error=False)
     with pytest.raises(Exception) as cm:
-        scheduler.product_request(MyFloat, subjects=[MyInt(0)])
+        scheduler.product_request(MyFloat, subject=MyInt(0))
     assert (
         "No installed QueryRules return the type MyFloat. Try registering QueryRule(MyFloat "
         "for MyInt)."
@@ -346,7 +327,7 @@ def test_streaming_workunits_reporting(tmp_path: Path) -> None:
         tmp_path / "start", [fib, QueryRule(Fib, (int,))]
     )
     with handler:
-        scheduler.product_request(Fib, subjects=[0])
+        scheduler.product_request(Fib, subject=0)
     flattened = list(itertools.chain.from_iterable(tracker.finished_workunit_chunks))
     # The execution of the single named @rule "fib" should be providing this one workunit.
     assert len(flattened) == 1
@@ -355,7 +336,7 @@ def test_streaming_workunits_reporting(tmp_path: Path) -> None:
         tmp_path / "second", [fib, QueryRule(Fib, (int,))]
     )
     with handler:
-        scheduler.product_request(Fib, subjects=[10])
+        scheduler.product_request(Fib, subject=10)
 
     # Requesting a bigger fibonacci number will result in more rule executions and thus
     # more reported workunits. In this case, we expect 11 invocations of the `fib` rule.
@@ -371,7 +352,7 @@ def test_streaming_workunits_parent_id_and_rule_metadata(tmp_path: Path) -> None
     )
     with handler:
         i = Input()
-        scheduler.product_request(Beta, subjects=[i])
+        scheduler.product_request(Beta, subject=i)
     assert tracker.finished
 
     # rule_one should complete well-after the other rules because of the artificial delay in
@@ -423,7 +404,7 @@ def test_streaming_workunit_log_levels(tmp_path: Path) -> None:
     )
     with handler:
         i = Input()
-        scheduler.product_request(Beta, subjects=[i])
+        scheduler.product_request(Beta, subject=i)
 
     assert tracker.finished
     finished = list(itertools.chain.from_iterable(tracker.finished_workunit_chunks))
@@ -454,7 +435,7 @@ def test_streaming_workunit_log_level_parent_rewrite(tmp_path: Path) -> None:
     scheduler, tracker, info_level_handler = _fixture_for_rules(tmp_path, rules)
     with info_level_handler:
         i = Input()
-        scheduler.product_request(Alpha, subjects=[i])
+        scheduler.product_request(Alpha, subject=i)
 
     assert tracker.finished
     finished = list(itertools.chain.from_iterable(tracker.finished_workunit_chunks))
@@ -474,7 +455,7 @@ def test_streaming_workunit_log_level_parent_rewrite(tmp_path: Path) -> None:
     )
     with debug_level_handler:
         i = Input()
-        scheduler.product_request(Alpha, subjects=[i])
+        scheduler.product_request(Alpha, subject=i)
 
     assert tracker.finished
     finished = list(itertools.chain.from_iterable(tracker.finished_workunit_chunks))
@@ -511,7 +492,7 @@ def test_engine_aware_rule(tmp_path: Path) -> None:
         max_workunit_verbosity=LogLevel.TRACE,
     )
     with handler:
-        scheduler.product_request(ModifiedOutput, subjects=[0])
+        scheduler.product_request(ModifiedOutput, 0)
 
     finished = list(itertools.chain.from_iterable(tracker.finished_workunit_chunks))
     workunit = next(
@@ -538,7 +519,7 @@ def test_engine_aware_param(tmp_path: Path) -> None:
         max_workunit_verbosity=LogLevel.TRACE,
     )
     with handler:
-        scheduler.product_request(int, subjects=[ModifiedMetadata()])
+        scheduler.product_request(int, subject=ModifiedMetadata())
 
     finished = list(itertools.chain.from_iterable(tracker.finished_workunit_chunks))
     workunit = next(
@@ -570,7 +551,7 @@ def test_engine_aware_none_case(tmp_path: Path) -> None:
         max_workunit_verbosity=LogLevel.TRACE,
     )
     with handler:
-        scheduler.product_request(ModifiedOutput, subjects=[0])
+        scheduler.product_request(ModifiedOutput, subject=0)
 
     finished = list(itertools.chain.from_iterable(tracker.finished_workunit_chunks))
     workunit = next(
@@ -597,7 +578,7 @@ def test_artifacts_on_engine_aware_type(tmp_path: Path) -> None:
         tmp_path, [a_rule, QueryRule(Output, (int,))], max_workunit_verbosity=LogLevel.TRACE
     )
     with handler:
-        scheduler.product_request(Output, subjects=[0])
+        scheduler.product_request(Output, subject=0)
 
     finished = list(itertools.chain.from_iterable(tracker.finished_workunit_chunks))
     workunit = next(
@@ -626,7 +607,7 @@ def test_metadata_on_engine_aware_type(tmp_path: Path) -> None:
         tmp_path, [a_rule, QueryRule(Output, (int,))], max_workunit_verbosity=LogLevel.TRACE
     )
     with handler:
-        scheduler.product_request(Output, subjects=[0])
+        scheduler.product_request(Output, subject=0)
 
     finished = list(itertools.chain.from_iterable(tracker.finished_workunit_chunks))
     workunit = next(
@@ -660,7 +641,7 @@ def test_metadata_non_string_key_behavior(tmp_path: Path) -> None:
         tmp_path, [a_rule, QueryRule(Output, (int,))], max_workunit_verbosity=LogLevel.TRACE
     )
     with handler:
-        scheduler.product_request(Output, subjects=[0])
+        scheduler.product_request(Output, subject=0)
 
     finished = list(itertools.chain.from_iterable(tracker.finished_workunit_chunks))
     workunit = next(

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -570,30 +570,30 @@ class SchedulerSession:
             )
         with self._goals._execute(product):
             (return_value,) = self.product_request(
-                product, [subject], poll=poll, poll_delay=poll_delay
+                product, subject, poll=poll, poll_delay=poll_delay
             )
         return cast(int, return_value.exit_code)
 
     def product_request(
         self,
         product: type,
-        subjects: Sequence[Any | Params],
+        subject: Any | Params,
         *,
         poll: bool = False,
         poll_delay: float | None = None,
         timeout: float | None = None,
     ) -> list:
-        """Executes a request for a single product for some subjects, and returns the products.
+        """Executes a request for a single product for a subject, and returns the products.
 
         :param product: A product type for the request.
-        :param subjects: A list of subjects or Params instances for the request.
+        :param subject: A subject or Params instance for the request.
         :param poll: See self.execution_request.
         :param poll_delay: See self.execution_request.
         :param timeout: See self.execution_request.
         :returns: A list of the requested products, with length match len(subjects).
         """
         request = self.execution_request(
-            [(product, subject) for subject in subjects],
+            [(product, subject)],
             poll=poll,
             poll_delay=poll_delay,
             timeout=timeout,
@@ -625,7 +625,7 @@ class SchedulerSession:
         each snapshot needs to yield a separate `DigestContents`.
         """
         return tuple(
-            self.product_request(DigestContents, [snapshot.digest])[0] for snapshot in snapshots
+            self.product_request(DigestContents, snapshot.digest)[0] for snapshot in snapshots
         )
 
     def ensure_remote_has_recursive(self, digests: Sequence[Digest | FileDigest]) -> None:

--- a/src/python/pants/goal/explorer.py
+++ b/src/python/pants/goal/explorer.py
@@ -56,7 +56,7 @@ class ExplorerBuiltinGoal(BuiltinGoal):
 
         env_name = determine_bootstrap_environment(graph_session.scheduler_session)
         build_symbols = graph_session.scheduler_session.product_request(
-            BuildFileSymbolsInfo, [Params(env_name)]
+            BuildFileSymbolsInfo, Params(env_name)
         )[0]
         all_help_info = HelpInfoExtracter.get_all_help_info(
             options,

--- a/src/python/pants/goal/help.py
+++ b/src/python/pants/goal/help.py
@@ -46,7 +46,7 @@ class HelpBuiltinGoalBase(BuiltinGoal):
     ) -> ExitCode:
         env_name = determine_bootstrap_environment(graph_session.scheduler_session)
         build_symbols = graph_session.scheduler_session.product_request(
-            BuildFileSymbolsInfo, [Params(env_name)]
+            BuildFileSymbolsInfo, Params(env_name)
         )[0]
         all_help_info = HelpInfoExtracter.get_all_help_info(
             options,

--- a/src/python/pants/goal/migrate_call_by_name.py
+++ b/src/python/pants/goal/migrate_call_by_name.py
@@ -89,7 +89,7 @@ class MigrateCallByNameBuiltinGoal(BuiltinGoal):
 
         plan_files = {item["filepath"] for item in migration_plan}
 
-        paths: list[Paths] = graph_session.scheduler_session.product_request(Paths, [path_globs])
+        paths: list[Paths] = graph_session.scheduler_session.product_request(Paths, path_globs)
         requested_files = set(paths[0].files)
 
         files_to_migrate = requested_files.intersection(plan_files)

--- a/src/python/pants/init/plugin_resolver.py
+++ b/src/python/pants/init/plugin_resolver.py
@@ -178,7 +178,7 @@ class PluginResolver:
         params = Params(request, determine_bootstrap_environment(session))
         return cast(
             ResolvedPluginDistributions,
-            session.product_request(ResolvedPluginDistributions, [params])[0],
+            session.product_request(ResolvedPluginDistributions, params)[0],
         )
 
 

--- a/src/python/pants/init/specs_calculator.py
+++ b/src/python/pants/init/specs_calculator.py
@@ -62,9 +62,9 @@ def calculate_specs(
 
     bootstrap_environment = determine_bootstrap_environment(session)
 
-    (git_binary,) = session.product_request(GitBinary, [Params(bootstrap_environment)])
+    (git_binary,) = session.product_request(GitBinary, Params(bootstrap_environment))
     (maybe_git_worktree,) = session.product_request(
-        MaybeGitWorktree, [Params(GitWorktreeRequest(), git_binary, bootstrap_environment)]
+        MaybeGitWorktree, Params(GitWorktreeRequest(), git_binary, bootstrap_environment)
     )
     if not maybe_git_worktree.git_worktree:
         raise InvalidSpecConstraint(
@@ -72,7 +72,7 @@ def calculate_specs(
         )
 
     (files_with_sources_blocks,) = session.product_request(
-        FilesWithSourceBlocks, [Params(bootstrap_environment)]
+        FilesWithSourceBlocks, Params(bootstrap_environment)
     )
     changed_files = tuple(
         file
@@ -104,7 +104,7 @@ def calculate_specs(
     )
     (changed_addresses,) = session.product_request(
         ChangedAddresses,
-        [Params(changed_request, options_bootstrapper, bootstrap_environment)],
+        Params(changed_request, options_bootstrapper, bootstrap_environment),
     )
     logger.debug("changed addresses: %s", changed_addresses)
 

--- a/src/python/pants/pantsd/service/scheduler_service.py
+++ b/src/python/pants/pantsd/service/scheduler_service.py
@@ -81,7 +81,7 @@ class SchedulerService(PantsService):
         try:
             snapshot = self._scheduler_session.product_request(
                 Snapshot,
-                subjects=[PathGlobs(globs)],
+                subject=PathGlobs(globs),
                 poll=poll,
                 timeout=timeout,
             )[0]

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -409,7 +409,7 @@ class RuleRunner:
             else Params(*inputs)
         )
         with self.pushd():
-            result = assert_single_element(self.scheduler.product_request(output_type, [params]))
+            result = assert_single_element(self.scheduler.product_request(output_type, params))
         return cast(_O, result)
 
     def run_goal_rule(


### PR DESCRIPTION
In practice we were only ever passing a single subject. And the
behavior with multiple subjects is odd: we'd request the same
product multiple times, once for each subject.

Note that a single subject can encompass multiple params,
if it is a Params instance.
