### PR TITLE
Added a cooldown to dep bot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,8 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
+    cooldown:
+      default-days: 7
     directory: "/"
     groups:
       gha-deps:
@@ -21,6 +23,8 @@ updates:
       interval: "monthly"
 
   - package-ecosystem: "cargo"
+    cooldown:
+      default-days: 7
     directory: "/src/rust"
     ignore:
       # No longer developed, referred to 1.3.3 as complete, lots of drama (https://sr.ht/~stygianentity/bincode/ and https://old.reddit.com/r/rust/comments/1pnz1iz/bincode_development_has_ceased_permanently/)
@@ -50,6 +54,8 @@ updates:
       interval: "monthly"
   
   - package-ecosystem: pip
+    cooldown:
+      default-days: 7
     directory: "/3rdparty/python"
     groups:
       python-security-updates:
@@ -76,6 +82,8 @@ updates:
       interval: "monthly"
 
   - package-ecosystem: "npm"
+    cooldown:
+      default-days: 7
     directories: 
       - "build-support/**/*"
       - "src/python/pants/backend/javascript/**/*"


### PR DESCRIPTION
Dep bot runs every "schedule interval" days, but dependencies need to be older than "cooldown"

https://github.blog/changelog/2025-07-01-dependabot-supports-configuration-of-a-minimum-package-age/

https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-