### PR TITLE
Error out of `./cargo` scripts if we don't have the `protoc` dependency available

### DIFF
--- a/cargo
+++ b/cargo
@@ -24,7 +24,11 @@ if is_macos_big_sur; then
 fi
 
 if ! command -v rustup &> /dev/null; then
-  die "Please install Rustup and ensure \`rustup\` is on your PATH (usually by adding ~/.cargo/bin). See https://rustup.rs."
+  die "Please install Rustup and ensure \`rustup\` is on your PATH (usually by adding ~/.cargo/bin). See https://rustup.rs"
+fi
+
+if ! command -v protoc &> /dev/null; then
+  die "Please install the protocol buffers compiler and ensure \`protoc\` is on your PATH (as required by tonic-build). See https://protobuf.dev/installation/"
 fi
 
 cd "${REPO_ROOT}/src/rust" || exit "${PIPESTATUS[0]}"


### PR DESCRIPTION
Closes #22998 
Closes #20666 

Normally this would fail sometime later during bootstrapping, but as this is now a hard dependency since `prost-build` (and/or `tonic-build`) stopped shipping it, we shouldn't even start compilation without it being present.

I debated auto-installing it, but then decided that since we error out on missing rustup and require the developer to install that, we should do the same for all deps in that script.

If there comes a day where we use Pants to bootstrap Pants, this can be revisited.