### PR TITLE
invalid-lockfile-behavior=invalid for separate metadata too

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex_requirements.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements.py
@@ -230,29 +230,30 @@ async def load_lockfile(
 
     metadata_url = PythonLockfileMetadata.metadata_location_for_lockfile(lockfile.url)
     metadata = None
-    try:
-        metadata_digest = await read_file_or_resource(
-            metadata_url,
-            description_of_origin="We squelch errors, so this is never seen by users",
-        )
-        digest_contents = await get_digest_contents(metadata_digest)
-        metadata_bytes = digest_contents[0].content
-        json_dict = json.loads(metadata_bytes)
-        metadata = PythonLockfileMetadata.from_json_dict(
-            json_dict,
-            lockfile_description=f"the lockfile for `{lockfile.resolve_name}`",
-            error_suffix=softwrap(
-                f"""
-                To resolve this error, you will need to regenerate the lockfile by running
-                `{bin_name()} generate-lockfiles --resolve={lockfile.resolve_name}.
-                """
-            ),
-        )
-        requirement_estimate = _pex_lockfile_requirement_count(lock_bytes)
-    except (IntrinsicError, FileNotFoundError):
-        # No metadata file or resource found, so fall through to finding a metadata
-        # header block prepended to the lockfile itself.
-        pass
+    if python_setup.invalid_lockfile_behavior != InvalidLockfileBehavior.ignore:
+        try:
+            metadata_digest = await read_file_or_resource(
+                metadata_url,
+                description_of_origin="We squelch errors, so this is never seen by users",
+            )
+            digest_contents = await get_digest_contents(metadata_digest)
+            metadata_bytes = digest_contents[0].content
+            json_dict = json.loads(metadata_bytes)
+            metadata = PythonLockfileMetadata.from_json_dict(
+                json_dict,
+                lockfile_description=f"the lockfile for `{lockfile.resolve_name}`",
+                error_suffix=softwrap(
+                    f"""
+                    To resolve this error, you will need to regenerate the lockfile by running
+                    `{bin_name()} generate-lockfiles --resolve={lockfile.resolve_name}.
+                    """
+                ),
+            )
+            requirement_estimate = _pex_lockfile_requirement_count(lock_bytes)
+        except (IntrinsicError, FileNotFoundError):
+            # No metadata file or resource found, so fall through to finding a metadata
+            # header block prepended to the lockfile itself.
+            pass
 
     if not metadata:
         if is_pex_native:

--- a/src/python/pants/backend/python/util_rules/pex_requirements_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements_test.py
@@ -13,6 +13,8 @@ from pants.backend.python.subsystems.setup import InvalidLockfileBehavior, Pytho
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.lockfile_metadata import PythonLockfileMetadataV3
 from pants.backend.python.util_rules.pex_requirements import (
+    LoadedLockfile,
+    LoadedLockfileRequest,
     Lockfile,
     ResolvePexConfig,
     ResolvePexConstraintsFile,
@@ -22,6 +24,7 @@ from pants.backend.python.util_rules.pex_requirements import (
     strip_comments_from_pex_json_lockfile,
     validate_metadata,
 )
+from pants.backend.python.util_rules.pex_requirements import rules as pex_requirements_rules
 from pants.core.util_rules.lockfile_metadata import (
     BEGIN_LOCKFILE_HEADER,
     END_LOCKFILE_HEADER,
@@ -29,6 +32,7 @@ from pants.core.util_rules.lockfile_metadata import (
 )
 from pants.engine.internals.native_engine import EMPTY_DIGEST
 from pants.testutil.option_util import create_subsystem
+from pants.testutil.rule_runner import QueryRule, RuleRunner
 from pants.util.ordered_set import FrozenOrderedSet
 from pants.util.pip_requirement import PipRequirement
 from pants.util.strutil import comma_separated_list
@@ -425,3 +429,23 @@ class TestResolvePexConfigPexArgs:
 
         assert "--wheel" in self.simple_config_args(no_binary=["foo", ":none:"])
         assert "--only-build" not in " ".join(self.simple_config_args(no_binary=["foo", ":none:"]))
+
+
+def test_load_lockfile_ignores_unknown_sidecar_metadata_version() -> None:
+    rule_runner = RuleRunner(
+        rules=[
+            *pex_requirements_rules(),
+            QueryRule(LoadedLockfile, [LoadedLockfileRequest]),
+        ],
+    )
+    rule_runner.set_options(["--python-invalid-lockfile-behavior=ignore"])
+    rule_runner.write_files(
+        {
+            "lock.json": "{}",
+            "lock.json.metadata": json.dumps({"version": 9999}),
+        }
+    )
+
+    lockfile = Lockfile(url="lock.json", url_description_of_origin="test", resolve_name="a")
+    result = rule_runner.request(LoadedLockfile, [LoadedLockfileRequest(lockfile)])
+    assert result.metadata is None


### PR DESCRIPTION
With the "inline" metadata invalid-lockfile-behavior=invalid would avoid even trying to read the metadata, but this conditional wasn't present for the separate file code path.  This meant that if you had a Pants from the past read a lockfile from the future, it would error with something like `KeyError: (<LockfileScope.PYTHON: 'python'>, 6)` unless you deleted the metadata files.

LLM: Claude explained how these functions worked and explored the history, proposed a fix when given a stack trace, and then proposed a better fix after being pointed out from the docs what invalid-lockfile-behavior actually did.