### PR TITLE
update to Pex 2.81.0

### DIFF
--- a/docs/notes/2.31.x.md
+++ b/docs/notes/2.31.x.md
@@ -49,7 +49,7 @@ used by Pants itself works.
 
 Added the `[python].default_to_resolve_interpreter_constraints` option which when set the true, allows Python targets with both `interpreter_constraints` and `resolve` fields to fallback on their resolve's interpreter constraints before the global constraints if no interpreter constraints are set on the actual target.
 
-The version of [Pex](https://github.com/pex-tool/pex) used by the Python backend has been upgraded to [`v2.79.0`](https://github.com/pex-tool/pex/releases/tag/v2.79.0). Of particular note for Pants users:
+The version of [Pex](https://github.com/pex-tool/pex) used by the Python backend has been upgraded to [`v2.81.0`](https://github.com/pex-tool/pex/releases/tag/v2.81.0). Of particular note for Pants users:
 - A [bug](https://github.com/pantsbuild/pants/issues/22886) that hindered the use of multiple custom package indexes
 - A [bug](https://github.com/pex-tool/pex/issues/3032) that prevented invalidation of a lockfile when the URL of a URL-based requirement changed.
 - An issue with [`PEX_PYTHON/PEX_PYTHON_PATH` stripping](https://github.com/pex-tool/pex/issues/1075).

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -37,9 +37,9 @@ from pants.util.strutil import softwrap
 logger = logging.getLogger(__name__)
 
 
-_PEX_VERSION = "v2.79.0"
-_PEX_BINARY_HASH = "f7a50bfb31c2304f4b30ef6eabb623c86abae0b5841dc3d8a147afd1568ecd4e"
-_PEX_BINARY_SIZE = 4940234
+_PEX_VERSION = "v2.81.0"
+_PEX_BINARY_HASH = "654c561d4fc2b833f1ed6b23cf9251eb7dab812b12deaac365d7150afd96fca5"
+_PEX_BINARY_SIZE = 4945588
 
 
 class PexCli(TemplatedExternalTool):


### PR DESCRIPTION
Release Notes:
 * https://github.com/pex-tool/pex/releases/tag/v2.80.0
 * https://github.com/pex-tool/pex/releases/tag/v2.81.0