### PR TITLE
Re-ignore a flaky test.

### DIFF
--- a/src/rust/graph/src/tests.rs
+++ b/src/rust/graph/src/tests.rs
@@ -194,7 +194,8 @@ async fn invalidate_with_changed_dependencies() {
     );
 }
 
-// Historically flaky: https://github.com/pantsbuild/pants/issues/10839
+#[ignore] // flaky:
+// https://github.com/pantsbuild/pants/issues/10839
 #[tokio::test]
 async fn invalidate_randomly() {
     let graph = empty_graph();


### PR DESCRIPTION
It was restored in #19912 and we got lucky for
a couple of years, but it has now returned.

See #10839 for details.