### PR TITLE
silence new HdrHistogram induced deprecation warning on Python 3.14

### DIFF
--- a/src/python/pants/bin/pants_loader.py
+++ b/src/python/pants/bin/pants_loader.py
@@ -39,6 +39,13 @@ class PantsLoader:
         # TODO: Eric-Arellano has emailed the author to see if he is willing to accept a PR fixing the
         # deprecation warnings and to release the fix. If he says yes, remove this once fixed.
         warnings.filterwarnings("ignore", category=DeprecationWarning, module="ansicolors")
+        # Silence ctypes _pack_/_layout_ warning from HdrHistogram; due by Python 3.19
+        # See: https://github.com/HdrHistogram/HdrHistogram/issues/216
+        warnings.filterwarnings(
+            "ignore",
+            category=DeprecationWarning,
+            message=r"Due to '_pack_', the '.+' Structure will use memory layout compatible with MSVC",
+        )
         # Silence this ubiquitous warning. Several of our 3rd party deps incur this.
         warnings.filterwarnings(
             "ignore",


### PR DESCRIPTION
No more:
```
/usr/lib/python3.14/ctypes/_endian.py:33: DeprecationWarning: Due to '_pack_', the
'ExternalHeader' Structure will use memory layout compatible with MSVC (Windows). If this is intended, set _layout_ to 'ms'. The
 implicit default is deprecated and slated to become an error in Python 3.19.
  super().__setattr__(attrname, value)
/usr/lib/python3.14/ctypes/_endian.py:33: DeprecationWarning: Due to '_pack_', the 'PayloadHeader' Structure will use memory
layout compatible with MSVC (Windows). If this is intended, set _layout_ to 'ms'. The implicit default is deprecated and slated
to become an error in Python 3.19.
  super().__setattr__(attrname, value)
```