### PR TITLE
basic "did you mean?" typo suggestion for resolve names

### DIFF
--- a/docs/notes/2.32.x.md
+++ b/docs/notes/2.32.x.md
@@ -22,6 +22,10 @@ The plugin API's `Get()` and `MultiGet()` constructs, deprecated in 2.30, are no
 
 ### Goals
 
+#### Lockfiles
+
+For `generate-lockfiles`, typos in the name of a resolve now give "Did you mean?" style suggestions.
+
 #### Publish
 
 `PublishFieldSet` now has a `check_skip_request` hook to enable preemptive skips of packaging requests for targets where the publishing will be skipped (such as when a `skip_push=True` field exists).

--- a/src/python/pants/core/goals/generate_lockfiles.py
+++ b/src/python/pants/core/goals/generate_lockfiles.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import difflib
 import itertools
 import logging
 from collections import defaultdict
@@ -291,7 +292,6 @@ class UnrecognizedResolveNamesError(Exception):
     ) -> None:
         all_valid_binaries = all_valid_binaries or set()
 
-        # TODO(#12314): maybe implement "Did you mean?"
         if len(unrecognized_resolve_names) == 1:
             unrecognized_str = unrecognized_resolve_names[0]
             name_description = "name"
@@ -316,6 +316,13 @@ class UnrecognizedResolveNamesError(Exception):
         if should_be_resolves:
             cmd = " ".join([f"--resolve={e}" for e in should_be_resolves])
             message.append(f"HINT: Some binaries should be resolves, try with `{cmd}`")
+
+        # "Did you mean?"
+        for name in unrecognized_resolve_names:
+            close_matches = difflib.get_close_matches(name, all_valid_names)
+            if close_matches:
+                suggestions = ", ".join(f"`{m}`" for m in close_matches)
+                message.append(f"Did you mean: {suggestions} (for `{name}`)")
 
         super().__init__(softwrap("\n\n".join(message)))
 

--- a/src/python/pants/core/goals/generate_lockfiles_test.py
+++ b/src/python/pants/core/goals/generate_lockfiles_test.py
@@ -79,6 +79,10 @@ def test_determine_tool_sentinels_to_generate() -> None:
     with pytest.raises(UnrecognizedResolveNamesError):
         assert_chosen({"fake"}, expected_user_resolves=[])
 
+    # "Did you mean?"
+    with pytest.raises(UnrecognizedResolveNamesError, match=r"Did you mean.*`u3`.*\(for `u33`\)"):
+        assert_chosen({"u33"}, expected_user_resolves=[])
+
     # Error if the same resolve name is used for multiple user lockfiles.
     with pytest.raises(AmbiguousResolveNamesError):
         determine_resolves_to_generate(


### PR DESCRIPTION
Knocking out an old TODO.

Example expanded output:
```
pants.core.goals.generate_lockfiles.UnrecognizedResolveNamesError: Unrecognized resolve name from the option `--generate-lockfiles-resolve`: backinblack

All valid resolve names: ['black', 'coverage-py', 'docformatter', 'flake8', 'ipython', 'isort', 'mypy', 'pytest', 'python-default']

Did you mean: `black` (for `backinblack`)
```