### PR TITLE
Feature: Add generic option to docker image

### DIFF
--- a/docs/notes/2.32.x.md
+++ b/docs/notes/2.32.x.md
@@ -81,6 +81,12 @@ The option `[docker].push_on_package` can be used to prevent Docker images from 
 
 Running `pants publish` on a `docker_image` target with `skip_push=True` will no longer package the `docker_image`.
 
+The option `[docker].build_extra_options` or/and the `build_extra_options` field of `docker_image` targets can now be used to pass extra options to docker build or podman build. Make sure that the options are understood by the tool.
+For example, you can now set `build_extra_options=["--no-cache"]` to do not use existing cached images for the container build.
+
+Fields that are already present in the docker image target are surpressed by the extra options when they conflict. 
+For example, if you set `build_extra_options=["--pull"]`, the `pull` field of the docker image target will be ignored. 
+
 #### Helm
 
 When `pants publish` is invoked, Pants will now skip packaging for `helm_chart` targets if either `skip_push=True` or the target has no registries.

--- a/docs/notes/2.32.x.md
+++ b/docs/notes/2.32.x.md
@@ -93,6 +93,12 @@ The option `[docker].push_on_package` can be used to prevent Docker images from 
 
 Running `pants publish` on a `docker_image` target with `skip_push=True` will no longer package the `docker_image`.
 
+The option `[docker].build_extra_options` or/and the `build_extra_options` field of `docker_image` targets can now be used to pass extra options to docker build or podman build. Make sure that the options are understood by the tool.
+For example, you can now set `build_extra_options=["--no-cache"]` to do not use existing cached images for the container build.
+
+Fields that are already present in the docker image target are surpressed by the extra options when they conflict. 
+For example, if you set `build_extra_options=["--pull"]`, the `pull` field of the docker image target will be ignored. 
+
 #### Helm
 
 When `pants publish` is invoked, Pants will now skip packaging for `helm_chart` targets if either `skip_push=True` or the target has no registries.

--- a/docs/notes/2.32.x.md
+++ b/docs/notes/2.32.x.md
@@ -93,12 +93,6 @@ The option `[docker].push_on_package` can be used to prevent Docker images from 
 
 Running `pants publish` on a `docker_image` target with `skip_push=True` will no longer package the `docker_image`.
 
-The option `[docker].build_extra_options` or/and the `build_extra_options` field of `docker_image` targets can now be used to pass extra options to docker build or podman build. Make sure that the options are understood by the tool.
-For example, you can now set `build_extra_options=["--no-cache"]` to do not use existing cached images for the container build.
-
-Fields that are already present in the docker image target are surpressed by the extra options when they conflict. 
-For example, if you set `build_extra_options=["--pull"]`, the `pull` field of the docker image target will be ignored. 
-
 #### Helm
 
 When `pants publish` is invoked, Pants will now skip packaging for `helm_chart` targets if either `skip_push=True` or the target has no registries.

--- a/docs/notes/2.34.x.md
+++ b/docs/notes/2.34.x.md
@@ -20,6 +20,14 @@ Thank you to [Klaviyo](https://www.klaviyo.com/) for their Platinum tier support
 
 ### Backends
 
+#### Docker
+
+The option `[docker].build_extra_options` or/and the `build_extra_options` field of `docker_image` targets can now be used to pass extra options to docker build or podman build. Make sure that the options are understood by the tool.
+For example, you can now set `build_extra_options=["--no-cache"]` to do not use existing cached images for the container build.
+
+Fields that are already present in the docker image target are surpressed by the extra options when they conflict. 
+For example, if you set `build_extra_options=["--pull"]`, the `pull` field of the docker image target will be ignored. 
+
 #### Helm
 
 #### JVM

--- a/docs/notes/2.34.x.md
+++ b/docs/notes/2.34.x.md
@@ -23,10 +23,8 @@ Thank you to [Klaviyo](https://www.klaviyo.com/) for their Platinum tier support
 #### Docker
 
 The option `[docker].build_extra_options` or/and the `build_extra_options` field of `docker_image` targets can now be used to pass extra options to docker build or podman build. Make sure that the options are understood by the tool.
-For example, you can now set `build_extra_options=["--no-cache"]` to do not use existing cached images for the container build.
-
-Fields that are already present in the docker image target are surpressed by the extra options when they conflict. 
-For example, if you set `build_extra_options=["--pull"]`, the `pull` field of the docker image target will be ignored. 
+The build_extra_options field allows you to pass any valid build flags directly to docker or podman. 
+Options that are set in the docker image target such as `pull` or `build_no_cache` in pants.toml are surpressed by the extra options when they conflict. 
 
 #### Helm
 

--- a/src/python/pants/backend/docker/goals/package_image.py
+++ b/src/python/pants/backend/docker/goals/package_image.py
@@ -423,10 +423,10 @@ def get_build_options(
             )
 
     if target_stage:
-        extra_options.extend(("--target", target_stage))
+        extra_options = extra_options + ("--target", target_stage)
 
     if global_build_no_cache_option:
-        extra_options.extend("--no-cache")
+        extra_options = extra_options + ("--no-cache",)
 
     # Append extra options last so that they take precedence over the structured fields above.
     yield from extra_options

--- a/src/python/pants/backend/docker/goals/package_image.py
+++ b/src/python/pants/backend/docker/goals/package_image.py
@@ -27,6 +27,7 @@ from pants.backend.docker.target_types import (
     DockerBuildOptionFieldMultiValueMixin,
     DockerBuildOptionFieldValueMixin,
     DockerBuildOptionFlagFieldMixin,
+    DockerImageBuildExtraOptionsField,
     DockerImageBuildImageOutputField,
     DockerImageContextRootField,
     DockerImageRegistriesField,
@@ -323,6 +324,20 @@ class DockerInfoV1ImageTag:
     name: str
 
 
+def _extra_options_flag_names(extra_options: tuple[str, ...]) -> frozenset[str]:
+    """Return the set of flag names (e.g. ``--pull``) present in *extra_options*.
+
+    Handles both ``--flag=value`` and ``--flag value`` styles so that any structured field whose
+    ``docker_build_option`` class variable matches one of these names will be suppressed in favour
+    of the caller-supplied value, avoiding duplicate or conflicting flags on the command line.
+    """
+    names: set[str] = set()
+    for opt in extra_options:
+        if opt.startswith("-"):
+            names.add(opt.split("=")[0])
+    return frozenset(names)
+
+
 def get_build_options(
     context: DockerBuildContext,
     field_set: DockerPackageFieldSet,
@@ -331,7 +346,23 @@ def get_build_options(
     global_build_no_cache_option: bool | None,
     use_buildx_option: bool,
     target: Target,
+    global_extra_options: tuple[str, ...] = (),
 ) -> Iterator[str]:
+    target_extra = tuple(target[DockerImageBuildExtraOptionsField].value or ())
+    target_flag_names = _extra_options_flag_names(target_extra)
+
+    # Per-target wins: drop any global entry whose flag is already covered by the per-target list.
+    filtered_global = tuple(
+        opt
+        for opt in global_extra_options
+        if opt.startswith("-") and opt.split("=")[0] not in target_flag_names
+    )
+
+    extra_options: tuple[str, ...] = (*filtered_global, *target_extra)
+
+    # Compute the set of flag names that are provided by global and target extra options.
+    overridden_flags = _extra_options_flag_names(extra_options)
+
     # Build options from target fields inheriting from DockerBuildOptionFieldMixin
     for field_type in target.field_types:
         if issubclass(field_type, DockerBuildKitOptionField):
@@ -356,6 +387,11 @@ def get_build_options(
                 DockerBuildOptionFlagFieldMixin,
             ),
         ):
+   
+            flag = getattr(field_type, "docker_build_option", None) # get the flag name if it exists such as --pull or --network, etc.
+            if flag and flag in overridden_flags:
+                continue # skip this field since its flag is already covered by extra_options
+
             source = InterpolationContext.TextSource(
                 address=target.address, target_alias=target.alias, field_alias=field_type.alias
             )
@@ -387,10 +423,13 @@ def get_build_options(
             )
 
     if target_stage:
-        yield from ("--target", target_stage)
+        extra_options.extend(("--target", target_stage))
 
     if global_build_no_cache_option:
-        yield "--no-cache"
+        extra_options.extend("--no-cache")
+
+    # Append extra options last so that they take precedence over the structured fields above.
+    yield from extra_options
 
 
 @dataclass(frozen=True)
@@ -510,6 +549,7 @@ async def get_docker_image_build_process(
                 global_build_no_cache_option=options.build_no_cache,
                 use_buildx_option=options.use_buildx,
                 target=wrapped_target.target,
+                global_extra_options=options.build_extra_options,
             )
         ),
     )

--- a/src/python/pants/backend/docker/goals/package_image.py
+++ b/src/python/pants/backend/docker/goals/package_image.py
@@ -387,10 +387,11 @@ def get_build_options(
                 DockerBuildOptionFlagFieldMixin,
             ),
         ):
-   
-            flag = getattr(field_type, "docker_build_option", None) # get the flag name if it exists such as --pull or --network, etc.
+            flag = getattr(
+                field_type, "docker_build_option", None
+            )  # get the flag name if it exists such as --pull or --network, etc.
             if flag and flag in overridden_flags:
-                continue # skip this field since its flag is already covered by extra_options
+                continue  # skip this field since its flag is already covered by extra_options
 
             source = InterpolationContext.TextSource(
                 address=target.address, target_alias=target.alias, field_alias=field_type.alias

--- a/src/python/pants/backend/docker/goals/package_image.py
+++ b/src/python/pants/backend/docker/goals/package_image.py
@@ -423,13 +423,12 @@ def get_build_options(
                 )
             )
 
-    if target_stage:
+    if target_stage and "--target" not in overridden_flags:
         extra_options = extra_options + ("--target", target_stage)
 
-    if global_build_no_cache_option:
+    if global_build_no_cache_option and "--no-cache" not in overridden_flags:
         extra_options = extra_options + ("--no-cache",)
 
-    # Append extra options last so that they take precedence over the structured fields above.
     yield from extra_options
 
 

--- a/src/python/pants/backend/docker/goals/package_image.py
+++ b/src/python/pants/backend/docker/goals/package_image.py
@@ -348,17 +348,23 @@ class DockerInfoV1ImageTag:
 
 
 def _extra_options_flag_names(extra_options: tuple[str, ...]) -> frozenset[str]:
-    """Return the set of flag names (e.g. ``--pull``) present in *extra_options*.
-
-    Handles both ``--flag=value`` and ``--flag value`` styles so that any structured field whose
-    ``docker_build_option`` class variable matches one of these names will be suppressed in favour
-    of the caller-supplied value, avoiding duplicate or conflicting flags on the command line.
-    """
+    """Returns a set of flag names (e.g. --pull, -network, etc)"""
     names: set[str] = set()
     for opt in extra_options:
         if opt.startswith("-"):
             names.add(opt.split("=")[0])
     return frozenset(names)
+
+
+def _filter_global_extra_options(
+    global_extra_options: tuple[str, ...], target_flag_names: frozenset[str]
+) -> tuple[str, ...]:
+    """Remove any global extra options that are included in the per-target options."""
+    return tuple(
+        opt
+        for opt in global_extra_options
+        if opt.startswith("-") and opt.split("=")[0] not in target_flag_names
+    )
 
 
 def get_build_options(
@@ -376,11 +382,7 @@ def get_build_options(
     target_flag_names = _extra_options_flag_names(target_extra)
 
     # Per-target wins: drop any global entry whose flag is already covered by the per-target list.
-    filtered_global = tuple(
-        opt
-        for opt in global_extra_options
-        if opt.startswith("-") and opt.split("=")[0] not in target_flag_names
-    )
+    filtered_global = _filter_global_extra_options(global_extra_options, target_flag_names)
 
     extra_options: tuple[str, ...] = (*filtered_global, *target_extra)
 
@@ -415,7 +417,7 @@ def get_build_options(
                 field_type, "docker_build_option", None
             )  # get the flag name if it exists such as --pull or --network, etc.
             if flag and flag in overridden_flags:
-                continue  # skip this field since its flag is already covered by extra_options
+                continue
 
             source = InterpolationContext.TextSource(
                 address=target.address, target_alias=target.alias, field_alias=field_type.alias

--- a/src/python/pants/backend/docker/goals/package_image.py
+++ b/src/python/pants/backend/docker/goals/package_image.py
@@ -453,10 +453,10 @@ def get_build_options(
             )
 
     if target_stage:
-        extra_options.extend(("--target", target_stage))
+        extra_options = extra_options + ("--target", target_stage)
 
     if global_build_no_cache_option:
-        extra_options.extend("--no-cache")
+        extra_options = extra_options + ("--no-cache",)
 
     # Append extra options last so that they take precedence over the structured fields above.
     yield from extra_options

--- a/src/python/pants/backend/docker/goals/package_image.py
+++ b/src/python/pants/backend/docker/goals/package_image.py
@@ -71,7 +71,7 @@ from pants.engine.intrinsics import (
 )
 from pants.engine.process import Process, ProcessExecutionFailure
 from pants.engine.rules import collect_rules, concurrently, implicitly, rule
-from pants.engine.target import InvalidFieldException, Target, WrappedTargetRequest
+from pants.engine.target import Field, InvalidFieldException, Target, WrappedTargetRequest
 from pants.engine.unions import UnionMembership, UnionRule
 from pants.option.global_options import GlobalOptions, KeepSandboxes
 from pants.util.frozendict import FrozenDict
@@ -348,7 +348,7 @@ class DockerInfoV1ImageTag:
 
 
 def _extra_options_flag_names(extra_options: tuple[str, ...]) -> frozenset[str]:
-    """Returns a set of flag names (e.g. --pull, -network, etc)"""
+    """Returns a set of flag names (e.g. --pull, --network, etc)"""
     names: set[str] = set()
     for opt in extra_options:
         if opt.startswith("-"):
@@ -360,10 +360,40 @@ def _filter_global_extra_options(
     global_extra_options: tuple[str, ...], target_flag_names: frozenset[str]
 ) -> tuple[str, ...]:
     """Remove any global extra options that are included in the per-target options."""
-    return tuple(
-        opt
-        for opt in global_extra_options
-        if opt.startswith("-") and opt.split("=")[0] not in target_flag_names
+    result = []
+    for opt in global_extra_options:
+        if opt.startswith("-") and opt.split("=")[0] in target_flag_names:
+            logger.warning(
+                f"Global docker extra option `{opt}` is overridden by a per-target option and will be ignored."
+            )
+        else:
+            result.append(opt)
+    return tuple(result)
+
+
+def _overwriten_flag_warning(
+    target: Target, field_type: type[Field], extra_options: tuple[str, ...]
+) -> None:
+    for opt in extra_options:
+        if opt.startswith(f"--{field_type.alias}"):
+            extra_build_options = opt
+            break
+    logger.warning(
+        f"The individual `--{field_type.alias}={target[field_type].value}` field on the `{target.alias}` target in `{target.address}` is overridden by "
+        f"`extra_build_options` (`{extra_build_options}`). Individual build option fields are deprecated in favor of using `extra_build_options`"
+    )
+
+
+def _overwrite_flag_warning_global_option(
+    target: Target, option_name: str, extra_options: tuple[str, ...]
+) -> None:
+    for opt in extra_options:
+        if opt.startswith(f"{option_name}"):
+            extra_build_options = opt
+            break
+    logger.warning(
+        f"The individual `{option_name}` field on the `{target.alias}` target in `{target.address}` is overridden by "
+        f"`extra_build_options` (`{extra_build_options}`). Individual build option fields are deprecated in favor of using `extra_build_options`"
     )
 
 
@@ -417,6 +447,7 @@ def get_build_options(
                 field_type, "docker_build_option", None
             )  # get the flag name if it exists such as --pull or --network, etc.
             if flag and flag in overridden_flags:
+                _overwriten_flag_warning(target, field_type, extra_options)
                 continue
 
             source = InterpolationContext.TextSource(
@@ -455,11 +486,17 @@ def get_build_options(
                 )
             )
 
-    if target_stage and "--target" not in overridden_flags:
-        extra_options = extra_options + ("--target", target_stage)
+    if target_stage:
+        if "--target" in overridden_flags:
+            _overwrite_flag_warning_global_option(target, "--target", extra_options)
+        else:
+            extra_options = extra_options + ("--target", target_stage)
 
-    if global_build_no_cache_option and "--no-cache" not in overridden_flags:
-        extra_options = extra_options + ("--no-cache",)
+    if global_build_no_cache_option:
+        if "--no-cache" in overridden_flags:
+            _overwrite_flag_warning_global_option(target, "--no-cache", extra_options)
+        else:
+            extra_options = extra_options + ("--no-cache",)
 
     yield from extra_options
 

--- a/src/python/pants/backend/docker/goals/package_image.py
+++ b/src/python/pants/backend/docker/goals/package_image.py
@@ -363,7 +363,7 @@ def _filter_global_extra_options(
     result = []
     for opt in global_extra_options:
         if opt.startswith("-") and opt.split("=")[0] in target_flag_names:
-            logger.info(
+            logger.debug(
                 f"Global docker extra option `{opt}` is overridden by a per-target option and will be ignored."
             )
         else:

--- a/src/python/pants/backend/docker/goals/package_image.py
+++ b/src/python/pants/backend/docker/goals/package_image.py
@@ -363,7 +363,7 @@ def _filter_global_extra_options(
     result = []
     for opt in global_extra_options:
         if opt.startswith("-") and opt.split("=")[0] in target_flag_names:
-            logger.warning(
+            logger.info(
                 f"Global docker extra option `{opt}` is overridden by a per-target option and will be ignored."
             )
         else:
@@ -371,7 +371,7 @@ def _filter_global_extra_options(
     return tuple(result)
 
 
-def _overwriten_flag_warning(
+def _overwrite_flag_warning(
     target: Target, field_type: type[Field], extra_options: tuple[str, ...]
 ) -> None:
     for opt in extra_options:
@@ -379,8 +379,8 @@ def _overwriten_flag_warning(
             extra_build_options = opt
             break
     logger.warning(
-        f"The individual `--{field_type.alias}={target[field_type].value}` field on the `{target.alias}` target in `{target.address}` is overridden by "
-        f"`extra_build_options` (`{extra_build_options}`). Individual build option fields are deprecated in favor of using `extra_build_options`"
+        f"The individual `{field_type.alias}={target[field_type].value}` field on the `{target.alias}` target in `{target.address}` is overridden by "
+        f"`extra_build_options` (`{extra_build_options}`). Consider using `extra_build_options` instead of specifying individual build option fields."
     )
 
 
@@ -393,7 +393,7 @@ def _overwrite_flag_warning_global_option(
             break
     logger.warning(
         f"The individual `{option_name}` field on the `{target.alias}` target in `{target.address}` is overridden by "
-        f"`extra_build_options` (`{extra_build_options}`). Individual build option fields are deprecated in favor of using `extra_build_options`"
+        f"`extra_build_options` (`{extra_build_options}`). Consider using `extra_build_options` instead of specifying individual build option fields."
     )
 
 
@@ -447,7 +447,7 @@ def get_build_options(
                 field_type, "docker_build_option", None
             )  # get the flag name if it exists such as --pull or --network, etc.
             if flag and flag in overridden_flags:
-                _overwriten_flag_warning(target, field_type, extra_options)
+                _overwrite_flag_warning(target, field_type, extra_options)
                 continue
 
             source = InterpolationContext.TextSource(

--- a/src/python/pants/backend/docker/goals/package_image.py
+++ b/src/python/pants/backend/docker/goals/package_image.py
@@ -453,13 +453,12 @@ def get_build_options(
                 )
             )
 
-    if target_stage:
+    if target_stage and "--target" not in overridden_flags:
         extra_options = extra_options + ("--target", target_stage)
 
-    if global_build_no_cache_option:
+    if global_build_no_cache_option and "--no-cache" not in overridden_flags:
         extra_options = extra_options + ("--no-cache",)
 
-    # Append extra options last so that they take precedence over the structured fields above.
     yield from extra_options
 
 

--- a/src/python/pants/backend/docker/goals/package_image.py
+++ b/src/python/pants/backend/docker/goals/package_image.py
@@ -388,7 +388,7 @@ def _overwrite_flag_warning_global_option(
     target: Target, option_name: str, extra_options: tuple[str, ...]
 ) -> None:
     for opt in extra_options:
-        if opt.startswith(f"{option_name}"):
+        if opt.split("=")[0] == option_name.split("=")[0]:
             extra_build_options = opt
             break
     logger.warning(
@@ -488,7 +488,7 @@ def get_build_options(
 
     if target_stage:
         if "--target" in overridden_flags:
-            _overwrite_flag_warning_global_option(target, "--target", extra_options)
+            _overwrite_flag_warning_global_option(target, f"--target={target_stage}", extra_options)
         else:
             extra_options = extra_options + ("--target", target_stage)
 

--- a/src/python/pants/backend/docker/goals/package_image.py
+++ b/src/python/pants/backend/docker/goals/package_image.py
@@ -411,10 +411,11 @@ def get_build_options(
                 DockerBuildOptionFlagFieldMixin,
             ),
         ):
-   
-            flag = getattr(field_type, "docker_build_option", None) # get the flag name if it exists such as --pull or --network, etc.
+            flag = getattr(
+                field_type, "docker_build_option", None
+            )  # get the flag name if it exists such as --pull or --network, etc.
             if flag and flag in overridden_flags:
-                continue # skip this field since its flag is already covered by extra_options
+                continue  # skip this field since its flag is already covered by extra_options
 
             source = InterpolationContext.TextSource(
                 address=target.address, target_alias=target.alias, field_alias=field_type.alias

--- a/src/python/pants/backend/docker/goals/package_image.py
+++ b/src/python/pants/backend/docker/goals/package_image.py
@@ -27,6 +27,7 @@ from pants.backend.docker.target_types import (
     DockerBuildOptionFieldMultiValueMixin,
     DockerBuildOptionFieldValueMixin,
     DockerBuildOptionFlagFieldMixin,
+    DockerImageBuildExtraOptionsField,
     DockerImageBuildImageOutputField,
     DockerImageContextRootField,
     DockerImageOutputDirectoriesField,
@@ -346,6 +347,20 @@ class DockerInfoV1ImageTag:
     name: str
 
 
+def _extra_options_flag_names(extra_options: tuple[str, ...]) -> frozenset[str]:
+    """Return the set of flag names (e.g. ``--pull``) present in *extra_options*.
+
+    Handles both ``--flag=value`` and ``--flag value`` styles so that any structured field whose
+    ``docker_build_option`` class variable matches one of these names will be suppressed in favour
+    of the caller-supplied value, avoiding duplicate or conflicting flags on the command line.
+    """
+    names: set[str] = set()
+    for opt in extra_options:
+        if opt.startswith("-"):
+            names.add(opt.split("=")[0])
+    return frozenset(names)
+
+
 def get_build_options(
     context: DockerBuildContext,
     field_set: DockerPackageFieldSet,
@@ -355,7 +370,23 @@ def get_build_options(
     use_buildx_option: bool,
     target: Target,
     output_options: FrozenDict[str, str] | None = None,
+    global_extra_options: tuple[str, ...] = (),
 ) -> Iterator[str]:
+    target_extra = tuple(target[DockerImageBuildExtraOptionsField].value or ())
+    target_flag_names = _extra_options_flag_names(target_extra)
+
+    # Per-target wins: drop any global entry whose flag is already covered by the per-target list.
+    filtered_global = tuple(
+        opt
+        for opt in global_extra_options
+        if opt.startswith("-") and opt.split("=")[0] not in target_flag_names
+    )
+
+    extra_options: tuple[str, ...] = (*filtered_global, *target_extra)
+
+    # Compute the set of flag names that are provided by global and target extra options.
+    overridden_flags = _extra_options_flag_names(extra_options)
+
     # Build options from target fields inheriting from DockerBuildOptionFieldMixin
     for field_type in target.field_types:
         if issubclass(field_type, DockerBuildKitOptionField):
@@ -380,6 +411,11 @@ def get_build_options(
                 DockerBuildOptionFlagFieldMixin,
             ),
         ):
+   
+            flag = getattr(field_type, "docker_build_option", None) # get the flag name if it exists such as --pull or --network, etc.
+            if flag and flag in overridden_flags:
+                continue # skip this field since its flag is already covered by extra_options
+
             source = InterpolationContext.TextSource(
                 address=target.address, target_alias=target.alias, field_alias=field_type.alias
             )
@@ -417,10 +453,13 @@ def get_build_options(
             )
 
     if target_stage:
-        yield from ("--target", target_stage)
+        extra_options.extend(("--target", target_stage))
 
     if global_build_no_cache_option:
-        yield "--no-cache"
+        extra_options.extend("--no-cache")
+
+    # Append extra options last so that they take precedence over the structured fields above.
+    yield from extra_options
 
 
 @dataclass(frozen=True)
@@ -620,6 +659,7 @@ async def get_docker_image_build_process(
                 use_buildx_option=options.use_buildx,
                 target=wrapped_target.target,
                 output_options=captured_outputs.output_options if captured_outputs else None,
+                global_extra_options=options.build_extra_options,
             )
         ),
         output_files=captured_outputs.output_files if captured_outputs else (),

--- a/src/python/pants/backend/docker/goals/package_image_test.py
+++ b/src/python/pants/backend/docker/goals/package_image_test.py
@@ -2974,6 +2974,7 @@ def test_field_set_pushes_on_package(output: dict | None, expected: bool) -> Non
     )
     assert field_set.pushes_on_package() is expected
 
+
 def test_global_build_extra_options(rule_runner: RuleRunner) -> None:
     """Global build_extra_options from [docker] should be passed to the docker build command."""
     rule_runner.set_options(
@@ -3066,6 +3067,7 @@ def test_extra_build_options_overrides_pull_field(rule_runner: RuleRunner) -> No
         build_process_assertions=check_build_process,
     )
 
+
 def test_global_extra_options_overridden_by_target_extra_options(
     rule_runner: RuleRunner,
 ) -> None:
@@ -3127,13 +3129,14 @@ def test_global_build_no_cache_options_exits(
 
     def check_build_process(result: DockerImageBuildProcess):
         argv = result.process.argv
-        assert "--no-cache" in argv 
+        assert "--no-cache" in argv
 
     assert_build_process(
         rule_runner,
         Address("docker/test", target_name="img1"),
         build_process_assertions=check_build_process,
     )
+
 
 def test_global_build_no_cache_options_overridden_by_target_extra_options(
     rule_runner: RuleRunner,
@@ -3153,7 +3156,7 @@ def test_global_build_no_cache_options_overridden_by_target_extra_options(
 
     def check_build_process(result: DockerImageBuildProcess):
         argv = result.process.argv
-        assert "--no-cache" in argv 
+        assert "--no-cache" in argv
 
     assert_build_process(
         rule_runner,

--- a/src/python/pants/backend/docker/goals/package_image_test.py
+++ b/src/python/pants/backend/docker/goals/package_image_test.py
@@ -3107,13 +3107,18 @@ def test_global_extra_options_overridden_by_target_extra_options(
 def test_global_build_no_cache_options_exits(
     rule_runner: RuleRunner,
 ) -> None:
+    rule_runner.set_options(
+        [],
+        env={
+            "PANTS_DOCKER_BUILD_EXTRA_OPTIONS": '["--no-cache"]',
+        },
+    )
     rule_runner.write_files(
         {
             "docker/test/BUILD": dedent(
                 """\
                 docker_image(
                   name="img1",
-                  no_cache=True,
                 )
                 """
             ),
@@ -3139,8 +3144,7 @@ def test_global_build_no_cache_options_overridden_by_target_extra_options(
                 """\
                 docker_image(
                   name="img1",
-                  no_cache=False,
-                  extra_build_options=["--no_cache"],
+                  extra_build_options=["--no-cache"],
                 )
                 """
             ),

--- a/src/python/pants/backend/docker/goals/package_image_test.py
+++ b/src/python/pants/backend/docker/goals/package_image_test.py
@@ -151,6 +151,7 @@ def _setup_docker_options(rule_runner: RuleRunner, options: dict | None) -> Dock
         opts.setdefault("build_hosts", None)
         opts.setdefault("build_verbose", False)
         opts.setdefault("build_no_cache", False)
+        opts.setdefault("build_extra_options", [])
         opts.setdefault("use_buildx", False)
         opts.setdefault("env_vars", [])
         opts.setdefault("suggest_renames", True)
@@ -2972,3 +2973,186 @@ def test_field_set_pushes_on_package(output: dict | None, expected: bool) -> Non
         rule_runner.get_target(Address("", target_name="image"))
     )
     assert field_set.pushes_on_package() is expected
+
+def test_global_build_extra_options(rule_runner: RuleRunner) -> None:
+    """Global build_extra_options from [docker] should be passed to the docker build command."""
+    rule_runner.set_options(
+        [],
+        env={
+            "PANTS_DOCKER_BUILD_EXTRA_OPTIONS": '["--compress"]',
+        },
+    )
+    rule_runner.write_files(
+        {
+            "docker/test/BUILD": dedent(
+                """\
+                docker_image(
+                  name="img1",
+                )
+                """
+            ),
+        }
+    )
+
+    def check_build_process(result: DockerImageBuildProcess):
+        assert "--compress" in result.process.argv
+
+    assert_build_process(
+        rule_runner,
+        Address("docker/test", target_name="img1"),
+        build_process_assertions=check_build_process,
+    )
+
+
+def test_extra_build_options_global_and_target_merged(rule_runner: RuleRunner) -> None:
+    """Global options come first; per-target options come last."""
+    rule_runner.set_options(
+        [],
+        env={
+            "PANTS_DOCKER_BUILD_EXTRA_OPTIONS": '["--compress"]',
+        },
+    )
+    rule_runner.write_files(
+        {
+            "docker/test/BUILD": dedent(
+                """\
+                docker_image(
+                  name="img1",
+                  extra_build_options=["--pull=always"],
+                )
+                """
+            ),
+        }
+    )
+
+    def check_build_process(result: DockerImageBuildProcess):
+        argv = result.process.argv
+        assert "--compress" in argv
+        assert "--pull=always" in argv
+
+    assert_build_process(
+        rule_runner,
+        Address("docker/test", target_name="img1"),
+        build_process_assertions=check_build_process,
+    )
+
+
+def test_extra_build_options_overrides_pull_field(rule_runner: RuleRunner) -> None:
+    """When extra_build_options contains --pull, the docker_image target pull argument is suppressed."""
+    rule_runner.write_files(
+        {
+            "docker/test/BUILD": dedent(
+                """\
+                docker_image(
+                  name="img1",
+                  pull=True,
+                  extra_build_options=["--pull=always"],
+                )
+                """
+            ),
+        }
+    )
+
+    def check_build_process(result: DockerImageBuildProcess):
+        argv = result.process.argv
+        # Only the extra_build_options value should appear; the structured field's
+        # --pull=True must NOT be present to avoid duplicate flags.
+        assert "--pull=always" in argv
+        assert "--pull=True" not in argv
+
+    assert_build_process(
+        rule_runner,
+        Address("docker/test", target_name="img1"),
+        build_process_assertions=check_build_process,
+    )
+
+def test_global_extra_options_overridden_by_target_extra_options(
+    rule_runner: RuleRunner,
+) -> None:
+    """When both global and target extra options specify the same flag, the target wins
+    (it comes last) and the global does not appear."""
+    rule_runner.set_options(
+        [],
+        env={
+            "PANTS_DOCKER_BUILD_EXTRA_OPTIONS": '["--pull=missing"]',
+        },
+    )
+    rule_runner.write_files(
+        {
+            "docker/test/BUILD": dedent(
+                """\
+                docker_image(
+                  name="img1",
+                  extra_build_options=["--pull=always"],
+                )
+                """
+            ),
+        }
+    )
+
+    def check_build_process(result: DockerImageBuildProcess):
+        argv = result.process.argv
+        # Both global and target specify --pull; the per-target value wins and the global
+        # entry is dropped at the flag-level dedup stage.
+        assert "--pull=always" in argv
+        assert "--pull=missing" not in argv  # global dropped because target specifies --pull
+
+    assert_build_process(
+        rule_runner,
+        Address("docker/test", target_name="img1"),
+        build_process_assertions=check_build_process,
+    )
+
+
+def test_global_build_no_cache_options_exits(
+    rule_runner: RuleRunner,
+) -> None:
+    rule_runner.write_files(
+        {
+            "docker/test/BUILD": dedent(
+                """\
+                docker_image(
+                  name="img1",
+                  no_cache=True,
+                )
+                """
+            ),
+        }
+    )
+
+    def check_build_process(result: DockerImageBuildProcess):
+        argv = result.process.argv
+        assert "--no-cache" in argv 
+
+    assert_build_process(
+        rule_runner,
+        Address("docker/test", target_name="img1"),
+        build_process_assertions=check_build_process,
+    )
+
+def test_global_build_no_cache_options_overridden_by_target_extra_options(
+    rule_runner: RuleRunner,
+) -> None:
+    rule_runner.write_files(
+        {
+            "docker/test/BUILD": dedent(
+                """\
+                docker_image(
+                  name="img1",
+                  no_cache=False,
+                  extra_build_options=["--no_cache"],
+                )
+                """
+            ),
+        }
+    )
+
+    def check_build_process(result: DockerImageBuildProcess):
+        argv = result.process.argv
+        assert "--no-cache" in argv 
+
+    assert_build_process(
+        rule_runner,
+        Address("docker/test", target_name="img1"),
+        build_process_assertions=check_build_process,
+    )

--- a/src/python/pants/backend/docker/goals/package_image_test.py
+++ b/src/python/pants/backend/docker/goals/package_image_test.py
@@ -3006,7 +3006,7 @@ def test_global_build_extra_options(rule_runner: RuleRunner) -> None:
 
 
 def test_extra_build_options_global_and_target_merged(rule_runner: RuleRunner) -> None:
-    """Global options come first; per-target options come last."""
+    """Global options and per-target options should be merged correctly."""
     rule_runner.set_options(
         [],
         env={
@@ -3072,7 +3072,7 @@ def test_global_extra_options_overridden_by_target_extra_options(
     rule_runner: RuleRunner,
 ) -> None:
     """When both global and target extra options specify the same flag, the target wins
-    (it comes last) and the global does not appear."""
+    and the global does not appear."""
     rule_runner.set_options(
         [],
         env={

--- a/src/python/pants/backend/docker/goals/package_image_test.py
+++ b/src/python/pants/backend/docker/goals/package_image_test.py
@@ -3407,13 +3407,10 @@ def test_extra_build_options_overrides_pull_field_and_global_field(
     warning_messages = [
         record.message for record in caplog.records if record.levelno == logging.WARNING
     ]
+
     assert (
         warning_messages[0]
-        == "Global docker extra option `--pull=missing` is overridden by a per-target option and will be ignored."
-    )
-    assert (
-        warning_messages[1]
-        == "The individual `--pull=True` field on the `docker_image` target in `docker/test:img1` is overridden by `extra_build_options` (`--pull=always`). Individual build option fields are deprecated in favor of using `extra_build_options`"
+        == "The individual `pull=True` field on the `docker_image` target in `docker/test:img1` is overridden by `extra_build_options` (`--pull=always`). Consider using `extra_build_options` instead of specifying individual build option fields."
     )
 
 
@@ -3458,5 +3455,5 @@ def test_warning_on_deprecated_target_stage_field(
     ]
     assert (
         warning_messages[0]
-        == "The individual `--target=dev` field on the `docker_image` target in `docker/test:img1` is overridden by `extra_build_options` (`--target=test`). Individual build option fields are deprecated in favor of using `extra_build_options`"
+        == "The individual `--target=dev` field on the `docker_image` target in `docker/test:img1` is overridden by `extra_build_options` (`--target=test`). Consider using `extra_build_options` instead of specifying individual build option fields."
     )

--- a/src/python/pants/backend/docker/goals/package_image_test.py
+++ b/src/python/pants/backend/docker/goals/package_image_test.py
@@ -3451,13 +3451,18 @@ def test_global_extra_options_overridden_by_target_extra_options(
 def test_global_build_no_cache_options_exits(
     rule_runner: RuleRunner,
 ) -> None:
+    rule_runner.set_options(
+        [],
+        env={
+            "PANTS_DOCKER_BUILD_EXTRA_OPTIONS": '["--no-cache"]',
+        },
+    )
     rule_runner.write_files(
         {
             "docker/test/BUILD": dedent(
                 """\
                 docker_image(
                   name="img1",
-                  no_cache=True,
                 )
                 """
             ),
@@ -3483,8 +3488,7 @@ def test_global_build_no_cache_options_overridden_by_target_extra_options(
                 """\
                 docker_image(
                   name="img1",
-                  no_cache=False,
-                  extra_build_options=["--no_cache"],
+                  extra_build_options=["--no-cache"],
                 )
                 """
             ),

--- a/src/python/pants/backend/docker/goals/package_image_test.py
+++ b/src/python/pants/backend/docker/goals/package_image_test.py
@@ -3409,21 +3409,21 @@ def test_extra_build_options_overrides_pull_field_and_global_field(
     ]
     assert (
         warning_messages[0]
-        == f"Global docker extra option `--pull=missing` is overridden by a per-target option and will be ignored."
+        == "Global docker extra option `--pull=missing` is overridden by a per-target option and will be ignored."
     )
     assert (
         warning_messages[1]
-        == f"The individual `--pull=True` field on the `docker_image` target in `docker/test:img1` is overridden by `extra_build_options` (`--pull=always`). Individual build option fields are deprecated in favor of using `extra_build_options`"
+        == "The individual `--pull=True` field on the `docker_image` target in `docker/test:img1` is overridden by `extra_build_options` (`--pull=always`). Individual build option fields are deprecated in favor of using `extra_build_options`"
     )
 
 
-def test_warning_on_deprecated_no_cache_field(
+def test_warning_on_deprecated_target_stage_field(
     rule_runner: RuleRunner, caplog: pytest.LogCaptureFixture
 ) -> None:
     rule_runner.set_options(
         [],
         env={
-            "PANTS_DOCKER_BUILD_NO_CACHE": "True",
+            "PANTS_DOCKER_BUILD_TARGET_STAGE": "dev",
         },
     )
     rule_runner.write_files(
@@ -3432,21 +3432,23 @@ def test_warning_on_deprecated_no_cache_field(
                 """\
                 docker_image(
                   name="img1",
-                  extra_build_options=["--no-cache"],
+                  extra_build_options=["--target=test"],
                 )
+                """
+            ),
+            "docker/test/Dockerfile": dedent(
+                """\
+                FROM base AS dev
+                FROM dev AS prod
                 """
             ),
         }
     )
 
-    def check_build_process(result: DockerImageBuildProcess):
-        argv = result.process.argv
-        assert "--no-cache" in argv
-
     assert_build_process(
         rule_runner,
         Address("docker/test", target_name="img1"),
-        build_process_assertions=check_build_process,
+        version_tags=("dev latest", "prod latest"),
     )
 
     caplog.set_level(logging.WARNING)
@@ -3456,5 +3458,5 @@ def test_warning_on_deprecated_no_cache_field(
     ]
     assert (
         warning_messages[0]
-        == f"The individual `--no-cache` field on the `docker_image` target in `docker/test:img1` is overridden by `extra_build_options` (`--no-cache`). Individual build option fields are deprecated in favor of using `extra_build_options`"
+        == "The individual `--target=dev` field on the `docker_image` target in `docker/test:img1` is overridden by `extra_build_options` (`--target=test`). Individual build option fields are deprecated in favor of using `extra_build_options`"
     )

--- a/src/python/pants/backend/docker/goals/package_image_test.py
+++ b/src/python/pants/backend/docker/goals/package_image_test.py
@@ -3319,20 +3319,36 @@ def test_field_set_pushes_on_package(output: dict | None, expected: bool) -> Non
     assert field_set.pushes_on_package() is expected
 
 
-def test_global_build_extra_options(rule_runner: RuleRunner) -> None:
-    """Global build_extra_options from [docker] should be passed to the docker build command."""
-    rule_runner.set_options(
-        [],
-        env={
-            "PANTS_DOCKER_BUILD_EXTRA_OPTIONS": '["--compress"]',
-        },
-    )
+@pytest.mark.parametrize(
+    ("global_options", "target_options", "expected"),
+    [
+        (["--compress"], None, ["--compress"]),
+        (["--compress"], ["--pull=always"], ["--compress", "--pull=always"]),
+        # The `--no-cache` option is set in a different place in the code and hence requires separate tests.
+        (["--no-cache"], None, ["--no-cache"]),
+        (None, ["--no-cache"], ["--no-cache"]),
+    ],
+)
+def test_global_build_extra_options_merge(
+    rule_runner: RuleRunner,
+    global_options: list | None,
+    target_options: list | None,
+    expected: list,
+) -> None:
+    if global_options:
+        rule_runner.set_options(
+            [],
+            env={
+                "PANTS_DOCKER_BUILD_EXTRA_OPTIONS": f"{global_options}",
+            },
+        )
     rule_runner.write_files(
         {
             "docker/test/BUILD": dedent(
-                """\
+                f"""\
                 docker_image(
                   name="img1",
+                  extra_build_options={target_options},
                 )
                 """
             ),
@@ -3340,7 +3356,8 @@ def test_global_build_extra_options(rule_runner: RuleRunner) -> None:
     )
 
     def check_build_process(result: DockerImageBuildProcess):
-        assert "--compress" in result.process.argv
+        for expected_option in expected:
+            assert expected_option in result.process.argv
 
     assert_build_process(
         rule_runner,
@@ -3349,41 +3366,13 @@ def test_global_build_extra_options(rule_runner: RuleRunner) -> None:
     )
 
 
-def test_extra_build_options_global_and_target_merged(rule_runner: RuleRunner) -> None:
-    """Global options and per-target options should be merged correctly."""
+def test_extra_build_options_overrides_pull_field_and_global_field(rule_runner: RuleRunner) -> None:
     rule_runner.set_options(
         [],
         env={
-            "PANTS_DOCKER_BUILD_EXTRA_OPTIONS": '["--compress"]',
+            "PANTS_DOCKER_BUILD_EXTRA_OPTIONS": '["--pull=missing"]',
         },
     )
-    rule_runner.write_files(
-        {
-            "docker/test/BUILD": dedent(
-                """\
-                docker_image(
-                  name="img1",
-                  extra_build_options=["--pull=always"],
-                )
-                """
-            ),
-        }
-    )
-
-    def check_build_process(result: DockerImageBuildProcess):
-        argv = result.process.argv
-        assert "--compress" in argv
-        assert "--pull=always" in argv
-
-    assert_build_process(
-        rule_runner,
-        Address("docker/test", target_name="img1"),
-        build_process_assertions=check_build_process,
-    )
-
-
-def test_extra_build_options_overrides_pull_field(rule_runner: RuleRunner) -> None:
-    """When extra_build_options contains --pull, the docker_image target pull argument is suppressed."""
     rule_runner.write_files(
         {
             "docker/test/BUILD": dedent(
@@ -3400,107 +3389,9 @@ def test_extra_build_options_overrides_pull_field(rule_runner: RuleRunner) -> No
 
     def check_build_process(result: DockerImageBuildProcess):
         argv = result.process.argv
-        # Only the extra_build_options value should appear; the structured field's
-        # --pull=True must NOT be present to avoid duplicate flags.
         assert "--pull=always" in argv
         assert "--pull=True" not in argv
-
-    assert_build_process(
-        rule_runner,
-        Address("docker/test", target_name="img1"),
-        build_process_assertions=check_build_process,
-    )
-
-
-def test_global_extra_options_overridden_by_target_extra_options(
-    rule_runner: RuleRunner,
-) -> None:
-    """When both global and target extra options specify the same flag, the target wins
-    and the global does not appear."""
-    rule_runner.set_options(
-        [],
-        env={
-            "PANTS_DOCKER_BUILD_EXTRA_OPTIONS": '["--pull=missing"]',
-        },
-    )
-    rule_runner.write_files(
-        {
-            "docker/test/BUILD": dedent(
-                """\
-                docker_image(
-                  name="img1",
-                  extra_build_options=["--pull=always"],
-                )
-                """
-            ),
-        }
-    )
-
-    def check_build_process(result: DockerImageBuildProcess):
-        argv = result.process.argv
-        # Both global and target specify --pull; the per-target value wins and the global
-        # entry is dropped at the flag-level dedup stage.
-        assert "--pull=always" in argv
-        assert "--pull=missing" not in argv  # global dropped because target specifies --pull
-
-    assert_build_process(
-        rule_runner,
-        Address("docker/test", target_name="img1"),
-        build_process_assertions=check_build_process,
-    )
-
-
-def test_global_build_no_cache_options_exits(
-    rule_runner: RuleRunner,
-) -> None:
-    rule_runner.set_options(
-        [],
-        env={
-            "PANTS_DOCKER_BUILD_EXTRA_OPTIONS": '["--no-cache"]',
-        },
-    )
-    rule_runner.write_files(
-        {
-            "docker/test/BUILD": dedent(
-                """\
-                docker_image(
-                  name="img1",
-                )
-                """
-            ),
-        }
-    )
-
-    def check_build_process(result: DockerImageBuildProcess):
-        argv = result.process.argv
-        assert "--no-cache" in argv
-
-    assert_build_process(
-        rule_runner,
-        Address("docker/test", target_name="img1"),
-        build_process_assertions=check_build_process,
-    )
-
-
-def test_global_build_no_cache_options_overridden_by_target_extra_options(
-    rule_runner: RuleRunner,
-) -> None:
-    rule_runner.write_files(
-        {
-            "docker/test/BUILD": dedent(
-                """\
-                docker_image(
-                  name="img1",
-                  extra_build_options=["--no-cache"],
-                )
-                """
-            ),
-        }
-    )
-
-    def check_build_process(result: DockerImageBuildProcess):
-        argv = result.process.argv
-        assert "--no-cache" in argv
+        assert "--pull=missing" not in argv
 
     assert_build_process(
         rule_runner,

--- a/src/python/pants/backend/docker/goals/package_image_test.py
+++ b/src/python/pants/backend/docker/goals/package_image_test.py
@@ -3318,6 +3318,7 @@ def test_field_set_pushes_on_package(output: dict | None, expected: bool) -> Non
     )
     assert field_set.pushes_on_package() is expected
 
+
 def test_global_build_extra_options(rule_runner: RuleRunner) -> None:
     """Global build_extra_options from [docker] should be passed to the docker build command."""
     rule_runner.set_options(
@@ -3410,6 +3411,7 @@ def test_extra_build_options_overrides_pull_field(rule_runner: RuleRunner) -> No
         build_process_assertions=check_build_process,
     )
 
+
 def test_global_extra_options_overridden_by_target_extra_options(
     rule_runner: RuleRunner,
 ) -> None:
@@ -3471,13 +3473,14 @@ def test_global_build_no_cache_options_exits(
 
     def check_build_process(result: DockerImageBuildProcess):
         argv = result.process.argv
-        assert "--no-cache" in argv 
+        assert "--no-cache" in argv
 
     assert_build_process(
         rule_runner,
         Address("docker/test", target_name="img1"),
         build_process_assertions=check_build_process,
     )
+
 
 def test_global_build_no_cache_options_overridden_by_target_extra_options(
     rule_runner: RuleRunner,
@@ -3497,7 +3500,7 @@ def test_global_build_no_cache_options_overridden_by_target_extra_options(
 
     def check_build_process(result: DockerImageBuildProcess):
         argv = result.process.argv
-        assert "--no-cache" in argv 
+        assert "--no-cache" in argv
 
     assert_build_process(
         rule_runner,

--- a/src/python/pants/backend/docker/goals/package_image_test.py
+++ b/src/python/pants/backend/docker/goals/package_image_test.py
@@ -3350,7 +3350,7 @@ def test_global_build_extra_options(rule_runner: RuleRunner) -> None:
 
 
 def test_extra_build_options_global_and_target_merged(rule_runner: RuleRunner) -> None:
-    """Global options come first; per-target options come last."""
+    """Global options and per-target options should be merged correctly."""
     rule_runner.set_options(
         [],
         env={
@@ -3416,7 +3416,7 @@ def test_global_extra_options_overridden_by_target_extra_options(
     rule_runner: RuleRunner,
 ) -> None:
     """When both global and target extra options specify the same flag, the target wins
-    (it comes last) and the global does not appear."""
+    and the global does not appear."""
     rule_runner.set_options(
         [],
         env={

--- a/src/python/pants/backend/docker/goals/package_image_test.py
+++ b/src/python/pants/backend/docker/goals/package_image_test.py
@@ -3366,7 +3366,10 @@ def test_global_build_extra_options_merge(
     )
 
 
-def test_extra_build_options_overrides_pull_field_and_global_field(rule_runner: RuleRunner) -> None:
+def test_extra_build_options_overrides_pull_field_and_global_field(
+    rule_runner: RuleRunner,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     rule_runner.set_options(
         [],
         env={
@@ -3397,4 +3400,61 @@ def test_extra_build_options_overrides_pull_field_and_global_field(rule_runner: 
         rule_runner,
         Address("docker/test", target_name="img1"),
         build_process_assertions=check_build_process,
+    )
+
+    caplog.set_level(logging.WARNING)
+
+    warning_messages = [
+        record.message for record in caplog.records if record.levelno == logging.WARNING
+    ]
+    assert (
+        warning_messages[0]
+        == f"Global docker extra option `--pull=missing` is overridden by a per-target option and will be ignored."
+    )
+    assert (
+        warning_messages[1]
+        == f"The individual `--pull=True` field on the `docker_image` target in `docker/test:img1` is overridden by `extra_build_options` (`--pull=always`). Individual build option fields are deprecated in favor of using `extra_build_options`"
+    )
+
+
+def test_warning_on_deprecated_no_cache_field(
+    rule_runner: RuleRunner, caplog: pytest.LogCaptureFixture
+) -> None:
+    rule_runner.set_options(
+        [],
+        env={
+            "PANTS_DOCKER_BUILD_NO_CACHE": "True",
+        },
+    )
+    rule_runner.write_files(
+        {
+            "docker/test/BUILD": dedent(
+                """\
+                docker_image(
+                  name="img1",
+                  extra_build_options=["--no-cache"],
+                )
+                """
+            ),
+        }
+    )
+
+    def check_build_process(result: DockerImageBuildProcess):
+        argv = result.process.argv
+        assert "--no-cache" in argv
+
+    assert_build_process(
+        rule_runner,
+        Address("docker/test", target_name="img1"),
+        build_process_assertions=check_build_process,
+    )
+
+    caplog.set_level(logging.WARNING)
+
+    warning_messages = [
+        record.message for record in caplog.records if record.levelno == logging.WARNING
+    ]
+    assert (
+        warning_messages[0]
+        == f"The individual `--no-cache` field on the `docker_image` target in `docker/test:img1` is overridden by `extra_build_options` (`--no-cache`). Individual build option fields are deprecated in favor of using `extra_build_options`"
     )

--- a/src/python/pants/backend/docker/goals/package_image_test.py
+++ b/src/python/pants/backend/docker/goals/package_image_test.py
@@ -156,6 +156,7 @@ def _setup_docker_options(rule_runner: RuleRunner, options: dict | None) -> Dock
         opts.setdefault("build_hosts", None)
         opts.setdefault("build_verbose", False)
         opts.setdefault("build_no_cache", False)
+        opts.setdefault("build_extra_options", [])
         opts.setdefault("use_buildx", False)
         opts.setdefault("env_vars", [])
         opts.setdefault("suggest_renames", True)
@@ -3316,3 +3317,186 @@ def test_field_set_pushes_on_package(output: dict | None, expected: bool) -> Non
         rule_runner.get_target(Address("", target_name="image"))
     )
     assert field_set.pushes_on_package() is expected
+
+def test_global_build_extra_options(rule_runner: RuleRunner) -> None:
+    """Global build_extra_options from [docker] should be passed to the docker build command."""
+    rule_runner.set_options(
+        [],
+        env={
+            "PANTS_DOCKER_BUILD_EXTRA_OPTIONS": '["--compress"]',
+        },
+    )
+    rule_runner.write_files(
+        {
+            "docker/test/BUILD": dedent(
+                """\
+                docker_image(
+                  name="img1",
+                )
+                """
+            ),
+        }
+    )
+
+    def check_build_process(result: DockerImageBuildProcess):
+        assert "--compress" in result.process.argv
+
+    assert_build_process(
+        rule_runner,
+        Address("docker/test", target_name="img1"),
+        build_process_assertions=check_build_process,
+    )
+
+
+def test_extra_build_options_global_and_target_merged(rule_runner: RuleRunner) -> None:
+    """Global options come first; per-target options come last."""
+    rule_runner.set_options(
+        [],
+        env={
+            "PANTS_DOCKER_BUILD_EXTRA_OPTIONS": '["--compress"]',
+        },
+    )
+    rule_runner.write_files(
+        {
+            "docker/test/BUILD": dedent(
+                """\
+                docker_image(
+                  name="img1",
+                  extra_build_options=["--pull=always"],
+                )
+                """
+            ),
+        }
+    )
+
+    def check_build_process(result: DockerImageBuildProcess):
+        argv = result.process.argv
+        assert "--compress" in argv
+        assert "--pull=always" in argv
+
+    assert_build_process(
+        rule_runner,
+        Address("docker/test", target_name="img1"),
+        build_process_assertions=check_build_process,
+    )
+
+
+def test_extra_build_options_overrides_pull_field(rule_runner: RuleRunner) -> None:
+    """When extra_build_options contains --pull, the docker_image target pull argument is suppressed."""
+    rule_runner.write_files(
+        {
+            "docker/test/BUILD": dedent(
+                """\
+                docker_image(
+                  name="img1",
+                  pull=True,
+                  extra_build_options=["--pull=always"],
+                )
+                """
+            ),
+        }
+    )
+
+    def check_build_process(result: DockerImageBuildProcess):
+        argv = result.process.argv
+        # Only the extra_build_options value should appear; the structured field's
+        # --pull=True must NOT be present to avoid duplicate flags.
+        assert "--pull=always" in argv
+        assert "--pull=True" not in argv
+
+    assert_build_process(
+        rule_runner,
+        Address("docker/test", target_name="img1"),
+        build_process_assertions=check_build_process,
+    )
+
+def test_global_extra_options_overridden_by_target_extra_options(
+    rule_runner: RuleRunner,
+) -> None:
+    """When both global and target extra options specify the same flag, the target wins
+    (it comes last) and the global does not appear."""
+    rule_runner.set_options(
+        [],
+        env={
+            "PANTS_DOCKER_BUILD_EXTRA_OPTIONS": '["--pull=missing"]',
+        },
+    )
+    rule_runner.write_files(
+        {
+            "docker/test/BUILD": dedent(
+                """\
+                docker_image(
+                  name="img1",
+                  extra_build_options=["--pull=always"],
+                )
+                """
+            ),
+        }
+    )
+
+    def check_build_process(result: DockerImageBuildProcess):
+        argv = result.process.argv
+        # Both global and target specify --pull; the per-target value wins and the global
+        # entry is dropped at the flag-level dedup stage.
+        assert "--pull=always" in argv
+        assert "--pull=missing" not in argv  # global dropped because target specifies --pull
+
+    assert_build_process(
+        rule_runner,
+        Address("docker/test", target_name="img1"),
+        build_process_assertions=check_build_process,
+    )
+
+
+def test_global_build_no_cache_options_exits(
+    rule_runner: RuleRunner,
+) -> None:
+    rule_runner.write_files(
+        {
+            "docker/test/BUILD": dedent(
+                """\
+                docker_image(
+                  name="img1",
+                  no_cache=True,
+                )
+                """
+            ),
+        }
+    )
+
+    def check_build_process(result: DockerImageBuildProcess):
+        argv = result.process.argv
+        assert "--no-cache" in argv 
+
+    assert_build_process(
+        rule_runner,
+        Address("docker/test", target_name="img1"),
+        build_process_assertions=check_build_process,
+    )
+
+def test_global_build_no_cache_options_overridden_by_target_extra_options(
+    rule_runner: RuleRunner,
+) -> None:
+    rule_runner.write_files(
+        {
+            "docker/test/BUILD": dedent(
+                """\
+                docker_image(
+                  name="img1",
+                  no_cache=False,
+                  extra_build_options=["--no_cache"],
+                )
+                """
+            ),
+        }
+    )
+
+    def check_build_process(result: DockerImageBuildProcess):
+        argv = result.process.argv
+        assert "--no-cache" in argv 
+
+    assert_build_process(
+        rule_runner,
+        Address("docker/test", target_name="img1"),
+        build_process_assertions=check_build_process,
+    )

--- a/src/python/pants/backend/docker/subsystems/docker_options.py
+++ b/src/python/pants/backend/docker/subsystems/docker_options.py
@@ -207,6 +207,24 @@ class DockerOptions(Subsystem):
         default=False,
         help="Do not use the Docker cache when building images.",
     )
+    _build_extra_options = ShellStrListOption(
+        help=softwrap(
+            f"""
+            Global extra options to pass to the `docker build` / `podman build` command.
+
+            These are appended after all other computed flags. If any option specified here uses a
+            flag that is already covered by a dedicated field (e.g. `--pull`, `--network`,
+            `--platform`), the dedicated field's contribution is suppressed in favour of
+            the value given here, to avoid duplicate or conflicting flags.
+
+            Example:
+
+                [{options_scope}]
+                build_extra_options = ["--pull=always"]
+
+            """
+        ),
+    )
     build_verbose = BoolOption(
         default=False,
         help="Whether to log the Docker output to the console. If false, only the image ID is logged.",
@@ -301,6 +319,10 @@ class DockerOptions(Subsystem):
     @property
     def build_args(self) -> tuple[str, ...]:
         return tuple(sorted(set(self._build_args)))
+
+    @property
+    def build_extra_options(self) -> tuple[str, ...]:
+        return tuple(self._build_extra_options)
 
     @property
     def tools(self) -> tuple[str, ...]:

--- a/src/python/pants/backend/docker/target_types.py
+++ b/src/python/pants/backend/docker/target_types.py
@@ -596,6 +596,30 @@ class DockerImageRunExtraArgsField(StringSequenceField):
     )
 
 
+class DockerImageBuildExtraOptionsField(StringSequenceField):
+    alias = "extra_build_options"
+    default = ()
+    help = help_text(
+        lambda: f"""
+        Additional options to pass directly to the `docker build` (or `podman build`) command.
+
+        These are appended after all other computed flags. If any option specified here uses a
+        flag that is already covered by a dedicated field (e.g. `--pull`, `--network`,
+        `--platform`), the dedicated field's contribution is suppressed in favour of
+        the value given here, to avoid duplicate or conflicting flags on the command line.
+
+        Example:
+
+            docker_image(
+                extra_build_options=["--pull=always", "--compress"],
+            )
+
+        Use `[{DockerOptions.options_scope}].build_extra_options` to set default options for all
+        images. Per-target option overrides a conflicting global one.
+        """
+    )
+
+
 class DockerImageTarget(Target):
     alias = "docker_image"
     core_fields = (
@@ -622,6 +646,7 @@ class DockerImageTarget(Target):
         DockerImageBuildImageCacheFromField,
         DockerImageBuildImageOutputField,
         DockerImageRunExtraArgsField,
+        DockerImageBuildExtraOptionsField,
         OutputPathField,
         RestartableField,
     )

--- a/src/python/pants/backend/docker/target_types.py
+++ b/src/python/pants/backend/docker/target_types.py
@@ -690,6 +690,30 @@ class DockerImageRunExtraArgsField(StringSequenceField):
     )
 
 
+class DockerImageBuildExtraOptionsField(StringSequenceField):
+    alias = "extra_build_options"
+    default = ()
+    help = help_text(
+        lambda: f"""
+        Additional options to pass directly to the `docker build` (or `podman build`) command.
+
+        These are appended after all other computed flags. If any option specified here uses a
+        flag that is already covered by a dedicated field (e.g. `--pull`, `--network`,
+        `--platform`), the dedicated field's contribution is suppressed in favour of
+        the value given here, to avoid duplicate or conflicting flags on the command line.
+
+        Example:
+
+            docker_image(
+                extra_build_options=["--pull=always", "--compress"],
+            )
+
+        Use `[{DockerOptions.options_scope}].build_extra_options` to set default options for all
+        images. Per-target option overrides a conflicting global one.
+        """
+    )
+
+
 class DockerImageTarget(Target):
     alias = "docker_image"
     core_fields = (
@@ -719,6 +743,7 @@ class DockerImageTarget(Target):
         DockerImageOutputDirectoriesField,
         DockerImageOutputsMatchModeField,
         DockerImageRunExtraArgsField,
+        DockerImageBuildExtraOptionsField,
         OutputPathField,
         RestartableField,
     )


### PR DESCRIPTION
This pull request allows it now to add generic build options to docker/podman build. It will also work as a workaround for issue: https://github.com/pantsbuild/pants/issues/21450 

It is now possible to use pass generic build options to docker and podman. The old arguments such as pull on docker_image target level or no-cache on global level will still work, however the new build_extra_option will have precedence. 

AI was used to find the right locations in the code base for the changes and to write the tests faster. However, most of the code was written by human. 

This is an improvement of pull request: https://github.com/pantsbuild/pants/pull/23032