### PR TITLE
update the default Pex version to v2.93.0

### DIFF
--- a/docs/notes/2.33.x.md
+++ b/docs/notes/2.33.x.md
@@ -32,6 +32,9 @@ The `docker_image` target now supports capturing file and directory artifacts fr
 
 The Python Build Standalone backend ([pants.backend.python.providers.experimental.python_build_standalone](https://www.pantsbuild.org/stable/reference/subsystems/python-build-standalone-python-provider)) has release metadata current through PBS release [20260414](https://github.com/astral-sh/python-build-standalone/releases/tag/20260414).
 
+The version of [Pex](https://github.com/pex-tool/pex) used by the Python backend has been upgraded to [`v2.93.0`](https://github.com/pex-tool/pex/releases/tag/v2.93.0). Of particular note for Pants users:
+ - Support for [Pip 26.1](https://pip.pypa.io/en/stable/news/#v26-1).
+
 #### Shell
 
 #### Javascript

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -37,9 +37,9 @@ from pants.util.strutil import softwrap
 logger = logging.getLogger(__name__)
 
 
-_PEX_VERSION = "v2.92.2"
-_PEX_BINARY_HASH = "5ccaf151161debe5381d767c7631b39d5516c7106e725c45dbae24aa0e5fe569"
-_PEX_BINARY_SIZE = 5081502
+_PEX_VERSION = "v2.93.0"
+_PEX_BINARY_HASH = "6f8b9f52c1a96e51345c0a60317165837d07309dce357ecb11d54e9c36d974e3"
+_PEX_BINARY_SIZE = 5134461
 
 
 class PexCli(TemplatedExternalTool):


### PR DESCRIPTION
Release Notes:
 * https://github.com/pex-tool/pex/releases/tag/v2.92.3
 * https://github.com/pex-tool/pex/releases/tag/v2.93.0