### PR TITLE
Use a PAT for the RunsOn AMI generator job

### DIFF
--- a/.github/workflows/build_runson_ami.yaml
+++ b/.github/workflows/build_runson_ami.yaml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 10
       - name: Run packer
         env:
-            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            GH_TOKEN: ${{ secrets.WORKER_PANTS_RUNSON_AMI_PAT }}
             AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
             AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |


### PR DESCRIPTION
The default GITHUB_TOKEN cannot trigger checks, so
we must use a custom PAT (which has been set up).