### PR TITLE
Add --test-show-all-batch-targets to expose all targets in batched pytest

### DIFF
--- a/docs/notes/2.32.x.md
+++ b/docs/notes/2.32.x.md
@@ -78,6 +78,10 @@ The `find-links` automatically injected by `pants.backend.plugin_development` is
 
 Fixed inverted logic when setting noninteractive_process_output to only log failures.
 
+#### Test
+
+The `test` goal has a new `--show-all-batch-targets` option. When tests are batched via `batch_compatibility_tag`, the default output truncates the list of targets (e.g. `path/to:tests and 3 other files`). Enabling this option shows all target addresses in test result summaries and workunit descriptions, which is useful for understanding exactly which targets are grouped together in each test invocation.
+
 ### Backends
 
 #### Docker

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -441,11 +441,14 @@ async def setup_pytest_for_target(
             else:
                 timeout_seconds = timeout
 
-    run_description = request.field_sets[0].address.spec
-    if len(request.field_sets) > 1:
-        run_description = (
-            f"batch of {run_description} and {len(request.field_sets) - 1} other files"
-        )
+    if test_subsystem.show_all_batch_targets and len(request.field_sets) > 1:
+        run_description = ", ".join(fs.address.spec for fs in request.field_sets)
+    else:
+        run_description = request.field_sets[0].address.spec
+        if len(request.field_sets) > 1:
+            run_description = (
+                f"batch of {run_description} and {len(request.field_sets) - 1} other files"
+            )
     process = await setup_venv_pex_process(
         VenvPexProcess(
             pytest_runner_pex,
@@ -533,11 +536,14 @@ async def run_python_tests(
     last_result = results.last
 
     def warning_description() -> str:
-        description = batch.elements[0].address.spec
-        if len(batch.elements) > 1:
-            description = (
-                f"batch containing {description} and {len(batch.elements) - 1} other files"
-            )
+        if test_subsystem.show_all_batch_targets and len(batch.elements) > 1:
+            description = ", ".join(fs.address.spec for fs in batch.elements)
+        else:
+            description = batch.elements[0].address.spec
+            if len(batch.elements) > 1:
+                description = (
+                    f"batch containing {description} and {len(batch.elements) - 1} other files"
+                )
         if batch.partition_metadata.description:
             description = f"{description} ({batch.partition_metadata.description})"
         return description

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -1042,9 +1042,7 @@ async def run_tests(
                 "source": result.result_metadata.source(run_id).value
             }
         console.print_stderr(
-            _format_test_summary(
-                result, run_id, console, test_subsystem.show_all_batch_targets
-            )
+            _format_test_summary(result, run_id, console, test_subsystem.show_all_batch_targets)
         )
 
         if result.extra_output and result.extra_output.files:

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -739,6 +739,23 @@ class TestSubsystem(GoalSubsystem):
             """
         ),
     )
+    show_all_batch_targets = BoolOption(
+        default=False,
+        help=softwrap(
+            """
+            When tests are batched via `batch_compatibility_tag`, show all target addresses in
+            the batch in test result summaries, workunit descriptions, and warning messages.
+
+            By default, batched test descriptions are truncated to show only the first target
+            address (e.g. "path/to:tests and 3 other files"). When this option is enabled, all
+            target addresses in the batch are listed (e.g.
+            "path/to:tests, path/to:tests2, path/to:tests3, path/to:tests4").
+
+            This is useful for CI environments where you need to know exactly which targets
+            are grouped together in each test invocation.
+            """
+        ),
+    )
 
     def report_dir(self, distdir: DistDir) -> PurePath:
         return PurePath(self._report_dir.format(distdir=distdir.relpath))
@@ -1024,7 +1041,11 @@ async def run_tests(
             test_result_info[result.addresses[0].spec] = {
                 "source": result.result_metadata.source(run_id).value
             }
-        console.print_stderr(_format_test_summary(result, run_id, console))
+        console.print_stderr(
+            _format_test_summary(
+                result, run_id, console, test_subsystem.show_all_batch_targets
+            )
+        )
 
         if result.extra_output and result.extra_output.files:
             path_prefix = str(distdir.relpath / "test" / result.path_safe_description)
@@ -1121,7 +1142,12 @@ _SOURCE_MAP = {
 }
 
 
-def _format_test_summary(result: TestResult, run_id: RunId, console: Console) -> str:
+def _format_test_summary(
+    result: TestResult,
+    run_id: RunId,
+    console: Console,
+    show_all_batch_targets: bool = False,
+) -> str:
     """Format the test summary printed to the console."""
     assert result.result_metadata is not None, (
         "Skipped test results should not be outputted in the test summary"
@@ -1164,7 +1190,12 @@ def _format_test_summary(result: TestResult, run_id: RunId, console: Console) ->
         elapsed_secs = total_elapsed_ms / 1000
         elapsed_print = f"in {elapsed_secs:.2f}s"
 
-    return f"{sigil} {result.description} {status}{attempt_msg} {elapsed_print}{source_desc}."
+    if show_all_batch_targets and len(result.addresses) > 1:
+        description = ", ".join(addr.spec for addr in result.addresses)
+    else:
+        description = result.description
+
+    return f"{sigil} {description} {status}{attempt_msg} {elapsed_print}{source_desc}."
 
 
 def _format_test_rerun_command(results: Iterable[TestResult]) -> None | str:

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -342,8 +342,8 @@ def run_test_rule(
             ],
             mock_calls={
                 "pants.core.goals.test.partition_tests": mock_partitioner,
-                "pants.core.environments.rules.resolve_single_environment_name": lambda _a: EnvironmentName(
-                    None
+                "pants.core.environments.rules.resolve_single_environment_name": lambda _a: (
+                    EnvironmentName(None)
                 ),
                 "pants.core.goals.test.test_batch_to_debug_request": mock_debug_request,
                 "pants.core.goals.test.test_batch_to_debug_adapter_request": mock_debug_request,
@@ -351,8 +351,9 @@ def run_test_rule(
                 "pants.core.goals.test.create_coverage_report": mock_coverage_report_generation,
                 "pants.engine.internals.specs_rules.find_valid_field_sets_for_target_roots": mock_find_valid_field_sets,
                 "pants.engine.intrinsics.merge_digests": lambda _: EMPTY_DIGEST,
-                "pants.engine.intrinsics._interactive_process": lambda _p,
-                _e: InteractiveProcessResult(0),
+                "pants.engine.intrinsics._interactive_process": lambda _p, _e: (
+                    InteractiveProcessResult(0)
+                ),
             },
             union_membership=union_membership,
             # We don't want temporary warnings to interfere with our expected output.

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -276,6 +276,7 @@ def run_test_rule(
         shard="",
         batch_size=1,
         show_rerun_command=show_rerun_command,
+        show_all_batch_targets=False,
     )
     debug_adapter_subsystem = create_subsystem(
         DebugAdapterSubsystem,


### PR DESCRIPTION
## Summary
- Adds a `--test-show-all-batch-targets` CLI flag (default: `False`) to the `[test]` subsystem
- When enabled, all target addresses in a batched pytest invocation are listed in test result summaries, workunit descriptions, and warning messages
- Default behavior is unchanged: truncated format like `"path/to:tests and 3 other files"`

## Problem
When `python_tests` targets use `batch_compatibility_tag`, multiple targets are grouped into a single pytest invocation. The output only shows the first target plus a count (e.g. `"batch of path/to:tests and 3 other files"`), making it impossible to determine which specific targets are grouped together in each pytest process.

In practice, this is a real pain point when batched test runs hang or timeout in CI. A long-running batch that never finishes gives you no way to identify which specific targets in that batch are responsible. You're left guessing across potentially dozens of targets, manually bisecting to find the culprit. This flag makes that debugging tractable by showing exactly which targets are in each batch.

## Solution
A new `--test-show-all-batch-targets` flag that, when enabled, replaces the truncated descriptions with comma-separated lists of all target addresses in three locations:
1. Test result summary line (`✓ path/to:tests, path/to:tests2, path/to:tests3 succeeded`)
2. Workunit/process description (`Run Pytest for path/to:tests, path/to:tests2, path/to:tests3`)
3. Warning messages for missing coverage/XML data

## Test plan
- [ ] Verify default behavior is unchanged (flag off)
- [ ] Verify `--test-show-all-batch-targets` lists all addresses in test summaries
- [ ] Verify workunit descriptions show all addresses when flag is on
- [ ] Verify warning messages show all addresses when flag is on
- [ ] Test with large batch sizes to confirm readability

🤖 Generated with [Claude Code](https://claude.com/claude-code)