### PR TITLE
remove `CARGO_BUILD_JOBS` debug leftover

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -109,7 +109,6 @@ jobs:
           src/python/pants/engine/internals/native_engine.so
           src/python/pants/engine/internals/native_engine.so.metadata
     - env:
-        CARGO_BUILD_JOBS: '1'
         TMPDIR: ${{ runner.temp }}
       if: needs.classify_changes.outputs.rust == 'true'
       name: Test Rust
@@ -224,7 +223,6 @@ jobs:
       run: |
         ./pants run src/python/pants_release/generate_github_workflows.py -- --check
     - env:
-        CARGO_BUILD_JOBS: '1'
         TMPDIR: ${{ runner.temp }}
       if: needs.classify_changes.outputs.rust == 'true'
       name: Test and lint Rust
@@ -334,7 +332,6 @@ jobs:
           src/python/pants/engine/internals/native_engine.so
           src/python/pants/engine/internals/native_engine.so.metadata
     - env:
-        CARGO_BUILD_JOBS: '1'
         TMPDIR: ${{ runner.temp }}
       if: needs.classify_changes.outputs.rust == 'true'
       name: Test Rust

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -777,7 +777,6 @@ def bootstrap_jobs(
                         # invalid doc tests in their comments.
                         "run": step_cmd,
                         "env": {
-                            "CARGO_BUILD_JOBS": "1",
                             "TMPDIR": f"{gha_expr('runner.temp')}",
                         },
                         "if": DONT_SKIP_RUST,


### PR DESCRIPTION
Remove `CARGO_BUILD_JOBS` debug config left over from https://github.com/pantsbuild/pants/pull/22950 when trying to better understand the disk space full issues.