### PR TITLE
dogfood new mypy fixed-format cache

### DIFF
--- a/docs/notes/2.32.x.md
+++ b/docs/notes/2.32.x.md
@@ -48,7 +48,7 @@ When `pants publish` is invoked, Pants will now skip packaging for `python_distr
 
 Pants will attempt to only preserve the `mypy` cache when `mypy` returns a [probably-not-a-crash](https://github.com/python/mypy/issues/6003) exit code.  This is intended as a defensive guard against propagating crash induced inconsistencies back to the ["named cache"](https://www.pantsbuild.org/2.32/reference/global-options#named_caches_dir) and propagated to future runs.
 
-The default version of mypy used by Pants has been updated to [1.19.1](https://mypy-lang.blogspot.com/2025/11/mypy-119-released.html).
+The default version of mypy used by Pants has been updated to [1.19.1](https://mypy-lang.blogspot.com/2025/11/mypy-119-released.html).  This includes support for the new "Fixed‑Format" cache.
 
 #### Shell
 

--- a/pants.toml
+++ b/pants.toml
@@ -202,6 +202,7 @@ timeout_default = 60
 [mypy]
 install_from_resolve = "mypy"
 requirements = ["//3rdparty/python:mypy"]
+args = ["--fixed-format-cache"]
 
 
 [coverage-py]


### PR DESCRIPTION
This was not on a computer free of other processes doing work, but directionaly:
```
$ hyperfine -w 1 -r 10 -p "echo \"#hi\" >> src/python/pants/version.py" "pants check --only=mypy src::" "pants check --mypy-args=\"['--fixed-format-cache']\" --only=mypy src::"
Benchmark 1: pants check --only=mypy src::
  Time (mean ± σ):     25.052 s ± 12.049 s    [User: 0.478 s, System: 0.137 s]
  Range (min … max):   11.628 s … 37.638 s    10 runs

Benchmark 2: pants check --mypy-args="['--fixed-format-cache']" --only=mypy src::
  Time (mean ± σ):     21.774 s ± 10.489 s    [User: 0.434 s, System: 0.119 s]
  Range (min … max):    9.888 s … 33.018 s    10 runs

Summary
  pants check --mypy-args="['--fixed-format-cache']" --only=mypy src:: ran
    1.15 ± 0.78 times faster than pants check --only=mypy src::
```

closes #22795

NOTE: In the issue I suggested there was more work to do than this, but I was incorrect.  The new blobs are still stored in sqlite, it isn't a new "on-disk" arrangement.