### PR TITLE
update the default Pex version to v2.92.2

### DIFF
--- a/docs/notes/2.32.x.md
+++ b/docs/notes/2.32.x.md
@@ -138,13 +138,14 @@ All version of [Ruff](https://docs.astral.sh/ruff/) from [0.13.1](https://github
 
 The default version of the [Ruff](https://docs.astral.sh/ruff/) tool has been updated to [0.14.14](https://github.com/astral-sh/ruff/releases/tag/0.14.14).
 
-The version of [Pex](https://github.com/pex-tool/pex) used by the Python backend has been upgraded to [`v2.92.1`](https://github.com/pex-tool/pex/releases/tag/v2.92.1). Of particular note for Pants users:
+The version of [Pex](https://github.com/pex-tool/pex) used by the Python backend has been upgraded to [`v2.92.2`](https://github.com/pex-tool/pex/releases/tag/v2.92.2). Of particular note for Pants users:
  - Fixes a bug where wheels built from sdists weren't cached.
  - Support for [pip 26.0.1](https://pip.pypa.io/en/stable/news/#v26-0-1).
  - A new `--interpreter-selection-strategy` option to select the `"oldest"` or `"newest"` interpreter when multiple match constraints.
  - Linux PEX scies can now install themselves with a desktop entry.
  - [Performance improvements](https://github.com/pex-tool/pex/releases/tag/v2.91.4) for large PEXes
  - Support for [Pip's `--uploaded-prior-to`](https://github.com/pex-tool/pex/releases/tag/v2.92.0).
+ - Fixes a bug in the [hashing of VCS requirements](https://github.com/pex-tool/pex/releases/tag/v2.92.2) where the VCS repository contains symlinks.
  - And for Pants *developers* [fixes the most common case of a rare interpreter caching bug for CPython interpreters that have the same binary contents across patch versions](https://github.com/pex-tool/pex/releases/tag/v2.91.1).
 
 When generating lockfiles, the new `python.resolves_to_uploaded_prior_to` option can be used to pass along [`--uploaded-prior-to`](https://pip.pypa.io/en/stable/user_guide/#filtering-by-upload-time).  This allows you to filter packages by their upload time to an index, only considering packages that were uploaded before a specified point in time.

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -37,9 +37,9 @@ from pants.util.strutil import softwrap
 logger = logging.getLogger(__name__)
 
 
-_PEX_VERSION = "v2.92.1"
-_PEX_BINARY_HASH = "116da6936a81563ee2f1bafb221666b77617caec9ec82e38269d5e31784b932d"
-_PEX_BINARY_SIZE = 5081477
+_PEX_VERSION = "v2.92.2"
+_PEX_BINARY_HASH = "5ccaf151161debe5381d767c7631b39d5516c7106e725c45dbae24aa0e5fe569"
+_PEX_BINARY_SIZE = 5081502
 
 
 class PexCli(TemplatedExternalTool):


### PR DESCRIPTION
Release Notes:
 * https://github.com/pex-tool/pex/releases/tag/v2.92.2