### PR TITLE
un bitrot flaky tests

### DIFF
--- a/src/python/pants/jvm/jdk_rules_test.py
+++ b/src/python/pants/jvm/jdk_rules_test.py
@@ -97,7 +97,7 @@ def test_java_binary_versions(rule_runner: RuleRunner) -> None:
     assert 'openjdk version "11.0' in run_javac_version(rule_runner)
 
     rule_runner.set_options(["--jvm-tool-jdk=temurin:1.17"], env_inherit=PYTHON_BOOTSTRAP_ENV)
-    assert 'openjdk version "17"' in run_javac_version(rule_runner)
+    assert 'openjdk version "17.' in run_javac_version(rule_runner)
 
     rule_runner.set_options(["--jvm-tool-jdk=bogusjdk:999"], env_inherit=PYTHON_BOOTSTRAP_ENV)
     expected_exception_msg = r".*?JVM bogusjdk:999 not found in index.*?"

--- a/src/python/pants/pantsd/pantsd_integration_test.py
+++ b/src/python/pants/pantsd/pantsd_integration_test.py
@@ -299,7 +299,7 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
             ctx.checker.assert_started()
 
             # Launch a separate thread to poke files in 3rdparty.
-            join = launch_file_toucher("3rdparty/jvm/com/google/auto/value/BUILD")
+            join = launch_file_toucher("testprojects/src/python/hello/BUILD")
 
             # Repeatedly re-list 3rdparty while the file is being invalidated.
             for _ in range(0, 16):


### PR DESCRIPTION
The goal isn't to fix the flakyness, just to make them runnable again as a prerequisite to eventual fixing.

For `pantsd_integration_test.py` the files were moved around in 2d1794f582.

For `jdk_rules_test.py` the prefix switch pattern was already intoduced in 45c51ae6de.

This was accomplished by having an LLM go through the list of all flaky tests and uncomment the 'skip' one by one and then try to fix any bitrot.