### PR TITLE
@rule support for Python multi-file dep inference.

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -22,9 +22,9 @@ from pants.backend.python.dependency_inference.module_mapper import (
 )
 from pants.backend.python.dependency_inference.parse_python_dependencies import (
     ParsedPythonAssetPaths,
-    ParsedPythonDependencies,
     ParsedPythonImports,
     ParsePythonDependenciesRequest,
+    PythonFileDependencies,
 )
 from pants.backend.python.dependency_inference.parse_python_dependencies import (
     parse_python_dependencies as parse_python_dependencies_get,
@@ -369,7 +369,7 @@ async def _handle_unowned_imports(
 async def _exec_parse_deps(
     field_set: PythonImportDependenciesInferenceFieldSet,
     python_setup: PythonSetup,
-) -> ParsedPythonDependencies:
+) -> PythonFileDependencies:
     interpreter_constraints = InterpreterConstraints.create_from_field_sets(
         [field_set], python_setup
     )
@@ -381,13 +381,14 @@ async def _exec_parse_deps(
         ),
         **implicitly(),
     )
-    return resp
+    assert len(resp.path_to_deps) == 1
+    return next(iter(resp.path_to_deps.values()))
 
 
 @dataclass(frozen=True)
 class ResolvedParsedPythonDependenciesRequest:
     field_set: PythonImportDependenciesInferenceFieldSet
-    parsed_dependencies: ParsedPythonDependencies
+    parsed_dependencies: PythonFileDependencies
     resolve: str | None
 
 

--- a/src/python/pants/backend/python/framework/django/dependency_inference.py
+++ b/src/python/pants/backend/python/framework/django/dependency_inference.py
@@ -7,9 +7,9 @@ from pathlib import PurePath
 from pants.backend.python import dependency_inference
 from pants.backend.python.dependency_inference.parse_python_dependencies import (
     ParsedPythonAssetPaths,
-    ParsedPythonDependencies,
     ParsedPythonImportInfo,
     ParsedPythonImports,
+    PythonFileDependencies,
 )
 from pants.backend.python.dependency_inference.rules import (
     ImportOwnerStatus,
@@ -97,7 +97,7 @@ async def _django_migration_dependencies(
     resolved_dependencies = await resolve_parsed_dependencies(
         ResolvedParsedPythonDependenciesRequest(
             request.field_set,
-            ParsedPythonDependencies(
+            PythonFileDependencies(
                 ParsedPythonImports(
                     (module, ParsedPythonImportInfo(0, False)) for module in modules
                 ),
@@ -141,7 +141,7 @@ async def _django_app_implicit_dependencies(
     resolved_dependencies = await resolve_parsed_dependencies(
         ResolvedParsedPythonDependenciesRequest(
             request.field_set,
-            ParsedPythonDependencies(
+            PythonFileDependencies(
                 ParsedPythonImports(
                     (package, ParsedPythonImportInfo(0, False))
                     for package in implicit_dependency_packages

--- a/src/python/pants/backend/python/goals/debug_goals.py
+++ b/src/python/pants/backend/python/goals/debug_goals.py
@@ -11,8 +11,8 @@ from typing import Any
 from pants.backend.project_info.peek import _PeekJsonEncoder
 from pants.backend.python.dependency_inference.module_mapper import ResolveName
 from pants.backend.python.dependency_inference.parse_python_dependencies import (
-    ParsedPythonDependencies,
     ParsedPythonImportInfo,
+    PythonFileDependencies,
 )
 from pants.backend.python.dependency_inference.rules import (
     ImportResolveResult,
@@ -74,7 +74,7 @@ class PythonSourceAnalysis:
     results."""
 
     fs: PythonImportDependenciesInferenceFieldSet
-    identified: ParsedPythonDependencies
+    identified: PythonFileDependencies
     resolved: ResolvedParsedPythonDependencies
     possible_owners: UnownedImportsPossibleOwners
 


### PR DESCRIPTION
Updates the @rule for Python dep inference to support multiple files
in a single call. 

In practice we still call this rule with one file at a time, but a future
PR can change that.

Also renames the relevant Python-side dataclasses to be in line
with their Native* counterparts, and to get rid of the "Parsed"
verbiage, which wasn't contributing to comprehension.