### PR TITLE
free up disk space in runner image (even from containers)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -126,7 +126,7 @@ jobs:
     container:
       image: quay.io/pypa/manylinux_2_28_x86_64:latest
       volumes:
-      - /: /mnt/host-root
+      - /:/mnt/host-root
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
       PANTS_REMOTE_CACHE_READ: 'false'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -422,7 +422,7 @@ jobs:
     container:
       image: quay.io/pypa/manylinux_2_28_x86_64:latest
       volumes:
-      - /: /mnt/host-root
+      - /:/mnt/host-root
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
       MODE: debug

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -976,7 +976,7 @@ def build_wheels_job(
     if platform == Platform.LINUX_X86_64:
         container = {
             "image": "quay.io/pypa/manylinux_2_28_x86_64:latest",
-            "volumes": [{"/": "/mnt/host-root"}],
+            "volumes": ["/:/mnt/host-root"],
         }
     elif platform == Platform.LINUX_ARM64:
         container = {"image": "quay.io/pypa/manylinux_2_28_aarch64:latest"}


### PR DESCRIPTION
This extends @tdyas work in #22954 by deleting files on the host in the one  wheel building instance we are running from within a container.