### PR TITLE
reduce usage of PEX_MODULE in tests when not needed

### DIFF
--- a/src/python/pants/backend/awslambda/python/rules_test.py
+++ b/src/python/pants/backend/awslambda/python/rules_test.py
@@ -71,6 +71,7 @@ def rule_runner() -> PythonRuleRunner:
             *package.rules(),
             QueryRule(BuiltPackage, (PythonAwsLambdaFieldSet,)),
             QueryRule(BuiltPackage, (PythonAwsLambdaLayerFieldSet,)),
+            QueryRule(BuiltPackage, (PexBinaryFieldSet,)),
         ],
         target_types=[
             FileTarget,
@@ -141,7 +142,6 @@ def complete_platform(rule_runner: PythonRuleRunner) -> bytes:
     pex_executable = os.path.join(rule_runner.build_root, "pex_exe/pex_exe.pex")
     return subprocess.run(
         args=[pex_executable, "interpreter", "inspect", "-mt"],
-        env=dict(PEX_MODULE="pex.cli", **os.environ),
         check=True,
         stdout=subprocess.PIPE,
     ).stdout

--- a/src/python/pants/backend/awslambda/python/rules_test.py
+++ b/src/python/pants/backend/awslambda/python/rules_test.py
@@ -4,8 +4,6 @@
 from __future__ import annotations
 
 import json
-import os
-import subprocess
 from io import BytesIO
 from textwrap import dedent
 from typing import Any
@@ -28,10 +26,7 @@ from pants.backend.awslambda.python.target_types import (
     PythonAWSLambdaLayer,
 )
 from pants.backend.awslambda.python.target_types import rules as target_rules
-from pants.backend.python.goals import package_pex_binary
-from pants.backend.python.goals.package_pex_binary import PexBinaryFieldSet
 from pants.backend.python.target_types import (
-    PexBinary,
     PythonRequirementTarget,
     PythonSourcesGeneratorTarget,
 )
@@ -65,18 +60,15 @@ def rule_runner() -> PythonRuleRunner:
         rules=[
             *awslambda_python_rules(),
             *core_target_types_rules(),
-            *package_pex_binary.rules(),
             *python_target_types_rules(),
             *target_rules(),
             *package.rules(),
             QueryRule(BuiltPackage, (PythonAwsLambdaFieldSet,)),
             QueryRule(BuiltPackage, (PythonAwsLambdaLayerFieldSet,)),
-            QueryRule(BuiltPackage, (PexBinaryFieldSet,)),
         ],
         target_types=[
             FileTarget,
             FilesGeneratorTarget,
-            PexBinary,
             PythonAWSLambda,
             PythonAWSLambdaLayer,
             PythonRequirementTarget,
@@ -121,30 +113,6 @@ def create_python_awslambda(
     assert expected_metadata == json.loads(metadata.content)
 
     return relpath, artifact.content
-
-
-@pytest.fixture
-def complete_platform(rule_runner: PythonRuleRunner) -> bytes:
-    rule_runner.write_files(
-        {
-            "pex_exe/BUILD": dedent(
-                """\
-                python_requirement(name="req", requirements=["pex==2.1.112"])
-                pex_binary(dependencies=[":req"], script="pex")
-                """
-            ),
-        }
-    )
-    result = rule_runner.request(
-        BuiltPackage, [PexBinaryFieldSet.create(rule_runner.get_target(Address("pex_exe")))]
-    )
-    rule_runner.write_digest(result.digest)
-    pex_executable = os.path.join(rule_runner.build_root, "pex_exe/pex_exe.pex")
-    return subprocess.run(
-        args=[pex_executable, "interpreter", "inspect", "-mt"],
-        check=True,
-        stdout=subprocess.PIPE,
-    ).stdout
 
 
 def test_warn_files_targets(rule_runner: PythonRuleRunner, caplog) -> None:

--- a/src/python/pants/backend/google_cloud_function/python/rules_test.py
+++ b/src/python/pants/backend/google_cloud_function/python/rules_test.py
@@ -63,6 +63,7 @@ def rule_runner() -> PythonRuleRunner:
             *core_target_types_rules(),
             *package.rules(),
             QueryRule(BuiltPackage, (PythonGoogleCloudFunctionFieldSet,)),
+            QueryRule(BuiltPackage, (PexBinaryFieldSet,)),
         ],
         target_types=[
             FileTarget,

--- a/src/python/pants/backend/google_cloud_function/python/rules_test.py
+++ b/src/python/pants/backend/google_cloud_function/python/rules_test.py
@@ -132,7 +132,7 @@ def complete_platform(rule_runner: PythonRuleRunner) -> bytes:
     pex_executable = os.path.join(rule_runner.build_root, "pex_exe/pex_exe.pex")
     return subprocess.run(
         args=[pex_executable, "interpreter", "inspect", "-mt"],
-        env=dict(PEX_MODULE="pex.cli", **os.environ),
+        env=dict(PEX_SCRIPT="pex3", **os.environ),
         check=True,
         stdout=subprocess.PIPE,
     ).stdout

--- a/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
@@ -524,7 +524,6 @@ def create_dists(
     find_links = workdir / "find-links"
     subprocess.run(
         args=[
-            pex_binary,
             pex_output,
             "repository",
             "extract",
@@ -532,7 +531,7 @@ def create_dists(
             find_links,
         ],
         check=True,
-        env=os.environ.copy() | {"PEX_MODULE": "pex.tools"},
+        env=os.environ.copy() | {"PEX_TOOLS": "1"},
     )
     return find_links
 


### PR DESCRIPTION
See
https://github.com/pantsbuild/pants/commit/31ca16c861eb6c032da496e3746563429ee4a7e0#r174188058

Using PEX_TOOLs as we do elsewhere is less coupling to Pex's internals.

AI Disclosure: An LLM was instructed to generate code to cleanup the mess it made.