### PR TITLE
Removed the optimization flag from dev builds

### DIFF
--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -2,11 +2,6 @@
 # tokio_unstable is necessary for access to the `id`-related functions of tokio::task::JoinSet.
 # See https://docs.rs/tokio/1.21.1/tokio/task/struct.JoinSet.html#method.join_next_with_id.
 
-[profile.dev]
-# Increase the optimization level of the dev profile slightly, as otherwise `rule_graph`
-# solving takes prohibitively long.
-opt-level = 1
-
 [profile.release]
 # Enable only "line tables", which give line information in backtraces, but do not record information
 # about local variables.


### PR DESCRIPTION
Ideally, the need for this flag should be reduced ever since call-by-name was in, and the rule-graph work is simplified. The iteration time improvement is worth its weight in gold.

On my Mac Mini M2:

- 2x compile speed up for cold build (100s to 50s)
- 3x speed up for incremental - e.g. change a print string in the engine (10s to 3s)