### PR TITLE
[pants-ng] Add infer-deps pragmas to various files.

### DIFF
--- a/src/python/pants/backend/cc/lint/clangformat/subsystem.py
+++ b/src/python/pants/backend/cc/lint/clangformat/subsystem.py
@@ -15,6 +15,8 @@ from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, SkipOption
 from pants.util.strutil import help_text
 
+# pants: infer-dep(clangformat.lock*)
+
 
 class ClangFormat(PythonToolBase):
     options_scope = "clang-format"

--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
@@ -28,6 +28,9 @@ from pants.source.source_root import SourceRootRequest, get_source_root
 from pants.util.docutil import doc_url
 from pants.util.strutil import help_text, softwrap
 
+# pants: infer-dep(grpclib.lock*)
+# pants: infer-dep(mypy_protobuf.lock*)
+
 
 class PythonProtobufSubsystem(Subsystem):
     options_scope = "python-protobuf"

--- a/src/python/pants/backend/docker/subsystems/dockerfile_parser.py
+++ b/src/python/pants/backend/docker/subsystems/dockerfile_parser.py
@@ -33,6 +33,8 @@ from pants.util.logging import LogLevel
 from pants.util.resources import read_resource
 from pants.util.strutil import softwrap
 
+# pants: infer-dep(dockerfile.lock*)
+
 _DOCKERFILE_SANDBOX_TOOL = "dockerfile_wrapper_script.py"
 _DOCKERFILE_PACKAGE = "pants.backend.docker.subsystems"
 

--- a/src/python/pants/backend/helm/subsystems/k8s_parser.py
+++ b/src/python/pants/backend/helm/subsystems/k8s_parser.py
@@ -29,6 +29,8 @@ from pants.option.option_types import DictOption
 from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize, softwrap
 
+# pants: infer-dep(k8s_parser.lock*)
+
 logger = logging.getLogger(__name__)
 
 _HELM_K8S_PARSER_SOURCE = "k8s_parser_main.py"

--- a/src/python/pants/backend/helm/subsystems/post_renderer.py
+++ b/src/python/pants/backend/helm/subsystems/post_renderer.py
@@ -39,6 +39,8 @@ from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.strutil import bullet_list, pluralize, softwrap
 
+# pants: infer-dep(post_renderer.lock*)
+
 logger = logging.getLogger(__name__)
 
 _HELM_POSTRENDERER_SOURCE = "post_renderer_main.py"

--- a/src/python/pants/backend/nfpm/native_libs/elfdeps/subsystem.py
+++ b/src/python/pants/backend/nfpm/native_libs/elfdeps/subsystem.py
@@ -17,6 +17,8 @@ from pants.util.logging import LogLevel
 from pants.util.resources import read_resource
 from pants.util.strutil import help_text
 
+# pants: infer-dep(elfdeps.lock*)
+
 _ELFDEPS_PACKAGE = "pants.backend.nfpm.native_libs.elfdeps"
 _ANALYZE_SCRIPT = "analyze.py"
 _ANALYZE_TOOL = "__pants_elfdeps_analyze.py"

--- a/src/python/pants/backend/python/goals/coverage_py.py
+++ b/src/python/pants/backend/python/goals/coverage_py.py
@@ -69,6 +69,8 @@ from pants.source.source_root import AllSourceRoots
 from pants.util.logging import LogLevel
 from pants.util.strutil import softwrap
 
+# pants: infer-dep(../subsystems/coverage_py.lock*)
+
 """
 An overview:
 

--- a/src/python/pants/backend/python/lint/add_trailing_comma/subsystem.py
+++ b/src/python/pants/backend/python/lint/add_trailing_comma/subsystem.py
@@ -10,6 +10,8 @@ from pants.engine.rules import collect_rules
 from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, SkipOption
 
+# pants: infer-dep(add_trailing_comma.lock*)
+
 
 class AddTrailingComma(PythonToolBase):
     options_scope = "add-trailing-comma"

--- a/src/python/pants/backend/python/lint/autoflake/subsystem.py
+++ b/src/python/pants/backend/python/lint/autoflake/subsystem.py
@@ -10,6 +10,8 @@ from pants.engine.rules import collect_rules
 from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, SkipOption
 
+# pants: infer-dep(autoflake.lock*)
+
 
 class Autoflake(PythonToolBase):
     options_scope = "autoflake"

--- a/src/python/pants/backend/python/lint/bandit/subsystem.py
+++ b/src/python/pants/backend/python/lint/bandit/subsystem.py
@@ -21,6 +21,8 @@ from pants.engine.target import FieldSet, Target
 from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, FileOption, SkipOption
 
+# pants: infer-dep(bandit.lock*)
+
 
 @dataclass(frozen=True)
 class BanditFieldSet(FieldSet):

--- a/src/python/pants/backend/python/lint/black/subsystem.py
+++ b/src/python/pants/backend/python/lint/black/subsystem.py
@@ -23,6 +23,8 @@ from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, BoolOption, FileOption, SkipOption
 from pants.util.strutil import softwrap
 
+# pants: infer-dep(black.lock*)
+
 
 @dataclass(frozen=True)
 class BlackFieldSet(FieldSet):

--- a/src/python/pants/backend/python/lint/docformatter/subsystem.py
+++ b/src/python/pants/backend/python/lint/docformatter/subsystem.py
@@ -9,6 +9,8 @@ from pants.engine.rules import collect_rules
 from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, SkipOption
 
+# pants: infer-dep(docformatter.lock*)
+
 
 class Docformatter(PythonToolBase):
     options_scope = "docformatter"

--- a/src/python/pants/backend/python/lint/flake8/subsystem.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem.py
@@ -36,6 +36,8 @@ from pants.util.docutil import doc_url
 from pants.util.logging import LogLevel
 from pants.util.strutil import softwrap
 
+# pants: infer-dep(flake8.lock*)
+
 
 @dataclass(frozen=True)
 class Flake8FieldSet(FieldSet):

--- a/src/python/pants/backend/python/lint/isort/subsystem.py
+++ b/src/python/pants/backend/python/lint/isort/subsystem.py
@@ -15,6 +15,8 @@ from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, BoolOption, FileListOption, SkipOption
 from pants.util.strutil import softwrap
 
+# pants: infer-dep(isort.lock*)
+
 
 class Isort(PythonToolBase):
     options_scope = "isort"

--- a/src/python/pants/backend/python/lint/pydocstyle/subsystem.py
+++ b/src/python/pants/backend/python/lint/pydocstyle/subsystem.py
@@ -18,6 +18,8 @@ from pants.option.option_types import ArgsListOption, BoolOption, FileOption, Sk
 from pants.util.docutil import bin_name
 from pants.util.strutil import softwrap
 
+# pants: infer-dep(pydocstyle.lock*)
+
 
 @dataclass(frozen=True)
 class PydocstyleFieldSet(FieldSet):

--- a/src/python/pants/backend/python/lint/pylint/subsystem.py
+++ b/src/python/pants/backend/python/lint/pylint/subsystem.py
@@ -36,6 +36,8 @@ from pants.util.docutil import doc_url
 from pants.util.logging import LogLevel
 from pants.util.strutil import softwrap
 
+# pants: infer-dep(pylint.lock*)
+
 
 @dataclass(frozen=True)
 class PylintFieldSet(FieldSet):

--- a/src/python/pants/backend/python/lint/pyupgrade/subsystem.py
+++ b/src/python/pants/backend/python/lint/pyupgrade/subsystem.py
@@ -10,6 +10,8 @@ from pants.engine.rules import collect_rules
 from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, SkipOption
 
+# pants: infer-dep(pyupgrade.lock*)
+
 
 class PyUpgrade(PythonToolBase):
     options_scope = "pyupgrade"

--- a/src/python/pants/backend/python/lint/yapf/subsystem.py
+++ b/src/python/pants/backend/python/lint/yapf/subsystem.py
@@ -15,6 +15,8 @@ from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, BoolOption, FileOption, SkipOption
 from pants.util.strutil import softwrap
 
+# pants: infer-dep(yapf.lock*)
+
 
 class Yapf(PythonToolBase):
     options_scope = "yapf"

--- a/src/python/pants/backend/python/packaging/pyoxidizer/subsystem.py
+++ b/src/python/pants/backend/python/packaging/pyoxidizer/subsystem.py
@@ -9,6 +9,8 @@ from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption
 from pants.util.strutil import help_text
 
+# pants: infer-dep(pyoxidizer.lock*)
+
 
 class PyOxidizer(PythonToolBase):
     options_scope = "pyoxidizer"

--- a/src/python/pants/backend/python/subsystems/debugpy.py
+++ b/src/python/pants/backend/python/subsystems/debugpy.py
@@ -9,6 +9,8 @@ from pants.core.subsystems.debug_adapter import DebugAdapterSubsystem
 from pants.engine.rules import collect_rules
 from pants.option.option_types import ArgsListOption
 
+# pants: infer-dep(debugpy.lock*)
+
 
 class DebugPy(PythonToolBase):
     options_scope = "debugpy"

--- a/src/python/pants/backend/python/subsystems/ipython.py
+++ b/src/python/pants/backend/python/subsystems/ipython.py
@@ -11,6 +11,8 @@ from pants.engine.unions import UnionRule
 from pants.option.option_types import BoolOption
 from pants.util.strutil import softwrap
 
+# pants: infer-dep(ipython.lock*)
+
 
 class IPython(PythonToolBase):
     options_scope = "ipython"

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -29,6 +29,8 @@ from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, BoolOption, FileOption, SkipOption, StrOption
 from pants.util.strutil import softwrap
 
+# pants: infer-dep(pytest.lock*)
+
 
 @dataclass(frozen=True)
 class PythonTestFieldSet(TestFieldSet):

--- a/src/python/pants/backend/python/subsystems/setuptools.py
+++ b/src/python/pants/backend/python/subsystems/setuptools.py
@@ -9,6 +9,8 @@ from pants.backend.python.target_types import PythonProvidesField
 from pants.core.goals.package import PackageFieldSet
 from pants.engine.rules import collect_rules
 
+# pants: infer-dep(setuptools.lock*)
+
 
 @dataclass(frozen=True)
 class PythonDistributionFieldSet(PackageFieldSet):

--- a/src/python/pants/backend/python/subsystems/setuptools_scm.py
+++ b/src/python/pants/backend/python/subsystems/setuptools_scm.py
@@ -7,6 +7,8 @@ from pants.core.goals.resolves import ExportableTool
 from pants.engine.rules import collect_rules
 from pants.engine.unions import UnionRule
 
+# pants: infer-dep(setuptools_scm.lock*)
+
 
 class SetuptoolsSCM(PythonToolBase):
     options_scope = "setuptools-scm"

--- a/src/python/pants/backend/python/subsystems/twine.py
+++ b/src/python/pants/backend/python/subsystems/twine.py
@@ -15,6 +15,8 @@ from pants.option.option_types import ArgsListOption, BoolOption, FileOption, Sk
 from pants.util.docutil import doc_url
 from pants.util.strutil import softwrap
 
+# pants: infer-dep(twine.lock*)
+
 
 class TwineSubsystem(PythonToolBase):
     options_scope = "twine"

--- a/src/python/pants/backend/python/typecheck/pytype/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/pytype/subsystem.py
@@ -9,6 +9,8 @@ from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.option.option_types import ArgsListOption, FileOption, SkipOption
 from pants.util.strutil import help_text, softwrap
 
+# pants: infer-dep(pytype.lock*)
+
 
 class Pytype(PythonToolBase):
     options_scope = "pytype"

--- a/src/python/pants/backend/sql/lint/sqlfluff/subsystem.py
+++ b/src/python/pants/backend/sql/lint/sqlfluff/subsystem.py
@@ -18,6 +18,8 @@ from pants.engine.target import FieldSet, Target
 from pants.option.option_types import ArgsListOption, BoolOption, FileOption, SkipOption
 from pants.util.strutil import softwrap
 
+# pants: infer-dep(sqlfluff.lock*)
+
 
 @dataclass(frozen=True)
 class SqlfluffFieldSet(FieldSet):

--- a/src/python/pants/backend/terraform/dependency_inference.py
+++ b/src/python/pants/backend/terraform/dependency_inference.py
@@ -54,6 +54,8 @@ from pants.util.ordered_set import OrderedSet
 from pants.util.resources import read_resource
 from pants.util.strutil import bullet_list, softwrap
 
+# pants: infer-dep(hcl2.lock*)
+
 
 class TerraformHcl2Parser(PythonToolRequirementsBase):
     options_scope = "terraform-hcl2-parser"

--- a/src/python/pants/backend/tools/semgrep/subsystem.py
+++ b/src/python/pants/backend/tools/semgrep/subsystem.py
@@ -15,6 +15,8 @@ from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, BoolOption, SkipOption, StrOption
 from pants.util.strutil import softwrap
 
+# pants: infer-dep(semgrep.lock*)
+
 
 @dataclass(frozen=True)
 class SemgrepFieldSet(FieldSet):

--- a/src/python/pants/backend/tools/yamllint/subsystem.py
+++ b/src/python/pants/backend/tools/yamllint/subsystem.py
@@ -20,6 +20,8 @@ from pants.option.option_types import (
 )
 from pants.util.strutil import softwrap
 
+# pants: infer-dep(yamllint.lock*)
+
 
 class Yamllint(PythonToolBase):
     name = "Yamllint"

--- a/src/python/pants/base/build_root_test.py
+++ b/src/python/pants/base/build_root_test.py
@@ -10,6 +10,8 @@ from pants.base.build_root import BuildRoot
 from pants.util.contextutil import environment_as, pushd, temporary_dir
 from pants.util.dirutil import safe_mkdir, safe_mkdtemp, safe_rmtree, touch
 
+# pants: infer-dep(/BUILD_ROOT)
+
 
 @pytest.fixture
 def tmp_build_root() -> Generator[tuple[BuildRoot, str, str]]:

--- a/src/python/pants/base/exception_sink_integration_test.py
+++ b/src/python/pants/base/exception_sink_integration_test.py
@@ -15,6 +15,8 @@ from pants.pantsd.pantsd_integration_test_base import PantsDaemonIntegrationTest
 from pants.testutil.pants_integration_test import run_pants_with_workdir
 from pants.util.dirutil import read_file
 
+# pants: infer-dep(/testprojects/pants-plugins/src/python/test_pants_plugin/*)
+
 pytestmark = pytest.mark.platform_specific_behavior
 
 

--- a/src/python/pants/engine/internals/native_engine.pyi
+++ b/src/python/pants/engine/internals/native_engine.pyi
@@ -1,6 +1,9 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+# pants: infer-dep(native_engine.so)
+# pants: infer-dep(native_engine.so.metadata)
+
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Mapping, Sequence

--- a/src/python/pants/version.py
+++ b/src/python/pants/version.py
@@ -6,9 +6,11 @@ from typing import Any
 
 from packaging.version import Version as _Version
 
+# pants: infer-dep(/src/python/pants/_version/__init__.py)
+# pants: infer-dep(/src/python/pants/_version/VERSION)
 import pants._version
 
-# Generate an inferable dependency on the `pants._version` package and its associated resources.
+# Generate an OG inferable dependency on the `pants._version` package and its associated resources.
 from pants.util.resources import read_resource
 
 


### PR DESCRIPTION
This is needed for pants-ng to run the legacy code's tests.