### PR TITLE
docs: codify the expected number of concurrent stable branches

### DIFF
--- a/docs/docs/contributions/releases/release-strategy.mdx
+++ b/docs/docs/contributions/releases/release-strategy.mdx
@@ -96,7 +96,7 @@ Dev releases are named with the major, minor, and patch version, and end in `.de
 Dev releases can include any changes, so long as they comply with the [Deprecation policy](../../releases/deprecation-policy.mdx).
 
 :::note How many dev releases until starting a release candidate?
-Usually, we release about six dev releases (aligning with the desired stable release cadence) before switching to the alpha release `a0`. This means we usually release `dev0`, `dev1`, `dev2`, sometimes `dev3`, and then `a0`.
+Usually, we release about six dev releases (aligning with the desired stable release cadence) before switching to the alpha release `a0`. This means we usually release `dev0`, `dev1`, etc through about `dev5`, and then `a0`.
 
 We try to limit the number of changes in each stable release to make it easier for users to upgrade. If the dev releases have been particularly disruptive, such as making major deprecations, we may start a release candidate sooner, such as after `dev1`.
 :::


### PR DESCRIPTION
Following up from the Dec 8 dev meeting,