### PR TITLE
Updated the default Pex version to v2.91.4

### DIFF
--- a/docs/notes/2.32.x.md
+++ b/docs/notes/2.32.x.md
@@ -114,10 +114,11 @@ All version of [Ruff](https://docs.astral.sh/ruff/) from [0.13.1](https://github
 
 The default version of the [Ruff](https://docs.astral.sh/ruff/) tool has been updated to [0.14.14](https://github.com/astral-sh/ruff/releases/tag/0.14.14).
 
-The version of [Pex](https://github.com/pex-tool/pex) used by the Python backend has been upgraded to [`v2.91.2`](https://github.com/pex-tool/pex/releases/tag/v2.91.2). Of particular note for Pants users:
+The version of [Pex](https://github.com/pex-tool/pex) used by the Python backend has been upgraded to [`v2.91.4`](https://github.com/pex-tool/pex/releases/tag/v2.91.4). Of particular note for Pants users:
  - Support for [pip 26.0.1](https://pip.pypa.io/en/stable/news/#v26-0-1).
  - A new `--interpreter-selection-strategy` option to select the `"oldest"` or `"newest"` interpreter when multiple match constraints.
  - Linux PEX scies can now install themselves with a desktop entry.
+ - [Performance improvements](https://github.com/pex-tool/pex/releases/tag/v2.91.4) for large PEXes
  - And for Pants *developers* [fixes the most common case of a rare interpreter caching bug for CPython interpreters that have the same binary contents across patch versions](https://github.com/pex-tool/pex/releases/tag/v2.91.1).
 
 #### Shell

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -37,9 +37,9 @@ from pants.util.strutil import softwrap
 logger = logging.getLogger(__name__)
 
 
-_PEX_VERSION = "v2.91.2"
-_PEX_BINARY_HASH = "0aa2f9100c6775d7f6b1db1658d0c70a9f62d17e4cc7d1301df3e8fa364a1034"
-_PEX_BINARY_SIZE = 4992632
+_PEX_VERSION = "v2.91.4"
+_PEX_BINARY_HASH = "41540a3777f344cfd975c33fc2eae7c18dbef7810de89da0477acfe231e1c150"
+_PEX_BINARY_SIZE = 5078680
 
 
 class PexCli(TemplatedExternalTool):


### PR DESCRIPTION
Release notes:

https://github.com/pex-tool/pex/releases/tag/v2.91.4
https://github.com/pex-tool/pex/releases/tag/v2.91.3