### PR TITLE
set plugin development find-links only on the needed resolve

### DIFF
--- a/docs/notes/2.32.x.md
+++ b/docs/notes/2.32.x.md
@@ -60,6 +60,8 @@ For those language ecosystems that use separate type checkers from compilers (So
 
 For `generate-lockfiles`, typos in the name of a resolve now give "Did you mean?" style suggestions.
 
+The `find-links` automatically injected by `pants.backend.plugin_development` is no longer injected into *all* Python resolves, only the resolve associated with `pants_requirements(name="pants")`.  Having extraneous un-scoped `find-links` can materially affect dependency resolution time.  In some real world user reports, this results in a  >30% improvements in `generate-lockfiles` wall time.
+
 #### Publish
 
 `PublishFieldSet` now has a `check_skip_request` hook to enable preemptive skips of packaging requests for targets where the publishing will be skipped (such as when a `skip_push=True` field exists).

--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -361,13 +361,13 @@ async def setup_user_lockfile_requests(
         return UserGenerateLockfiles()
 
     resolve_to_requirements_fields = defaultdict(set)
-    find_links: set[str] = set()
+    resolve_to_find_links: dict[str, set[str]] = defaultdict(set)
     for tgt in all_targets:
         if not tgt.has_fields((PythonRequirementResolveField, PythonRequirementsField)):
             continue
         resolve = tgt[PythonRequirementResolveField].normalized_value(python_setup)
         resolve_to_requirements_fields[resolve].add(tgt[PythonRequirementsField])
-        find_links.update(tgt[PythonRequirementFindLinksField].value or ())
+        resolve_to_find_links[resolve].update(tgt[PythonRequirementFindLinksField].value or ())
 
     tools = ExportableTool.filter_for_subclasses(union_membership, PythonToolBase)
 
@@ -379,7 +379,7 @@ async def setup_user_lockfile_requests(
                     requirements=PexRequirements.req_strings_from_requirement_fields(
                         resolve_to_requirements_fields[resolve]
                     ),
-                    find_links=FrozenOrderedSet(find_links),
+                    find_links=FrozenOrderedSet(resolve_to_find_links[resolve]),
                     interpreter_constraints=InterpreterConstraints(
                         python_setup.resolves_to_interpreter_constraints.get(
                             resolve, python_setup.interpreter_constraints
@@ -408,7 +408,7 @@ async def setup_user_lockfile_requests(
             out.add(
                 GeneratePythonLockfile(
                     requirements=FrozenOrderedSet(sorted(tool.requirements)),
-                    find_links=FrozenOrderedSet(find_links),
+                    find_links=FrozenOrderedSet(),
                     interpreter_constraints=ic,
                     resolve_name=resolve,
                     lockfile_dest=DEFAULT_TOOL_LOCKFILE,


### PR DESCRIPTION
As described at
<https://github.com/pantsbuild/pants/issues/21223#issuecomment-3688234056>, if you set find-links (and that includes everyone with in-repo plugins by way of `pants.backend.plugin_development`) on one resolve, we were erroneously setting it for *all* resolves during lockfile generation. This materially impacts resolution time.