### PR TITLE
Simplify API of Python dep inference.

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/parse_python_dependencies.py
+++ b/src/python/pants/backend/python/dependency_inference/parse_python_dependencies.py
@@ -8,15 +8,14 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 
 from pants.backend.python.dependency_inference.subsystem import PythonInferSubsystem
-from pants.backend.python.target_types import PythonSourceField
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
-from pants.core.util_rules.source_files import SourceFilesRequest
+from pants.core.util_rules.source_files import SourceFiles
 from pants.core.util_rules.stripped_source_files import strip_source_roots
 from pants.engine.collection import DeduplicatedCollection
 from pants.engine.fs import CreateDigest, Digest, FileContent
 from pants.engine.internals.native_engine import NativeDependenciesRequest
 from pants.engine.intrinsics import create_digest, parse_python_deps
-from pants.engine.rules import collect_rules, implicitly, rule
+from pants.engine.rules import collect_rules, rule
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.resources import read_resource
@@ -52,7 +51,7 @@ class ParsedPythonDependencies:
 
 @dataclass(frozen=True)
 class ParsePythonDependenciesRequest:
-    source: PythonSourceField
+    source: SourceFiles
     interpreter_constraints: InterpreterConstraints
 
 
@@ -103,7 +102,7 @@ async def parse_python_dependencies(
     request: ParsePythonDependenciesRequest,
     python_infer_subsystem: PythonInferSubsystem,
 ) -> ParsedPythonDependencies:
-    stripped_sources = await strip_source_roots(**implicitly(SourceFilesRequest([request.source])))
+    stripped_sources = await strip_source_roots(request.source)
     # We operate on PythonSourceField, which should be one file.
     assert len(stripped_sources.snapshot.files) == 1
 

--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -49,6 +49,7 @@ from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.core import target_types
 from pants.core.target_types import AllAssetTargetsByPath, map_assets_by_path
 from pants.core.util_rules import stripped_source_files
+from pants.core.util_rules.source_files import SourceFilesRequest, determine_source_files
 from pants.core.util_rules.unowned_dependency_behavior import (
     UnownedDependencyError,
     UnownedDependencyUsage,
@@ -372,9 +373,10 @@ async def _exec_parse_deps(
     interpreter_constraints = InterpreterConstraints.create_from_field_sets(
         [field_set], python_setup
     )
+    source = await determine_source_files(SourceFilesRequest([field_set.source]))
     resp = await parse_python_dependencies_get(
         ParsePythonDependenciesRequest(
-            field_set.source,
+            source,
             interpreter_constraints,
         ),
         **implicitly(),


### PR DESCRIPTION
Previously it took a `PythonSourceField`, which entangled
it with BUILD file APIs. 

Now it takes a `SourceFiles`, which allows it to be used
by code that doesn't traffic in BUILD files, such as Pants NG.