### PR TITLE
Upgrade pex to 2.91.7

### DIFF
--- a/docs/notes/2.32.x.md
+++ b/docs/notes/2.32.x.md
@@ -117,7 +117,7 @@ All version of [Ruff](https://docs.astral.sh/ruff/) from [0.13.1](https://github
 
 The default version of the [Ruff](https://docs.astral.sh/ruff/) tool has been updated to [0.14.14](https://github.com/astral-sh/ruff/releases/tag/0.14.14).
 
-The version of [Pex](https://github.com/pex-tool/pex) used by the Python backend has been upgraded to [`v2.91.6`](https://github.com/pex-tool/pex/releases/tag/v2.91.6). Of particular note for Pants users:
+The version of [Pex](https://github.com/pex-tool/pex) used by the Python backend has been upgraded to [`v2.91.7`](https://github.com/pex-tool/pex/releases/tag/v2.91.7). Of particular note for Pants users:
  - Support for [pip 26.0.1](https://pip.pypa.io/en/stable/news/#v26-0-1).
  - A new `--interpreter-selection-strategy` option to select the `"oldest"` or `"newest"` interpreter when multiple match constraints.
  - Linux PEX scies can now install themselves with a desktop entry.

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -37,9 +37,9 @@ from pants.util.strutil import softwrap
 logger = logging.getLogger(__name__)
 
 
-_PEX_VERSION = "v2.91.6"
-_PEX_BINARY_HASH = "7ad93771823900012ecd5386ed00cc4a15393ef76a76c410853708f9f91abecd"
-_PEX_BINARY_SIZE = 5079012
+_PEX_VERSION = "v2.91.7"
+_PEX_BINARY_HASH = "7bb032815401788789c46b498d705b730a4b52736558fc6b11e3593e7ee23d2c"
+_PEX_BINARY_SIZE = 5080310
 
 
 class PexCli(TemplatedExternalTool):


### PR DESCRIPTION
Picks up a much more robust defense against bad tag metadata.