### PR TITLE
fix: preserve workunit log level in local cache metadata update

### DIFF
--- a/docs/notes/2.32.x.md
+++ b/docs/notes/2.32.x.md
@@ -27,6 +27,8 @@ a specific field inside a TOML/YAML/JSON file, using the `@path/to/file:trail.wi
 
 The "spinner line" indicator now displays work unit times to one decimal place instead of two, and should look smoother.
 
+Fixed "Scheduling:" workunits (process execution wrappers) being logged at INFO instead of DEBUG, which caused duplicate log lines like `Completed: Scheduling: Generate lockfile for pytest` alongside the actual `Completed: Generate lockfile for pytest`.
+
 #### Internal Python Upgrade
 
 The version of Python used by Pants itself has been updated to [3.14](https://docs.python.org/3/whatsnew/3.14.html). To support this, the [Pants Launcher Binary](https://www.pantsbuild.org/blog/2023/02/23/the-pants-launcher-binary-a-much-simpler-way-to-install-and-run-pants) (also known as [`scie-pants`](https://github.com/pantsbuild/scie-pants/)) now has a minimum version of `0.13.0`. To update to the latest launcher binary, either:

--- a/src/rust/process_execution/src/cache.rs
+++ b/src/rust/process_execution/src/cache.rs
@@ -94,14 +94,14 @@ impl crate::CommandRunner for CommandRunner {
         };
 
         workunit.update_metadata(|initial| {
-            initial.map(|(initial, _)| {
+            initial.map(|(initial, level)| {
                 (
                     WorkunitMetadata {
                         local_command: Some(command_digest),
                         local_action: Some(action_digest),
                         ..initial
                     },
-                    Level::Info,
+                    level,
                 )
             })
         });


### PR DESCRIPTION
## Problem

When a process runs (e.g. `generate-lockfiles`), the local cache runner updates the "Scheduling:" workunit metadata to attach cache digests. As a side effect, it **overrides the workunit log level to `Info`**, regardless of its original level. Since `ExecuteProcess` workunits intentionally start at `Debug` (to avoid rendering until execution actually begins), this promotion causes duplicate INFO-level output:

```
23:22:27.30 [INFO] Starting: Generate lockfile for pytest
23:22:53.66 [INFO] Completed: Generate lockfile for pytest (26.4s)
23:22:53.66 [INFO] Completed: Scheduling: Generate lockfile for pytest (26.4s)
```

The third line is redundant — the scheduling workunit is a wrapper whose duration mirrors its child.

## Root Cause

This was inadvertently introduced in #22212, which added Action/Command digest metadata to workunits. The `update_metadata` call needed to attach `local_command` and `local_action` digests, but the closure also hardcoded `Level::Info` as the new level — discarding the original. The PR was focused on metadata, not log levels, and the level override was not discussed in review.

## Solution

Preserve the workunit's original log level when updating cache metadata, instead of unconditionally overriding it to `Level::Info`. The metadata update only needs to set `local_command` and `local_action` — it has no reason to change the log level.

## Result

Default (INFO-level) output is now clean:

```
23:22:27.30 [INFO] Starting: Generate lockfile for pytest
23:22:53.66 [INFO] Completed: Generate lockfile for pytest
```

The "Scheduling:" message remains visible at `-ldebug` for debugging purposes.

## LLM Disclosure

This PR was written with Amp (Claude). The LLM diagnosed the root cause by tracing the workunit level flow through the codebase, identified the accidental `Level::Info` override in #22212, and wrote the one-line fix. I reviewed the diagnosis and fix, validated it by running Pants from sources against our monorepo, and confirmed the duplicate log line no longer appears.

Related: #22992