### PR TITLE
Port ScalarField, AsyncFieldMixin and friends to rust

### DIFF
--- a/src/python/pants/engine/internals/native_engine.pyi
+++ b/src/python/pants/engine/internals/native_engine.pyi
@@ -8,9 +8,10 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from datetime import datetime
+from enum import Enum
 from io import RawIOBase
 from pathlib import Path
-from typing import Any, ClassVar, Protocol, Self, TextIO, TypeVar, overload
+from typing import Any, ClassVar, Generic, Protocol, Self, TextIO, TypeVar, overload
 
 from pants.engine.fs import (
     CreateDigest,
@@ -434,6 +435,8 @@ class Field:
 
     value: ImmutableValue | None
 
+    _raw_value_type: ClassVar[str]
+
     def __init__(self, raw_value: Any | None, address: Address) -> None: ...
     @classmethod
     def compute_value(cls, raw_value: Any | None, address: Address) -> ImmutableValue:
@@ -445,6 +448,128 @@ class Field:
         The resulting value must be hashable (and should be immutable).
         """
         ...
+
+_ST = TypeVar("_ST")
+
+class ScalarField(Field, Generic[_ST]):
+    expected_type: ClassVar[type[_ST]]
+    expected_type_description: ClassVar[str]
+    value: _ST | None
+    default: ClassVar[_ST | None] = None
+
+    @classmethod
+    def compute_value(cls, raw_value: Any | None, address: Address) -> _ST | None: ...
+
+class BoolField(ScalarField[bool]):
+    """A field whose value is a boolean.
+
+    Subclasses must either set `default: bool` or `required = True` so that the value is always
+    defined.
+    """
+
+    expected_type: ClassVar[type[bool]]
+    expected_type_description: ClassVar[str]
+    value: bool
+    default: ClassVar[bool]
+
+    @classmethod
+    def compute_value(cls, raw_value: bool, address: Address) -> bool: ...  # type: ignore[override]
+
+class TriBoolField(ScalarField[bool]):
+    """A field whose value is a boolean or None, which is meant to represent a tri-state."""
+
+    expected_type: ClassVar[type[bool]]
+    expected_type_description: ClassVar[str]
+
+    @classmethod
+    def compute_value(cls, raw_value: bool | None, address: Address) -> bool | None: ...
+
+class StringField(ScalarField[str]):
+    expected_type: ClassVar[type[str]]
+    expected_type_description: ClassVar[str]
+    valid_choices: ClassVar[type[Enum] | tuple[str, ...] | None]
+
+    @classmethod
+    def compute_value(cls, raw_value: str | None, address: Address) -> str | None: ...
+
+_ET = TypeVar("_ET")
+
+class SequenceField(Field, Generic[_ET]):
+    expected_element_type: ClassVar[type]
+    expected_type_description: ClassVar[str]
+    value: tuple[_ET, ...] | None
+    default: ClassVar[tuple[_ET, ...] | None] = None
+
+    @classmethod
+    def compute_value(
+        cls, raw_value: Iterable[Any] | None, address: Address
+    ) -> tuple[_ET, ...] | None: ...
+
+class StringSequenceField(SequenceField[str]):
+    expected_element_type: ClassVar[type[str]]
+    expected_type_description: ClassVar[str]
+    valid_choices: ClassVar[type[Enum] | tuple[str, ...] | None]
+
+    @classmethod
+    def compute_value(
+        cls, raw_value: Iterable[str] | None, address: Address
+    ) -> tuple[str, ...] | None: ...
+
+# NB: By subclassing `Field`, MyPy understands our type hints, and it means it doesn't matter
+# which order you use for inheriting the field template vs. the mixin.
+class AsyncFieldMixin(Field):
+    """A mixin to store the field's original `Address` for use during hydration by the engine.
+
+    Typically, you should also create a dataclass representing the hydrated value and another for
+    the request, then a rule to go from the request to the hydrated value. The request class should
+    store the async field as a property.
+
+    (Why use the request class as the rule input, rather than the field itself? It's a wrapper so
+    that subclasses of the async field work properly, given that the engine uses exact type IDs.
+    This is like WrappedTarget.)
+
+    For example:
+
+        class Sources(StringSequenceField, AsyncFieldMixin):
+            alias = "sources"
+
+            # Often, async fields will want to define entry points like this to allow subclasses to
+            # change behavior.
+            def validate_resolved_files(self, files: Sequence[str]) -> None:
+                pass
+
+
+        @dataclass(frozen=True)
+        class HydrateSourcesRequest:
+            field: Sources
+
+
+        @dataclass(frozen=True)
+        class HydratedSources:
+            snapshot: Snapshot
+
+
+        @rule
+        async def hydrate_sources(request: HydrateSourcesRequest) -> HydratedSources:
+            digest = await path_globs_to_digest(PathGlobs(request.field.value))
+            result = await digest_to_snapshot(digest)
+            request.field.validate_resolved_files(result.files)
+            ...
+            return HydratedSources(result)
+
+    Then, call sites can `await` if they need to hydrate the field, even if they subclassed
+    the original async field to have custom behavior:
+
+        sources1 = hydrate_sources(HydrateSourcesRequest(my_tgt.get(Sources)))
+        sources2 = hydrate_sources(HydrateSourcesRequest(custom_tgt.get(CustomSources)))
+    """
+
+    address: Address
+
+    def __hash__(self) -> int: ...
+    def __eq__(self, other: Any) -> bool: ...
+    def __ne__(self, other: Any) -> bool: ...
+    def __repr__(self) -> str: ...
 
 # ------------------------------------------------------------------------------
 # FS

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -25,7 +25,6 @@ from typing import (
     ClassVar,
     Generic,
     Protocol,
-    Self,
     TypeVar,
     cast,
     final,
@@ -49,13 +48,20 @@ from pants.engine.internals.dep_rules import (
     DependencyRuleApplication,
 )
 from pants.engine.internals.native_engine import NO_VALUE as NO_VALUE  # noqa: F401
+from pants.engine.internals.native_engine import AsyncFieldMixin as AsyncFieldMixin
+from pants.engine.internals.native_engine import BoolField as BoolField  # noqa: F401
 from pants.engine.internals.native_engine import Field as Field
+from pants.engine.internals.native_engine import ScalarField as ScalarField
+from pants.engine.internals.native_engine import SequenceField as SequenceField  # noqa: F401
+from pants.engine.internals.native_engine import StringField as StringField
+from pants.engine.internals.native_engine import StringSequenceField as StringSequenceField
+from pants.engine.internals.native_engine import TriBoolField as TriBoolField  # noqa: F401
 from pants.engine.internals.target_adaptor import SourceBlock, SourceBlocks  # noqa: F401
 from pants.engine.rules import rule
 from pants.engine.unions import UnionMembership, UnionRule, distinct_union_type_per_subclass, union
 from pants.option.bootstrap_options import UnmatchedBuildFileGlobs
 from pants.source.filespec import Filespec, FilespecMatcher
-from pants.util.collections import ensure_list, ensure_str_list
+from pants.util.collections import ensure_str_list
 from pants.util.dirutil import fast_relpath
 from pants.util.docutil import bin_name, doc_url
 from pants.util.frozendict import FrozenDict
@@ -72,92 +78,6 @@ logger = logging.getLogger(__name__)
 # Type alias to express the intent that the type should be immutable and hashable. There's nothing
 # to actually enforce this, outside of convention. Maybe we could develop a MyPy plugin?
 ImmutableValue = Any
-
-
-# NB: By subclassing `Field`, MyPy understands our type hints, and it means it doesn't matter which
-# order you use for inheriting the field template vs. the mixin.
-class AsyncFieldMixin(Field):
-    """A mixin to store the field's original `Address` for use during hydration by the engine.
-
-    Typically, you should also create a dataclass representing the hydrated value and another for
-    the request, then a rule to go from the request to the hydrated value. The request class should
-    store the async field as a property.
-
-    (Why use the request class as the rule input, rather than the field itself? It's a wrapper so
-    that subclasses of the async field work properly, given that the engine uses exact type IDs.
-    This is like WrappedTarget.)
-
-    For example:
-
-        class Sources(StringSequenceField, AsyncFieldMixin):
-            alias = "sources"
-
-            # Often, async fields will want to define entry points like this to allow subclasses to
-            # change behavior.
-            def validate_resolved_files(self, files: Sequence[str]) -> None:
-                pass
-
-
-        @dataclass(frozen=True)
-        class HydrateSourcesRequest:
-            field: Sources
-
-
-        @dataclass(frozen=True)
-        class HydratedSources:
-            snapshot: Snapshot
-
-
-        @rule
-        async def hydrate_sources(request: HydrateSourcesRequest) -> HydratedSources:
-            digest = await path_globs_to_digest(PathGlobs(request.field.value))
-            result = await digest_to_snapshot(digest)
-            request.field.validate_resolved_files(result.files)
-            ...
-            return HydratedSources(result)
-
-    Then, call sites can `await` if they need to hydrate the field, even if they subclassed
-    the original async field to have custom behavior:
-
-        sources1 = hydrate_sources(HydrateSourcesRequest(my_tgt.get(Sources)))
-        sources2 = hydrate_sources(HydrateSourcesRequest(custom_tgt.get(CustomSources)))
-    """
-
-    address: Address
-
-    @final
-    def __new__(cls, raw_value: Any | None, address: Address) -> Self:
-        obj = super().__new__(cls, raw_value, address)  # type: ignore[call-arg]
-        # N.B.: We store the address here and not in the Field base class, because the memory usage
-        # of storing this value in every field was shown to be excessive / lead to performance
-        # issues.
-        object.__setattr__(obj, "address", address)
-        return obj
-
-    def __repr__(self) -> str:
-        params = [
-            f"alias={self.alias!r}",
-            f"address={self.address}",
-            f"value={self.value!r}",
-        ]
-        if hasattr(self, "default"):
-            params.append(f"default={self.default!r}")
-        return f"{self.__class__}({', '.join(params)})"
-
-    def __hash__(self) -> int:
-        return hash((self.__class__, self.value, self.address))
-
-    def __eq__(self, other: Any) -> bool:
-        if not isinstance(other, AsyncFieldMixin):
-            return False
-        return (
-            self.__class__ == other.__class__
-            and self.value == other.value
-            and self.address == other.address
-        )
-
-    def __ne__(self, other: Any) -> bool:
-        return not (self == other)
 
 
 @union
@@ -1763,74 +1683,6 @@ class UnrecognizedTargetTypeException(InvalidTargetException):
 T = TypeVar("T")
 
 
-class ScalarField(Generic[T], Field):
-    """A field with a scalar value (vs. a compound value like a sequence or dict).
-
-    Subclasses must define the class properties `expected_type` and `expected_type_description`.
-    They should also override the type hints for the classmethod `compute_value` so that we use the
-    correct type annotation in generated documentation.
-
-        class Example(ScalarField):
-            alias = "example"
-            expected_type = MyPluginObject
-            expected_type_description = "a `my_plugin` object"
-
-            @classmethod
-            def compute_value(
-                cls, raw_value: Optional[MyPluginObject], address: Address
-            ) -> Optional[MyPluginObject]:
-                return super().compute_value(raw_value, address=address)
-    """
-
-    expected_type: ClassVar[type[T]]
-    expected_type_description: ClassVar[str]
-    value: T | None
-    default: ClassVar[T | None] = None
-
-    @classmethod
-    def compute_value(cls, raw_value: Any | None, address: Address) -> T | None:
-        value_or_default = super().compute_value(raw_value, address)
-        if value_or_default is not None and not isinstance(value_or_default, cls.expected_type):
-            raise InvalidFieldTypeException(
-                address,
-                cls.alias,
-                raw_value,
-                expected_type=cls.expected_type_description,
-            )
-        return value_or_default
-
-
-class BoolField(Field):
-    """A field whose value is a boolean.
-
-    Subclasses must either set `default: bool` or `required = True` so that the value is always
-    defined.
-    """
-
-    value: bool
-    default: ClassVar[bool]
-
-    @classmethod
-    def compute_value(cls, raw_value: bool, address: Address) -> bool:  # type: ignore[override]
-        value_or_default = super().compute_value(raw_value, address)
-        if not isinstance(value_or_default, bool):
-            raise InvalidFieldTypeException(
-                address, cls.alias, raw_value, expected_type="a boolean"
-            )
-        return value_or_default
-
-
-class TriBoolField(ScalarField[bool]):
-    """A field whose value is a boolean or None, which is meant to represent a tri-state."""
-
-    expected_type = bool
-    expected_type_description = "a boolean or None"
-
-    @classmethod
-    def compute_value(cls, raw_value: bool | None, address: Address) -> bool | None:
-        return super().compute_value(raw_value, address)
-
-
 class ValidNumbers(Enum):
     """What range of numbers are allowed for IntField and FloatField."""
 
@@ -1877,70 +1729,6 @@ class FloatField(ScalarField[float]):
         value_or_default = super().compute_value(raw_value, address)
         cls.valid_numbers.validate(value_or_default, cls.alias, address)
         return value_or_default
-
-
-class StringField(ScalarField[str]):
-    """A field whose value is a string.
-
-    If you expect the string to only be one of several values, set the class property
-    `valid_choices`.
-    """
-
-    expected_type = str
-    expected_type_description = "a string"
-    valid_choices: ClassVar[type[Enum] | tuple[str, ...] | None] = None
-
-    @classmethod
-    def compute_value(cls, raw_value: str | None, address: Address) -> str | None:
-        value_or_default = super().compute_value(raw_value, address)
-        if value_or_default is not None and cls.valid_choices is not None:
-            _validate_choices(
-                address, cls.alias, [value_or_default], valid_choices=cls.valid_choices
-            )
-        return value_or_default
-
-
-class SequenceField(Generic[T], Field):
-    """A field whose value is a homogeneous sequence.
-
-    Subclasses must define the class properties `expected_element_type` and
-    `expected_type_description`. They should also override the type hints for the classmethod
-    `compute_value` so that we use the correct type annotation in generated documentation.
-
-        class Example(SequenceField):
-            alias = "example"
-            expected_element_type = MyPluginObject
-            expected_type_description = "an iterable of `my_plugin` objects"
-
-            @classmethod
-            def compute_value(
-                cls, raw_value: Optional[Iterable[MyPluginObject]], address: Address
-            ) -> Optional[Tuple[MyPluginObject, ...]]:
-                return super().compute_value(raw_value, address=address)
-    """
-
-    expected_element_type: ClassVar[type]
-    expected_type_description: ClassVar[str]
-    value: tuple[T, ...] | None
-    default: ClassVar[tuple[T, ...] | None] = None
-
-    @classmethod
-    def compute_value(
-        cls, raw_value: Iterable[Any] | None, address: Address
-    ) -> tuple[T, ...] | None:
-        value_or_default = super().compute_value(raw_value, address)
-        if value_or_default is None:
-            return None
-        try:
-            ensure_list(value_or_default, expected_type=cls.expected_element_type)
-        except ValueError:
-            raise InvalidFieldTypeException(
-                address,
-                cls.alias,
-                raw_value,
-                expected_type=cls.expected_type_description,
-            )
-        return tuple(value_or_default)
 
 
 class TupleSequenceField(Generic[T], Field):
@@ -1997,21 +1785,6 @@ class TupleSequenceField(Generic[T], Field):
             validated.append(cast(tuple[T, ...], element))
 
         return tuple(validated)
-
-
-class StringSequenceField(SequenceField[str]):
-    expected_element_type = str
-    expected_type_description = "an iterable of strings (e.g. a list of strings)"
-    valid_choices: ClassVar[type[Enum] | tuple[str, ...] | None] = None
-
-    @classmethod
-    def compute_value(
-        cls, raw_value: Iterable[str] | None, address: Address
-    ) -> tuple[str, ...] | None:
-        value_or_default = super().compute_value(raw_value, address)
-        if value_or_default and cls.valid_choices is not None:
-            _validate_choices(address, cls.alias, value_or_default, valid_choices=cls.valid_choices)
-        return value_or_default
 
 
 class DictStringToStringField(Field):
@@ -2125,25 +1898,6 @@ class DictStringToStringSequenceField(Field):
             except ValueError:
                 raise invalid_type_exception
         return FrozenDict(result)
-
-
-def _validate_choices(
-    address: Address,
-    field_alias: str,
-    values: Iterable[Any],
-    *,
-    valid_choices: type[Enum] | tuple[Any, ...],
-) -> None:
-    _valid_choices = set(
-        valid_choices
-        if isinstance(valid_choices, tuple)
-        else (choice.value for choice in valid_choices)
-    )
-    for choice in values:
-        if choice not in _valid_choices:
-            raise InvalidFieldChoiceException(
-                address, field_alias, choice, valid_choices=_valid_choices
-            )
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -201,8 +201,11 @@ class TargetFieldHelpInfo:
 
     @classmethod
     def create(cls, field: type[Field], *, provider: str) -> TargetFieldHelpInfo:
-        raw_value_type = get_type_hints(field.compute_value)["raw_value"]
-        type_hint = pretty_print_type_hint(raw_value_type)
+        hints = get_type_hints(field.compute_value)
+        if "raw_value" in hints:
+            type_hint = pretty_print_type_hint(hints["raw_value"])
+        else:
+            type_hint = field._raw_value_type
 
         # Check if the field only allows for certain choices.
         if issubclass(field, StringField) and field.valid_choices is not None:

--- a/src/rust/engine/src/externs/target.rs
+++ b/src/rust/engine/src/externs/target.rs
@@ -2,22 +2,119 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 use std::fmt::Write;
+use std::hash::{Hash, Hasher};
+
+use fnv::FnvHasher;
 
 use pyo3::basic::CompareOp;
 use pyo3::exceptions::PyValueError;
 use pyo3::intern;
 use pyo3::prelude::*;
+use pyo3::pyclass_init::PyClassInitializer;
 use pyo3::types::PyType;
 
 use crate::externs::address::Address;
 use crate::python::PyComparedBool;
 
+use std::sync::OnceLock;
+
+static INVALID_FIELD_TYPE_EXCEPTION: OnceLock<Py<PyAny>> = OnceLock::new();
+static INVALID_FIELD_CHOICE_EXCEPTION: OnceLock<Py<PyAny>> = OnceLock::new();
+
 pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Field>()?;
+    m.add_class::<ScalarField>()?;
+    m.add_class::<BoolField>()?;
+    m.add_class::<TriBoolField>()?;
+    m.add_class::<StringField>()?;
+    m.add_class::<SequenceField>()?;
+    m.add_class::<StringSequenceField>()?;
+    m.add_class::<AsyncFieldMixin>()?;
     m.add_class::<NoFieldValue>()?;
 
     m.add("NO_VALUE", NoFieldValue)?;
 
+    Ok(())
+}
+
+fn combine_hashes(hashes: &[isize]) -> isize {
+    let mut hasher = FnvHasher::default();
+    for h in hashes {
+        h.hash(&mut hasher);
+    }
+    hasher.finish() as isize
+}
+
+fn get_cached_exception<'py>(
+    py: Python<'py>,
+    cache: &OnceLock<Py<PyAny>>,
+    name: &str,
+) -> PyResult<Bound<'py, PyAny>> {
+    if let Some(exc) = cache.get() {
+        return Ok(exc.bind(py).clone());
+    }
+    let exc = py.import("pants.engine.target")?.getattr(name)?;
+    let _ = cache.set(exc.clone().unbind());
+    Ok(exc)
+}
+
+fn raise_invalid_field_type(
+    py: Python,
+    address: &Bound<PyAny>,
+    alias: &str,
+    raw_value: Option<&Bound<PyAny>>,
+    expected_type_desc: &str,
+) -> PyErr {
+    match get_cached_exception(
+        py,
+        &INVALID_FIELD_TYPE_EXCEPTION,
+        "InvalidFieldTypeException",
+    ) {
+        Ok(exc_cls) => {
+            let kwargs = pyo3::types::PyDict::new(py);
+            let _ = kwargs.set_item("expected_type", expected_type_desc);
+            match exc_cls.call((address, alias, raw_value), Some(&kwargs)) {
+                Ok(exc) => PyErr::from_value(exc),
+                Err(e) => e,
+            }
+        }
+        Err(e) => e,
+    }
+}
+
+fn validate_choices(
+    py: Python,
+    address: &Bound<PyAny>,
+    alias: &str,
+    values: &Bound<PyAny>,
+    valid_choices: &Bound<PyAny>,
+) -> PyResult<()> {
+    let choices_set = pyo3::types::PySet::empty(py)?;
+    if valid_choices.is_instance_of::<pyo3::types::PyTuple>() {
+        for item in valid_choices.try_iter()? {
+            choices_set.add(item?)?;
+        }
+    } else {
+        for member in valid_choices.try_iter()? {
+            let member = member?;
+            choices_set.add(member.getattr(intern!(py, "value"))?)?;
+        }
+    }
+    for choice in values.try_iter()? {
+        let choice = choice?;
+        if !choices_set.contains(&choice)? {
+            let exc_cls = get_cached_exception(
+                py,
+                &INVALID_FIELD_CHOICE_EXCEPTION,
+                "InvalidFieldChoiceException",
+            )?;
+            let kwargs = pyo3::types::PyDict::new(py);
+            kwargs.set_item("valid_choices", &choices_set)?;
+            return Err(PyErr::from_value(
+                exc_cls.call((address, alias, &choice), Some(&kwargs))?,
+            ));
+        }
+    }
     Ok(())
 }
 
@@ -36,7 +133,7 @@ impl NoFieldValue {
     }
 }
 
-#[pyclass(subclass)]
+#[pyclass(subclass, frozen, module = "pants.engine.internals.native_engine")]
 pub struct Field {
     value: Py<PyAny>,
 }
@@ -67,11 +164,16 @@ impl Field {
             rv => rv,
         };
 
-        Ok(Self {
-            value: cls
-                .call_method(intern!(py, "compute_value"), (raw_value, address), None)?
-                .into(),
-        })
+        let value = cls
+            .call_method(intern!(py, "compute_value"), (raw_value, &address), None)?
+            .into();
+
+        Ok(Self { value })
+    }
+
+    #[classattr]
+    fn _raw_value_type() -> &'static str {
+        "Any | None"
     }
 
     #[classattr]
@@ -142,7 +244,10 @@ impl Field {
     }
 
     fn __hash__(self_: &Bound<'_, Self>, py: Python) -> PyResult<isize> {
-        Ok(self_.get_type().hash()? & self_.borrow().value.bind(py).hash()?)
+        Ok(combine_hashes(&[
+            self_.get_type().hash()?,
+            self_.get().value.bind(py).hash()?,
+        ]))
     }
 
     fn __repr__(self_: &Bound<'_, Self>) -> PyResult<String> {
@@ -152,7 +257,7 @@ impl Field {
             "{}(alias={}, value={}",
             self_.get_type(),
             Self::cls_alias(self_)?,
-            self_.borrow().value
+            self_.get().value
         )
         .unwrap();
         if let Ok(default) = self_.getattr("default") {
@@ -164,11 +269,7 @@ impl Field {
     }
 
     fn __str__(self_: &Bound<'_, Self>) -> PyResult<String> {
-        Ok(format!(
-            "{}={}",
-            Self::cls_alias(self_)?,
-            self_.borrow().value
-        ))
+        Ok(format!("{}={}", Self::cls_alias(self_)?, self_.get().value))
     }
 
     fn __richcmp__<'py>(
@@ -179,10 +280,10 @@ impl Field {
     ) -> PyResult<PyComparedBool> {
         let is_eq = self_.get_type().eq(other.get_type())?
             && self_
-                .borrow()
+                .get()
                 .value
                 .bind(py)
-                .eq(&other.extract::<PyRef<Field>>()?.value)?;
+                .eq(other.cast::<Field>()?.get().value.bind(py))?;
         Ok(PyComparedBool(match op {
             CompareOp::Eq => Some(is_eq),
             CompareOp::Ne => Some(!is_eq),
@@ -192,6 +293,17 @@ impl Field {
 }
 
 impl Field {
+    fn init(
+        cls: &Bound<'_, PyType>,
+        raw_value: Option<&Bound<'_, PyAny>>,
+        address: Bound<'_, Address>,
+        py: Python,
+    ) -> PyResult<PyClassInitializer<Field>> {
+        Ok(PyClassInitializer::from(Self::__new__(
+            cls, raw_value, address, py,
+        )?))
+    }
+
     fn cls_none_is_valid_value(cls: &Bound<'_, PyAny>) -> PyResult<bool> {
         cls.getattr("none_is_valid_value")?.extract::<bool>()
     }
@@ -252,5 +364,429 @@ impl Field {
             None,
         )?;
         Ok(())
+    }
+}
+
+#[pyclass(subclass, frozen, extends = Field, generic, module = "pants.engine.internals.native_engine")]
+pub struct ScalarField;
+
+#[pymethods]
+impl ScalarField {
+    #[new]
+    #[classmethod]
+    #[pyo3(signature = (raw_value, address))]
+    fn __new__(
+        cls: &Bound<'_, PyType>,
+        raw_value: Option<&Bound<'_, PyAny>>,
+        address: Bound<'_, Address>,
+        py: Python,
+    ) -> PyResult<PyClassInitializer<Self>> {
+        Ok(Field::init(cls, raw_value, address, py)?.add_subclass(Self))
+    }
+
+    #[classattr]
+    fn default<'py>(py: Python<'py>) -> Bound<'py, PyAny> {
+        py.None().into_bound(py)
+    }
+
+    #[classmethod]
+    #[pyo3(signature = (raw_value, address))]
+    fn compute_value<'py>(
+        cls: &Bound<'py, PyType>,
+        raw_value: Option<&Bound<'py, PyAny>>,
+        address: Bound<'py, Address>,
+        py: Python<'py>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let value_or_default = Field::compute_value(cls, raw_value, address.extract()?, py)?;
+        if !value_or_default.is_none() {
+            let expected_type = cls.getattr(intern!(py, "expected_type"))?;
+            if !value_or_default.is_instance(&expected_type)? {
+                let alias: String = Field::cls_alias(cls)?;
+                let expected_type_desc: String = cls
+                    .getattr(intern!(py, "expected_type_description"))?
+                    .extract()?;
+                return Err(raise_invalid_field_type(
+                    py,
+                    address.as_any(),
+                    &alias,
+                    raw_value,
+                    &expected_type_desc,
+                ));
+            }
+        }
+        Ok(value_or_default)
+    }
+}
+
+#[pyclass(subclass, frozen, extends = ScalarField, module = "pants.engine.internals.native_engine")]
+pub struct BoolField;
+
+#[pymethods]
+impl BoolField {
+    #[new]
+    #[classmethod]
+    #[pyo3(signature = (raw_value, address))]
+    fn __new__(
+        cls: &Bound<'_, PyType>,
+        raw_value: Option<&Bound<'_, PyAny>>,
+        address: Bound<'_, Address>,
+        py: Python,
+    ) -> PyResult<PyClassInitializer<Self>> {
+        Ok(Field::init(cls, raw_value, address, py)?
+            .add_subclass(ScalarField)
+            .add_subclass(Self))
+    }
+
+    #[classattr]
+    fn _raw_value_type() -> &'static str {
+        "bool"
+    }
+
+    #[classattr]
+    fn expected_type<'py>(py: Python<'py>) -> Bound<'py, PyType> {
+        py.get_type::<pyo3::types::PyBool>()
+    }
+
+    #[classattr]
+    fn expected_type_description() -> &'static str {
+        "a boolean"
+    }
+}
+
+#[pyclass(subclass, frozen, extends = ScalarField, module = "pants.engine.internals.native_engine")]
+pub struct TriBoolField;
+
+#[pymethods]
+impl TriBoolField {
+    #[new]
+    #[classmethod]
+    #[pyo3(signature = (raw_value, address))]
+    fn __new__(
+        cls: &Bound<'_, PyType>,
+        raw_value: Option<&Bound<'_, PyAny>>,
+        address: Bound<'_, Address>,
+        py: Python,
+    ) -> PyResult<PyClassInitializer<Self>> {
+        Ok(Field::init(cls, raw_value, address, py)?
+            .add_subclass(ScalarField)
+            .add_subclass(Self))
+    }
+
+    #[classattr]
+    fn _raw_value_type() -> &'static str {
+        "bool | None"
+    }
+
+    #[classattr]
+    fn expected_type<'py>(py: Python<'py>) -> Bound<'py, PyType> {
+        py.get_type::<pyo3::types::PyBool>()
+    }
+
+    #[classattr]
+    fn expected_type_description() -> &'static str {
+        "a boolean or None"
+    }
+}
+
+#[pyclass(subclass, frozen, extends = ScalarField, module = "pants.engine.internals.native_engine")]
+pub struct StringField;
+
+#[pymethods]
+impl StringField {
+    #[new]
+    #[classmethod]
+    #[pyo3(signature = (raw_value, address))]
+    fn __new__(
+        cls: &Bound<'_, PyType>,
+        raw_value: Option<&Bound<'_, PyAny>>,
+        address: Bound<'_, Address>,
+        py: Python,
+    ) -> PyResult<PyClassInitializer<Self>> {
+        Ok(Field::init(cls, raw_value, address, py)?
+            .add_subclass(ScalarField)
+            .add_subclass(Self))
+    }
+
+    #[classattr]
+    fn _raw_value_type() -> &'static str {
+        "str | None"
+    }
+
+    #[classattr]
+    fn expected_type<'py>(py: Python<'py>) -> Bound<'py, PyType> {
+        py.get_type::<pyo3::types::PyString>()
+    }
+
+    #[classattr]
+    fn expected_type_description() -> &'static str {
+        "a string"
+    }
+
+    #[classattr]
+    fn valid_choices<'py>(py: Python<'py>) -> Bound<'py, PyAny> {
+        py.None().into_bound(py)
+    }
+
+    #[classmethod]
+    #[pyo3(signature = (raw_value, address))]
+    fn compute_value<'py>(
+        cls: &Bound<'py, PyType>,
+        raw_value: Option<&Bound<'py, PyAny>>,
+        address: Bound<'py, Address>,
+        py: Python<'py>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let value_or_default = ScalarField::compute_value(cls, raw_value, address.clone(), py)?;
+        if !value_or_default.is_none() {
+            let valid_choices = cls.getattr(intern!(py, "valid_choices"))?;
+            if !valid_choices.is_none() {
+                let as_list = pyo3::types::PyList::new(py, [&value_or_default])?;
+                validate_choices(
+                    py,
+                    address.as_any(),
+                    &Field::cls_alias(cls)?,
+                    as_list.as_any(),
+                    &valid_choices,
+                )?;
+            }
+        }
+        Ok(value_or_default)
+    }
+}
+
+#[pyclass(subclass, frozen, extends = Field, generic, module = "pants.engine.internals.native_engine")]
+pub struct SequenceField;
+
+#[pymethods]
+impl SequenceField {
+    #[new]
+    #[classmethod]
+    #[pyo3(signature = (raw_value, address))]
+    fn __new__(
+        cls: &Bound<'_, PyType>,
+        raw_value: Option<&Bound<'_, PyAny>>,
+        address: Bound<'_, Address>,
+        py: Python,
+    ) -> PyResult<PyClassInitializer<Self>> {
+        Ok(Field::init(cls, raw_value, address, py)?.add_subclass(Self))
+    }
+
+    #[classattr]
+    fn _raw_value_type() -> &'static str {
+        "Iterable[Any] | None"
+    }
+
+    #[classattr]
+    fn default<'py>(py: Python<'py>) -> Bound<'py, PyAny> {
+        py.None().into_bound(py)
+    }
+
+    #[classmethod]
+    #[pyo3(signature = (raw_value, address))]
+    fn compute_value<'py>(
+        cls: &Bound<'py, PyType>,
+        raw_value: Option<&Bound<'py, PyAny>>,
+        address: Bound<'py, Address>,
+        py: Python<'py>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let value_or_default = Field::compute_value(cls, raw_value, address.extract()?, py)?;
+        if value_or_default.is_none() {
+            return Ok(value_or_default);
+        }
+        let expected_element_type = cls.getattr(intern!(py, "expected_element_type"))?;
+        if value_or_default.is_instance(&expected_element_type)? {
+            let alias = Field::cls_alias(cls)?;
+            let desc: String = cls
+                .getattr(intern!(py, "expected_type_description"))?
+                .extract()?;
+            return Err(raise_invalid_field_type(
+                py,
+                address.as_any(),
+                &alias,
+                raw_value,
+                &desc,
+            ));
+        }
+        let iter = match value_or_default.try_iter() {
+            Ok(iter) => iter,
+            Err(_) => {
+                let alias = Field::cls_alias(cls)?;
+                let desc: String = cls
+                    .getattr(intern!(py, "expected_type_description"))?
+                    .extract()?;
+                return Err(raise_invalid_field_type(
+                    py,
+                    address.as_any(),
+                    &alias,
+                    raw_value,
+                    &desc,
+                ));
+            }
+        };
+        let mut elements: Vec<Bound<'py, PyAny>> = Vec::new();
+        for item in iter {
+            let item = item?;
+            if !item.is_instance(&expected_element_type)? {
+                let alias = Field::cls_alias(cls)?;
+                let desc: String = cls
+                    .getattr(intern!(py, "expected_type_description"))?
+                    .extract()?;
+                return Err(raise_invalid_field_type(
+                    py,
+                    address.as_any(),
+                    &alias,
+                    raw_value,
+                    &desc,
+                ));
+            }
+            elements.push(item);
+        }
+        Ok(pyo3::types::PyTuple::new(py, &elements)?.into_any())
+    }
+}
+
+#[pyclass(subclass, frozen, extends = SequenceField, module = "pants.engine.internals.native_engine")]
+pub struct StringSequenceField;
+
+#[pymethods]
+impl StringSequenceField {
+    #[new]
+    #[classmethod]
+    #[pyo3(signature = (raw_value, address))]
+    fn __new__(
+        cls: &Bound<'_, PyType>,
+        raw_value: Option<&Bound<'_, PyAny>>,
+        address: Bound<'_, Address>,
+        py: Python,
+    ) -> PyResult<PyClassInitializer<Self>> {
+        Ok(Field::init(cls, raw_value, address, py)?
+            .add_subclass(SequenceField)
+            .add_subclass(Self))
+    }
+
+    #[classattr]
+    fn _raw_value_type() -> &'static str {
+        "Iterable[str] | None"
+    }
+
+    #[classattr]
+    fn expected_element_type<'py>(py: Python<'py>) -> Bound<'py, PyType> {
+        py.get_type::<pyo3::types::PyString>()
+    }
+
+    #[classattr]
+    fn expected_type_description() -> &'static str {
+        "an iterable of strings (e.g. a list of strings)"
+    }
+
+    #[classattr]
+    fn valid_choices<'py>(py: Python<'py>) -> Bound<'py, PyAny> {
+        py.None().into_bound(py)
+    }
+
+    #[classmethod]
+    #[pyo3(signature = (raw_value, address))]
+    fn compute_value<'py>(
+        cls: &Bound<'py, PyType>,
+        raw_value: Option<&Bound<'py, PyAny>>,
+        address: Bound<'py, Address>,
+        py: Python<'py>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let value_or_default = SequenceField::compute_value(cls, raw_value, address.clone(), py)?;
+        if !value_or_default.is_none() {
+            let valid_choices = cls.getattr(intern!(py, "valid_choices"))?;
+            if !valid_choices.is_none() {
+                validate_choices(
+                    py,
+                    address.as_any(),
+                    &Field::cls_alias(cls)?,
+                    &value_or_default,
+                    &valid_choices,
+                )?;
+            }
+        }
+        Ok(value_or_default)
+    }
+}
+
+#[pyclass(subclass, frozen, extends = Field, module = "pants.engine.internals.native_engine")]
+pub struct AsyncFieldMixin {
+    address: Py<Address>,
+}
+
+#[pymethods]
+impl AsyncFieldMixin {
+    #[new]
+    #[classmethod]
+    #[pyo3(signature = (raw_value, address))]
+    fn __new__(
+        cls: &Bound<'_, PyType>,
+        raw_value: Option<&Bound<'_, PyAny>>,
+        address: Bound<'_, Address>,
+        py: Python,
+    ) -> PyResult<PyClassInitializer<Self>> {
+        Ok(
+            Field::init(cls, raw_value, address.clone(), py)?.add_subclass(Self {
+                address: address.unbind(),
+            }),
+        )
+    }
+
+    #[getter]
+    fn address<'py>(&self, py: Python<'py>) -> Bound<'py, Address> {
+        self.address.bind(py).clone()
+    }
+
+    fn __repr__(self_: &Bound<Self>) -> PyResult<String> {
+        let py = self_.py();
+        let cls = self_.get_type();
+        let alias: String = Field::cls_alias(&cls)?;
+        let value = self_.getattr(intern!(py, "value"))?;
+        let address = self_.get().address.bind(py);
+        let mut result = String::new();
+        write!(
+            result,
+            "{cls}(alias='{alias}', address={address}, value={value}"
+        )
+        .unwrap();
+        if let Ok(default) = cls.getattr(intern!(py, "default")) {
+            write!(result, ", default={default}").unwrap();
+        }
+        result.push(')');
+        Ok(result)
+    }
+
+    fn __hash__(self_: &Bound<Self>, py: Python) -> PyResult<isize> {
+        Ok(combine_hashes(&[
+            self_.get_type().hash()?,
+            self_.getattr(intern!(py, "value"))?.hash()?,
+            self_.get().address.bind(py).hash()?,
+        ]))
+    }
+
+    fn __richcmp__<'py>(
+        self_: &Bound<'py, Self>,
+        other: &Bound<'py, PyAny>,
+        op: CompareOp,
+        py: Python,
+    ) -> PyResult<PyComparedBool> {
+        let is_eq = if other.is_instance_of::<AsyncFieldMixin>() {
+            let other_afm = other.cast::<AsyncFieldMixin>()?;
+            self_.get_type().eq(other.get_type())?
+                && self_
+                    .getattr(intern!(py, "value"))?
+                    .eq(other.getattr(intern!(py, "value"))?)?
+                && self_
+                    .get()
+                    .address
+                    .bind(py)
+                    .eq(other_afm.get().address.bind(py))?
+        } else {
+            false
+        };
+        Ok(PyComparedBool(match op {
+            CompareOp::Eq => Some(is_eq),
+            CompareOp::Ne => Some(!is_eq),
+            _ => None,
+        }))
     }
 }


### PR DESCRIPTION
The real juice is in porting `SourcesField` and what that unlocks. This is a stepping stone, hopefully worth the squeeze.

This additionally marks Field as frozen, allowing to avoid additional ref-counting overhead.

Still noticable in our 26k python, 100 JS file file repo
```console
hyperfine --warmup 1 --runs 3 \                                                         
        -n 'main' \                                                                                                             
        --prepare 'git -C <redacted>/pants checkout main --quiet' \                                                      
        'PANTS_SOURCE=<redacted>/pants PYENV_VERSION=pants@3.14.3 pants --no-pantsd dependencies :: > /dev/null' \     
        -n 'branch' \                                                                                                           
        --prepare 'git -C <redacted>/pants checkout add/port-scalar-and-async-mixin-fields --quiet' \                  
        'PANTS_SOURCE=<redacted>/pants PYENV_VERSION=pants@3.14.3 pants --no-pantsd dependencies :: > /dev/null' \     
        2>&1)
  ⎿  Benchmark 1: main
       Time (mean ± σ):     35.261 s ±  1.261 s    [User: 40.704 s, System: 12.371 s]
       Range (min … max):   34.021 s … 36.542 s    3 runs
      
     Benchmark 2: branch                                                                                                        
       Time (mean ± σ):     33.615 s ±  0.202 s    [User: 38.675 s, System: 12.403 s]
       Range (min … max):   33.478 s … 33.847 s    3 runs      
```
