### PR TITLE
Updated shell completions to allow filesystem completions

### DIFF
--- a/src/python/pants/goal/pants-completion.bash
+++ b/src/python/pants/goal/pants-completion.bash
@@ -1,19 +1,22 @@
 # bash completion support for Pants
 
 function _pants_completions() {
-    local current_word
-    current_word=${COMP_WORDS[COMP_CWORD]}
+    local current_word=${COMP_WORDS[COMP_CWORD]}
 
     # Check if we're completing a relative (.), absolute (/), or homedir (~) path. If so, fallback to readline (default) completion.
     # This short-circuits the call to the complete goal, which can take a couple hundred milliseconds to complete
-    if [[ $current_word =~ "^(\.|/|~\/)" ]]; then
+    if [[ $current_word =~ ^[./~] ]]; then
         COMPREPLY=()
     else 
-        # Call the pants complete goal with all of the arguments that we've received so far.
-        COMPREPLY=( $(pants complete -- "${COMP_WORDS[@]}") )
+        # Call the pants complete goal with all of the arguments that we've received so far
+        local pants_completions=( $(pants complete -- "${COMP_WORDS[@]}") )
+        # Generate file/directory completions
+        local file_completions=( $(compgen -f -- "$current_word") )
+
+        COMPREPLY=( "${pants_completions[@]}" "${file_completions[@]}" )
     fi
 
     return 0
 }
 
-complete -o default -F _pants_completions pants
+complete -o default -o filenames -F _pants_completions pants

--- a/src/python/pants/goal/pants-completion.zsh
+++ b/src/python/pants/goal/pants-completion.zsh
@@ -1,18 +1,26 @@
-#compdef _pants_completions pants
+#compdef pants
 
 # zsh completion support for Pants
 function _pants_completions() {
-    local current_word
-    current_word=${words[CURRENT]}
+    local current_word=${words[CURRENT]}
 
     # Check if we're completing a relative (.), absolute (/), or homedir (~) path. If so, fallback to readline (default) completion.
     # This short-circuits the call to the complete goal, which can take a couple hundred milliseconds to complete
-    if [[ $current_word =~ "^(\.|/|~\/)" ]]; then
+    if [[ $current_word =~ ^[./~] ]]; then
         _files
     else
-        # Call the pants complete goal with all of the arguments that we've received so far.
-        compadd $(pants complete -- "${words[@]}")
+        # Call the pants complete goal with all of the arguments that we've received so far
+        compadd -- $(pants complete -- "${words[@]}")
+        # Generate file/directory completions - with a line between them and the pants completions
+        _files -X "" 
     fi
 
     return 0
 }
+
+# Don't run completions when we're sourcing the file
+if [[ $funcstack[1] == _pants_completions ]]; then
+    _pants_completions "$@"
+else
+    compdef _pants_completions pants
+fi


### PR DESCRIPTION
AI disclosure: I asked Gemini, Claude, and ChatGPT the same set of questions to add filesystem support to the shell completions, given the associated 2 files and python completion code.

They each gave a different set of answers, noted different bugs in the current implementation, and suggested different solutions. Then I gave each solution to each clanker, and they each said the other's was incorrect. 

They did all agree on `^[./~]` though - which was a nice feeling. And I went with Gemini on `$(compgen -f -- "$current_word")`. 

The rest was stuff I saw in the zsh completions on my computer.

Of note: Bash merges completions and filesystem values into a single array, while in zsh, I add a visual separator.

```
% pants <TAB>
__no_goal                      dependents                     filter                         help-advanced                  package                        roots
__unknown_goal                 experimental-deploy            fix                            help-all                       paths                          run
check                          experimental-explorer          fmt                            lint                           peek                           tailor
complete                       export                         generate-lockfiles             list                           publish                        test
count-loc                      export-codegen                 generate-snapshots             migrate                        python-dump-source-analysis    update-build-files
dependencies                   filedeps                       help                           migrate-call-by-name           repl                           version

build-support/       c1.zsh               examples/            init-pants/          mypy.ini             pants-plugins/       pants.toml           README.md            
BUILD.pants          dist/                foo/                 LICENSE              pants_from_sources*  pants.ci.toml        pyproject.toml       requirements.txt    
```

```
% pants r<TAB>
repl        roots       run

README.md         requirements.txt
```

Closes #22244 