### PR TITLE
add missing `flush`/`close` methods to `PyStdioRead` / `PyStdioWrite`

### DIFF
--- a/src/rust/engine/src/externs/stdio.rs
+++ b/src/rust/engine/src/externs/stdio.rs
@@ -49,6 +49,10 @@ impl PyStdioRead {
     fn seekable(&self) -> bool {
         false
     }
+
+    fn flush(&self) {}
+
+    fn close(&self) {}
 }
 
 /// A Python file-like that proxies to the `stdio` module, which implements thread-local output.
@@ -91,4 +95,6 @@ impl PyStdioWrite {
     fn flush(&self) {
         // All of our destinations are line-buffered.
     }
+
+    fn close(&self) {}
 }


### PR DESCRIPTION
Add missing `close` and `flush` methods to `PyStdioRead` / `PyStdioWrite` to avoid this warning:

```
Exception ignored while finalizing file <_io.TextIOWrapper encoding='UTF-8'>:
Traceback (most recent call last):
  File "REDACTED/pants/src/python/pants/init/logging.py", line 227, in initialize_stdio_raw
    sys.__stdin__, sys.__stdout__, sys.__stderr__ = sys.stdin, sys.stdout, sys.stderr  # type: ignore[misc,assignment]
AttributeError: 'builtins.PyStdioRead' object has no attribute 'close'
Exception ignored while finalizing file <_io.BufferedReader>:
Traceback (most recent call last):
  File "REDACTEDpants/src/python/pants/init/logging.py", line 227, in initialize_stdio_raw
    sys.__stdin__, sys.__stdout__, sys.__stderr__ = sys.stdin, sys.stdout, sys.stderr  # type: ignore[misc,assignment]
AttributeError: 'builtins.PyStdioRead' object has no attribute 'close'
```