### PR TITLE
[Issue 23005] Add apache-airflow-client to default module mapping (Cherry-pick of #23007)

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
+++ b/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
@@ -110,6 +110,7 @@ DEFAULT_MODULE_MAPPING: dict[str, tuple[str, ...]] = {
     "ansicolors": ("colors",),
     "antlr4-python3-runtime": ("antlr4",),
     "apache-airflow": ("airflow",),
+    "apache-airflow-client": ("airflow_client",),
     "atlassian-python-api": ("atlassian",),
     "attrs": ("attr", "attrs"),
     "auth0-python": ("auth0",),


### PR DESCRIPTION
## Motivation/Problem
`apache-airflow-client` is an official Apache Airflow python package that provides the `airflow_client` module. Currently, there is no default mapping, so pants users need to add the mapping to their python requirement target when using this package.

This fixes https://github.com/pantsbuild/pants/issues/23005

## What changed/Solution
Added `apache-airflow-client` to `airflow_client` mapping to the  default module mapping

## How did you test it?
Added the `airflow_client` module name to `modules` in the `python_requirement` target and then tested that pants inferred the requirement target for source code that imported and used `airflow_client`

```py
python_requirement(
    name="apache-airflow-client",
    requirements=["apache-airflow-client~=3.1.3"],
    modules=["airflow_client"], # adding this fixed dependency inference
)
```
