### PR TITLE
option to disable mypy caching

### DIFF
--- a/docs/notes/2.32.x.md
+++ b/docs/notes/2.32.x.md
@@ -81,6 +81,8 @@ The default version of mypy used by Pants has been updated to [1.19.1](https://m
 
 Copying the `mypy` cache back to the ["named cache"](https://www.pantsbuild.org/2.32/reference/global-options#named_caches_dir) should now be atomic in all cases.
 
+The mypy subsystem now supports a new `cache_mode="none"` to disable mypy's caching entirely.  This is slower and intended as an "escape valve".  It is hoped that on the latest mypy with the above Pants side fixes it will not be necessary.
+
 The `runtime` field of [`aws_python_lambda_layer`](https://www.pantsbuild.org/2.32/reference/targets/python_aws_lambda_layer#runtime) or [`aws_python_lambda_function`](https://www.pantsbuild.org/2.32/reference/targets/python_aws_lambda_function#runtime) now has built-in complete platform configurations for x86-64 and arm64 Python 3.14. This provides stable support for Python 3.14 lambdas out of the box, allowing deleting manual `complete_platforms` configuration if any.
 
 The `grpc-python-plugin` tool now uses an updated `v1.73.1` plugin built from  <https://github.com/nhurden/protoc-gen-grpc-python-prebuilt]. This also brings `macos_arm64` support.

--- a/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
@@ -27,7 +27,6 @@ from pants.backend.python.typecheck.mypy.rules import (
     MyPyPartition,
     MyPyPartitions,
     MyPyRequest,
-    determine_python_files,
 )
 from pants.backend.python.typecheck.mypy.rules import rules as mypy_rules
 from pants.backend.python.typecheck.mypy.subsystem import MyPy, MyPyFieldSet
@@ -744,15 +743,6 @@ def test_partition_targets(rule_runner: PythonRuleRunner) -> None:
         "3.9",
         "b",
     )
-
-
-def test_determine_python_files() -> None:
-    assert determine_python_files([]) == ()
-    assert determine_python_files(["f.py"]) == ("f.py",)
-    assert determine_python_files(["f.pyi"]) == ("f.pyi",)
-    assert determine_python_files(["f.py", "f.pyi"]) == ("f.pyi",)
-    assert determine_python_files(["f.pyi", "f.py"]) == ("f.pyi",)
-    assert determine_python_files(["script-without-extension"]) == ("script-without-extension",)
 
 
 def test_colors_and_formatting(rule_runner: PythonRuleRunner) -> None:

--- a/src/python/pants/backend/python/typecheck/mypy/rules_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules_test.py
@@ -1,0 +1,38 @@
+# Copyright 2026 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import packaging.version
+
+from pants.backend.python.typecheck.mypy.rules import _get_cache_args, determine_python_files
+from pants.backend.python.typecheck.mypy.subsystem import MyPyCacheMode
+
+
+def test_get_cache_args() -> None:
+    modern_mypy = packaging.version.Version("1.0")
+    old_mypy = packaging.version.Version("0.600")
+
+    args = _get_cache_args(modern_mypy, "3.12", MyPyCacheMode.sqlite, "/cache")
+    assert "--sqlite-cache" in args
+    assert "--skip-cache-mtime-check" in args
+    assert "--cache-dir" in args
+    assert "/cache" in args
+
+    args = _get_cache_args(modern_mypy, "3.12", MyPyCacheMode.none, "/cache")
+    assert args == ("--cache-dir=/dev/null",)
+
+    args = _get_cache_args(old_mypy, "3.12", MyPyCacheMode.sqlite, "/cache")
+    assert args == ("--cache-dir=/dev/null",)
+
+    args = _get_cache_args(modern_mypy, None, MyPyCacheMode.sqlite, "/cache")
+    assert args == ("--cache-dir=/dev/null",)
+
+
+def test_determine_python_files() -> None:
+    assert determine_python_files([]) == ()
+    assert determine_python_files(["f.py"]) == ("f.py",)
+    assert determine_python_files(["f.pyi"]) == ("f.pyi",)
+    assert determine_python_files(["f.py", "f.pyi"]) == ("f.pyi",)
+    assert determine_python_files(["f.pyi", "f.py"]) == ("f.pyi",)
+    assert determine_python_files(["script-without-extension"]) == ("script-without-extension",)

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Iterable
 from dataclasses import dataclass
+from enum import StrEnum
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.subsystems.setup import PythonSetup
@@ -37,6 +38,7 @@ from pants.engine.unions import UnionRule
 from pants.option.option_types import (
     ArgsListOption,
     BoolOption,
+    EnumOption,
     FileOption,
     SkipOption,
     TargetListOption,
@@ -47,6 +49,11 @@ from pants.util.ordered_set import FrozenOrderedSet
 from pants.util.strutil import softwrap
 
 logger = logging.getLogger(__name__)
+
+
+class MyPyCacheMode(StrEnum):
+    sqlite = "sqlite"
+    none = "none"
 
 
 @dataclass(frozen=True)
@@ -119,6 +126,19 @@ class MyPy(PythonToolBase):
             To instead load third-party plugins, set the option `[mypy].install_from_resolve`
             to a resolve whose lockfile includes those plugins, and set the `plugins` option
             in `mypy.ini`.  See {doc_url("docs/python/goals/check")}.
+            """
+        ),
+    )
+    cache_mode = EnumOption(
+        default=MyPyCacheMode.sqlite,
+        advanced=True,
+        help=softwrap(
+            """
+            `sqlite`: Default. Uses mypy's SQLite cache.
+
+            `none`: Disables caching entirely (--cache-dir=/dev/null). Much
+            slower.  Intended as an "escape valve" if you believe you are
+            encountering a Pants or mypy related bug.
             """
         ),
     )


### PR DESCRIPTION
We do a lot of work (see history of mypy/rules.py) to provide a working solution for the mypy cache and to move it around between sandboxes correctly.  Unfortunately, sometimes bugs in mypy or Pants prevent the cache from being viable -- see the looong journey in https://github.com/pantsbuild/pants/issues/18519 -- and the user might reasonably want to disable the cache entirely in those situation.  (In my DAYJOB repo for example, the mypy sqlite cache is > 700 MiB which is a lot of write out and get no value from. They can't do --no-incremental because that still writes the cache https://github.com/python/mypy/issues/19489 so we need to facilitate pointing to /dev/null