### PR TITLE
linux `perf` support for pants itself

### DIFF
--- a/docs/notes/2.32.x.md
+++ b/docs/notes/2.32.x.md
@@ -20,7 +20,7 @@ The plugin API's `Get()` and `MultiGet()` constructs, deprecated in 2.30, are no
 
 ### General
 
-### Internal Python Upgrade
+#### Internal Python Upgrade
 
 The version of Python used by Pants itself has been updated to [3.14](https://docs.python.org/3/whatsnew/3.14.html). To support this, the [Pants Launcher Binary](https://www.pantsbuild.org/blog/2023/02/23/the-pants-launcher-binary-a-much-simpler-way-to-install-and-run-pants) (also known as [`scie-pants`](https://github.com/pantsbuild/scie-pants/)) now has a minimum version of `0.13.0`. To update to the latest launcher binary, either:
 - Use the package manager you used to install Pants. For example, with Homebrew: `brew update && brew upgrade pantsbuild/tap/pants`.
@@ -29,6 +29,14 @@ The version of Python used by Pants itself has been updated to [3.14](https://do
 Note: Pants uses its own separately-installed Python installation to run itself. This installation is managed by the Pants Launcher Binary. The Pants choice of Python 3.14 for its own code does not limit the versions of Python that you can use to test and build your own code.
 
 For GitHub Actions users that use the [pantsbuild/actions/init-pants](https://github.com/pantsbuild/actions/tree/main/init-pants) action with `setup-python-for-plugins=true`, you will need to update your GHA workflows to use [v11](https://github.com/pantsbuild/actions/releases/tag/v11) or newer to get the correct version of Python.
+
+#### Profiling Pants Itself
+
+As an aid to developing Pants itself (or plugins!), Pants 2.32 includes two developments to assist in profiling:
+ * The [rust engine](https://www.pantsbuild.org/blog/2020/10/27/introducing-pants-v2) is now built with [frame pointers](https://www.brendangregg.com/blog/2024-03-17/the-return-of-the-frame-pointers.html).
+ * The global [enable_stack_trampoline](https://www.pantsbuild.org/2.32/reference/global-options#enable_stack_trampoline) is an ergonomic option to toggle [Python's `perf` support](https://docs.python.org/3/howto/perf_profiling.html) on both the pants client and daemon.
+
+ Together these can produce unified C/Rust/Python tracing data suitable for [flamegraphs](https://www.brendangregg.com/flamegraphs.html), <https://www.speedscope.app/>, and other tools.
 
 ### Goals
 

--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -17,6 +17,7 @@ from pants.base.exiter import ExitCode
 from pants.engine.env_vars import CompleteEnvironmentVars
 from pants.init.logging import initialize_stdio, stdio_destination
 from pants.init.util import init_workdir
+from pants.option.bootstrap_options import BootstrapOptions
 from pants.option.option_value_container import OptionValueContainer
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.util.docutil import doc_url
@@ -79,6 +80,8 @@ class PantsRunner:
         with warnings.catch_warnings(record=True):
             bootstrap_options = options_bootstrapper.bootstrap_options
             global_bootstrap_options = bootstrap_options.for_global_scope()
+
+        BootstrapOptions.maybe_enable_stack_trampoline(global_bootstrap_options)
 
         # We enable logging here, and everything before it will be routed through regular
         # Python logging.

--- a/src/python/pants/option/bootstrap_options.py
+++ b/src/python/pants/option/bootstrap_options.py
@@ -7,6 +7,7 @@ import enum
 import logging
 import os
 import re
+import sys
 import tempfile
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -1069,6 +1070,19 @@ class BootstrapOptions:
             """
         ),
     )
+    enable_stack_trampoline = StrOption(
+        default=None,
+        daemon=True,
+        help=softwrap(
+            """ Enable `sys.activate_stack_trampoline` for Pants's own Python
+            code. This allows profilers like the Linux `perf` profiler to see
+            Python stack frames. Set to `perf` to enable the `perf`
+            trampoline.
+
+            See https://docs.python.org/3/howto/perf_profiling.html
+            """
+        ),
+    )
     sandboxer = BoolOption(
         default=False,
         daemon=False,
@@ -1896,3 +1910,8 @@ class BootstrapOptions:
                     """
                 )
             )
+
+    @staticmethod
+    def maybe_enable_stack_trampoline(opts: OptionValueContainer) -> None:
+        if sys.platform == "linux" and opts.enable_stack_trampoline is not None:
+            sys.activate_stack_trampoline(opts.enable_stack_trampoline)

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -20,7 +20,7 @@ from pants.engine.internals.native_engine import PyExecutor, PyNailgunServer
 from pants.init.engine_initializer import GraphScheduler
 from pants.init.logging import initialize_stdio, pants_log_path
 from pants.init.util import init_workdir
-from pants.option.bootstrap_options import LocalStoreOptions
+from pants.option.bootstrap_options import BootstrapOptions, LocalStoreOptions
 from pants.option.global_options import GlobalOptions
 from pants.option.option_value_container import OptionValueContainer
 from pants.option.options import Options
@@ -246,5 +246,9 @@ def launch_new_pantsd_instance():
     options_bootstrapper = OptionsBootstrapper.create(
         args=sys.argv, env=os.environ, allow_pantsrc=True
     )
+
+    bootstrap_options = options_bootstrapper.bootstrap_options.for_global_scope()
+    BootstrapOptions.maybe_enable_stack_trampoline(bootstrap_options)
+
     daemon = PantsDaemon.create(options_bootstrapper)
     daemon.run_sync()

--- a/src/rust/.cargo/config.toml
+++ b/src/rust/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-C", "force-frame-pointers=yes"]

--- a/src/rust/pantsd/src/lib.rs
+++ b/src/rust/pantsd/src/lib.rs
@@ -352,5 +352,6 @@ pub fn fingerprinted_options(build_root: &BuildRoot) -> Result<Vec<Fingerprinted
         FingerprintedOption::new(option_id!("pantsd"), true),
         FingerprintedOption::new(option_id!("pantsd", "pailgun", "port"), 0),
         FingerprintedOption::new(option_id!("pantsd", "invalidation", "globs"), vec![]),
+        FingerprintedOption::new(option_id!("enable", "stack", "trampoline"), "<none>"),
     ])
 }


### PR DESCRIPTION
When Pants itself executes we are running a mix of C, Rust, and Python code. Those languages historically all have their own performance tooling and ecosystems. (Well C/Rust overlap, but that is the gist.) The Linux perf tooling ecosystem is able to unify all that to give a unified view into what is on and off cpu at a given time.  This allows holistic performance analysis across languages.

Concretely this change does two things:
 * Rust code is always compiled with [frame pointers](https://www.brendangregg.com/blog/2024-03-17/the-return-of-the-frame-pointers.html). We don't support any idiosyncratic 32-bit or otherwise registry starved cpu architectures, so the overhead should be de minimis. (Fedora and Ubuntu have them near-globally enabled.)
 * For Python, a global option acts as a wrapper around toggling <https://docs.python.org/3/howto/perf_profiling.html>.  Obviously there are various other ways to twiddle this, but I want it to be easy and not have everyone repeat "oops I enabled it for the client but not the daemon".  The dream is that eventually when someone in slack says "Pants is slow but I can't show my corporate repository", they can share useful tracing information.

This should be useful enough to glean at least some information for everyone out of the box.  For best results developers need to compile Python and its native dependencies frame pointers as well.  The last barrier to "the dream" above for endusers is PythonBuildStandalone including frame pointers, but this should be useful for Pants development (in this repo, or plugins) today.

Zoomed in screenshot showing C/Rust/Python:
<img width="2557" height="1473" alt="image" src="https://github.com/user-attachments/assets/5ea56f11-bd87-4a6a-9483-0fa88d13a9c2" />
