### PR TITLE
free up disk space in runner image

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,6 +26,16 @@ jobs:
     - image=ubuntu22-full-arm64-python3.7-3.13
     - run-id=${{ github.run_id }}
     steps:
+    - name: Free up disk space
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+      with:
+        android: true
+        docker-images: false
+        dotnet: true
+        haskell: true
+        large-packages: false
+        swap-storage: false
+        tool-cache: false
     - name: Check out code
       uses: actions/checkout@v5
       with:
@@ -132,6 +142,16 @@ jobs:
     runs-on:
     - ubuntu-22.04
     steps:
+    - name: Free up disk space
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+      with:
+        android: true
+        docker-images: false
+        dotnet: true
+        haskell: true
+        large-packages: false
+        swap-storage: false
+        tool-cache: false
     - name: Check out code
       uses: actions/checkout@v5
       with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -360,6 +360,16 @@ jobs:
     - image=ubuntu22-full-arm64-python3.7-3.13
     - run-id=${{ github.run_id }}
     steps:
+    - name: Free up disk space
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+      with:
+        android: true
+        docker-images: false
+        dotnet: true
+        haskell: true
+        large-packages: false
+        swap-storage: false
+        tool-cache: false
     - name: Check out code
       uses: actions/checkout@v5
       with:
@@ -429,6 +439,16 @@ jobs:
     runs-on:
     - ubuntu-22.04
     steps:
+    - name: Free up disk space
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+      with:
+        android: true
+        docker-images: false
+        dotnet: true
+        haskell: true
+        large-packages: false
+        swap-storage: false
+        tool-cache: false
     - name: Check out code
       uses: actions/checkout@v5
       with:

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -965,6 +965,7 @@ def build_wheels_job(
 
     if container:
         initial_steps = [
+            free_disk_space_step(),
             *checkout(containerized=True, ref=for_deploy_ref),
             *install_rustup(),
             {


### PR DESCRIPTION
We were hitting disk space issues in other PRs (e.g., https://github.com/pantsbuild/pants/pull/22950#issuecomment-3665657803). Use the same action [as used by pex](https://github.com/pex-tool/pex/blob/724c208ad4749c8d89d7f63c67da43619939bdcf/.github/workflows/ci.yml#L132-L143) to free up disk space (although we pin to a specific commit for supply chain reasons).