### PR TITLE
Fix incorrect use of `PEX_PYTHON`. (Cherry-pick of #22994)

### DIFF
--- a/src/python/pants/backend/python/goals/export.py
+++ b/src/python/pants/backend/python/goals/export.py
@@ -262,10 +262,11 @@ async def do_export(
                 complete_pex_env.create_argv(
                     os.path.join(tmpdir_under_digest_root, pex_pex.exe),
                     *pex_args,
+                    python=requirements_pex.python,
                 ),
                 {
-                    **complete_pex_env.environment_dict(python=requirements_pex.python),
-                    "PEX_MODULE": "pex.tools",
+                    **complete_pex_env.environment_dict(python_configured=True),
+                    "PEX_SCRIPT": "pex-tools",
                 },
             ),
             # Remove the requirements and pex pexes, to avoid confusion.

--- a/src/python/pants/backend/python/goals/export_test.py
+++ b/src/python/pants/backend/python/goals/export_test.py
@@ -166,7 +166,7 @@ def test_export_venv_new_codepath(
             else:
                 assert ppc0.argv[7] == "--non-hermetic-scripts"
             assert ppc0.argv[-1] == "{digest_root}"
-            assert ppc0.extra_env["PEX_MODULE"] == "pex.tools"
+            assert ppc0.extra_env["PEX_SCRIPT"] == "pex-tools"
             assert ppc0.extra_env.get("PEX_ROOT") is not None
 
             ppc1 = result.post_processing_cmds[-1]

--- a/src/python/pants/backend/python/goals/repl.py
+++ b/src/python/pants/backend/python/goals/repl.py
@@ -111,11 +111,13 @@ async def create_python_repl_request(
     )
 
     complete_pex_env = pex_env.in_workspace()
-    args = complete_pex_env.create_argv(request.in_chroot(requirements_pex.name))
+    args = complete_pex_env.create_argv(
+        request.in_chroot(requirements_pex.name), python=requirements_pex.python
+    )
 
     chrooted_source_roots = [request.in_chroot(sr) for sr in sources.source_roots]
     extra_env = {
-        **complete_pex_env.environment_dict(python=requirements_pex.python),
+        **complete_pex_env.environment_dict(python_configured=requirements_pex.python is not None),
         "PEX_EXTRA_SYS_PATH": ":".join(chrooted_source_roots),
         "PEX_PATH": request.in_chroot(local_dists.pex.name),
         "PEX_INTERPRETER_HISTORY": "1" if python_setup.repl_history else "0",
@@ -175,13 +177,15 @@ async def create_ipython_repl_request(
     )
 
     complete_pex_env = pex_env.in_workspace()
-    args = list(complete_pex_env.create_argv(request.in_chroot(ipython_pex.name)))
+    args = list(
+        complete_pex_env.create_argv(request.in_chroot(ipython_pex.name), python=ipython_pex.python)
+    )
     if ipython.ignore_cwd:
         args.append("--ignore-cwd")
 
     chrooted_source_roots = [request.in_chroot(sr) for sr in sources.source_roots]
     extra_env = {
-        **complete_pex_env.environment_dict(python=ipython_pex.python),
+        **complete_pex_env.environment_dict(python_configured=ipython_pex.python is not None),
         "PEX_PATH": os.pathsep.join(
             [
                 request.in_chroot(requirements_pex.name),

--- a/src/python/pants/backend/python/goals/run_helper.py
+++ b/src/python/pants/backend/python/goals/run_helper.py
@@ -19,7 +19,6 @@ from pants.backend.python.util_rules.pex import (
     Pex,
     VenvPexRequest,
     create_venv_pex,
-    find_interpreter,
 )
 from pants.backend.python.util_rules.pex_environment import PexEnvironment
 from pants.backend.python.util_rules.pex_from_targets import (
@@ -97,9 +96,8 @@ async def _create_python_source_run_request(
         complete_pex_environment = pex_env.in_sandbox(working_directory=None)
     else:
         complete_pex_environment = pex_env.in_workspace()
-    venv_pex, python = await concurrently(
-        create_venv_pex(VenvPexRequest(pex_request, complete_pex_environment), **implicitly()),
-        find_interpreter(pex_request.interpreter_constraints, **implicitly()),
+    venv_pex = await create_venv_pex(
+        VenvPexRequest(pex_request, complete_pex_environment), **implicitly()
     )
     input_digests = [
         venv_pex.digest,
@@ -121,7 +119,7 @@ async def _create_python_source_run_request(
         *chrooted_source_roots,
     ]
     extra_env = {
-        **complete_pex_environment.environment_dict(python=python),
+        **complete_pex_environment.environment_dict(python_configured=True),
         "PEX_EXTRA_SYS_PATH": os.pathsep.join(source_roots),
     }
     append_only_caches = (

--- a/src/python/pants/backend/python/goals/run_python_requirement.py
+++ b/src/python/pants/backend/python/goals/run_python_requirement.py
@@ -162,7 +162,7 @@ async def create_python_requirement_run_request(
     input_digest = venv_pex.digest
 
     extra_env = {
-        **complete_pex_environment.environment_dict(python=None),
+        **complete_pex_environment.environment_dict(python_configured=venv_pex.python is not None),
     }
 
     return RunRequest(

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -937,7 +937,7 @@ class VenvScriptWriter:
         env_vars = (
             f"{name}={shlex.quote(value)}"
             for name, value in self.complete_pex_env.environment_dict(
-                python=self.pex.python
+                python_configured=True
             ).items()
         )
 
@@ -945,7 +945,7 @@ class VenvScriptWriter:
         venv_dir = shlex.quote(str(self.venv_dir))
         execute_pex_args = " ".join(
             f"$(adjust_relative_paths {shlex.quote(arg)})"
-            for arg in self.complete_pex_env.create_argv(self.pex.name)
+            for arg in self.complete_pex_env.create_argv(self.pex.name, python=self.pex.python)
         )
 
         script = dedent(
@@ -1222,9 +1222,9 @@ class PexProcess:
 async def setup_pex_process(request: PexProcess, pex_environment: PexEnvironment) -> Process:
     pex = request.pex
     complete_pex_env = pex_environment.in_sandbox(working_directory=request.working_directory)
-    argv = complete_pex_env.create_argv(pex.name, *request.argv)
+    argv = complete_pex_env.create_argv(pex.name, *request.argv, python=pex.python)
     env = {
-        **complete_pex_env.environment_dict(python=pex.python),
+        **complete_pex_env.environment_dict(python_configured=pex.python is not None),
         **request.extra_env,
     }
     input_digest = (

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -199,9 +199,9 @@ async def setup_pex_cli_process(
     ]
 
     complete_pex_env = pex_env.in_sandbox(working_directory=None)
-    normalized_argv = complete_pex_env.create_argv(pex_pex.exe, *args)
+    normalized_argv = complete_pex_env.create_argv(pex_pex.exe, *args, python=bootstrap_python)
     env = {
-        **complete_pex_env.environment_dict(python=bootstrap_python),
+        **complete_pex_env.environment_dict(python_configured=True),
         **python_native_code.subprocess_env_vars,
         **(request.extra_env or {}),  # type: ignore[dict-item]
         # If a subcommand is used, we need to use the `pex3` console script.

--- a/src/python/pants/backend/python/util_rules/pex_environment.py
+++ b/src/python/pants/backend/python/util_rules/pex_environment.py
@@ -212,17 +212,21 @@ class CompletePexEnvironment:
     def interpreter_search_paths(self) -> tuple[str, ...]:
         return self._pex_environment.interpreter_search_paths
 
-    def create_argv(self, pex_filepath: str, *args: str) -> tuple[str, ...]:
+    def create_argv(
+        self,
+        pex_filepath: str,
+        *args: str,
+        python: PythonExecutable | PythonBuildStandaloneBinary | None = None,
+    ) -> tuple[str, ...]:
+        python_exe = python or self._pex_environment.bootstrap_python
         pex_relpath = (
             os.path.relpath(pex_filepath, self._working_directory)
             if self._working_directory
             else pex_filepath
         )
-        return (self._pex_environment.bootstrap_python.path, pex_relpath, *args)
+        return (python_exe.path, pex_relpath, *args)
 
-    def environment_dict(
-        self, *, python: PythonExecutable | PythonBuildStandaloneBinary | None = None
-    ) -> Mapping[str, str]:
+    def environment_dict(self, *, python_configured: bool) -> Mapping[str, str]:
         """The environment to use for running anything with PEX.
 
         If the Process is run with a pre-selected Python interpreter, set `python_configured=True`
@@ -244,9 +248,10 @@ class CompletePexEnvironment:
             ),
             **subprocess_env_dict,
         )
-        if python:
-            d["PEX_PYTHON"] = python.path
-        else:
+        # NB: We only set `PEX_PYTHON_PATH` if the Python interpreter has not already been
+        # pre-selected by Pants. Otherwise, Pex would inadvertently try to find another interpreter
+        # when running PEXes. (Creating a PEX will ignore this env var in favor of `--python-path`.)
+        if not python_configured:
             d["PEX_PYTHON_PATH"] = os.pathsep.join(self.interpreter_search_paths)
         return d
 


### PR DESCRIPTION
This was established in #18433 and only worked due to a Pex bug that
unconditionally stripped `PEX_PYTHON` on PEX boot. the portions of 
#18433 related to the cleanup so described are reverted:

> Additionally when making this change, the Python/pex code was
> refactored so that we always use this Python to run pex, with Python
> either being chosen by pex, or by using PEX_PYTHON env var at
> runtime. I think this is a nice cleanup of the handshake between
> CompletePexEnvironment.create_argv and
> CompletePexEnvironment.environment_dict used to have.

Fixes #22988
