### PR TITLE
avoid copying mypy cache back to named_caches after crash

### DIFF
--- a/docs/notes/2.32.x.md
+++ b/docs/notes/2.32.x.md
@@ -44,6 +44,8 @@ The Python Build Standalone backend (`pants.backend.python.providers.experimenta
 
 When `pants publish` is invoked, Pants will now skip packaging for `python_distribution` targets if either `skip_twine=True`, the target has no registries, or if `[twine].skip = true`.
 
+Pants will attempt to only preserve the `mypy` cache when `mypy` returns a [probably-not-a-crash](https://github.com/python/mypy/issues/6003) exit code.  This is intended as a defensive guard against propagating crash induced inconsistencies back to the ["named cache"](https://www.pantsbuild.org/2.32/reference/global-options#named_caches_dir) and propagated to future runs.
+
 #### Shell
 
 #### Javascript


### PR DESCRIPTION
If mypy crashes it could leave the cache in an inconsistent state. (Due to bugs in mypy for example.) We can guard against that by only copying back when -- per the exit codes -- mypy didn't crash. This is intended to help with cases like those reported in <https://github.com/pantsbuild/pants/issues/18519> but to temper expectations:
 * It would not help with any of the errors I've been able to reproduce.
 * The mypy exit code guidance is not yet always consistent https://github.com/python/mypy/issues/20633