### PR TITLE
Mostly revert "Temporarily disable macos cache"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -280,8 +280,7 @@ jobs:
         version: 23.x
     - name: Set rustup profile
       run: rustup set profile default
-    - if: runner.os != 'macOS'
-      name: Cache Rust toolchain
+    - name: Cache Rust toolchain
       uses: actions/cache@v4
       with:
         key: macOS14-ARM64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
@@ -403,8 +402,7 @@ jobs:
         version: 23.x
     - name: Set rustup profile
       run: rustup set profile default
-    - if: runner.os != 'macOS'
-      name: Cache Rust toolchain
+    - name: Cache Rust toolchain
       uses: actions/cache@v4
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,8 +39,7 @@ jobs:
         version: 23.x
     - name: Set rustup profile
       run: rustup set profile default
-    - if: runner.os != 'macOS'
-      name: Cache Rust toolchain
+    - name: Cache Rust toolchain
       uses: actions/cache@v4
       with:
         key: Linux-ARM64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
@@ -138,8 +137,7 @@ jobs:
         version: 23.x
     - name: Set rustup profile
       run: rustup set profile default
-    - if: runner.os != 'macOS'
-      name: Cache Rust toolchain
+    - name: Cache Rust toolchain
       uses: actions/cache@v4
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
@@ -245,8 +243,7 @@ jobs:
         version: 23.x
     - name: Set rustup profile
       run: rustup set profile default
-    - if: runner.os != 'macOS'
-      name: Cache Rust toolchain
+    - name: Cache Rust toolchain
       uses: actions/cache@v4
       with:
         key: macOS14-ARM64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
@@ -498,8 +495,7 @@ jobs:
         version: 23.x
     - name: Set rustup profile
       run: rustup set profile default
-    - if: runner.os != 'macOS'
-      name: Cache Rust toolchain
+    - name: Cache Rust toolchain
       uses: actions/cache@v4
       with:
         key: macOS14-ARM64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -523,7 +523,6 @@ class Helper:
             },
             {
                 "name": "Cache Rust toolchain",
-                "if": "runner.os != 'macOS'",
                 "uses": action("cache"),
                 "with": {
                     "path": f"~/.rustup/toolchains/{rust_channel()}-*\n~/.rustup/update-hashes\n~/.rustup/settings.toml\n",


### PR DESCRIPTION
Reverts pantsbuild/pants#22912

Did this manually, so I could keep the comment I left at the top of the github workflow generation script. 

The bug is supposedly fixed (via rollback): https://github.com/actions/runner-images/issues/13341#issuecomment-3570231171