### PR TITLE
Support custom globs in Python tailoring.

### DIFF
--- a/docs/notes/2.32.x.md
+++ b/docs/notes/2.32.x.md
@@ -42,6 +42,9 @@ When `pants publish` is invoked, Pants will now skip packaging for `helm_chart` 
 
 #### Python
 
+`pants tailor` now supports custom glob patterns for detecting Python tests. This makes it easier to get started with
+Pants when your test files (e.g., `*_tests.py`) don't match the default patterns.
+
 The Python Build Standalone backend (`pants.backend.python.providers.experimental.python_build_standalone`) has release metadata current through PBS release `220260127`.
 
 When `pants publish` is invoked, Pants will now skip packaging for `python_distribution` targets if either `skip_twine=True`, the target has no registries, or if `[twine].skip = true`.

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -15,7 +15,11 @@ from typing import TYPE_CHECKING, ClassVar, cast
 from packaging.utils import canonicalize_name as canonicalize_project_name
 
 from pants.backend.python.macros.python_artifact import PythonArtifact
-from pants.backend.python.subsystems.setup import PythonSetup
+from pants.backend.python.subsystems.setup import (
+    DEFAULT_TEST_FILE_GLOBS,
+    DEFAULT_TESTUTIL_FILE_GLOBS,
+    PythonSetup,
+)
 from pants.core.environments.target_types import EnvironmentField
 from pants.core.goals.generate_lockfiles import UnrecognizedResolveNamesError
 from pants.core.goals.package import OutputPathField
@@ -1376,7 +1380,7 @@ class PythonTestTarget(Target):
 
 class PythonTestsGeneratingSourcesField(PythonGeneratingSourcesBase):
     expected_file_extensions = (".py", "")  # Note that this does not include `.pyi`.
-    default = ("test_*.py", "*_test.py", "tests.py")
+    default = DEFAULT_TEST_FILE_GLOBS
     help = generate_multiple_sources_field_help_message(
         "Example: `sources=['test_*.py', '*_test.py', 'tests.py']`"
     )
@@ -1463,7 +1467,7 @@ class PythonSourcesOverridesField(OverridesField):
 
 
 class PythonTestUtilsGeneratingSourcesField(PythonGeneratingSourcesBase):
-    default = ("conftest.py", "test_*.pyi", "*_test.pyi", "tests.pyi")
+    default = DEFAULT_TESTUTIL_FILE_GLOBS
     help = generate_multiple_sources_field_help_message(
         "Example: `sources=['conftest.py', 'test_*.pyi', '*_test.pyi', 'tests.pyi']`"
     )


### PR DESCRIPTION
Allows setting custom globs for Python test/testutils in tailor.

This came up in the context of a large repo that uses 
`*_tests.py` for tests, which is not in our default globs. 