### PR TITLE
[pants-ng] bypass common_dir computation if unneeded

### DIFF
--- a/src/python/pants/ng/source_partition.py
+++ b/src/python/pants/ng/source_partition.py
@@ -52,23 +52,25 @@ async def find_common_dir(source_paths: SourcePaths) -> CommonDir:
     if not source_paths.paths:  # We don't expect empty SourcePaths, but might as well be robust.
         return CommonDir(None)
     commonpath = os.path.commonpath(source_paths.paths)
-    meta = await path_metadata_request(PathMetadataRequest(commonpath))
-    # Chase any symlinks back to the final path they point to.
-    while (
-        meta.metadata
-        and meta.metadata.kind == PathMetadataKind.SYMLINK
-        and meta.metadata.symlink_target
-    ):
-        # NB: We don't `normpath` because eliminating `..` might change the meaning of the path
-        #  if any of the intermediate directories are themselves symlinks.
-        symlink_target = os.path.join(os.path.dirname(commonpath), meta.metadata.symlink_target)
-        meta = await path_metadata_request(PathMetadataRequest(symlink_target))
-    if meta.metadata and meta.metadata.kind == PathMetadataKind.FILE:
-        # The args were a single file (or symlink to a file), so the commonpath is that file, but
-        # we want its enclosing dir.
-        common_dir = os.path.dirname(commonpath)
-    else:
-        common_dir = commonpath
+    common_dir = commonpath
+    if len(source_paths.paths) == 1:
+        # If there is only one path, and it's a file, then commonpath will be that file, whereas
+        # we want its enclosing dir. So detect that case.
+        meta = await path_metadata_request(PathMetadataRequest(commonpath))
+        # Chase any symlinks back to the final path they point to.
+        while (
+            meta.metadata
+            and meta.metadata.kind == PathMetadataKind.SYMLINK
+            and meta.metadata.symlink_target
+        ):
+            # NB: We don't `normpath` because eliminating `..` might change the meaning of the path
+            #  if any of the intermediate directories are themselves symlinks.
+            symlink_target = os.path.join(os.path.dirname(commonpath), meta.metadata.symlink_target)
+            meta = await path_metadata_request(PathMetadataRequest(symlink_target))
+        if meta.metadata and meta.metadata.kind == PathMetadataKind.FILE:
+            common_dir = os.path.dirname(commonpath)
+        else:
+            common_dir = commonpath
     return CommonDir(Path(common_dir))
 
 


### PR DESCRIPTION
The complicated case need only be triggered if there was
a single input. Otherwise the `commonpath` is already
definitely a dir.