### PR TITLE
update the default Pex version to v2.92.0

### DIFF
--- a/docs/notes/2.32.x.md
+++ b/docs/notes/2.32.x.md
@@ -127,7 +127,7 @@ All version of [Ruff](https://docs.astral.sh/ruff/) from [0.13.1](https://github
 
 The default version of the [Ruff](https://docs.astral.sh/ruff/) tool has been updated to [0.14.14](https://github.com/astral-sh/ruff/releases/tag/0.14.14).
 
-The version of [Pex](https://github.com/pex-tool/pex) used by the Python backend has been upgraded to [`v2.91.7`](https://github.com/pex-tool/pex/releases/tag/v2.91.7). Of particular note for Pants users:
+The version of [Pex](https://github.com/pex-tool/pex) used by the Python backend has been upgraded to [`v2.92.0`](https://github.com/pex-tool/pex/releases/tag/v2.92.0). Of particular note for Pants users:
  - Support for [pip 26.0.1](https://pip.pypa.io/en/stable/news/#v26-0-1).
  - A new `--interpreter-selection-strategy` option to select the `"oldest"` or `"newest"` interpreter when multiple match constraints.
  - Linux PEX scies can now install themselves with a desktop entry.

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -37,9 +37,9 @@ from pants.util.strutil import softwrap
 logger = logging.getLogger(__name__)
 
 
-_PEX_VERSION = "v2.91.7"
-_PEX_BINARY_HASH = "7bb032815401788789c46b498d705b730a4b52736558fc6b11e3593e7ee23d2c"
-_PEX_BINARY_SIZE = 5080310
+_PEX_VERSION = "v2.92.0"
+_PEX_BINARY_HASH = "fc49e0705c2e72f56d41e6139ca95b4e3f942fe92211c51a80c3fc2dfd19cd8d"
+_PEX_BINARY_SIZE = 5080952
 
 
 class PexCli(TemplatedExternalTool):


### PR DESCRIPTION
Release Notes:
 * https://github.com/pex-tool/pex/releases/tag/v2.91.8
 * https://github.com/pex-tool/pex/releases/tag/v2.92.0