### PR TITLE
plumb through more of Pex's --scie flags

### DIFF
--- a/src/python/pants/backend/python/goals/package_pex_binary.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary.py
@@ -28,12 +28,15 @@ from pants.backend.python.target_types import (
     PexLayout,
     PexLayoutField,
     PexScieBusyBox,
-    PexScieBusyboxPexEntrypointEnvPassthrough,
     PexScieField,
     PexScieHashAlgField,
+    PexScieLoadDotenvField,
     PexScieNameStyleField,
+    PexSciePbsDebug,
+    PexSciePbsFreeThreaded,
     PexSciePbsReleaseField,
     PexSciePbsStripped,
+    PexSciePexEntrypointEnvPassthrough,
     PexSciePlatformField,
     PexSciePythonVersion,
     PexScriptField,
@@ -100,13 +103,16 @@ class PexBinaryFieldSet(PackageFieldSet, RunFieldSet):
     extra_build_args: PexExtraBuildArgsField
 
     scie: PexScieField
+    scie_load_dotenv: PexScieLoadDotenvField
     scie_name_style: PexScieNameStyleField
     scie_busybox: PexScieBusyBox
-    scie_busybox_pex_entrypoint_env_passthrough: PexScieBusyboxPexEntrypointEnvPassthrough
+    scie_pex_entrypoint_env_passthrough: PexSciePexEntrypointEnvPassthrough
     scie_platform: PexSciePlatformField
     scie_pbs_release: PexSciePbsReleaseField
     scie_python_version: PexSciePythonVersion
     scie_hash_alg: PexScieHashAlgField
+    scie_pbs_free_threaded: PexSciePbsFreeThreaded
+    scie_pbs_debug: PexSciePbsDebug
     scie_pbs_stripped: PexSciePbsStripped
 
     def builds_pex_and_scie(self) -> bool:
@@ -152,11 +158,16 @@ class PexBinaryFieldSet(PackageFieldSet, RunFieldSet):
         args = []
         if self.scie.value is not None:
             args.append(f"--scie={self.scie.value}")
+        if self.scie_load_dotenv.value is not None:
+            if self.scie_load_dotenv.value:
+                args.append("--scie-load-dotenv")
+            else:
+                args.append("--no-scie-load-dotenv")
         if self.scie_name_style.value is not None:
             args.append(f"--scie-name-style={self.scie_name_style.value}")
         if self.scie_busybox.value is not None:
             args.append(f"--scie-busybox={self.scie_busybox.value}")
-        if self.scie_busybox_pex_entrypoint_env_passthrough.value is True:
+        if self.scie_pex_entrypoint_env_passthrough.value is True:
             args.append("--scie-busybox-pex-entrypoint-env-passthrough")
         if self.scie_platform.value is not None:
             args.extend([f"--scie-platform={platform}" for platform in self.scie_platform.value])
@@ -166,6 +177,16 @@ class PexBinaryFieldSet(PackageFieldSet, RunFieldSet):
             args.append(f"--scie-python-version={self.scie_python_version.value}")
         if self.scie_hash_alg.value is not None:
             args.append(f"--scie-hash-alg={self.scie_hash_alg.value}")
+        if self.scie_pbs_debug.value is not None:
+            if self.scie_pbs_debug.value:
+                args.append("--scie-pbs-debug")
+            else:
+                args.append("--no-scie-pbs-debug")
+        if self.scie_pbs_free_threaded.value is not None:
+            if self.scie_pbs_free_threaded.value:
+                args.append("--scie-pbs-free-threaded")
+            else:
+                args.append("--no-scie-pbs-free-threaded")
         if self.scie_pbs_stripped.value is True:
             args.append("--scie-pbs-stripped")
 

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -767,6 +767,19 @@ class ScieNameStyle(StrEnum):
     PLATFORM_FILE_SUFFIX = "platform-file-suffix"
 
 
+class PexScieLoadDotenvField(TriBoolField):
+    alias = "scie_load_dotenv"
+    required = False
+    default = None
+    help = help_text(
+        """ Have the scie launcher load `.env` files and apply the loaded env
+        vars to the PEX scie environment. See the 'load_dotenv' docs here for
+        more on the `.env` loading specifics: https://github.com/a-
+        scie/jump/blob/main/docs/packaging.md#optional-fields (Pex default:
+        False) """
+    )
+
+
 class PexScieNameStyleField(StringField):
     alias = "scie_name_style"
     valid_choices = ScieNameStyle
@@ -822,15 +835,19 @@ class PexScieBusyBox(StringField):
     )
 
 
-class PexScieBusyboxPexEntrypointEnvPassthrough(TriBoolField):
-    alias = "scie_busybox_pex_entrypoint_env_passthrough"
+class PexSciePexEntrypointEnvPassthrough(TriBoolField):
+    alias = "scie_pex_entrypoint_env_passthrough"
     required = False
     default = None
     help = help_text(
-        """ When creating a busybox, allow overriding the primary entrypoint
-        at runtime via PEX_INTERPRETER, PEX_SCRIPT and PEX_MODULE. Note that
-        when using the `venv` execution mode this adds modest startup overhead
-        on the order of 10ms.  """
+        """
+        Allow overriding the primary entrypoint at runtime via
+        PEX_INTERPRETER, PEX_SCRIPT and PEX_MODULE. Note that
+        when using --venv with a script entrypoint this adds
+        modest startup overhead on the order of 10ms. Defaults
+        to false for busybox scies and true for single
+        entrypoint scies.
+        """
     )
 
 
@@ -891,6 +908,31 @@ class PexSciePythonVersion(StringField):
     )
 
 
+class PexSciePbsFreeThreaded(TriBoolField):
+    alias = "scie_pbs_free_threaded"
+    default = None
+    help = help_text(
+        """
+        Should the Python Standalone Builds CPython
+        distributions be free-threaded. If left unspecified or
+        otherwise turned off, creating a scie from a PEX with
+        free-threaded abi wheels will automatically turn this
+        option on. Note that this option is not compatible
+        with `scie_pbs_stripped=True`. (Pex default: False)
+        """
+    )
+
+
+class PexSciePbsDebug(TriBoolField):
+    alias = "scie_pbs_debug"
+    default = None
+    help = help_text(
+        """ Should the Python Standalone Builds CPython distributions be debug
+        builds. Note that this option is not compatible with
+        `scie_pbs_stripped=True`. (default: False) """
+    )
+
+
 class PexSciePbsStripped(TriBoolField):
     alias = "scie_pbs_stripped"
     required = False
@@ -899,7 +941,9 @@ class PexSciePbsStripped(TriBoolField):
         """ Should the Python Standalone Builds CPython distributions used be
         stripped of debug symbols or not. For Linux and Windows particularly,
         the stripped distributions are less than half the size of the
-        distributions that ship with debug symbols.  """
+        distributions that ship with debug symbols.  Note that this option is
+        not compatible with `scie_pbs_free_threaded=True` or
+        `scie_pbs_debug=True`. (Pex default: False) """
     )
 
 
@@ -944,12 +988,15 @@ _PEX_BINARY_COMMON_FIELDS = (
 
 _PEX_SCIE_BINARY_FIELDS = (
     PexScieField,
+    PexScieLoadDotenvField,
     PexScieNameStyleField,
     PexScieBusyBox,
-    PexScieBusyboxPexEntrypointEnvPassthrough,
+    PexSciePexEntrypointEnvPassthrough,
     PexSciePlatformField,
     PexSciePbsReleaseField,
     PexSciePythonVersion,
+    PexSciePbsFreeThreaded,
+    PexSciePbsDebug,
     PexSciePbsStripped,
     PexScieHashAlgField,
 )

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -49,7 +49,7 @@ class PexCli(TemplatedExternalTool):
 
     default_version = _PEX_VERSION
     default_url_template = "https://github.com/pex-tool/pex/releases/download/{version}/pex"
-    version_constraints = ">=2.13.0,<3.0"
+    version_constraints = ">=2.76.0,<3.0"
 
     # extra args to be passed to the pex tool; note that they
     # are going to apply to all invocations of the pex tool.


### PR DESCRIPTION
 * --scie-pbs-free-threaded / --scie-pbs-debug which are new since when I started #22866
 * --scie-load-dotenv https://github.com/pex-tool/pex/releases/tag/v2.75.0
 * revised entrypoint https://github.com/pex-tool/pex/releases/tag/v2.76.0

Since there has not been a relase with these yet, I've changed the name without doing a depreciation cycle