### PR TITLE
cleanup a pile of warning: messages when running ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ select = ["I", "UP"]
 # UP036: Outdated version check (in rule_visitor for Python 3.8)
 # UP040/UP046/UP047:  Cost-benefit unclear, see https://github.com/python/cpython/issues/114159
 ignore = ["UP006", "UP007", "UP018", "UP031", "UP035", "UP036", "UP040", "UP046", "UP047"]
+external = ["PNT20"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["internal_plugins", "pants", "pants_test", "python_constant"]

--- a/src/python/pants/backend/cc/util_rules/toolchain.py
+++ b/src/python/pants/backend/cc/util_rules/toolchain.py
@@ -75,7 +75,7 @@ async def _executable_path(binary_names: Iterable[str], search_paths: Iterable[s
     option."""
     for name in binary_names:
         binary_paths = await find_binary(
-            BinaryPathRequest(  # noqa: PNT30: requires triage
+            BinaryPathRequest(
                 binary_name=name,
                 search_path=search_paths,
                 test=BinaryPathTest(args=["-v"]),

--- a/src/python/pants/backend/go/goals/debug_goals.py
+++ b/src/python/pants/backend/go/goals/debug_goals.py
@@ -83,7 +83,7 @@ async def go_show_package_analysis(targets: Targets, console: Console) -> ShowGo
         elif target.has_field(GoThirdPartyPackageDependenciesField):
             import_path = target[GoImportPathField].value
             go_mod_address = target.address.maybe_convert_to_target_generator()
-            go_mod_info = await determine_go_mod_info(GoModInfoRequest(go_mod_address))  # noqa: PNT30: requires triage
+            go_mod_info = await determine_go_mod_info(GoModInfoRequest(go_mod_address))
             third_party_analysis_gets.append(
                 extract_package_info(
                     ThirdPartyPkgAnalysisRequest(
@@ -137,7 +137,7 @@ async def dump_go_import_paths_for_module(
             continue
 
         console.write_stdout(f"{tgt.address}:\n")
-        package_mapping = await map_import_paths_to_packages(  # noqa: PNT30: requires triage
+        package_mapping = await map_import_paths_to_packages(
             GoImportPathMappingRequest(tgt.address), **implicitly()
         )
         for import_path, address_set in package_mapping.mapping.items():

--- a/src/python/pants/backend/go/goals/generate.py
+++ b/src/python/pants/backend/go/goals/generate.py
@@ -219,7 +219,7 @@ async def _run_generators(
             args[i] = _expand_env(arg, env)
 
         # Invoke the subprocess and store its output for use as input root of next command (if any).
-        result = await execute_process_or_raise(  # noqa: PNT30: this is inherently sequential
+        result = await execute_process_or_raise(
             **implicitly(
                 Process(
                     argv=args,
@@ -232,9 +232,7 @@ async def _run_generators(
             ),
         )
 
-        digest = await add_prefix(  # noqa: PNT30: this is inherently sequential
-            AddPrefix(result.output_digest, dir_path)
-        )
+        digest = await add_prefix(AddPrefix(result.output_digest, dir_path))
 
     return digest
 
@@ -322,7 +320,7 @@ async def run_go_package_generators(
         output_digest_for_go_file = await _run_generators(
             analysis, pkg_digest.digest, dir_path, go_file, goroot, env
         )
-        output_digest = await merge_digests_with_overwrite(  # noqa: PNT30: requires triage
+        output_digest = await merge_digests_with_overwrite(
             OverwriteMergeDigests(output_digest, output_digest_for_go_file)
         )
 

--- a/src/python/pants/backend/go/util_rules/goroot.py
+++ b/src/python/pants/backend/go/util_rules/goroot.py
@@ -120,7 +120,7 @@ async def setup_goroot(
         if compatible_go_version(
             compiler_version=version, target_version=golang_subsystem.minimum_expected_version
         ):
-            env_result = await fallible_to_exec_result_or_raise(  # noqa: PNT30: requires triage
+            env_result = await fallible_to_exec_result_or_raise(
                 **implicitly(
                     Process(
                         (binary_path.path, "env", "-json"),

--- a/src/python/pants/backend/javascript/subsystems/nodejs.py
+++ b/src/python/pants/backend/javascript/subsystems/nodejs.py
@@ -538,7 +538,7 @@ async def _nodejs_search_paths(
         expanded.append(nvm_path)
     for s in paths:
         if s == "<PATH>":
-            expanded.extend(await environment_path_variable(**implicitly()))  # noqa: PNT30: Linear search
+            expanded.extend(await environment_path_variable(**implicitly()))
         elif s in special_strings:
             expanded.extend(special_strings[s])
         elif s == "<NVM>" or s == "<NVM_LOCAL>":

--- a/src/python/pants/backend/openapi/goals/tailor.py
+++ b/src/python/pants/backend/openapi/goals/tailor.py
@@ -49,7 +49,7 @@ async def find_putative_targets(
     paths = tuple(targets)
 
     while paths:
-        digest = await path_globs_to_digest(PathGlobs(paths))  # noqa: PNT30: this is inherently sequential
+        digest = await path_globs_to_digest(PathGlobs(paths))
         result = await parse_openapi_sources(
             ParseOpenApiSources(
                 sources_digest=digest,

--- a/src/python/pants/backend/python/framework/django/detect_apps.py
+++ b/src/python/pants/backend/python/framework/django/detect_apps.py
@@ -111,7 +111,7 @@ async def detect_django_apps(python_setup: PythonSetup) -> DjangoApps:
         ics_to_tgts[ics].append(tgt)
 
     for ics, tgts in ics_to_tgts.items():
-        sources = await concurrently(  # noqa: PNT30: requires triage
+        sources = await concurrently(
             [
                 hydrate_sources(HydrateSourcesRequest(tgt[SourcesField]), **implicitly())
                 for tgt in tgts

--- a/src/python/pants/backend/shell/goals/test.py
+++ b/src/python/pants/backend/shell/goals/test.py
@@ -101,7 +101,7 @@ async def test_shell_command(
     for _ in range(test_subsystem.attempts_default):
         result = await run_prepared_adhoc_process(
             **implicitly({shell_process: AdhocProcessRequest})
-        )  # noqa: PNT30: retry loop
+        )
         results.append(result)
         if result.process_result.exit_code == 0:
             break

--- a/src/python/pants/core/goals/fix.py
+++ b/src/python/pants/core/goals/fix.py
@@ -315,9 +315,7 @@ async def fix_batch_sequential(
     results = []
     for request_type, tool_name, files, key in request:
         batch = request_type(tool_name, files, key, current_snapshot)
-        result = await fix_batch(  # noqa: PNT30: this is inherently sequential
-            **implicitly({batch: AbstractFixRequest.Batch})
-        )
+        result = await fix_batch(**implicitly({batch: AbstractFixRequest.Batch}))
         results.append(result)
 
         assert set(result.output.files) == set(batch.files), (

--- a/src/python/pants/core/goals/update_build_files.py
+++ b/src/python/pants/core/goals/update_build_files.py
@@ -259,7 +259,7 @@ async def update_build_files(
     }
     build_file_to_change_descriptions: DefaultDict[str, list[str]] = defaultdict(list)
     for rewrite_request_cls in rewrite_request_classes:
-        all_rewritten_files = await concurrently(  # noqa: PNT30: this is inherently sequential
+        all_rewritten_files = await concurrently(
             rewrite_build_file(
                 **implicitly(
                     {

--- a/src/python/pants/engine/addresses.py
+++ b/src/python/pants/engine/addresses.py
@@ -7,12 +7,12 @@ from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 
 from pants.build_graph.address import Address as Address
-from pants.build_graph.address import AddressInput as AddressInput  # noqa: F401: rexport.
-from pants.build_graph.address import BuildFileAddress as BuildFileAddress  # noqa: F401: rexport.
-from pants.build_graph.address import (  # noqa: F401: rexport.
+from pants.build_graph.address import AddressInput as AddressInput  # noqa: F401  # rexport
+from pants.build_graph.address import BuildFileAddress as BuildFileAddress  # noqa: F401  # rexport
+from pants.build_graph.address import (  # noqa: F401  # rexport
     BuildFileAddressRequest as BuildFileAddressRequest,
 )
-from pants.build_graph.address import MaybeAddress as MaybeAddress  # noqa: F401: rexport.
+from pants.build_graph.address import MaybeAddress as MaybeAddress  # noqa: F401  # rexport
 from pants.build_graph.address import ResolveError
 from pants.engine.collection import Collection
 from pants.util.strutil import bullet_list

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -814,7 +814,7 @@ async def transitive_dependency_mapping(request: _DependencyMappingRequest) -> _
     while queued:
         direct_dependencies: tuple[Collection[Target], ...]
         if request.expanded_targets:
-            direct_dependencies = await concurrently(  # noqa: PNT30: this is inherently sequential
+            direct_dependencies = await concurrently(
                 resolve_targets(
                     **implicitly(
                         DependenciesRequest(
@@ -826,7 +826,7 @@ async def transitive_dependency_mapping(request: _DependencyMappingRequest) -> _
                 for tgt in queued
             )
         else:
-            direct_dependencies = await concurrently(  # noqa: PNT30: this is inherently sequential
+            direct_dependencies = await concurrently(
                 resolve_unexpanded_targets(
                     **implicitly(
                         DependenciesRequest(
@@ -1309,7 +1309,7 @@ async def find_owners(
             candidate_tgts = deleted_candidate_tgts
             sources_set = deleted_files
 
-        build_file_addresses = await concurrently(  # noqa: PNT30: requires triage
+        build_file_addresses = await concurrently(
             find_build_file(
                 BuildFileAddressRequest(
                     tgt.address, description_of_origin="<owners rule - cannot trigger>"

--- a/src/python/pants/engine/intrinsics.py
+++ b/src/python/pants/engine/intrinsics.py
@@ -116,9 +116,7 @@ async def execute_process_with_retry(req: ProcessWithRetries) -> ProcessResultWi
     results: list[FallibleProcessResult] = []
     for attempt in range(0, req.attempts):
         proc = dataclasses.replace(req.proc, attempt=attempt)
-        result = await execute_process(  # noqa: PNT30: We only know that we need to rerun the test after we run it
-            proc, **implicitly()
-        )
+        result = await execute_process(proc, **implicitly())
         results.append(result)
         if result.exit_code == 0:
             break

--- a/src/python/pants/jvm/goals/lockfile.py
+++ b/src/python/pants/jvm/goals/lockfile.py
@@ -145,7 +145,7 @@ async def validate_jvm_artifacts_for_resolve(
     impls = union_membership.get(ValidateJvmArtifactsForResolveRequest)
     for impl in impls:
         validate_request = impl(artifacts=request.artifacts, resolve_name=request.resolve_name)
-        _ = await _validate_jvm_artifacts_for_resolve(  # noqa: PNT30: requires triage
+        _ = await _validate_jvm_artifacts_for_resolve(
             **implicitly({validate_request: ValidateJvmArtifactsForResolveRequest})
         )
 

--- a/src/python/pants/option/bootstrap_options.py
+++ b/src/python/pants/option/bootstrap_options.py
@@ -904,7 +904,7 @@ class BootstrapOptions:
     )
     pants_bin_name = StrOption(
         advanced=True,
-        default="pants",  # noqa: PANTSBIN
+        default="pants",
         help=softwrap(
             """
             The name of the script or binary used to invoke Pants.
@@ -936,7 +936,7 @@ class BootstrapOptions:
         advanced=True,
         metavar="<dir>",
         default=lambda _: os.path.join(get_buildroot(), "dist"),
-        help="Write end products, such as the results of `pants package`, to this dir.",  # noqa: PANTSBIN
+        help="Write end products, such as the results of `pants package`, to this dir.",
     )
     pants_subprocessdir = StrOption(
         advanced=True,


### PR DESCRIPTION
 * PANTSBIN was renamed to PNT10 in c1eebc96fdcc and then removed in fbbfa4a0c355
 * PNT30 was removed in 89e424102f36
 * For PNT20, we can tell ruff "hey, nothing to see here"
 * The rest were misplaced :s