### PR TITLE
external tool upgrade: support constraints on added versions

### DIFF
--- a/build-support/bin/external_tool_upgrade.py
+++ b/build-support/bin/external_tool_upgrade.py
@@ -33,6 +33,7 @@ from external_tool.python import (
     get_class_variables,
     replace_class_variables,
 )
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.version import Version
 from tqdm import tqdm
 
@@ -148,12 +149,29 @@ def fetch_version(
 class Tool:
     default_known_versions: list[str]
     default_url_template: str
+    default_version: str
     default_url_platform_mapping: dict[str, str] | None = None
 
 
 class Mode(StrEnum):
     only_fetch_versions = "only-fetch-versions"
     calculate_sha_and_size = "calculate-sha-and-size"
+
+
+def filter_versions_by_constraint(
+    versions: list[ExternalToolVersion],
+    constraint: str | None,
+) -> list[ExternalToolVersion]:
+    """Filter versions using packaging.specifiers.
+
+    >>> filter_versions_by_constraint([ExternalToolVersion("5.0", "cowsay", "", 0)], ">=4.0,<6.0")
+    [ExternalToolVersion(version='5.0', platform='cowsay', sha256='', filesize=0, url_override=None)]
+    """
+    if constraint is None:
+        return versions
+
+    specifier = SpecifierSet(constraint)
+    return [v for v in versions if specifier.contains(v.version.lstrip("v"))]
 
 
 EXCLUDE_TOOLS = {
@@ -202,8 +220,25 @@ def main():
         type=Mode,
         default="calculate-sha-and-size",
     )
+    parser.add_argument(
+        "--version-constraint",
+        default=None,
+        help="Version constraint to filter versions (e.g., '>2.2.2,<3')",
+    )
+    parser.add_argument(
+        "--max-releases",
+        type=int,
+        default=64,
+        help="Maximum number of releases to fetch when --version-constraint is set (default: 64)",
+    )
 
     args = parser.parse_args()
+
+    if args.version_constraint:
+        try:
+            SpecifierSet(args.version_constraint)
+        except InvalidSpecifier as e:
+            parser.error(f"Invalid version constraint: {e}")
 
     level = logging.DEBUG if args.verbose else logging.INFO
     logging.basicConfig(level=logging.INFO, format="%(message)s")
@@ -227,9 +262,12 @@ def main():
     pool = ThreadPool(processes=args.workers)
     platforms = args.platforms.split(",")
 
+    # When a version constraint is specified, fetch more releases (up to --max-releases) to filter
+    only_latest = args.version_constraint is None
+
     mapping: dict[str, Releases | None] = {
-        "dl.k8s.io": KubernetesReleases(pool=pool, only_latest=True),
-        "github.com": GithubReleases(only_latest=True),
+        "dl.k8s.io": KubernetesReleases(pool=pool, only_latest=only_latest),
+        "github.com": GithubReleases(only_latest=only_latest),
         "releases.hashicorp.com": None,  # TODO
         "raw.githubusercontent.com": None,  # TODO
         "get.helm.sh": None,  # TODO
@@ -254,6 +292,20 @@ def main():
             continue
 
         releases = list(releases.get_releases(tool.default_url_template))
+
+        # Limit and filter releases by constraint before downloading binaries
+        if args.version_constraint:
+            releases = releases[: args.max_releases]
+            specifier = SpecifierSet(args.version_constraint)
+            releases = [v for v in releases if specifier.contains(v.lstrip("v"))]
+            if not releases:
+                logger.warning(
+                    "No releases for %s match constraint %r, skipping",
+                    class_name,
+                    args.version_constraint,
+                )
+                continue
+
         for version in releases:
             for platform in platforms:
                 futures.append(
@@ -285,18 +337,46 @@ def main():
         existing_versions = {
             ExternalToolVersion.decode(version) for version in tool.default_known_versions
         }
-        fetched_versions = {version.version for version in versions}
+
+        path, class_name = group
+
+        external_versions = [v.version for v in versions]
+        if args.version_constraint:
+            external_versions = filter_versions_by_constraint(
+                external_versions, args.version_constraint
+            )
+            if not external_versions:
+                logger.warning(
+                    "No fetched versions for %s match constraint %r, skipping",
+                    class_name,
+                    args.version_constraint,
+                )
+                continue
+
+        fetched_versions = set(external_versions)
 
         known_versions = list(existing_versions | fetched_versions)
         known_versions.sort(key=lambda tu: (Version(tu.version), tu.platform), reverse=True)
 
-        path, class_name = group
+        if args.version_constraint:
+            # Only upgrade if the newest matching version is greater than current default
+            filtered_versions = filter_versions_by_constraint(
+                known_versions, args.version_constraint
+            )
+            current_default = Version(tool.default_version.lstrip("v"))
+            newest_matching = Version(filtered_versions[0].version.lstrip("v"))
+            if newest_matching > current_default:
+                default_version = filtered_versions[0].version
+            else:
+                default_version = tool.default_version
+        else:
+            default_version = known_versions[0].version
 
         replace_class_variables(
             path,
             class_name,
             replacements={
-                "default_version": known_versions[0].version,
+                "default_version": default_version,
                 "default_known_versions": [v.encode() for v in known_versions],
             },
         )

--- a/build-support/bin/external_tool_upgrade_test.py
+++ b/build-support/bin/external_tool_upgrade_test.py
@@ -3,9 +3,151 @@
 import doctest
 
 import external_tool_upgrade
+from external_tool_upgrade import ExternalToolVersion, filter_versions_by_constraint
+from packaging.version import Version
 
 
 def test_docs() -> None:
     failure_count, test_count = doctest.testmod(external_tool_upgrade)
     assert test_count > 0
     assert failure_count == 0
+
+
+def test_filter_fetched_versions_with_constraint() -> None:
+    fetched = [
+        ExternalToolVersion("5.0", "linux_x86_64", "abc", 100),
+        ExternalToolVersion("6.0", "linux_x86_64", "def", 200),
+        ExternalToolVersion("6.1", "linux_x86_64", "ghi", 300),
+    ]
+
+    filtered = filter_versions_by_constraint(fetched, ">=6.0")
+
+    assert len(filtered) == 2
+    assert all(isinstance(v, ExternalToolVersion) for v in filtered)
+    assert {v.version for v in filtered} == {"6.0", "6.1"}
+
+
+def test_filter_versions_by_constraint_none() -> None:
+    versions = [
+        ExternalToolVersion("5.0", "cowsay", "abc", 100),
+        ExternalToolVersion("6.0", "cowsay", "def", 200),
+    ]
+    result = filter_versions_by_constraint(versions, None)
+    assert result == versions
+
+
+def test_filter_versions_by_constraint_basic() -> None:
+    versions = [
+        ExternalToolVersion("3.0", "cowsay", "abc", 100),
+        ExternalToolVersion("4.0", "cowsay", "def", 200),
+        ExternalToolVersion("5.0", "cowsay", "ghi", 300),
+    ]
+    result = filter_versions_by_constraint(versions, ">=4.0,<5.0")
+    assert len(result) == 1
+    assert result[0].version == "4.0"
+
+
+def test_filter_versions_by_constraint_with_v_prefix() -> None:
+    versions = [
+        ExternalToolVersion("v5.0", "cowsay", "abc", 100),
+        ExternalToolVersion("v6.0", "cowsay", "def", 200),
+    ]
+    result = filter_versions_by_constraint(versions, ">5.0")
+    assert len(result) == 1
+    assert result[0].version == "v6.0"
+
+
+def test_filter_versions_by_constraint_no_matches() -> None:
+    versions = [
+        ExternalToolVersion("6.1", "cowsay", "abc", 100),
+    ]
+    result = filter_versions_by_constraint(versions, ">7.0")
+    assert result == []
+
+
+def test_filter_versions_by_constraint_multiple_matches() -> None:
+    versions = [
+        ExternalToolVersion("3.0", "cowsay", "abc", 100),
+        ExternalToolVersion("4.0", "cowsay", "def", 200),
+        ExternalToolVersion("5.0", "cowsay", "ghi", 250),
+        ExternalToolVersion("6.0", "cowsay", "jkl", 300),
+    ]
+    result = filter_versions_by_constraint(versions, ">4.0,<6.0")
+    assert len(result) == 1
+    assert result[0].version == "5.0"
+
+
+def _select_default_version_with_constraint(
+    known_versions: list[ExternalToolVersion],
+    current_default: str,
+    constraint: str,
+) -> str:
+    """Helper that mirrors the upgrade logic in main().
+
+    Returns the new default_version based on the constraint and current default. Only upgrades if
+    the newest matching version is greater than current default.
+    """
+    filtered = filter_versions_by_constraint(known_versions, constraint)
+    if not filtered:
+        return current_default
+
+    current = Version(current_default.lstrip("v"))
+    newest_matching = Version(filtered[0].version.lstrip("v"))
+
+    if newest_matching > current:
+        return filtered[0].version
+    return current_default
+
+
+def test_version_constraint_upgrades_when_newer_version_available() -> None:
+    known_versions = [
+        ExternalToolVersion("6.1", "cowsay", "abc", 100),
+        ExternalToolVersion("6.0", "cowsay", "def", 200),
+        ExternalToolVersion("5.0", "cowsay", "ghi", 300),
+        ExternalToolVersion("4.0", "cowsay", "jkl", 400),
+    ]
+    current_default = "5.0"
+    constraint = ">=6.0,<7"
+
+    result = _select_default_version_with_constraint(known_versions, current_default, constraint)
+    assert result == "6.1"
+
+
+def test_version_constraint_no_upgrade_when_no_newer_matching_version() -> None:
+    known_versions = [
+        ExternalToolVersion("6.1", "cowsay", "abc", 100),
+        ExternalToolVersion("6.0", "cowsay", "def", 200),
+        ExternalToolVersion("5.0", "cowsay", "ghi", 300),
+        ExternalToolVersion("4.0", "cowsay", "jkl", 400),
+    ]
+    current_default = "6.0"
+    constraint = ">=3.0,<5.0"
+
+    result = _select_default_version_with_constraint(known_versions, current_default, constraint)
+    assert result == "6.0"
+
+
+def test_version_constraint_no_upgrade_when_already_at_newest_matching() -> None:
+    known_versions = [
+        ExternalToolVersion("6.1", "cowsay", "abc", 100),
+        ExternalToolVersion("6.0", "cowsay", "def", 200),
+        ExternalToolVersion("5.0", "cowsay", "ghi", 300),
+    ]
+    current_default = "6.0"
+    constraint = ">=5.0,<6.1"
+
+    result = _select_default_version_with_constraint(known_versions, current_default, constraint)
+    assert result == "6.0"
+
+
+def test_version_constraint_with_v_prefix_upgrades_correctly() -> None:
+    known_versions = [
+        ExternalToolVersion("v6.0", "cowsay", "abc", 100),
+        ExternalToolVersion("v5.0", "cowsay", "def", 200),
+        ExternalToolVersion("v4.0", "cowsay", "ghi", 300),
+    ]
+    current_default = "v4.0"
+    constraint = ">4.0,<6.0"
+
+    result = _select_default_version_with_constraint(known_versions, current_default, constraint)
+    assert result == "v5.0"


### PR DESCRIPTION
I often find myself wanting to do do something other than upgrading to the absolute latest.  For example, I might want to add the latest in a patch series in hold back from a major semver change.  This adds a --version-constraint argument to help assist with those situations.

The default behavior is unchanged.

Notable limitations:
 * Using packaging here, so not every idiosyncratic tool versioning scheme is necessarily understood.
 * There isn't a fast way to get an index of "all" the GitHub releases, so there are heuristics and a flag around how many to consider.