### PR TITLE
enable "thin LTO" in release profile

### DIFF
--- a/docs/notes/2.32.x.md
+++ b/docs/notes/2.32.x.md
@@ -20,6 +20,8 @@ The plugin API's `Get()` and `MultiGet()` constructs, deprecated in 2.30, are no
 
 ### General
 
+The rust engine of Pants is now compiled with ["thin" Link Time Optimization](https://nnethercote.github.io/perf-book/build-configuration.html#link-time-optimization).  This results in a slightly smaller binary and a few percentage points of improved performance on certain workloads.
+
 #### Internal Python Upgrade
 
 The version of Python used by Pants itself has been updated to [3.14](https://docs.python.org/3/whatsnew/3.14.html). To support this, the [Pants Launcher Binary](https://www.pantsbuild.org/blog/2023/02/23/the-pants-launcher-binary-a-much-simpler-way-to-install-and-run-pants) (also known as [`scie-pants`](https://github.com/pantsbuild/scie-pants/)) now has a minimum version of `0.13.0`. To update to the latest launcher binary, either:

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -4,6 +4,7 @@
 debug = 1
 # Optimise for the speed of our binary, rather than the speed of compilation.
 codegen-units = 1
+lto = "thin"
 
 [workspace]
 resolver = "2"


### PR DESCRIPTION
So the naming here is kind of a mess:
 * I don't know how Rust of all places ends up with this combo bool/string type.
 * "fat" isn't "more LTO" than "thin"; "thin" and "fat" are more like different algorithms.

But the summary is that "thin" is the new/better algorithm.

This takes `native_engine.so` from 189MiB to 172MiB and in various tests I've run with `hyperfine` I see results like `1.05 ± 0.06`, or `1.02 ± 0.09`.  So not going to write a blog post about it, but we don't seem to hit any pathological corner cases and I'll take a few percentage points for free.

References:
 * https://nnethercote.github.io/perf-book/build-configuration.html#link-time-optimization
 * https://doc.rust-lang.org/cargo/reference/profiles.html#lto