### PR TITLE
Added write permission to nudgebot

### DIFF
--- a/.github/workflows/nudgebot.yaml
+++ b/.github/workflows/nudgebot.yaml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'pantsbuild'
     permissions:
+      actions: write
       issues: write
     steps:
       - uses: actions/stale@v10
@@ -33,5 +34,5 @@ jobs:
           days-before-pr-stale: -1
           days-before-pr-close: -1
 
-          operations-per-run: 100
+          operations-per-run: 250
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Also increased the operations-per-run slightly

Was getting this the past few runs, and nothing was happening:
> Error delete _state: [403] Resource not accessible by integration

Turns out the actions/stale cache falls over pretty quick, and this additional permission lets it delete the cache to sort itself out. It happens pretty fast too - I manually deleted cache and did 3-4 runs, and it started popping up again.

https://github.com/actions/stale/issues/1131
https://github.com/actions/stale/pull/1248