### PR TITLE
docs: fix shell quote globing in example script

### DIFF
--- a/docs/docs/using-pants/using-pants-in-ci.mdx
+++ b/docs/docs/using-pants/using-pants-in-ci.mdx
@@ -47,7 +47,7 @@ You can use this script to nuke the cache when it gets too big:
      nuke_prefix="$(dirname "${path}")/$(basename "${path}").nuke"
      nuke_path=$(mktemp -d "${nuke_prefix}.XXXXXX")
      mv "${path}" "${nuke_path}/"
-     rm -rf "${nuke_prefix}.*"
+     rm -rf "${nuke_prefix}".*
    fi
  }
 


### PR DESCRIPTION
fixes #23132