### PR TITLE
external tool upgrade: fix version constraints support

### DIFF
--- a/build-support/bin/external_tool_upgrade.py
+++ b/build-support/bin/external_tool_upgrade.py
@@ -298,8 +298,8 @@ def main():
     only_latest = args.version_constraint is None
 
     mapping: dict[str, Releases | None] = {
-        "dl.k8s.io": KubernetesReleases(pool=pool, only_latest=True),
-        "github.com": GithubReleases(only_latest=True),
+        "dl.k8s.io": KubernetesReleases(pool=pool, only_latest=only_latest),
+        "github.com": GithubReleases(only_latest=only_latest),
         "get.helm.sh": HelmReleases(only_latest=only_latest),
         "releases.hashicorp.com": None,  # TODO
         "raw.githubusercontent.com": None,  # TODO


### PR DESCRIPTION
This is totally my bad, I messed up the rebase of
cd0aa95ea0c33eb8d5d206f7d844eb4a2b53e3d6 when landing both that and 2bfd2ac983ef7cb09000796d0e7517cf5ce67da1 in sequence.