### PR TITLE
Make one of the Pex tests more robust.

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -203,8 +203,19 @@ def test_pex_environment(rule_runner: RuleRunner, pex_type: type[Pex | VenvPex])
 
 
 @pytest.mark.parametrize("pex_type", [Pex, VenvPex])
-def test_pex_working_directory(rule_runner: RuleRunner, pex_type: type[Pex | VenvPex]) -> None:
-    named_caches_dir = rule_runner.request(GlobalOptions, []).named_caches_dir
+def test_pex_working_directory(tmp_path: Path, pex_type: type[Pex | VenvPex]) -> None:
+    named_caches_dir = tmp_path / "named_caches"
+
+    rule_runner = RuleRunner(
+        rules=[
+            *pex_test_utils.rules(),
+            *pex_rules(),
+            QueryRule(Pex, (PexRequest,)),
+            QueryRule(VenvPex, (PexRequest,)),
+        ],
+        bootstrap_args=[f"--named-caches-dir={named_caches_dir}"],
+    )
+
     sources = rule_runner.request(
         Digest,
         [


### PR DESCRIPTION
`test_pex_working_directory[VenvPex]` manually deletes the venv dir
in the PEX_ROOT, in order to test the situation where pex creation
hits the process cache, while venv seeding misses the pex cache.

However this test was using the real, persistent named_caches dir,
and when pex recreates the venv it also tries to recreate a short
symlink to it, and since we didn't delete the original symlink 
(and we can't because we don't know where it is), pex tries
longer and longer prefixes until it gives up. See:

https://github.com/pex-tool/pex/blob/v2.92.3/pex/pex_bootstrapper.py#L553

So if we run the test enough times we eventually hit the "universe is broken"
case in that comment.

The fix is simply to use a tmp_dir as the named_caches dir, like several
other tests in this file. Then pex will only use up two of it 33 possible
increasing prefixes, and we won't hit the apocalypse.