### PR TITLE
Fix pex_venv_test.py

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex_venv_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_venv_test.py
@@ -44,7 +44,7 @@ def rule_runner() -> RuleRunner:
     )
 
 
-requirements = PexRequirements(["psycopg2-binary==2.9.6"])
+requirements = PexRequirements(["psycopg2-binary==2.9.12"])
 
 
 @pytest.fixture


### PR DESCRIPTION
Several of the tests in that file use `psycopg2-binary` as
a test requirement. Previously it used version 2.9.6, which
is not compatible with Python 3.14 on macos.

This change upgrades to psycopg2-binary==2.9.12, 
so that the test passes on macos.