### PR TITLE
Fix the dynamic UI.

### DIFF
--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -58,6 +58,9 @@ _PRESERVED_ENV_VARS = [
     "http_proxy",  # for historical reasons, in some environments, *_proxy variables must be lowercase
     "https_proxy",
     "no_proxy",
+    # Used by indicatif.
+    "TERM",
+    "NO_COLOR",
 ]
 
 


### PR DESCRIPTION
In #23114 we upgraded to indicatif 0.18.4,
which included a fix to respect TERM, and 
display nothing if it's unset.

Since we did not pass TERM through pantsd, the
dynamic ui is now not shown. 

This change fixes that, and also pass NO_COLOR
through, since indicatif inspects it too.
