### PR TITLE
Docs updates for plugin API and generate-lockfiles

### DIFF
--- a/docs/docs/python/overview/lockfiles.mdx
+++ b/docs/docs/python/overview/lockfiles.mdx
@@ -166,6 +166,25 @@ You can have Pants display a useful summary of what changed between the old and 
 diff = true
 ```
 
+#### Lockfile syncing
+
+If you want to add or remove requirements from the lockfile without perturbing other requirement versions unnecessarily, you can use the `--sync` option:
+
+```shell title="Bash"
+$ pants generate-lockfiles --sync
+```
+
+This will attempt to perform a minimal update of the lockfile, adding and removing just what is necessary, without checking for more recent compatible versions of every requirement and upgrading to them.
+
+If you want this to be the default behavior, you can set it in config:
+
+```toml title="pants.toml"
+[generate-lockfiles]
+sync = true
+```
+
+And then override it with the `--no-sync` flag as needed.
+
 In theory, when you generate a lockfile, you should want to audit it for bugs, compliance and security concerns. In practice this is intractable to do manually. We would like to integrate with automated auditing tools and services in the future, so watch this space for updates, or feel free to [reach out on Slack](/community/members) if this is important to you and you'd like to work on it.
 
 ### Lockfile subsetting

--- a/docs/docs/writing-plugins/overview.mdx
+++ b/docs/docs/writing-plugins/overview.mdx
@@ -25,10 +25,14 @@ Thanks to Pants's execution engine, your plugins will automatically bring you th
 - Concurrent execution.
 - Remote execution.
 
-:::danger The Plugin API is not yet stable
-While we'll try our best to limit changes, the Plugin API does not yet follow the [Deprecation Policy](../releases/deprecation-policy.mdx). Components of the API may change between minor versions—e.g. 2.7 to 2.8—without a deprecation.
+:::caution Plugin API Stability
+The Plugin API is now considered largely stable.
 
-We will document changes at [Plugin upgrade guide](./common-plugin-tasks/plugin-upgrade-guide.mdx).
+- We are still working on integrating the Plugin API into the Pants [Deprecation Policy](../releases/deprecation-policy.mdx),
+and some API @rules may yet be renamed for consistency and clarity, so the API is not officially subject to that policy yet.
+However the API has not changed substantually in several releases, and we do not anticipate major changes in the future.
+
+- We will continue to document changes in the [Plugin upgrade guide](./common-plugin-tasks/plugin-upgrade-guide.mdx).
 :::
 
 ## Core concepts
@@ -182,7 +186,7 @@ See [Third-party dependencies](../python/overview/third-party-dependencies.mdx) 
 
 Pants plugins can be published to PyPI and consumed by other Pants users.
 
-As mentioned above: the plugin API is still unstable, and so supporting multiple versions of Pants with a single plugin version may be challenging. Give careful consideration to who you expect to consume the plugin, and what types of maintenance guarantees you hope to provide.
+As mentioned above: the plugin API is largely stable, but can still evolve over time like any API. and so you may wish to give careful consideration to who you expect to consume the plugin, which versions of Pants it should support, and what types of maintenance guarantees you hope to provide.
 
 ### Thirdparty dependencies
 


### PR DESCRIPTION
- The new `--sync` option for generate-lockfiles
- Plugin API is approaching stability