### PR TITLE
external tool upgrade: match ruff/black trailing comma format

### DIFF
--- a/build-support/bin/external_tool/python_test.py
+++ b/build-support/bin/external_tool/python_test.py
@@ -1,6 +1,7 @@
 # Copyright 2025 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from pathlib import Path
+from textwrap import dedent
 
 from external_tool.python import replace_class_variables
 
@@ -85,7 +86,7 @@ class Cue(TemplatedExternalTool):
         "v0.12.0|linux_x86_64|e55cd5abd98a592c110f87a7da9ef15bc72515200aecfe1bed04bf86311f5ba1|8731479",
         "v0.12.0|linux_arm64|488012bb0e5c080e2a9694ef8765403dd1075a4ec373dda618efa2d37b47f14f|8067539",
         "v0.12.0|macos_arm64|7055a6423f753c8ea763699d48d78d341e8543397399daee281c66ecdc9ec5a5|8400578",
-        "v0.12.0|macos_x86_64|8474e522a978ecadef49b06d706ff276cd07629b1aa107b88adfc1284d3f93cc|8902127"
+        "v0.12.0|macos_x86_64|8474e522a978ecadef49b06d706ff276cd07629b1aa107b88adfc1284d3f93cc|8902127",
     ]
     default_url_template = "https://github.com/cue-lang/cue/releases/download/{version}/cue_{version}_{platform}.tar.gz"
     default_url_platform_mapping = {
@@ -124,3 +125,34 @@ def test_replace_class_variables(tmpdir: str):
 
     updated_content = file_path.read_text()
     assert updated_content == EXPECTED
+
+
+def test_replace_class_variables_adds_trailing_comma(tmpdir: str):
+    file_path = Path(tmpdir) / "tool.py"
+    file_path.write_text(
+        dedent("""\
+        class MyTool:
+            default_known_versions = [
+                "1.0.0|linux_x86_64|abc123|1234",
+            ]
+        """)
+    )
+
+    replace_class_variables(
+        file_path,
+        "MyTool",
+        replacements={
+            "default_known_versions": [
+                "2.0.0|linux_x86_64|def456|5678",
+                "2.0.0|linux_arm64|ghi789|9012",
+            ],
+        },
+    )
+
+    assert file_path.read_text() == dedent("""\
+        class MyTool:
+            default_known_versions = [
+                "2.0.0|linux_x86_64|def456|5678",
+                "2.0.0|linux_arm64|ghi789|9012",
+            ]
+        """)


### PR DESCRIPTION
This is just a minor QoL improvement to minimize the fmt/fix churn when updating.