### PR TITLE
Fix sandboxer daemon inheriting parent stdin/stdout file descriptors (Cherry-pick of #23246)

### DIFF
--- a/src/rust/process_execution/sandboxer/src/lib.rs
+++ b/src/rust/process_execution/sandboxer/src/lib.rs
@@ -453,6 +453,8 @@ impl Sandboxer {
         // Pass the calling code's global log level to the sandboxer process.
         // TODO: Check for a relevant per-target log level?
         cmd.env("RUST_LOG", PANTS_LOGGER.global_level().as_str());
+        cmd.stdin(Stdio::null());
+        cmd.stdout(Stdio::null());
         cmd.stderr(Stdio::from(logfile.into_std().await));
 
         debug!(


### PR DESCRIPTION
## Summary
- Redirect the sandboxer daemon's stdin and stdout to `/dev/null` when spawning, preventing it from holding the parent's file descriptors open indefinitely
- Only stderr was previously redirected (to a logfile); stdin/stdout used Tokio's default (`Stdio::inherit()`), causing hangs when the parent's stdout was a pipe or regular file

## Context

Fixes #23169

When the sandboxer daemon is spawned without explicit stdin/stdout configuration, it inherits the parent's file descriptors. If those FDs are pipes (e.g., `pants ... | grep`, pre-commit hooks, IDE integrations, AI coding tools capturing output) or regular files, the sandboxer holds them open for its lifetime, preventing EOF and causing the caller to hang.

The sandboxer communicates exclusively via a Unix domain socket and never reads stdin or writes stdout. All logging goes to stderr via `env_logger`. This change matches the existing pattern used by other process runners in the codebase (`local.rs`, `workspace.rs`).

## Test plan
- [x] `cargo test -p sandboxer` passes (3 tests)
- [x] FD inspection before/after: verified the sandboxer's FD 1 changes from inherited `REG pants.log` to `CHR /dev/null` across all three stdout contexts (see [test script](https://gist.github.com/tarekrached/30c7f05cdf4eb6dd0975fe3d91697701) and [verification comment](https://github.com/pantsbuild/pants/pull/23246#issuecomment-4239525830))

🤖 Generated with [Claude Code](https://claude.com/claude-code)
