### PR TITLE
partially DRY out cache scope for test runners

### DIFF
--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -84,7 +84,6 @@ from pants.engine.intrinsics import (
 )
 from pants.engine.process import (
     Process,
-    ProcessCacheScope,
     ProcessWithRetries,
     execute_process_or_raise,
 )
@@ -661,9 +660,7 @@ async def run_go_tests(
     else:
         extra_env["PATH"] = goroot_bin_path
 
-    cache_scope = (
-        ProcessCacheScope.PER_SESSION if test_subsystem.force else ProcessCacheScope.SUCCESSFUL
-    )
+    cache_scope = test_subsystem.default_process_cache_scope
 
     test_flags = transform_test_args(
         go_test_subsystem.args,

--- a/src/python/pants/backend/javascript/goals/test.py
+++ b/src/python/pants/backend/javascript/goals/test.py
@@ -56,7 +56,7 @@ from pants.engine.internals.graph import transitive_targets
 from pants.engine.internals.native_engine import MergeDigests, Snapshot
 from pants.engine.internals.selectors import concurrently
 from pants.engine.intrinsics import digest_to_snapshot, execute_process_with_retry, merge_digests
-from pants.engine.process import ProcessCacheScope, ProcessWithRetries
+from pants.engine.process import ProcessWithRetries
 from pants.engine.rules import Rule, collect_rules, implicitly, rule
 from pants.engine.target import Dependencies, SourcesField, Target, TransitiveTargetsRequest
 from pants.engine.unions import UnionRule
@@ -229,8 +229,7 @@ async def run_javascript_tests(
         ),
         **implicitly(),
     )
-    if test.force:
-        process = dataclasses.replace(process, cache_scope=ProcessCacheScope.PER_SESSION)
+    process = dataclasses.replace(process, cache_scope=test.default_process_cache_scope)
 
     results = await execute_process_with_retry(ProcessWithRetries(process, test.attempts_default))
     coverage_data: JSCoverageData | None = None

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -83,7 +83,7 @@ from pants.engine.intrinsics import (
     get_digest_contents,
     merge_digests,
 )
-from pants.engine.process import InteractiveProcess, Process, ProcessCacheScope, ProcessWithRetries
+from pants.engine.process import InteractiveProcess, Process, ProcessWithRetries
 from pants.engine.rules import collect_rules, concurrently, implicitly, rule
 from pants.engine.target import Target, TransitiveTargetsRequest, WrappedTargetRequest
 from pants.engine.unions import UnionMembership, UnionRule, union
@@ -422,9 +422,7 @@ async def setup_pytest_for_target(
     }
 
     # Cache test runs only if they are successful, or not at all if `--test-force`.
-    cache_scope = (
-        ProcessCacheScope.PER_SESSION if test_subsystem.force else ProcessCacheScope.SUCCESSFUL
-    )
+    cache_scope = test_subsystem.default_process_cache_scope
 
     xdist_concurrency = 0
     if pytest.xdist_enabled and not request.is_debug:

--- a/src/python/pants/backend/scala/test/scalatest.py
+++ b/src/python/pants/backend/scala/test/scalatest.py
@@ -34,7 +34,7 @@ from pants.engine.intrinsics import (
     execute_process_with_retry,
     merge_digests,
 )
-from pants.engine.process import InteractiveProcess, ProcessCacheScope, ProcessWithRetries
+from pants.engine.process import InteractiveProcess, ProcessWithRetries
 from pants.engine.rules import collect_rules, concurrently, implicitly, rule
 from pants.engine.target import SourcesField, TransitiveTargetsRequest
 from pants.engine.unions import UnionRule
@@ -122,9 +122,7 @@ async def setup_scalatest_for_target(
     user_classpath_arg = ":".join(classpath.root_args())
 
     # Cache test runs only if they are successful, or not at all if `--test-force`.
-    cache_scope = (
-        ProcessCacheScope.PER_SESSION if test_subsystem.force else ProcessCacheScope.SUCCESSFUL
-    )
+    cache_scope = test_subsystem.default_process_cache_scope
 
     extra_jvm_args: list[str] = []
     if request.is_debug:

--- a/src/python/pants/backend/shell/shunit2_test_runner.py
+++ b/src/python/pants/backend/shell/shunit2_test_runner.py
@@ -47,7 +47,7 @@ from pants.engine.intrinsics import (
     merge_digests,
 )
 from pants.engine.platform import Platform
-from pants.engine.process import InteractiveProcess, Process, ProcessCacheScope, ProcessWithRetries
+from pants.engine.process import InteractiveProcess, Process, ProcessWithRetries
 from pants.engine.rules import collect_rules, concurrently, implicitly, rule
 from pants.engine.target import SourcesField, Target, TransitiveTargetsRequest
 from pants.option.global_options import GlobalOptions
@@ -227,9 +227,7 @@ async def setup_shunit2_for_target(
         if runner.shell == Shunit2Shell.zsh
         else [runner.binary_path.path, *field_set_sources.snapshot.files]
     )
-    cache_scope = (
-        ProcessCacheScope.PER_SESSION if test_subsystem.force else ProcessCacheScope.SUCCESSFUL
-    )
+    cache_scope = test_subsystem.default_process_cache_scope
     process = Process(
         argv=argv,
         input_digest=input_digest,

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -51,7 +51,12 @@ from pants.engine.internals.graph import find_valid_field_sets, resolve_targets
 from pants.engine.internals.session import RunId
 from pants.engine.internals.specs_rules import find_valid_field_sets_for_target_roots
 from pants.engine.intrinsics import merge_digests, run_interactive_process_in_environment
-from pants.engine.process import FallibleProcessResult, InteractiveProcess, ProcessResultMetadata
+from pants.engine.process import (
+    FallibleProcessResult,
+    InteractiveProcess,
+    ProcessCacheScope,
+    ProcessResultMetadata,
+)
 from pants.engine.rules import collect_rules, concurrently, goal_rule, implicitly, rule
 from pants.engine.target import (
     FieldSet,
@@ -586,6 +591,11 @@ class TestSubsystem(GoalSubsystem):
         default=False,
         help="Force the tests to run, even if they could be satisfied from cache.",
     )
+
+    @property
+    def default_process_cache_scope(self) -> ProcessCacheScope:
+        return ProcessCacheScope.PER_SESSION if self.force else ProcessCacheScope.SUCCESSFUL
+
     output = EnumOption(
         default=ShowOutput.FAILED,
         help="Show stdout/stderr for these tests.",

--- a/src/python/pants/jvm/test/junit.py
+++ b/src/python/pants/jvm/test/junit.py
@@ -31,7 +31,7 @@ from pants.engine.intrinsics import (
     execute_process_with_retry,
     merge_digests,
 )
-from pants.engine.process import InteractiveProcess, ProcessCacheScope, ProcessWithRetries
+from pants.engine.process import InteractiveProcess, ProcessWithRetries
 from pants.engine.rules import collect_rules, concurrently, implicitly, rule
 from pants.engine.target import SourcesField, TransitiveTargetsRequest
 from pants.engine.unions import UnionRule
@@ -124,9 +124,7 @@ async def setup_junit_for_target(
     user_classpath_arg = ":".join(classpath.root_args())
 
     # Cache test runs only if they are successful, or not at all if `--test-force`.
-    cache_scope = (
-        ProcessCacheScope.PER_SESSION if test_subsystem.force else ProcessCacheScope.SUCCESSFUL
-    )
+    cache_scope = test_subsystem.default_process_cache_scope
 
     extra_jvm_args: list[str] = []
     if request.is_debug:


### PR DESCRIPTION
We had the same conditional duplicated in a bunch of places, this does the basic thing of pulling that out into a method.  The motivation was that I am trying to do extend `--force` support to the check subsystem, was going to take this approach, started to pull on a larger ball of yarn, and wanted to back up and pull out this pattern at least for feedback.

Test backends left as is:
 * helm: There is already some special handling around snapshot generation.
 * shell: Uses target level cache_scope fields.