### PR TITLE
reduce workunit terminal display to one decimal

### DIFF
--- a/docs/notes/2.32.x.md
+++ b/docs/notes/2.32.x.md
@@ -25,6 +25,8 @@ The Pants [Contribution Overview](https://www.pantsbuild.org/2.32/docs/contribut
 Dict-valued options can now [read their values](https://www.pantsbuild.org/2.32/docs/using-pants/key-concepts/options#reading-individual-option-values-from-files) from `.toml` files. And any option value can be read from
 a specific field inside a TOML/YAML/JSON file, using the `@path/to/file:trail.within.file` syntax.
 
+The "spinner line" indicator now displays work unit times to one decimal place instead of two, and should look smoother.
+
 #### Internal Python Upgrade
 
 The version of Python used by Pants itself has been updated to [3.14](https://docs.python.org/3/whatsnew/3.14.html). To support this, the [Pants Launcher Binary](https://www.pantsbuild.org/blog/2023/02/23/the-pants-launcher-binary-a-much-simpler-way-to-install-and-run-pants) (also known as [`scie-pants`](https://github.com/pantsbuild/scie-pants/)) now has a minimum version of `0.13.0`. To update to the latest launcher binary, either:

--- a/src/rust/workunit_store/src/lib.rs
+++ b/src/rust/workunit_store/src/lib.rs
@@ -771,7 +771,7 @@ impl WorkunitStore {
 }
 
 pub fn format_workunit_duration_ms(duration: Duration) -> String {
-    format!("{:.2}s", (duration.as_millis() as f64) / 1000.0)
+    format!("{:.1}s", duration.as_secs_f64())
 }
 
 ///


### PR DESCRIPTION
Currently we have a render rate of 10 Hz
<https://github.com/pantsbuild/pants/blob/9b3c1562e2081d8e60433341ad8dc5585ec37323/src/rust/ui/src/lib.rs#L38> but try to display out to two decimal places.  This results in some awkward displays where the last digit will look stuck -- 1.25 --> 1.35 --> 1.45 -- until some jitter aligns it to a new digit for a bit. Since this is just for a visual display and humans can't actually count that fast, I think it's fine to show one digit after the decimal.  This is the granularity of `docker` for example.

Before: https://github.com/user-attachments/assets/c8ab5bf5-3336-44f2-ba14-76b887160715

After: https://github.com/user-attachments/assets/73b18e94-9097-49c9-a493-3e748ad5ccb2

An alternative approach would be to render at 100 Hz, but I don't think displaying the digit just to "look cool" is worth becoming terminal performance experts.

Disclosure: Claude connected the `render_interval`/`render_rate_hz`/`render` math together,  and made the change.