### PR TITLE
Avoid allocating in `pre_exec` closure

### DIFF
--- a/src/rust/process_execution/children/src/lib.rs
+++ b/src/rust/process_execution/children/src/lib.rs
@@ -39,9 +39,8 @@ impl ManagedChild {
         // later.
         unsafe {
             command.pre_exec(|| {
-                nix::unistd::setsid()
-                    .map(|_pgid| ())
-                    .map_err(|e| std::io::Error::other(format!("Could not create new pgid: {e}")))
+                nix::unistd::setsid()?;
+                Ok(())
             });
         };
 


### PR DESCRIPTION
`Error::other` allocates memory (see https://github.com/rust-lang/rust/pull/148971). This is bad in multi-threaded programs, which pants AFAIK is. If the fork occurs while the allocator lock is held by another thread, deadlocks can occur, since there's no one left in the new process to unlock the mutex. I do not believe this is UB, and modern libc offer protections against this issue, but this isn't POSIX-compliant and should preferably be avoided.

`nix` provides a non-allocating `impl From<Errno> for std::io::Error`, which can be used instead. This doesn't allow an additional message to be added, but since error messages aren't transmitted across `pre_exec` boundary anyway, this doesn't make visible behavior any worse. On the flip side, this ensures that the correct error code is forwarded to the parent process, instead of the default `-EINVAL`.