### PR TITLE
rust: upgrade to v1.95.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
     - name: Install Rust toolchain
       run: |
         # Set the default toolchain. Installs the toolchain if it is not already installed.
-        rustup default 1.94.1
+        rustup default 1.95.0
         cargo version
     - name: Expose Pythons
       run: |
@@ -175,7 +175,7 @@ jobs:
     - name: Install Rust toolchain
       run: |
         # Set the default toolchain. Installs the toolchain if it is not already installed.
-        rustup default 1.94.1
+        rustup default 1.95.0
         cargo version
     - name: Expose Pythons
       run: |
@@ -338,7 +338,7 @@ jobs:
       with:
         key: macOS14-ARM64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
         path: |
-          ~/.rustup/toolchains/1.94.1-*
+          ~/.rustup/toolchains/1.95.0-*
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo
@@ -473,7 +473,7 @@ jobs:
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
         path: |
-          ~/.rustup/toolchains/1.94.1-*
+          ~/.rustup/toolchains/1.95.0-*
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,7 +54,7 @@ jobs:
       with:
         key: Linux-ARM64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
         path: |
-          ~/.rustup/toolchains/1.94.1-*
+          ~/.rustup/toolchains/1.95.0-*
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo
@@ -163,7 +163,7 @@ jobs:
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
         path: |
-          ~/.rustup/toolchains/1.94.1-*
+          ~/.rustup/toolchains/1.95.0-*
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo
@@ -279,7 +279,7 @@ jobs:
       with:
         key: macOS14-ARM64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
         path: |
-          ~/.rustup/toolchains/1.94.1-*
+          ~/.rustup/toolchains/1.95.0-*
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo
@@ -383,7 +383,7 @@ jobs:
     - name: Install Rust toolchain
       run: |
         # Set the default toolchain. Installs the toolchain if it is not already installed.
-        rustup default 1.94.1
+        rustup default 1.95.0
         cargo version
     - name: Expose Pythons
       run: |
@@ -463,7 +463,7 @@ jobs:
     - name: Install Rust toolchain
       run: |
         # Set the default toolchain. Installs the toolchain if it is not already installed.
-        rustup default 1.94.1
+        rustup default 1.95.0
         cargo version
     - name: Expose Pythons
       run: |
@@ -564,7 +564,7 @@ jobs:
       with:
         key: macOS14-ARM64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
         path: |
-          ~/.rustup/toolchains/1.94.1-*
+          ~/.rustup/toolchains/1.95.0-*
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo

--- a/src/rust/dep_inference/build.rs
+++ b/src/rust/dep_inference/build.rs
@@ -162,7 +162,7 @@ fn gen_impl_hash_file(name: &'static str, source_dir: &Path, impl_dir: &Path, ou
     for entry in WalkDir::new(impl_dir)
         .sort_by_file_name()
         .into_iter()
-        .chain(WalkDir::new(source_dir).sort_by_file_name().into_iter())
+        .chain(WalkDir::new(source_dir).sort_by_file_name())
         .flatten()
     {
         if entry.file_type().is_file() && entry.path().file_name().unwrap() != "tests.rs" {

--- a/src/rust/engine/src/nodes/task.rs
+++ b/src/rust/engine/src/nodes/task.rs
@@ -246,12 +246,8 @@ impl Task {
                             .extract::<Bound<'_, PyTuple>>()
                             .map_err(PyErr::from)?;
                         let kwargs = PyDict::new(py);
-                        for ((name, _), value) in self
-                            .task
-                            .args
-                            .iter()
-                            .skip(self.args_arity.into())
-                            .zip(deps)
+                        for ((name, _), value) in
+                            self.task.args.iter().skip(self.args_arity.into()).zip(deps)
                         {
                             kwargs.set_item(name, &value)?;
                         }

--- a/src/rust/engine/src/nodes/task.rs
+++ b/src/rust/engine/src/nodes/task.rs
@@ -251,7 +251,7 @@ impl Task {
                             .args
                             .iter()
                             .skip(self.args_arity.into())
-                            .zip(deps.into_iter())
+                            .zip(deps)
                         {
                             kwargs.set_item(name, &value)?;
                         }

--- a/src/rust/fs/brfs/src/main.rs
+++ b/src/rust/fs/brfs/src/main.rs
@@ -614,13 +614,11 @@ impl fuser::Filesystem for BuildResultFS {
                     // 0 is a magic offset which means no offset, whereas a non-zero offset means start
                     // _after_ that entry. Inconsistency is fun.
                     let to_skip = if offset == 0 { 0 } else { offset + 1 } as usize;
-                    let mut i = offset;
-                    for entry in entries.into_iter().skip(to_skip) {
+                    for (i, entry) in (offset..).zip(entries.into_iter().skip(to_skip)) {
                         if reply.add(entry.inode, i, entry.kind, entry.name) {
                             // Buffer is full, don't add more entries.
                             break;
                         }
-                        i += 1;
                     }
                     reply.ok();
                 }

--- a/src/rust/fs/store/src/immutable_inputs.rs
+++ b/src/rust/fs/store/src/immutable_inputs.rs
@@ -141,7 +141,7 @@ impl ImmutableInputs {
 
         Ok(immutable_inputs
             .keys()
-            .zip(dsts.into_iter())
+            .zip(dsts)
             .map(|(src, dst)| WorkdirSymlink {
                 src: src.clone(),
                 dst,

--- a/src/rust/rust-toolchain
+++ b/src/rust/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.94.1"
+channel = "1.95.0"
 profile = "minimal"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Upgrade to Rust v1.95.0.

Interesting changes (from the [release notes](https://blog.rust-lang.org/2026/04/16/Rust-1.95.0/)):

- [`cfg_select!` macro](https://blog.rust-lang.org/2026/04/16/Rust-1.95.0/#cfg-select)
- [if-let guards in matches](https://blog.rust-lang.org/2026/04/16/Rust-1.95.0/#if-let-guards-in-matches)