### PR TITLE
Fix non-deterministic JDK preparation script causing cache misses

### DIFF
--- a/docs/notes/2.31.x.md
+++ b/docs/notes/2.31.x.md
@@ -33,6 +33,8 @@ pantsd now preserves web proxy environment variables (`HTTP_PROXY`, `HTTPS_PROXY
 
 #### JVM
 
+A [bug](https://github.com/pantsbuild/pants/pull/23036) was fixed where the JDK preparation script's non-deterministic behavior—caused by unsuppressed Coursier progress output—led to unnecessary cache misses.
+
 Java first party dependency inference logic [now](https://github.com/pantsbuild/pants/pull/22889) correctly identifies unqualified, same-package inner class references.
 
 Updated to use Coursier v2.1.24 by default to pick up a bug fix allowing us to [simplify our code a bit](https://github.com/pantsbuild/pants/pull/22906).

--- a/src/python/pants/jvm/jdk_rules.py
+++ b/src/python/pants/jvm/jdk_rules.py
@@ -205,10 +205,16 @@ async def prepare_jdk_environment(
         coursier_jdk_option = f"--jvm={version}"
 
     if not coursier.jvm_index:
-        coursier_options = ["java-home", coursier_jdk_option]
+        coursier_options = ["java-home", "--quiet", "--quiet", coursier_jdk_option]
     else:
         jvm_index_option = f"--jvm-index={coursier.jvm_index}"
-        coursier_options = ["java-home", jvm_index_option, coursier_jdk_option]
+        coursier_options = [
+            "java-home",
+            "--quiet",
+            "--quiet",
+            jvm_index_option,
+            coursier_jdk_option,
+        ]
 
     # TODO(#16104) This argument re-writing code should use the native {chroot} support.
     # See also `run` for other argument re-writing code.


### PR DESCRIPTION
The JDK preparation script (`jdk.sh`) embeds the output of `java -version` as a comment. However, when Coursier downloads the JDK, it outputs progress messages to stderr which get mixed with the actual `java -version` output.

These progress messages are non-deterministic (contain timing info like "Still downloading", "Downloaded", etc.) which causes the script content to vary between runs, resulting in different cache keys for all JVM compilation tasks.

This fix filters out Coursier download progress messages from the captured stderr, keeping only the actual `java -version` output lines.

Impact: In testing, this reduced cache misses from 92% to 0.09% for JVM builds across runs.