### PR TITLE
thread name for the workunit streamer

### DIFF
--- a/docs/notes/2.33.x.md
+++ b/docs/notes/2.33.x.md
@@ -16,6 +16,8 @@ Thank you to [Klaviyo](https://www.klaviyo.com/) for their Platinum tier support
 
 ### General
 
+The thread used by the [`workunit-logger`](https://www.pantsbuild.org/2.33/reference/subsystems/workunit-logger) is now named.
+
 ### Goals
 
 ### Backends

--- a/src/python/pants/engine/streaming_workunit_handler.py
+++ b/src/python/pants/engine/streaming_workunit_handler.py
@@ -294,7 +294,7 @@ class _InnerHandler(threading.Thread):
         max_workunit_verbosity: LogLevel,
         allow_async_completion: bool,
     ) -> None:
-        super().__init__(daemon=True)
+        super().__init__(daemon=True, name="workunit-stream")
         self.scheduler = scheduler
         self.context = context
         self.stop_request = threading.Event()


### PR DESCRIPTION
This is so it shows up more clearly in stacktraces or `perf`.


## Test Plan

In it this repo:
```
PANTS_WORKUNIT_LOGGER_ENABLED=true pants check ::
```
While running:
```
gstack $(cat .pants.d/pids/35b2225442f6/pantsd/pid ) > /tmp/stack
$ grep worku /tmp/stack
Thread 2 (Thread 0x7ee0728296c0 (LWP 426293) "workunit-stream"):
```