### PR TITLE
rust: Updated to Rust 1.93

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
     - name: Install Rust toolchain
       run: |
         # Set the default toolchain. Installs the toolchain if it is not already installed.
-        rustup default 1.92.0
+        rustup default 1.93.0
         cargo version
     - name: Expose Pythons
       run: |
@@ -164,7 +164,7 @@ jobs:
     - name: Install Rust toolchain
       run: |
         # Set the default toolchain. Installs the toolchain if it is not already installed.
-        rustup default 1.92.0
+        rustup default 1.93.0
         cargo version
     - name: Expose Pythons
       run: |
@@ -313,7 +313,7 @@ jobs:
       with:
         key: macOS14-ARM64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
         path: |
-          ~/.rustup/toolchains/1.92.0-*
+          ~/.rustup/toolchains/1.93.0-*
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo
@@ -435,7 +435,7 @@ jobs:
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
         path: |
-          ~/.rustup/toolchains/1.92.0-*
+          ~/.rustup/toolchains/1.93.0-*
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,7 +54,7 @@ jobs:
       with:
         key: Linux-ARM64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
         path: |
-          ~/.rustup/toolchains/1.92.0-*
+          ~/.rustup/toolchains/1.93.0-*
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo
@@ -162,7 +162,7 @@ jobs:
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
         path: |
-          ~/.rustup/toolchains/1.92.0-*
+          ~/.rustup/toolchains/1.93.0-*
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo
@@ -277,7 +277,7 @@ jobs:
       with:
         key: macOS14-ARM64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
         path: |
-          ~/.rustup/toolchains/1.92.0-*
+          ~/.rustup/toolchains/1.93.0-*
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo
@@ -381,7 +381,7 @@ jobs:
     - name: Install Rust toolchain
       run: |
         # Set the default toolchain. Installs the toolchain if it is not already installed.
-        rustup default 1.92.0
+        rustup default 1.93.0
         cargo version
     - name: Expose Pythons
       run: |
@@ -460,7 +460,7 @@ jobs:
     - name: Install Rust toolchain
       run: |
         # Set the default toolchain. Installs the toolchain if it is not already installed.
-        rustup default 1.92.0
+        rustup default 1.93.0
         cargo version
     - name: Expose Pythons
       run: |
@@ -557,7 +557,7 @@ jobs:
       with:
         key: macOS14-ARM64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
         path: |
-          ~/.rustup/toolchains/1.92.0-*
+          ~/.rustup/toolchains/1.93.0-*
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo

--- a/src/rust/rust-toolchain
+++ b/src/rust/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.92.0"
+channel = "1.93.0"
 profile = "minimal"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Upgrade to Rust v1.93.0. Release blog is [here](https://blog.rust-lang.org/2026/01/22/Rust-1.93.0/).