### PR TITLE
external tool upgrade: support helm

### DIFF
--- a/build-support/bin/external_tool/helm.py
+++ b/build-support/bin/external_tool/helm.py
@@ -1,0 +1,26 @@
+# Copyright 2026 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from collections.abc import Iterator
+
+from external_tool.github import GithubReleases
+
+
+class HelmReleases:
+    """Fetches Helm releases from GitHub.
+
+    Helm binaries are hosted on get.helm.sh, but releases are published on
+    GitHub (helm/helm). This class uses the GitHub Releases API to discover
+    available versions.
+
+    See https://github.com/helm/helm/issues/5663 for historical hosting discussion.
+    """
+
+    _GITHUB_URL_TEMPLATE = "https://github.com/helm/helm/releases/download/v{version}/helm-v{version}-{platform}.tar.gz"
+
+    def __init__(self, only_latest: bool) -> None:
+        self.only_latest = only_latest
+        self._github_releases = GithubReleases(only_latest=only_latest)
+
+    def get_releases(self, url_template: str) -> Iterator[str]:
+        # Ignore the url_template (which points to get.helm.sh) and use GitHub instead
+        return self._github_releases.get_releases(self._GITHUB_URL_TEMPLATE)

--- a/build-support/bin/external_tool/helm_test.py
+++ b/build-support/bin/external_tool/helm_test.py
@@ -1,0 +1,57 @@
+# Copyright 2026 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from external_tool.helm import HelmReleases
+
+
+def test_helm_releases_only_latest(monkeypatch) -> None:
+    mock_releases = [
+        {"tag_name": "v3.14.3"},
+        {"tag_name": "v3.14.2"},
+        {"tag_name": "v3.13.0"},
+    ]
+
+    def mock_fetch(url: str):
+        assert "helm/helm" in url
+        return mock_releases
+
+    monkeypatch.setattr("external_tool.github.fetch_releases", mock_fetch)
+
+    helm = HelmReleases(only_latest=True)
+    versions = list(helm.get_releases("https://get.helm.sh/helm-v{version}-{platform}.tar.gz"))
+
+    assert versions == ["3.14.3"]
+
+
+def test_helm_releases_all_versions(monkeypatch) -> None:
+    mock_releases = [
+        {"tag_name": "v3.14.3"},
+        {"tag_name": "v3.14.2"},
+        {"tag_name": "v3.13.0"},
+    ]
+
+    def mock_fetch(url: str):
+        assert "helm/helm" in url
+        return mock_releases
+
+    monkeypatch.setattr("external_tool.github.fetch_releases", mock_fetch)
+
+    helm = HelmReleases(only_latest=False)
+    versions = list(helm.get_releases("https://get.helm.sh/helm-v{version}-{platform}.tar.gz"))
+
+    assert versions == ["3.14.3", "3.14.2", "3.13.0"]
+
+
+def test_helm_releases_uses_github_api(monkeypatch) -> None:
+    captured_url = None
+
+    def mock_fetch(url: str):
+        nonlocal captured_url
+        captured_url = url
+        return [{"tag_name": "v3.14.3"}]
+
+    monkeypatch.setattr("external_tool.github.fetch_releases", mock_fetch)
+
+    helm = HelmReleases(only_latest=True)
+    list(helm.get_releases("https://get.helm.sh/helm-v{version}-{platform}.tar.gz"))
+
+    assert captured_url == "https://api.github.com/repos/helm/helm/releases"

--- a/build-support/bin/external_tool_upgrade.py
+++ b/build-support/bin/external_tool_upgrade.py
@@ -27,6 +27,7 @@ from urllib.parse import urlparse
 
 import requests
 from external_tool.github import GithubReleases
+from external_tool.helm import HelmReleases
 from external_tool.kubectl import KubernetesReleases
 from external_tool.python import (
     find_modules_with_subclasses,
@@ -266,11 +267,11 @@ def main():
     only_latest = args.version_constraint is None
 
     mapping: dict[str, Releases | None] = {
-        "dl.k8s.io": KubernetesReleases(pool=pool, only_latest=only_latest),
-        "github.com": GithubReleases(only_latest=only_latest),
+        "dl.k8s.io": KubernetesReleases(pool=pool, only_latest=True),
+        "github.com": GithubReleases(only_latest=True),
+        "get.helm.sh": HelmReleases(only_latest=only_latest),
         "releases.hashicorp.com": None,  # TODO
         "raw.githubusercontent.com": None,  # TODO
-        "get.helm.sh": None,  # TODO
         "binaries.pantsbuild.org": None,  # TODO
     }
 


### PR DESCRIPTION
Helm artifacts are hosted on get.helm.sh.  This is currently Azure Blob storage but has historically been other things (ex: Google Cloud).  I think "Helm source code is on GitHub" is a more stable assumption than whatever object store and/or CDN they want to use, so I took the approach of querying the GitHub releases (reusing the existing code) rather than trying to scrape get.helm.sh or assume Azure APIs would be available.