### PR TITLE
Update CI to get rid of warnings

### DIFF
--- a/.github/workflows/public_repos.yaml
+++ b/.github/workflows/public_repos.yaml
@@ -1070,13 +1070,15 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: '3.10'
-    - name: Install Go
+    - name: Install Go 1.25.3
       uses: actions/setup-go@v6
       with:
+        cache: false
         go-version: 1.25.3
-    - name: Install Go
+    - name: Install Go 1.24.9
       uses: actions/setup-go@v6
       with:
+        cache: false
         go-version: 1.24.9
     - name: Pants on
       run: |2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -192,13 +192,15 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         version: 23.x
-    - name: Install Go
+    - name: Install Go 1.25.3
       uses: actions/setup-go@v6
       with:
+        cache: false
         go-version: 1.25.3
-    - name: Install Go
+    - name: Install Go 1.24.9
       uses: actions/setup-go@v6
       with:
+        cache: false
         go-version: 1.24.9
     - env:
         HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY || '--DISABLED--' }}
@@ -340,7 +342,7 @@ jobs:
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo
-      uses: Swatinem/rust-cache@v2.8.2
+      uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
       with:
         cache-bin: 'false'
         shared-key: engine
@@ -350,13 +352,15 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         version: 23.x
-    - name: Install Go
+    - name: Install Go 1.25.3
       uses: actions/setup-go@v6
       with:
+        cache: false
         go-version: 1.25.3
-    - name: Install Go
+    - name: Install Go 1.24.9
       uses: actions/setup-go@v6
       with:
+        cache: false
         go-version: 1.24.9
     - env:
         ARCHFLAGS: -arch arm64
@@ -473,7 +477,7 @@ jobs:
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo
-      uses: Swatinem/rust-cache@v2.8.2
+      uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
       with:
         cache-bin: 'false'
         shared-key: engine

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -58,7 +58,7 @@ jobs:
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo
-      uses: Swatinem/rust-cache@v2.8.2
+      uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
       with:
         cache-bin: 'false'
         shared-key: engine
@@ -167,7 +167,7 @@ jobs:
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo
-      uses: Swatinem/rust-cache@v2.8.2
+      uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
       with:
         cache-bin: 'false'
         shared-key: engine
@@ -283,7 +283,7 @@ jobs:
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo
-      uses: Swatinem/rust-cache@v2.8.2
+      uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
       with:
         cache-bin: 'false'
         shared-key: engine
@@ -480,13 +480,15 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         version: 23.x
-    - name: Install Go
+    - name: Install Go 1.25.3
       uses: actions/setup-go@v6
       with:
+        cache: false
         go-version: 1.25.3
-    - name: Install Go
+    - name: Install Go 1.24.9
       uses: actions/setup-go@v6
       with:
+        cache: false
         go-version: 1.24.9
     - env:
         HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY || '--DISABLED--' }}
@@ -566,7 +568,7 @@ jobs:
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo
-      uses: Swatinem/rust-cache@v2.8.2
+      uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
       with:
         cache-bin: 'false'
         shared-key: engine
@@ -576,13 +578,15 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         version: 23.x
-    - name: Install Go
+    - name: Install Go 1.25.3
       uses: actions/setup-go@v6
       with:
+        cache: false
         go-version: 1.25.3
-    - name: Install Go
+    - name: Install Go 1.24.9
       uses: actions/setup-go@v6
       with:
+        cache: false
         go-version: 1.24.9
     - env:
         ARCHFLAGS: -arch arm64
@@ -620,7 +624,7 @@ jobs:
       with:
         fetch-depth: 10
     - name: Install MSYS2
-      uses: msys2/setup-msys2@v2
+      uses: msys2/setup-msys2@4f806de0a5a7294ffabaff804b38a9b435a73bda
       with:
         install: base-devel mingw-w64-ucrt-x86_64-toolchain mingw-w64-ucrt-x86_64-nasm mingw-w64-ucrt-x86_64-cmake mingw-w64-ucrt-x86_64-protobuf
         msystem: UCRT64
@@ -890,13 +894,15 @@ jobs:
       with:
         distribution: adopt
         java-version: '11'
-    - name: Install Go
+    - name: Install Go 1.25.3
       uses: actions/setup-go@v6
       with:
+        cache: false
         go-version: 1.25.3
-    - name: Install Go
+    - name: Install Go 1.24.9
       uses: actions/setup-go@v6
       with:
+        cache: false
         go-version: 1.24.9
     - name: Download native binaries
       uses: actions/download-artifact@v7
@@ -998,13 +1004,15 @@ jobs:
       with:
         distribution: adopt
         java-version: '11'
-    - name: Install Go
+    - name: Install Go 1.25.3
       uses: actions/setup-go@v6
       with:
+        cache: false
         go-version: 1.25.3
-    - name: Install Go
+    - name: Install Go 1.24.9
       uses: actions/setup-go@v6
       with:
+        cache: false
         go-version: 1.24.9
     - if: runner.os == 'Linux'
       name: Download Apache `thrift` binary (Linux)
@@ -1125,13 +1133,15 @@ jobs:
       with:
         distribution: adopt
         java-version: '11'
-    - name: Install Go
+    - name: Install Go 1.25.3
       uses: actions/setup-go@v6
       with:
+        cache: false
         go-version: 1.25.3
-    - name: Install Go
+    - name: Install Go 1.24.9
       uses: actions/setup-go@v6
       with:
+        cache: false
         go-version: 1.24.9
     - if: runner.os == 'Linux'
       name: Download Apache `thrift` binary (Linux)
@@ -1252,13 +1262,15 @@ jobs:
       with:
         distribution: adopt
         java-version: '11'
-    - name: Install Go
+    - name: Install Go 1.25.3
       uses: actions/setup-go@v6
       with:
+        cache: false
         go-version: 1.25.3
-    - name: Install Go
+    - name: Install Go 1.24.9
       uses: actions/setup-go@v6
       with:
+        cache: false
         go-version: 1.24.9
     - if: runner.os == 'Linux'
       name: Download Apache `thrift` binary (Linux)
@@ -1379,13 +1391,15 @@ jobs:
       with:
         distribution: adopt
         java-version: '11'
-    - name: Install Go
+    - name: Install Go 1.25.3
       uses: actions/setup-go@v6
       with:
+        cache: false
         go-version: 1.25.3
-    - name: Install Go
+    - name: Install Go 1.24.9
       uses: actions/setup-go@v6
       with:
+        cache: false
         go-version: 1.24.9
     - if: runner.os == 'Linux'
       name: Download Apache `thrift` binary (Linux)
@@ -1506,13 +1520,15 @@ jobs:
       with:
         distribution: adopt
         java-version: '11'
-    - name: Install Go
+    - name: Install Go 1.25.3
       uses: actions/setup-go@v6
       with:
+        cache: false
         go-version: 1.25.3
-    - name: Install Go
+    - name: Install Go 1.24.9
       uses: actions/setup-go@v6
       with:
+        cache: false
         go-version: 1.24.9
     - if: runner.os == 'Linux'
       name: Download Apache `thrift` binary (Linux)
@@ -1633,13 +1649,15 @@ jobs:
       with:
         distribution: adopt
         java-version: '11'
-    - name: Install Go
+    - name: Install Go 1.25.3
       uses: actions/setup-go@v6
       with:
+        cache: false
         go-version: 1.25.3
-    - name: Install Go
+    - name: Install Go 1.24.9
       uses: actions/setup-go@v6
       with:
+        cache: false
         go-version: 1.24.9
     - if: runner.os == 'Linux'
       name: Download Apache `thrift` binary (Linux)
@@ -1760,13 +1778,15 @@ jobs:
       with:
         distribution: adopt
         java-version: '11'
-    - name: Install Go
+    - name: Install Go 1.25.3
       uses: actions/setup-go@v6
       with:
+        cache: false
         go-version: 1.25.3
-    - name: Install Go
+    - name: Install Go 1.24.9
       uses: actions/setup-go@v6
       with:
+        cache: false
         go-version: 1.24.9
     - if: runner.os == 'Linux'
       name: Download Apache `thrift` binary (Linux)
@@ -1887,13 +1907,15 @@ jobs:
       with:
         distribution: adopt
         java-version: '11'
-    - name: Install Go
+    - name: Install Go 1.25.3
       uses: actions/setup-go@v6
       with:
+        cache: false
         go-version: 1.25.3
-    - name: Install Go
+    - name: Install Go 1.24.9
       uses: actions/setup-go@v6
       with:
+        cache: false
         go-version: 1.24.9
     - if: runner.os == 'Linux'
       name: Download Apache `thrift` binary (Linux)
@@ -2014,13 +2036,15 @@ jobs:
       with:
         distribution: adopt
         java-version: '11'
-    - name: Install Go
+    - name: Install Go 1.25.3
       uses: actions/setup-go@v6
       with:
+        cache: false
         go-version: 1.25.3
-    - name: Install Go
+    - name: Install Go 1.24.9
       uses: actions/setup-go@v6
       with:
+        cache: false
         go-version: 1.24.9
     - if: runner.os == 'Linux'
       name: Download Apache `thrift` binary (Linux)
@@ -2141,13 +2165,15 @@ jobs:
       with:
         distribution: adopt
         java-version: '11'
-    - name: Install Go
+    - name: Install Go 1.25.3
       uses: actions/setup-go@v6
       with:
+        cache: false
         go-version: 1.25.3
-    - name: Install Go
+    - name: Install Go 1.24.9
       uses: actions/setup-go@v6
       with:
+        cache: false
         go-version: 1.24.9
     - if: runner.os == 'Linux'
       name: Download Apache `thrift` binary (Linux)
@@ -2244,13 +2270,15 @@ jobs:
       with:
         distribution: adopt
         java-version: '11'
-    - name: Install Go
+    - name: Install Go 1.25.3
       uses: actions/setup-go@v6
       with:
+        cache: false
         go-version: 1.25.3
-    - name: Install Go
+    - name: Install Go 1.24.9
       uses: actions/setup-go@v6
       with:
+        cache: false
         go-version: 1.24.9
     - name: Set up Python 3.9, 3.10, 3.11, 3.12, 3.13, 3.14
       uses: actions/setup-python@v6

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -34,8 +34,8 @@ def action(name: str) -> str:
         "download-artifact": "actions/download-artifact@v7",
         "free-disk-space": "jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be",
         "github-action-required-labels": "mheap/github-action-required-labels@v4.0.0",
-        "msys2": "msys2/setup-msys2@v2",
-        "rust-cache": "Swatinem/rust-cache@v2.8.2",
+        "msys2": "msys2/setup-msys2@4f806de0a5a7294ffabaff804b38a9b435a73bda",
+        "rust-cache": "Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4",
         "setup-go": "actions/setup-go@v6",
         "setup-java": "actions/setup-java@v5",
         "setup-node": "actions/setup-node@v6",
@@ -389,9 +389,11 @@ def install_jdk() -> Step:
 def install_go() -> list[Step]:
     def go_cfg(go_version: str) -> Step:
         return {
-            "name": "Install Go",
+            "name": f"Install Go {go_version}",
             "uses": action("setup-go"),
-            "with": {"go-version": go_version},
+            # We use this action to install Go for testing against, but our repo is not a golang
+            # repo, and has no go.mod, so module caching would fail and is therefore disabled.
+            "with": {"go-version": go_version, "cache": False},
         }
 
     return [go_cfg(go_version) for go_version in ("1.25.3", "1.24.9")]


### PR DESCRIPTION
Previously we were getting:

- `Restore cache failed: Dependencies file is not found
  in /home/runner/work/pants/pants. Supported file
  pattern: go.mod` in the `setup-go` job.

- `Node.js 20 actions are deprecated.` on the `setup-msys2`
  and `rust-cache` jobs.

We still get this error on `setup-protoc`, but that doesn't
have a more recent version to upgrade to yet. See
https://github.com/arduino/setup-protoc/issues/112

There are a few more unrelated warnings to tackle, we can
do so in a separate change.