### PR TITLE
update the default Pex version to v2.93.2

### DIFF
--- a/docs/notes/2.33.x.md
+++ b/docs/notes/2.33.x.md
@@ -34,8 +34,9 @@ The `docker_image` target now supports capturing file and directory artifacts fr
 
 The Python Build Standalone backend ([pants.backend.python.providers.experimental.python_build_standalone](https://www.pantsbuild.org/stable/reference/subsystems/python-build-standalone-python-provider)) has release metadata current through PBS release [20260414](https://github.com/astral-sh/python-build-standalone/releases/tag/20260414).
 
-The version of [Pex](https://github.com/pex-tool/pex) used by the Python backend has been upgraded to [`v2.93.0`](https://github.com/pex-tool/pex/releases/tag/v2.93.0). Of particular note for Pants users:
+The version of [Pex](https://github.com/pex-tool/pex) used by the Python backend has been upgraded to [`v2.93.2`](https://github.com/pex-tool/pex/releases/tag/v2.93.2). Of particular note for Pants users:
  - Support for [Pip 26.1](https://pip.pypa.io/en/stable/news/#v26-1).
+ - In [some cases](https://github.com/pex-tool/pex/pull/3159) lockfile creation is significantly faster.
 
 #### Shell
 

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -37,9 +37,9 @@ from pants.util.strutil import softwrap
 logger = logging.getLogger(__name__)
 
 
-_PEX_VERSION = "v2.93.0"
-_PEX_BINARY_HASH = "6f8b9f52c1a96e51345c0a60317165837d07309dce357ecb11d54e9c36d974e3"
-_PEX_BINARY_SIZE = 5134461
+_PEX_VERSION = "v2.93.2"
+_PEX_BINARY_HASH = "75222f01b34cbe2bbe0aa9564dbf554d10dd22875ce59b6ea0c16665c92adc33"
+_PEX_BINARY_SIZE = 5116653
 
 
 class PexCli(TemplatedExternalTool):


### PR DESCRIPTION
Release Notes:
 * https://github.com/pex-tool/pex/releases/tag/v2.93.1
 * https://github.com/pex-tool/pex/releases/tag/v2.93.2