### PR TITLE
update the default Pex version to v2.90.2

### DIFF
--- a/docs/notes/2.32.x.md
+++ b/docs/notes/2.32.x.md
@@ -87,6 +87,10 @@ The `grpc-python-plugin` tool now uses an updated `v1.73.1` plugin built from  <
 
 The default version of the [Ruff](https://docs.astral.sh/ruff/) tool has been updated to [0.14.14](https://github.com/astral-sh/ruff/releases/tag/0.14.14).
 
+The version of [Pex](https://github.com/pex-tool/pex) used by the Python backend has been upgraded to [`v2.90.2`](https://github.com/pex-tool/pex/releases/tag/v2.90.2). Of particular note for Pants users:
+ - Support for [pip 26.0.1](https://pip.pypa.io/en/stable/news/#v26-0-1).
+ - A new `--interpreter-selection-strategy` option to select the `"oldest"` or `"newest"` interpreter when multiple match constraints.
+ - Linux PEX scies can now install themselves with a desktop entry.
 
 #### Shell
 

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -37,9 +37,9 @@ from pants.util.strutil import softwrap
 logger = logging.getLogger(__name__)
 
 
-_PEX_VERSION = "v2.81.0"
-_PEX_BINARY_HASH = "654c561d4fc2b833f1ed6b23cf9251eb7dab812b12deaac365d7150afd96fca5"
-_PEX_BINARY_SIZE = 4945588
+_PEX_VERSION = "v2.90.2"
+_PEX_BINARY_HASH = "311d8eb35ad3d64e1c508b7e7ac3479e1fd40911117396f754a9914eb5faf017"
+_PEX_BINARY_SIZE = 5069818
 
 
 class PexCli(TemplatedExternalTool):


### PR DESCRIPTION
Release Notes:
 * https://github.com/pex-tool/pex/releases/tag/v2.82.0
 * https://github.com/pex-tool/pex/releases/tag/v2.82.1
 * https://github.com/pex-tool/pex/releases/tag/v2.83.0
 * https://github.com/pex-tool/pex/releases/tag/v2.84.0
 * https://github.com/pex-tool/pex/releases/tag/v2.85.0
 * https://github.com/pex-tool/pex/releases/tag/v2.85.1
 * https://github.com/pex-tool/pex/releases/tag/v2.85.2
 * https://github.com/pex-tool/pex/releases/tag/v2.85.3
 * https://github.com/pex-tool/pex/releases/tag/v2.86.0
 * https://github.com/pex-tool/pex/releases/tag/v2.86.1
 * https://github.com/pex-tool/pex/releases/tag/v2.87.0
 * https://github.com/pex-tool/pex/releases/tag/v2.88.0
 * https://github.com/pex-tool/pex/releases/tag/v2.88.1
 * https://github.com/pex-tool/pex/releases/tag/v2.89.0
 * https://github.com/pex-tool/pex/releases/tag/v2.89.1
 * https://github.com/pex-tool/pex/releases/tag/v2.90.0
 * https://github.com/pex-tool/pex/releases/tag/v2.90.1
 * https://github.com/pex-tool/pex/releases/tag/v2.90.2

ref #23055 #21177
fixes #23136