### PR TITLE
First-Class Dependency Edge Tracking

### DIFF
--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -191,12 +191,15 @@ class LocalPantsRunner:
         return exit_code
 
     def _perform_run_body(self, goals: tuple[str, ...], poll: bool) -> ExitCode:
+        global_options = self.options.for_global_scope()
         return self.graph_session.run_goal_rules(
             union_membership=self.union_membership,
             goals=goals,
             specs=self.specs,
             poll=poll,
             poll_delay=(0.1 if poll else None),
+            dep_edges=global_options.dep_edges,
+            dist_dir=global_options.pants_distdir,
         )
 
     def _get_workunits_callbacks(self) -> tuple[WorkunitsCallback, ...]:

--- a/src/python/pants/engine/engine_aware.py
+++ b/src/python/pants/engine/engine_aware.py
@@ -88,6 +88,16 @@ class EngineAwareReturnType(ABC):
 
         return None
 
+    def dep_edges(self) -> list | None:
+        """If implemented, records dependency edges discovered by this rule.
+
+        Returns a list of objects with `source`, `target`, and `kind` string attributes.
+        These edges are accumulated session-wide and can be retrieved via
+        ``SchedulerSession.get_dep_edges()``.
+        """
+
+        return None
+
 
 class SideEffecting(ABC):
     """Marks a class as providing side-effecting APIs, which are handled specially in @rules.

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -656,6 +656,13 @@ class SchedulerSession:
     def record_test_observation(self, value: int) -> None:
         native_engine.session_record_test_observation(self.py_scheduler, self.py_session, value)
 
+    def get_dep_edges(self) -> list[tuple[str, str, str]]:
+        """Return all dependency edges recorded during this session.
+
+        Each edge is a (source, target, kind) tuple.
+        """
+        return native_engine.session_get_dep_edges(self.py_session)
+
     @property
     def is_cancelled(self) -> bool:
         return self.py_session.is_cancelled()

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -128,6 +128,8 @@ class GraphSession:
         specs: Specs,
         poll: bool = False,
         poll_delay: float | None = None,
+        dep_edges: bool = False,
+        dist_dir: str | None = None,
     ) -> int:
         """Runs @goal_rules sequentially and interactively by requesting their implicit Goal
         products.
@@ -155,9 +157,66 @@ class GraphSession:
                 self.console.flush()
 
             if exit_code != PANTS_SUCCEEDED_EXIT_CODE:
-                return exit_code
+                break
+        else:
+            exit_code = PANTS_SUCCEEDED_EXIT_CODE
 
-        return PANTS_SUCCEEDED_EXIT_CODE
+        if dep_edges:
+            self._render_dep_edges(dist_dir or "dist")
+
+        return exit_code
+
+    def _render_dep_edges(self, dist_dir: str) -> None:
+        """Render dependency edges collected during goal execution."""
+        from collections import defaultdict
+
+        raw_edges = self.scheduler_session.get_dep_edges()
+        if not raw_edges:
+            print("No dependency edges were recorded.")
+            return
+
+        seen: set[tuple[str, str, str]] = set()
+        unique_edges: list[tuple[str, str, str]] = []
+        for edge in raw_edges:
+            key = (edge[0], edge[1], edge[2])
+            if key not in seen:
+                seen.add(key)
+                unique_edges.append(key)
+
+        by_source: dict[str, list[tuple[str, str, str]]] = defaultdict(list)
+        for source, target, kind in unique_edges:
+            by_source[source].append((source, target, kind))
+
+        lines: list[str] = []
+        for source in sorted(by_source.keys()):
+            lines.append(source)
+            for _, target, kind in sorted(by_source[source], key=lambda e: (e[2], e[1])):
+                lines.append(f"  -> {target} ({kind})")
+            lines.append("")
+        print("\n".join(lines))
+
+        dot_lines = [
+            "digraph depgraph {",
+            '    rankdir=LR;',
+            '    node [shape=box, fontname="Courier", fontsize=9];',
+            '    edge [fontsize=8];',
+            "",
+        ]
+        for source, target, kind in sorted(unique_edges):
+            src = source.replace('"', '\\"')
+            tgt = target.replace('"', '\\"')
+            knd = kind.replace('"', '\\"')
+            dot_lines.append(f'    "{src}" -> "{tgt}" [label="{knd}"];')
+        dot_lines.append("}")
+        dot_lines.append("")
+
+        import os
+        os.makedirs(dist_dir, exist_ok=True)
+        dot_path = os.path.join(dist_dir, "depgraph.dot")
+        with open(dot_path, "w") as f:
+            f.write("\n".join(dot_lines))
+        print(f"DOT graph written to {dot_path}")
+        print(f"Render with: dot -Tpng {dot_path} -o {os.path.join(dist_dir, 'depgraph.png')}")
 
 
 class EngineInitializer:

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -240,6 +240,11 @@ class GlobalOptions(BootstrapOptions, Subsystem):
         ),
     )
 
+    dep_edges = BoolOption(
+        default=False,
+        help="After goal execution, output a dependency graph (DOT + text) of all edges discovered by rules.",
+    )
+
     docker_execution = BoolOption(
         default=True,
         advanced=True,

--- a/src/rust/engine/src/externs/engine_aware.rs
+++ b/src/rust/engine/src/externs/engine_aware.rs
@@ -11,7 +11,7 @@ use crate::nodes::{lift_directory_digest, lift_file_digest};
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
-use workunit_store::{ArtifactOutput, Level, RunningWorkunit, UserMetadataItem, WorkunitMetadata};
+use workunit_store::{ArtifactOutput, DepEdge, Level, RunningWorkunit, UserMetadataItem, WorkunitMetadata};
 
 // Note: these functions should not panic, but we also don't preserve errors (e.g. to log) because
 // we rely on MyPy to catch TypeErrors with using the APIs incorrectly. So we convert errors to
@@ -22,6 +22,13 @@ pub(crate) struct EngineAwareReturnType;
 
 impl EngineAwareReturnType {
     pub(crate) fn update_workunit(workunit: &mut RunningWorkunit, task_result: &Bound<'_, PyAny>) {
+        // Record dep edges to the session-level store
+        if let Some(edges) = Self::dep_edges(task_result) {
+            for edge in edges {
+                workunit.record_dep_edge(edge.source, edge.target, edge.kind);
+            }
+        }
+
         workunit.update_metadata(|old| {
             let new_level = Self::level(task_result);
 
@@ -81,6 +88,22 @@ impl EngineAwareReturnType {
             }
             .ok()?;
             output.push((key, artifact_output));
+        }
+        Some(output)
+    }
+
+    fn dep_edges(obj: &Bound<'_, PyAny>) -> Option<Vec<DepEdge>> {
+        let edges_val = obj.call_method0("dep_edges").ok()?;
+        if edges_val.is_none() {
+            return None;
+        }
+        let edges_list: Vec<Bound<'_, PyAny>> = edges_val.extract().ok()?;
+        let mut output = Vec::new();
+        for edge in edges_list {
+            let source: String = edge.getattr("source").ok()?.extract().ok()?;
+            let target: String = edge.getattr("target").ok()?.extract().ok()?;
+            let kind: String = edge.getattr("kind").ok()?.extract().ok()?;
+            output.push(DepEdge { source, target, kind });
         }
         Some(output)
     }

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -146,6 +146,7 @@ fn native_engine(py: Python, m: &Bound<'_, PyModule>) -> PyO3Result<()> {
     m.add_function(wrap_pyfunction!(session_get_metrics, m)?)?;
     m.add_function(wrap_pyfunction!(session_get_observation_histograms, m)?)?;
     m.add_function(wrap_pyfunction!(session_record_test_observation, m)?)?;
+    m.add_function(wrap_pyfunction!(session_get_dep_edges, m)?)?;
     m.add_function(wrap_pyfunction!(session_isolated_shallow_clone, m)?)?;
     m.add_function(wrap_pyfunction!(session_wait_for_tail_tasks, m)?)?;
 
@@ -1495,6 +1496,19 @@ fn session_record_test_observation(
             .workunit_store()
             .record_observation(ObservationMetric::TestObservation, value);
     })
+}
+
+#[pyfunction]
+fn session_get_dep_edges(
+    py: Python<'_>,
+    py_session: &Bound<'_, PySession>,
+) -> Vec<(String, String, String)> {
+    let session = &py_session.borrow().0;
+    let edges = py.detach(|| session.workunit_store().get_dep_edges());
+    edges
+        .into_iter()
+        .map(|e| (e.source, e.target, e.kind))
+        .collect()
 }
 
 #[pyfunction]

--- a/src/rust/workunit_store/src/lib.rs
+++ b/src/rust/workunit_store/src/lib.rs
@@ -325,6 +325,13 @@ pub enum ArtifactOutput {
     Snapshot(Arc<dyn DirectoryDigest>),
 }
 
+#[derive(Clone, Debug)]
+pub struct DepEdge {
+    pub source: String,
+    pub target: String,
+    pub kind: String,
+}
+
 #[derive(Clone, Debug, Default)]
 pub struct WorkunitMetadata {
     pub desc: Option<String>,
@@ -337,6 +344,7 @@ pub struct WorkunitMetadata {
     pub remote_action: Option<hashing::Digest>,
     pub artifacts: Vec<(String, ArtifactOutput)>,
     pub user_metadata: Vec<(String, UserMetadataItem)>,
+    pub dep_edges: Vec<DepEdge>,
 }
 
 /// Abstract id for passing user metadata items around
@@ -362,6 +370,7 @@ pub struct WorkunitStore {
     streaming_workunit_data: Arc<Mutex<StreamingWorkunitData>>,
     heavy_hitters_data: Arc<Mutex<HeavyHittersData>>,
     metrics_data: Arc<MetricsData>,
+    dep_edges: Arc<Mutex<Vec<DepEdge>>>,
 }
 
 struct StreamingWorkunitData {
@@ -559,6 +568,7 @@ impl WorkunitStore {
             streaming_workunit_data: Arc::new(Mutex::new(StreamingWorkunitData::new(receiver1))),
             heavy_hitters_data: Arc::new(Mutex::new(HeavyHittersData::new(receiver2))),
             metrics_data: Arc::default(),
+            dep_edges: Arc::default(),
         }
     }
 
@@ -717,6 +727,14 @@ impl WorkunitStore {
             .collect()
     }
 
+    pub fn record_dep_edge(&self, source: String, target: String, kind: String) {
+        self.dep_edges.lock().push(DepEdge { source, target, kind });
+    }
+
+    pub fn get_dep_edges(&self) -> Vec<DepEdge> {
+        self.dep_edges.lock().clone()
+    }
+
     ///
     /// Records an observation of a time-like metric into a histogram.
     ///
@@ -830,6 +848,13 @@ pub fn record_observation_if_in_workunit(metric: ObservationMetric, value: u64) 
     }
 }
 
+/// If this thread has a workunit set, record a dependency edge.
+pub fn record_dep_edge_if_in_workunit(source: String, target: String, kind: String) {
+    if let Some(handle) = get_workunit_store_handle() {
+        handle.store.record_dep_edge(source, target, kind)
+    }
+}
+
 /// Run the given async block. If the level given by the WorkunitMetadata is above a configured
 /// threshold, the block will run inside of a workunit recorded in the workunit store.
 ///
@@ -900,6 +925,10 @@ impl RunningWorkunit {
 
     pub fn increment_counter(&self, counter_name: Metric, change: u64) {
         self.store.increment_counter(counter_name, change);
+    }
+
+    pub fn record_dep_edge(&self, source: String, target: String, kind: String) {
+        self.store.record_dep_edge(source, target, kind);
     }
 
     ///


### PR DESCRIPTION
Generic way to capture and surface discovered dependencies Dependency edges are treated as a side-channel on rule execution The --dep-edges global option triggers a post-goal hook in run_goal_rules() that reads all edges and renders them as text + DOT.

Dependency edges are treated as a side-channel on rule execution, analogous to how level(), message(), and artifacts() already work on EngineAwareReturnType. Rules emit edges as a natural byproduct of their work; the engine accumulates them session-wide; any consumer can read them after the fact.

Layer 1 -- Rule-side (plugins): Any rule whose return type extends EngineAwareReturnType can implement dep_edges() to report discovered edges. The rule does its normal work and returns edges as a tuple on the result dataclass. No special infrastructure needed -- it's just a method on the return type.
Layer 2 -- Engine (Rust core): When a rule completes, the engine already inspects the return value for level(), message(), artifacts(), etc. Now it also calls dep_edges(). The returned edges are stored in a session-scoped Vec<DepEdge> in the workunit store. This survives rule memoization -- edges from cached rules were already recorded in prior runs.
Layer 3 -- Consumer (Python runner): SchedulerSession.get_dep_edges() exposes the accumulated edges as list[tuple[str, str, str]]. The --dep-edges global option triggers a post-goal hook in run_goal_rules() that reads all edges and renders them as text + DOT. Because it runs after goals complete, it works with any goal without the goal needing to know about edge tracking.