### PR TITLE
worktree friendly pants_dev_deps fingerprinting to stop the clobbering

### DIFF
--- a/build-support/pants_venv
+++ b/build-support/pants_venv
@@ -16,8 +16,10 @@ platform=$(uname -mps)
 function venv_dir() {
   # Include the entire version string in order to differentiate e.g. PyPy from CPython.
   # Fingerprinting uname and python output avoids shebang length limits and any odd chars.
+  # Include REPO_ROOT so that different checkouts or worktrees don't clobber each other.
   venv_fingerprint=$( (
     echo "${platform}"
+    echo "${REPO_ROOT}"
     ${PY} --version
   ) | fingerprint_data)
 


### PR DESCRIPTION
`pants_venv` maintains two *different* fingerprints:
 * `venv_dir`: Where to put the venv
 * `activate_pants_venv`: Should we delete and recreate the venv

`activate_pants_venv` hashes the requirements.txt, but `venv_dir` does not.  not so if you ran more than one pants from source -- such as through worktrees or multiple checkouts -- you would get terrible unpredictable results when requirements.txt differed.  One script doing `pip install` while the other does `rm -rf` does not go well.

Adding the repo/checkout directory to the `venv_dir` hash gives each Pants checkout a safe location.

The alternative would be to add requirements.txt to the `venv_dir` hash, but then you would get many venvs sitting around needing some sort of pruning.  Hashing on the repo dir maintains the current "one checkout" = "one activate_pants_venv" behavior like one would have with a regular old`.venv`.