### PR TITLE
update helm (and friends) to a recent 3.x seies

### DIFF
--- a/docs/notes/2.32.x.md
+++ b/docs/notes/2.32.x.md
@@ -64,6 +64,10 @@ Running `pants publish` on a `docker_image` target with `skip_push=True` will no
 
 When `pants publish` is invoked, Pants will now skip packaging for `helm_chart` targets if either `skip_push=True` or the target has no registries.
 
+The default version of the helm-unittest tool has been upgraded from `1.0.1` to [`1.0.3`](https://github.com/helm-unittest/helm-unittest/releases/tag/v1.0.3)
+
+The default version of Helm has been upgraded from `3.14.3` to [`3.19.5`](https://github.com/helm/helm/releases/tag/v3.19.5)
+
 #### JVM
 
 #### Python

--- a/src/python/pants/backend/helm/subsystems/helm.py
+++ b/src/python/pants/backend/helm/subsystems/helm.py
@@ -91,8 +91,12 @@ class HelmSubsystem(TemplatedExternalTool):
     options_scope = "helm"
     help = "The Helm command line (https://helm.sh)"
 
-    default_version = "3.14.3"
+    default_version = "3.19.5"
     default_known_versions = [
+        "3.19.5|linux_arm64 |ce02147ffee6d993bf8ae97a44a22e9e1daf0b69d2d5b69a0c8cf6706445ccf5|16236301",
+        "3.19.5|linux_x86_64|a0a5e8c592ed3f376ac110715eff214730c7422f9a44d96cf98117d2b8b0e6c0|18014445",
+        "3.19.5|macos_arm64 |195e24e587f423f15a78feebab04583ceee68323598575a0e8b3b11b43fd26fe|17061257",
+        "3.19.5|macos_x86_64|57f4a847c349382b7cc742a6434ef25f88f0928a113d8cf49084b464878ef0b9|18369542",
         "3.14.3|linux_arm64 |85e1573e76fa60af14ba7e9ec75db2129b6884203be866893fa0b3f7e41ccd5e|14558415",
         "3.14.3|linux_x86_64|3c90f24e180f8c207b8a18e5ec82cb0fa49858a7a0a86e4ed52a98398681e00b|16134525",
         "3.14.3|macos_arm64 |dff794152b62b7c1a9ff615d510f8657bcd7a3727c668e0d9d4955f70d5f7573|16104367",

--- a/src/python/pants/backend/helm/subsystems/unittest.py
+++ b/src/python/pants/backend/helm/subsystems/unittest.py
@@ -28,8 +28,12 @@ class HelmUnitTestSubsystem(ExternalHelmPlugin):
     plugin_name = "unittest"
     help = "BDD styled unit test framework for Kubernetes Helm charts as a Helm plugin. (https://github.com/helm-unittest)"
 
-    default_version = "1.0.1"
+    default_version = "1.0.3"
     default_known_versions = [
+        "1.0.3|linux_arm64 |1e645d96b36582cd8b9fbd53240110267f14d80aa01137341251c60438bbe6b0|24070114",
+        "1.0.3|linux_x86_64|9761f23d9509c98770c026e019e743b524b57010f4bc29175f78d2582ace0633|26143513",
+        "1.0.3|macos_arm64 |6a6b67b3f638f015e09c093b67c7609a07101b971a1a6d6a83d1a7f75861a4b2|24407946",
+        "1.0.3|macos_x86_64|46413a86ded6bfc70cd704ebac16f8d4a0f36712ae399a5d24e32bc44f96985f|26029601",
         "1.0.1|linux_arm64 |68e8ec894408bfd5a53de6299248cb438555a42b4cae1463a3fe4a4240dcbcd4|23979610",
         "1.0.1|linux_x86_64|7e99822df43aaf25e198d0b5c950c1d31d1c5baa528adee8fa9b4063a761aced|26056496",
         "1.0.1|macos_arm64 |92c5f3bcef1b75337d07ba05d48b40ec2190bc8a4fb4ba05e93664f93e28afa0|24374980",


### PR DESCRIPTION
v4 is a major breaking change, so holding off on that.  (There was also just a 3.20, but 3.19 has this reassuring series of bug fixes and was also quite recent.)