### PR TITLE
use a dedicated render thread for indicatif spinner

### DIFF
--- a/docs/notes/2.34.x.md
+++ b/docs/notes/2.34.x.md
@@ -20,6 +20,9 @@ Fixed a bug where `SingleSourceField` could not be hydrated for generated target
 
 Fixed an issue where `pants --changed-since` would unnecessarily invalidate all targets in a `BUILD` file when only whitespace or comment lines were modified.
 
+The `indicatif-spinner` `dynamic_ui_renderer` (default), now renders on a dedicated thread.  This should reduce jitter and display a smoother spinner under heavy load.
+
+
 ### Goals
 
 ### Backends

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -4801,6 +4801,7 @@ dependencies = [
  "futures",
  "indexmap 2.13.0",
  "indicatif",
+ "log",
  "logging",
  "parking_lot 0.12.5",
  "prodash",

--- a/src/rust/ui/Cargo.toml
+++ b/src/rust/ui/Cargo.toml
@@ -9,6 +9,7 @@ console = { workspace = true }
 futures = { workspace = true }
 indexmap = { workspace = true }
 indicatif = { workspace = true }
+log = { workspace = true }
 logging = { path = "../logging" }
 parking_lot = { workspace = true }
 # TODO: See https://github.com/Byron/prodash/pull/9.

--- a/src/rust/ui/src/instance.rs
+++ b/src/rust/ui/src/instance.rs
@@ -47,10 +47,11 @@ impl Instance {
 
         if ui_use_prodash {
             let instance =
-                prodash::ProdashInstance::new(executor.clone(), terminal_width, terminal_height)?;
+                prodash::ProdashInstance::new(executor, terminal_width, terminal_height)?;
             Ok(Instance::Prodash(instance))
         } else {
             let instance = indicatif::IndicatifInstance::new(
+                executor,
                 local_parallelism,
                 terminal_width,
                 terminal_height,

--- a/src/rust/ui/src/instance/indicatif.rs
+++ b/src/rust/ui/src/instance/indicatif.rs
@@ -5,7 +5,8 @@ use std::cmp;
 use std::collections::HashMap;
 use std::future;
 use std::sync::Arc;
-use std::time::SystemTime;
+use std::thread;
+use std::time::{Duration, SystemTime};
 
 use futures::FutureExt;
 use futures::future::BoxFuture;
@@ -15,7 +16,7 @@ use indicatif::ProgressBar;
 use indicatif::ProgressDrawTarget;
 use indicatif::ProgressStyle;
 use indicatif::WeakProgressBar;
-use parking_lot::Mutex;
+use parking_lot::{Condvar, Mutex};
 
 use workunit_store::SpanId;
 use workunit_store::format_workunit_duration_ms;
@@ -23,11 +24,17 @@ use workunit_store::format_workunit_duration_ms;
 use super::TaskState;
 use crate::ConsoleUI;
 
+#[derive(Clone)]
+struct Task {
+    label: String,
+    start_time: SystemTime,
+}
+
 pub struct IndicatifInstance {
     tasks_to_display: IndexSet<SpanId>,
-    // NB: Kept for Drop.
-    _multi_progress: MultiProgress,
-    bars: Vec<ProgressBar>,
+    snapshot: Arc<Mutex<Vec<Option<Task>>>>,
+    stopping: Arc<(Mutex<bool>, Condvar)>,
+    join_handle: Option<thread::JoinHandle<()>>,
 }
 
 impl IndicatifInstance {
@@ -59,17 +66,34 @@ impl IndicatifInstance {
             .collect::<Vec<_>>();
 
         *stderr_dest_bar_guard = Some(bars[0].downgrade());
+        drop(stderr_dest_bar_guard);
+
+        let snapshot = Arc::new(Mutex::new((0..bars.len()).map(|_| None).collect()));
+        let stopping = Arc::new((Mutex::new(false), Condvar::new()));
+
+        let render_loop = RenderLoop {
+            _multi_progress: multi_progress,
+            bars,
+            snapshot: snapshot.clone(),
+            stopping: stopping.clone(),
+            interval: ConsoleUI::render_interval(),
+        };
+        let join_handle = thread::Builder::new()
+            .name("pants-indicatif-render".into())
+            .spawn(move || render_loop.run())
+            .map_err(|e| format!("Failed to spawn indicatif render thread: {e}"))?;
 
         Ok(IndicatifInstance {
             tasks_to_display: IndexSet::new(),
-            _multi_progress: multi_progress,
-            bars,
+            snapshot,
+            stopping,
+            join_handle: Some(join_handle),
         })
     }
 
     pub fn teardown(self) -> BoxFuture<'static, ()> {
-        // When the MultiProgress completes, the Term(Destination) is dropped, which will restore
-        // direct access to the Console.
+        // Drop signals the render thread to stop, joins it, and then drops the MultiProgress
+        // (which restores direct access to the Console).
         std::mem::drop(self);
         future::ready(()).boxed()
     }
@@ -92,23 +116,81 @@ impl IndicatifInstance {
             },
         );
 
-        let now = SystemTime::now();
-        for (n, pbar) in self.bars.iter().enumerate() {
-            let maybe_label = tasks_to_display.get_index(n).map(|span_id| {
-                let (label, start_time) = heavy_hitters.get(span_id).unwrap();
-                let duration_label = match now.duration_since(*start_time).ok() {
-                    None => "(Waiting)".to_string(),
-                    Some(duration) => format_workunit_duration_ms(duration),
-                };
-                format!("{duration_label} {label}")
+        let mut snap = self.snapshot.lock();
+        for slot in snap.iter_mut() {
+            *slot = None;
+        }
+        for (n, span_id) in tasks_to_display.iter().enumerate() {
+            if n >= snap.len() {
+                break;
+            }
+            let (label, start_time) = heavy_hitters.get(span_id).unwrap();
+            snap[n] = Some(Task {
+                label: label.clone(),
+                start_time: *start_time,
             });
+        }
+    }
+}
 
-            match maybe_label {
-                Some(label) => pbar.set_message(label),
-                None => pbar.set_message(""),
+impl Drop for IndicatifInstance {
+    fn drop(&mut self) {
+        {
+            let (lock, cv) = &*self.stopping;
+            *lock.lock() = true;
+            cv.notify_all();
+        }
+        if let Some(h) = self.join_handle.take() {
+            // NB: The panic itself is reported by the global panic hook when it occurs; this
+            // only explains the consequence.
+            if h.join().is_err() {
+                log::warn!(
+                    "The UI render thread panicked (see error above); the dynamic UI was disabled for the remainder of the run."
+                );
+            }
+        }
+    }
+}
+
+struct RenderLoop {
+    // NB: Kept for Drop so the terminal is restored when the render thread exits.
+    _multi_progress: MultiProgress,
+    bars: Vec<ProgressBar>,
+    snapshot: Arc<Mutex<Vec<Option<Task>>>>,
+    stopping: Arc<(Mutex<bool>, Condvar)>,
+    interval: Duration,
+}
+
+impl RenderLoop {
+    fn run(self) {
+        loop {
+            // Clone the current snapshot out quickly so we don't hold the caller's lock
+            // while writing to the terminal.
+            let snap = self.snapshot.lock().clone();
+            let now = SystemTime::now();
+            for (n, pbar) in self.bars.iter().enumerate() {
+                match snap.get(n).and_then(|e| e.as_ref()) {
+                    Some(task) => {
+                        let duration_label = match now.duration_since(task.start_time).ok() {
+                            None => "(Waiting)".to_string(),
+                            Some(duration) => format_workunit_duration_ms(duration),
+                        };
+                        pbar.set_message(format!("{duration_label} {}", task.label));
+                    }
+                    None => pbar.set_message(""),
+                }
+                pbar.tick();
             }
 
-            pbar.tick();
+            let (lock, cv) = &*self.stopping;
+            let mut stopping = lock.lock();
+            if *stopping {
+                break;
+            }
+            cv.wait_for(&mut stopping, self.interval);
+            if *stopping {
+                break;
+            }
         }
     }
 }

--- a/src/rust/ui/src/instance/indicatif.rs
+++ b/src/rust/ui/src/instance/indicatif.rs
@@ -3,7 +3,6 @@
 
 use std::cmp;
 use std::collections::HashMap;
-use std::future;
 use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, SystemTime};
@@ -18,6 +17,8 @@ use indicatif::ProgressStyle;
 use indicatif::WeakProgressBar;
 use parking_lot::{Condvar, Mutex};
 
+use logging::fatal_log;
+use task_executor::Executor;
 use workunit_store::SpanId;
 use workunit_store::format_workunit_duration_ms;
 
@@ -32,6 +33,7 @@ struct Task {
 
 pub struct IndicatifInstance {
     tasks_to_display: IndexSet<SpanId>,
+    executor: Executor,
     snapshot: Arc<Mutex<Vec<Option<Task>>>>,
     stopping: Arc<(Mutex<bool>, Condvar)>,
     join_handle: Option<thread::JoinHandle<()>>,
@@ -39,6 +41,7 @@ pub struct IndicatifInstance {
 
 impl IndicatifInstance {
     pub fn new(
+        executor: Executor,
         local_parallelism: usize,
         terminal_width: u16,
         terminal_height: u16,
@@ -85,6 +88,7 @@ impl IndicatifInstance {
 
         Ok(IndicatifInstance {
             tasks_to_display: IndexSet::new(),
+            executor,
             snapshot,
             stopping,
             join_handle: Some(join_handle),
@@ -92,10 +96,26 @@ impl IndicatifInstance {
     }
 
     pub fn teardown(self) -> BoxFuture<'static, ()> {
-        // Drop signals the render thread to stop, joins it, and then drops the MultiProgress
-        // (which restores direct access to the Console).
-        std::mem::drop(self);
-        future::ready(()).boxed()
+        // Eagerly signal the render thread to stop, so that it winds down concurrently with
+        // acquiring a thread from the blocking pool below.
+        {
+            let (lock, cv) = &*self.stopping;
+            *lock.lock() = true;
+            cv.notify_all();
+        }
+        // Drop joins the render thread, which restores direct access to the Console as it exits:
+        // move the drop to the blocking pool so that the join cannot stall an async thread (or
+        // whoever holds the Session's display lock). The returned Future completes only once the
+        // Console has been restored; if it is instead dropped, teardown still completes in the
+        // background.
+        let executor = self.executor.clone();
+        let teardown = executor.spawn_blocking(move || std::mem::drop(self));
+        async move {
+            if let Err(e) = teardown.await {
+                fatal_log!("Failed to teardown UI: {e}");
+            }
+        }
+        .boxed()
     }
 
     pub fn render(&mut self, heavy_hitters: &HashMap<SpanId, (String, SystemTime)>) {

--- a/src/rust/ui/src/instance/indicatif.rs
+++ b/src/rust/ui/src/instance/indicatif.rs
@@ -82,7 +82,7 @@ impl IndicatifInstance {
             interval: ConsoleUI::render_interval(),
         };
         let join_handle = thread::Builder::new()
-            .name("pants-indicatif-render".into())
+            .name("pants-spinner".into())
             .spawn(move || render_loop.run())
             .map_err(|e| format!("Failed to spawn indicatif render thread: {e}"))?;
 


### PR DESCRIPTION
Previously we had the classic combination of doing "real work" and trying to keep a UI snappy on the same (scheduler) thread.  This results in jittery spinners that can be sluggish under load.

This change splits it out so there is a dedicated render thread.  This matches the architecture used by the `experimental-prodash` renderer. The "obvious" alternative to get a steady tick would be `enable_steady_tick`, but that was rejected in #19931 due to desync concerns.

Using the large repo from #23236

```
$ asciinema record data/baseline.cast --command  '_PANTS_VERSION_OVERRIDE=2.31.0 PANTS_DEBUG= /home/ecsb/src/o/pants-trees/baseline/pants --no-pantsd --changed-since=HEAD~1 --changed-dependents=transitive list'
```

baseline: https://asciinema.org/a/b67xISILRXqBQl4U

after: https://asciinema.org/a/DK0s3SB6ISjab6ji

Notice: I used a LLM to try a variety of approaches to reduce jitter and to write the code for this particular restructuring.  It is both the most clearly helpful, and a building block for anything else.  I also used a LLM to write a script to analyze asciinema logs, but in this case the visual outcome was obvious.