### PR TITLE
make test_cache_scope_per_restart "more random"

### DIFF
--- a/src/python/pants/engine/process_test.py
+++ b/src/python/pants/engine/process_test.py
@@ -189,8 +189,8 @@ def test_cache_scope_successful(rule_runner: RuleRunner) -> None:
 
 
 def test_cache_scope_per_restart() -> None:
-    success_argv = ("/bin/bash", "-c", "echo $RANDOM")
-    failure_argv = ("/bin/bash", "-c", "echo $RANDOM; exit 1")
+    success_argv = ("/bin/bash", "-c", "echo $RANDOM$RANDOM")
+    failure_argv = ("/bin/bash", "-c", "echo $RANDOM$RANDOM; exit 1")
 
     always_cache_success = Process(
         success_argv, cache_scope=ProcessCacheScope.PER_RESTART_ALWAYS, description="foo"


### PR DESCRIPTION
We have one report of this flaking at #12499.  I have not been able to reproduce it locally and the test has been enabled for ~5 years without further reports.  Per
https://www.gnu.org/software/bash/manual/html_node/Bash-Variables.html `$RANDOM` "expands to a random integer between 0 and 32767" which isn't a very wide range.  (And I think it would also be fair to characterize it as only pseudo-random.)

To make this even less likely to re-occur, add an extra `$RANDOM` and call it a day.

(A "better" change would be to use `$SRANDOM`, but macs are on super old bash.)

closes #12499