### PR TITLE
nfpm.native_libs.elfdeps: update test dep

### DIFF
--- a/src/python/pants/backend/nfpm/native_libs/elfdeps/rules_integration_test.py
+++ b/src/python/pants/backend/nfpm/native_libs/elfdeps/rules_integration_test.py
@@ -61,13 +61,11 @@ def rule_runner() -> RuleRunner:
     return rule_runner
 
 
-# This has SO versions for the setproctitle==1.3.6 NEEDS libc.so.6 by architecture.
+# This has SO versions for the setproctitle==1.3.7 NEEDS libc.so.6 by architecture.
 _SETPROCTITLE_LIBC6_SO_VERSIONS = {
     "x86_64": ("", "GLIBC_2.2.5"),
     "aarch64": ("", "GLIBC_2.17"),
     "powerpc64le": ("", "GLIBC_2.17"),
-    "i686": ("", "GLIBC_2.0", "GLIBC_2.1.3"),
-    "i386": ("", "GLIBC_2.0", "GLIBC_2.1.3"),
 }
 
 
@@ -77,7 +75,7 @@ _SETPROCTITLE_LIBC6_SO_VERSIONS = {
     (
         pytest.param(["cowsay==4.0"], "cowsay", (), (), id="cowsay"),
         pytest.param(
-            ["setproctitle==1.3.6"],
+            ["setproctitle==1.3.7"],
             None,
             (
                 SOInfo(
@@ -125,7 +123,12 @@ def test_elfdeps_analyze_pex_wheels(
             "BUILD": dedent(
                 f"""
                 python_requirement(name="req", requirements={pex_reqs!r})
-                pex_binary(name="pex", script={pex_script!r}, dependencies=[":req"])
+                pex_binary(
+                    name="pex",
+                    script={pex_script!r},
+                    extra_build_args=["--no-build"],  # no sdists
+                    dependencies=[":req"],
+                )
                 """
             )
         }


### PR DESCRIPTION
setproctitle is used to test inspecting ELF deps in wheels.
- [v1.3.6](https://pypi.org/project/setproctitle/1.3.6/#files) had wheels for py3.11, but not py3.14.
- [v1.3.7](https://pypi.org/project/setproctitle/1.3.7/#files) has wheels for both py3.11 and py3.14 (using same manylinux).

The version of libc linked in the library is constrained by the manylinux tag of the wheels. So, upgrading the actual libc deps should only have to be upgraded in this test if the manylinux tag gets updated.

I also added "--no-build" to the test pex_binary extra args to make sure we don't get spurious errors if someone runs this test on a platform that does not have setproctitle wheels available. This would have changed the error received when testing v1.3.6 with py3.14, making it complain about the lack of a wheel instead of checking the ELF deps of a wheel built locally from an sdist.

v1.3.7 stopped building i686/i386 wheels, so I dropped that from the test metadata as well. We don't test on i686 anyway, so no loss.