### PR TITLE
Better change detection on deleted files

### DIFF
--- a/docs/notes/2.33.x.md
+++ b/docs/notes/2.33.x.md
@@ -32,6 +32,8 @@ The `docker_image` target now supports capturing file and directory artifacts fr
 
 #### Python
 
+The `--changed-since` functionality now works correctly in the presence of deleted Python files. I.e., if test.py imports from foo.py and foo.py is deleted from the repo, then `--changed-since=...` with `--changed-dependents=transitive` will detect that test.py "depends" on the deleted file and, e.g., run it.
+
 The Python Build Standalone backend ([pants.backend.python.providers.experimental.python_build_standalone](https://www.pantsbuild.org/stable/reference/subsystems/python-build-standalone-python-provider)) has release metadata current through PBS release [20260414](https://github.com/astral-sh/python-build-standalone/releases/tag/20260414).
 
 The version of [Pex](https://github.com/pex-tool/pex) used by the Python backend has been upgraded to [`v2.93.2`](https://github.com/pex-tool/pex/releases/tag/v2.93.2). Of particular note for Pants users:

--- a/src/python/pants/backend/python/dependency_inference/module_mapper.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper.py
@@ -32,15 +32,18 @@ from pants.backend.python.target_types import (
     PythonResolveField,
     PythonSourceField,
 )
+from pants.core.target_types import DeletedSources, DeletedTarget
 from pants.core.util_rules.stripped_source_files import StrippedFileNameRequest, strip_file_name
 from pants.engine.addresses import Address
 from pants.engine.environment import EnvironmentName
+from pants.engine.internals.build_files import DELETED_ADDRESS
 from pants.engine.rules import collect_rules, concurrently, implicitly, rule
 from pants.engine.target import AllTargets, Target
 from pants.engine.unions import UnionMembership, UnionRule, union
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.strutil import softwrap
+from pants.vcs.changed import DeletedFiles, get_deleted_files
 
 logger = logging.getLogger(__name__)
 
@@ -83,10 +86,13 @@ def module_from_stripped_path(path: PurePath) -> str:
 class AllPythonTargets:
     first_party: tuple[Target, ...]
     third_party: tuple[Target, ...]
+    # Set this if using `--changed-since` and there are deleted files.
+    # Downstream code can use this to
+    deleted: DeletedTarget | None
 
 
 @rule(desc="Find all Python targets in project", level=LogLevel.DEBUG)
-async def find_all_python_projects(all_targets: AllTargets) -> AllPythonTargets:
+async def find_all_python_targets(all_targets: AllTargets) -> AllPythonTargets:
     first_party = []
     third_party = []
     for tgt in all_targets:
@@ -95,7 +101,12 @@ async def find_all_python_projects(all_targets: AllTargets) -> AllPythonTargets:
         if tgt.has_field(PythonRequirementsField):
             third_party.append(tgt)
 
-    return AllPythonTargets(tuple(sorted(first_party)), tuple(sorted(third_party)))
+    deleted_files: DeletedFiles = await get_deleted_files(**implicitly())
+    deleted_tgt = None
+    if deleted_files:
+        deleted_tgt = DeletedTarget({DeletedSources.alias: deleted_files.paths}, DELETED_ADDRESS)
+
+    return AllPythonTargets(tuple(sorted(first_party)), tuple(sorted(third_party)), deleted_tgt)
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/backend/python/dependency_inference/module_mapper.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper.py
@@ -32,18 +32,15 @@ from pants.backend.python.target_types import (
     PythonResolveField,
     PythonSourceField,
 )
-from pants.core.target_types import DeletedSources, DeletedTarget
 from pants.core.util_rules.stripped_source_files import StrippedFileNameRequest, strip_file_name
 from pants.engine.addresses import Address
 from pants.engine.environment import EnvironmentName
-from pants.engine.internals.build_files import DELETED_ADDRESS
 from pants.engine.rules import collect_rules, concurrently, implicitly, rule
 from pants.engine.target import AllTargets, Target
 from pants.engine.unions import UnionMembership, UnionRule, union
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.strutil import softwrap
-from pants.vcs.changed import DeletedFiles, get_deleted_files
 
 logger = logging.getLogger(__name__)
 
@@ -86,9 +83,6 @@ def module_from_stripped_path(path: PurePath) -> str:
 class AllPythonTargets:
     first_party: tuple[Target, ...]
     third_party: tuple[Target, ...]
-    # Set this if using `--changed-since` and there are deleted files.
-    # Downstream code can use this to
-    deleted: DeletedTarget | None
 
 
 @rule(desc="Find all Python targets in project", level=LogLevel.DEBUG)
@@ -101,12 +95,7 @@ async def find_all_python_targets(all_targets: AllTargets) -> AllPythonTargets:
         if tgt.has_field(PythonRequirementsField):
             third_party.append(tgt)
 
-    deleted_files: DeletedFiles = await get_deleted_files(**implicitly())
-    deleted_tgt = None
-    if deleted_files:
-        deleted_tgt = DeletedTarget({DeletedSources.alias: deleted_files.paths}, DELETED_ADDRESS)
-
-    return AllPythonTargets(tuple(sorted(first_party)), tuple(sorted(third_party)), deleted_tgt)
+    return AllPythonTargets(tuple(sorted(first_party)), tuple(sorted(third_party)))
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -15,10 +15,12 @@ from pants.backend.python.dependency_inference.default_unowned_dependencies impo
     DEFAULT_UNOWNED_DEPENDENCIES,
 )
 from pants.backend.python.dependency_inference.module_mapper import (
+    AllPythonTargets,
     PythonModuleOwners,
     PythonModuleOwnersRequest,
     ResolveName,
     map_module_to_address,
+    module_from_stripped_path,
 )
 from pants.backend.python.dependency_inference.parse_python_dependencies import (
     ParsedPythonAssetPaths,
@@ -46,7 +48,7 @@ from pants.backend.python.util_rules import ancestor_files, pex
 from pants.backend.python.util_rules.ancestor_files import AncestorFilesRequest, find_ancestor_files
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.core import target_types
-from pants.core.target_types import AllAssetTargetsByPath, map_assets_by_path
+from pants.core.target_types import AllAssetTargetsByPath, DeletedSources, map_assets_by_path
 from pants.core.util_rules import stripped_source_files
 from pants.core.util_rules.source_files import SourceFilesRequest, determine_source_files
 from pants.core.util_rules.unowned_dependency_behavior import (
@@ -54,6 +56,7 @@ from pants.core.util_rules.unowned_dependency_behavior import (
     UnownedDependencyUsage,
 )
 from pants.engine.addresses import Address, Addresses
+from pants.engine.internals.build_files import DELETED_ADDRESS
 from pants.engine.internals.graph import (
     OwnersRequest,
     determine_explicitly_provided_dependencies,
@@ -69,7 +72,12 @@ from pants.engine.target import (
     InferredDependencies,
 )
 from pants.engine.unions import UnionRule
-from pants.source.source_root import SourceRootRequest, get_source_root
+from pants.source.source_root import (
+    SourceRootRequest,
+    SourceRootsRequest,
+    get_source_root,
+    get_source_roots,
+)
 from pants.util.docutil import doc_url
 from pants.util.strutil import bullet_list, softwrap
 
@@ -461,6 +469,7 @@ async def infer_python_dependencies_via_source(
     request: InferPythonImportDependencies,
     python_infer_subsystem: PythonInferSubsystem,
     python_setup: PythonSetup,
+    all_python_targets: AllPythonTargets,
 ) -> InferredDependencies:
     if not python_infer_subsystem.imports and not python_infer_subsystem.assets:
         return InferredDependencies([])
@@ -490,6 +499,35 @@ async def infer_python_dependencies_via_source(
         parsed_dependencies.imports,
         resolve=resolve,
     )
+
+    if unowned_imports:
+        # Let's see if any of the unowned imports were provided by a deleted file.
+        deleted_python_files = (
+            tuple(
+                f
+                for f in (all_python_targets.deleted.get(DeletedSources).value or [])
+                if f.endswith((".py", ".pyi"))
+            )
+            if all_python_targets.deleted
+            else tuple()
+        )
+        if deleted_python_files:
+            source_roots_result = await get_source_roots(
+                SourceRootsRequest.for_files(deleted_python_files)
+            )
+            stripped_deleted_python_files = tuple(
+                f.relative_to(root.path) for f, root in source_roots_result.path_to_root.items()
+            )
+            deleted_modules = tuple(
+                module_from_stripped_path(f) for f in stripped_deleted_python_files
+            )
+            for impt in unowned_imports:
+                for mod in deleted_modules:
+                    if impt == mod or (impt.startswith(mod) and impt[len(mod)] == "."):
+                        # At least one unowned import was provided by a deleted file, so we
+                        # inject a dep on the DeletedTarget pseudo-target.
+                        inferred_deps = frozenset(inferred_deps | {DELETED_ADDRESS})
+                        break
 
     return InferredDependencies(sorted(inferred_deps))
 

--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -15,7 +15,6 @@ from pants.backend.python.dependency_inference.default_unowned_dependencies impo
     DEFAULT_UNOWNED_DEPENDENCIES,
 )
 from pants.backend.python.dependency_inference.module_mapper import (
-    AllPythonTargets,
     PythonModuleOwners,
     PythonModuleOwnersRequest,
     ResolveName,
@@ -48,7 +47,7 @@ from pants.backend.python.util_rules import ancestor_files, pex
 from pants.backend.python.util_rules.ancestor_files import AncestorFilesRequest, find_ancestor_files
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.core import target_types
-from pants.core.target_types import AllAssetTargetsByPath, DeletedSources, map_assets_by_path
+from pants.core.target_types import AllAssetTargetsByPath, map_assets_by_path
 from pants.core.util_rules import stripped_source_files
 from pants.core.util_rules.source_files import SourceFilesRequest, determine_source_files
 from pants.core.util_rules.unowned_dependency_behavior import (
@@ -80,6 +79,7 @@ from pants.source.source_root import (
 )
 from pants.util.docutil import doc_url
 from pants.util.strutil import bullet_list, softwrap
+from pants.vcs.changed import DeletedFiles, get_deleted_files
 
 logger = logging.getLogger(__name__)
 
@@ -469,7 +469,6 @@ async def infer_python_dependencies_via_source(
     request: InferPythonImportDependencies,
     python_infer_subsystem: PythonInferSubsystem,
     python_setup: PythonSetup,
-    all_python_targets: AllPythonTargets,
 ) -> InferredDependencies:
     if not python_infer_subsystem.imports and not python_infer_subsystem.assets:
         return InferredDependencies([])
@@ -502,15 +501,8 @@ async def infer_python_dependencies_via_source(
 
     if unowned_imports:
         # Let's see if any of the unowned imports were provided by a deleted file.
-        deleted_python_files = (
-            tuple(
-                f
-                for f in (all_python_targets.deleted.get(DeletedSources).value or [])
-                if f.endswith((".py", ".pyi"))
-            )
-            if all_python_targets.deleted
-            else tuple()
-        )
+        deleted_files: DeletedFiles = await get_deleted_files(**implicitly())
+        deleted_python_files = tuple(f for f in deleted_files.paths if f.endswith((".py", ".pyi")))
         if deleted_python_files:
             source_roots_result = await get_source_roots(
                 SourceRootsRequest.for_files(deleted_python_files)

--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -74,8 +74,8 @@ from pants.engine.unions import UnionRule
 from pants.source.source_root import (
     SourceRootRequest,
     SourceRootsRequest,
+    get_optional_source_roots,
     get_source_root,
-    get_source_roots,
 )
 from pants.util.docutil import doc_url
 from pants.util.strutil import bullet_list, softwrap
@@ -504,11 +504,14 @@ async def infer_python_dependencies_via_source(
         deleted_files: DeletedFiles = await get_deleted_files(**implicitly())
         deleted_python_files = tuple(f for f in deleted_files.paths if f.endswith((".py", ".pyi")))
         if deleted_python_files:
-            source_roots_result = await get_source_roots(
+            source_roots_result = await get_optional_source_roots(
                 SourceRootsRequest.for_files(deleted_python_files)
             )
+            # We drop files not under a source root, since they can't be used for import anyway.
             stripped_deleted_python_files = tuple(
-                f.relative_to(root.path) for f, root in source_roots_result.path_to_root.items()
+                f.relative_to(opt_root.source_root.path)
+                for f, opt_root in source_roots_result.path_to_optional_root.items()
+                if opt_root.source_root
             )
             deleted_modules = tuple(
                 module_from_stripped_path(f) for f in stripped_deleted_python_files

--- a/src/python/pants/core/register.py
+++ b/src/python/pants/core/register.py
@@ -36,6 +36,7 @@ from pants.core.goals import (
 )
 from pants.core.target_types import (
     ArchiveTarget,
+    DeletedTarget,
     FilesGeneratorTarget,
     FileTarget,
     GenericTarget,
@@ -125,6 +126,7 @@ def target_types():
         FilesGeneratorTarget,
         FileTarget,
         GenericTarget,
+        DeletedTarget,
         LocalEnvironmentTarget,
         LocalWorkspaceEnvironmentTarget,
         LockfilesGeneratorTarget,

--- a/src/python/pants/core/target_types.py
+++ b/src/python/pants/core/target_types.py
@@ -37,6 +37,8 @@ from pants.engine.fs import (
     RemovePrefix,
 )
 from pants.engine.internals.graph import find_valid_field_sets, hydrate_sources, resolve_targets
+from pants.engine.internals.mapper import DELETED_TARGET_TYPE
+from pants.engine.internals.native_engine import StringSequenceField
 from pants.engine.intrinsics import digest_to_snapshot
 from pants.engine.platform import Platform
 from pants.engine.rules import collect_rules, concurrently, implicitly, rule
@@ -647,6 +649,28 @@ class GenericTarget(Target):
 
         This can be used as a generic "bag of dependencies", i.e. you can group several different
         targets into one single target so that your other targets only need to depend on one thing.
+        """
+    )
+
+
+class DeletedSources(StringSequenceField):
+    alias = "deleted_sources"
+    help = "Deleted files"
+
+
+class DeletedTarget(Target):
+    alias = DELETED_TARGET_TYPE
+    core_fields = (DeletedSources,)
+    help = help_text(
+        """
+        A pseudo-target representing all files deleted from the repo, when using
+        `--changed-since`.
+
+        Not intended to be user-visible, and does not represent any "real" BUILD entity.
+        Can be used as a sentinel when inferring dependents of deleted files.
+
+        See DELETED_ADDRESS in src/python/pants/engine/internals/build_files.py for
+        details on how this is used.
         """
     )
 

--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -36,7 +36,12 @@ from pants.engine.internals.dep_rules import (
     DependencyRuleApplication,
     MaybeBuildFileDependencyRulesImplementation,
 )
-from pants.engine.internals.mapper import AddressFamily, AddressMap, DuplicateNameError
+from pants.engine.internals.mapper import (
+    DELETED_SPEC_PATH,
+    AddressFamily,
+    AddressMap,
+    DuplicateNameError,
+)
 from pants.engine.internals.parser import (
     BuildFilePreludeSymbols,
     BuildFileSymbolsInfo,
@@ -65,6 +70,24 @@ from pants.util.frozendict import FrozenDict
 from pants.util.strutil import softwrap
 
 logger = logging.getLogger(__name__)
+
+
+# Singleton for use as a reference to the DeletedTarget pseudo-target.
+# A backend can inject a dependency on DELETED_ADDRESS if it is capable of detecting
+# (via naming conventions) that a file depends on some other, deleted file.
+# The generic change detection mechanism will use that dependency to include the
+# files in the transitive closure of dependents of changed files.
+# This is somewhat limited - the backend doesn't get the content of the deleted file,
+# and so cannot use it in the regular inference pipeline.
+#
+# This is not the most elegant solution, but the legacy design of dep inference and of
+# change detection does not admit a simple one.
+#
+# A more global solution, that doesn't rely on backend specifics, would be to capture the
+# state of the repo before and after the changes and apply dep inference to both.
+# However that is a very substantial change from the status quo, so for now this
+# incremental improvement will suffice.
+DELETED_ADDRESS = Address(DELETED_SPEC_PATH)
 
 
 class BuildFileSyntaxError(SyntaxError):
@@ -168,6 +191,8 @@ async def get_all_build_file_symbols_info(
 
 @rule
 async def maybe_resolve_address(address_input: AddressInput) -> MaybeAddress:
+    if address_input.path_component == DELETED_ADDRESS.spec_path:
+        return MaybeAddress(DELETED_ADDRESS)
     # Determine the type of the path_component of the input.
     if address_input.path_component:
         paths = await path_globs_to_paths(PathGlobs(globs=(address_input.path_component,)))
@@ -225,6 +250,11 @@ class OptionalAddressFamily:
         if self.address_family is not None:
             return self.address_family
         raise ResolveError(f"Directory '{self.path}' does not contain any BUILD files.")
+
+
+_DELETED_OPTIONAL_ADDRESS_FAMILY = OptionalAddressFamily(
+    DELETED_ADDRESS.spec_path, AddressFamily.create(DELETED_ADDRESS.spec_path, [])
+)
 
 
 @rule
@@ -293,6 +323,9 @@ async def parse_address_family(
 
     The AddressFamily may be empty, but it will not be None.
     """
+    if directory.path == _DELETED_OPTIONAL_ADDRESS_FAMILY.path:
+        return _DELETED_OPTIONAL_ADDRESS_FAMILY
+
     digest_contents, all_synthetic_address_maps = await concurrently(
         get_digest_contents(
             **implicitly(

--- a/src/python/pants/engine/internals/mapper.py
+++ b/src/python/pants/engine/internals/mapper.py
@@ -34,6 +34,12 @@ class DuplicateNameError(MappingError):
 AddressMapT = TypeVar("AddressMapT", bound="AddressMap")
 
 
+# A pseudo-spec to refer to deleted paths.
+DELETED_SPEC_PATH = "__deleted"
+# A pseudo-target type to refer to deleted paths.
+DELETED_TARGET_TYPE = "__deleted_target"
+
+
 @dataclass(frozen=True)
 class AddressMap:
     """Maps target adaptors from a byte source."""
@@ -184,6 +190,8 @@ class AddressFamily:
         return tuple(addr.target_name for addr in self.addresses_to_target_adaptors)
 
     def get_target_adaptor(self, address: Address) -> TargetAdaptor | None:
+        if self.namespace == DELETED_SPEC_PATH:
+            return TargetAdaptor(DELETED_TARGET_TYPE, "deleted_files", "deleted files")
         assert address.spec_path == self.namespace
         entry = self.name_to_target_adaptors.get(address.target_name)
         if entry is None:

--- a/src/python/pants/init/specs_calculator.py
+++ b/src/python/pants/init/specs_calculator.py
@@ -11,6 +11,7 @@ from pants.core.environments.rules import determine_bootstrap_environment
 from pants.core.util_rules.system_binaries import GitBinary
 from pants.engine.addresses import AddressInput
 from pants.engine.environment import EnvironmentName
+from pants.engine.internals.build_files import DELETED_ADDRESS
 from pants.engine.internals.graph import FilesWithSourceBlocks
 from pants.engine.internals.scheduler import SchedulerSession
 from pants.engine.internals.selectors import Params
@@ -111,14 +112,16 @@ def calculate_specs(
     address_literal_specs = []
     for address in cast(ChangedAddresses, changed_addresses):
         address_input = AddressInput.parse(address.spec, description_of_origin="`--changed-since`")
-        address_literal_specs.append(
-            AddressLiteralSpec(
-                path_component=address_input.path_component,
-                target_component=address_input.target_component,
-                generated_component=address_input.generated_component,
-                parameters=FrozenDict(address_input.parameters),
+        # The pseudo-target has done its job, but we don't want to actually see it downstream.
+        if address != DELETED_ADDRESS:
+            address_literal_specs.append(
+                AddressLiteralSpec(
+                    path_component=address_input.path_component,
+                    target_component=address_input.target_component,
+                    generated_component=address_input.generated_component,
+                    parameters=FrozenDict(address_input.parameters),
+                )
             )
-        )
 
     return Specs(
         includes=RawSpecs(

--- a/src/python/pants/vcs/changed.py
+++ b/src/python/pants/vcs/changed.py
@@ -12,7 +12,13 @@ from pants.backend.project_info.dependents import DependentsRequest, find_depend
 from pants.base.build_environment import get_buildroot
 from pants.engine.addresses import Address, Addresses
 from pants.engine.collection import Collection
-from pants.engine.internals.graph import OwnersRequest, find_owners, resolve_unexpanded_targets
+from pants.engine.internals.build_files import DELETED_ADDRESS
+from pants.engine.internals.graph import (
+    Owners,
+    OwnersRequest,
+    find_owners,
+    resolve_unexpanded_targets,
+)
 from pants.engine.internals.mapper import SpecsFilter
 from pants.engine.rules import collect_rules, implicitly, rule
 from pants.option.option_types import EnumOption, StrOption
@@ -22,7 +28,8 @@ from pants.util.docutil import doc_url
 from pants.util.frozendict import FrozenDict
 from pants.util.ordered_set import FrozenOrderedSet
 from pants.util.strutil import help_text
-from pants.vcs.git import GitWorktree
+from pants.vcs.change import ChangedFile, ChangeType
+from pants.vcs.git import GitWorktree, GitWorktreeRequest, get_git_worktree
 from pants.vcs.hunk import Hunk, TextBlocks
 
 
@@ -62,6 +69,7 @@ async def find_changed_owners(
         ),
         **implicitly(),
     )
+    owners = Owners(owners | {DELETED_ADDRESS})
 
     if no_dependents:
         return ChangedAddresses(owners)
@@ -119,22 +127,27 @@ class ChangedOptions:
     def provided(self) -> bool:
         return bool(self.since) or bool(self.diffspec)
 
-    def changed_files(self, git_worktree: GitWorktree) -> set[str]:
-        """Determines the files changed according to SCM/workspace and options."""
+    def _changed_files(self, git_worktree: GitWorktree) -> set[ChangedFile]:
         if self.diffspec:
-            return {
-                cf.path
-                for cf in git_worktree.changes_in(self.diffspec, relative_to=get_buildroot())
-            }
+            return git_worktree.changes_in(self.diffspec, relative_to=get_buildroot())
 
         changes_since = self.since or git_worktree.current_rev_identifier
+        return git_worktree.changed_files(
+            from_commit=changes_since,
+            include_untracked=True,
+            relative_to=get_buildroot(),
+        )
+
+    def changed_files(self, git_worktree: GitWorktree) -> set[str]:
+        """Determines the files changed according to SCM/workspace and options."""
+        return {cf.path for cf in self._changed_files(git_worktree)}
+
+    def deleted_files(self, git_worktree: GitWorktree) -> set[str]:
+        """Determines the files deleted according to SCM/workspace and options."""
         return {
             cf.path
-            for cf in git_worktree.changed_files(
-                from_commit=changes_since,
-                include_untracked=True,
-                relative_to=get_buildroot(),
-            )
+            for cf in self._changed_files(git_worktree)
+            if cf.change_type == ChangeType.DELETED
         }
 
     def diff_hunks(
@@ -175,6 +188,24 @@ class Changed(Subsystem):
         default=DependentsOption.NONE,
         help="Include direct or transitive dependents of changed targets.",
     )
+
+
+@dataclass(frozen=True)
+class DeletedFiles:
+    paths: tuple[str, ...]
+
+
+@rule
+async def get_deleted_files(changed: Changed) -> DeletedFiles:
+    changed_options = ChangedOptions.from_options(changed.options)
+    maybe_git_worktree = await get_git_worktree(GitWorktreeRequest(), **implicitly())
+    if maybe_git_worktree.git_worktree:
+        deleted_files = tuple(
+            sorted(changed_options.deleted_files(maybe_git_worktree.git_worktree))
+        )
+    else:
+        deleted_files = tuple()
+    return DeletedFiles(deleted_files)
 
 
 def rules():

--- a/src/python/pants/vcs/changed.py
+++ b/src/python/pants/vcs/changed.py
@@ -198,6 +198,8 @@ class DeletedFiles:
 @rule
 async def get_deleted_files(changed: Changed) -> DeletedFiles:
     changed_options = ChangedOptions.from_options(changed.options)
+    if not changed_options.provided:
+        return DeletedFiles(tuple())
     maybe_git_worktree = await get_git_worktree(GitWorktreeRequest(), **implicitly())
     if maybe_git_worktree.git_worktree:
         deleted_files = tuple(

--- a/src/python/pants/vcs/changed_integration_test.py
+++ b/src/python/pants/vcs/changed_integration_test.py
@@ -106,7 +106,10 @@ def _run_pants_goal(
             goal,
         ],
         workdir=workdir,
-        config={"GLOBAL": {"backend_packages": ["pants.backend.shell"]}},
+        config={
+            "GLOBAL": {"backend_packages": ["pants.backend.python", "pants.backend.shell"]},
+            "python": {"interpreter_constraints": ["==3.14.*"]},
+        },
     )
 
 
@@ -293,3 +296,48 @@ def test_pants_ignored_file(repo: str) -> None:
     for dependents in (DependentsOption.NONE, DependentsOption.DIRECT):
         assert_list_stdout(repo, [], dependents)
         assert_count_loc(repo, dependents, expected_num_files=0)
+
+
+def test_deleted_file() -> None:
+    with temporary_dir(root_dir=get_buildroot()) as worktree:
+        _run_git(["init"])
+        _run_git(["config", "user.email", "you@example.com"])
+        _run_git(["config", "user.name", "Your Name"])
+        _run_git(["config", "commit.gpgsign", "false"])
+
+        # Currently only the python backend supports deleted file deps properly,
+        # so we use a python example.
+        project = {
+            ".gitignore": dedent(
+                f"""\
+                {Path(worktree).relative_to(get_buildroot())}
+                .pants.d/pids
+                __pycache__
+                .coverage.*  # For some reason, CI adds these files
+                """
+            ),
+            "src/python/top/foo.py": "",
+            "src/python/top/bar.py": "import top.foo",
+            "src/python/top/bar_test.py": "import top.bar",
+            "src/python/top/BUILD": dedent(
+                """\
+                python_sources()
+                python_tests(name="tests")
+                """
+            ),
+        }
+        for fp, content in project.items():
+            create_file(fp, content)
+
+        _run_git(["add", "."])
+        _run_git(["commit", "-m", "blah"])
+
+        delete_file("src/python/top/foo.py")
+        result = _run_pants_goal(worktree, "list", DependentsOption.TRANSITIVE)
+        result.assert_success()
+        assert sorted(result.stdout.strip().splitlines()) == [
+            "src/python/top/bar.py",
+            "src/python/top/bar_test.py:tests",
+            "src/python/top:tests",
+            "src/python/top:top",
+        ]


### PR DESCRIPTION
There are several longstanding issues on this:

https://github.com/pantsbuild/pants/issues/13232
https://github.com/pantsbuild/pants/issues/14975
https://github.com/pantsbuild/pants/issues/17512
https://github.com/pantsbuild/pants/issues/23240

This has historically been intractable because the
design of dep inference and of change detection
are at odds with each other.

A fully robust solution is still somewhat out of reach,
but this change provides a general-purpose mechanism
that backends can opt in to, and uses that mechanism
in the python backend.

The result is a substantial yet incremental improvement
in the most prominent use case.

The limitation of this mechanism is that it can only
be used if a backend can infer a likely dependency on
a file simply from its path. In Python this is possible because
dotted module paths must recapitulate the filesystem path
from the source root. But this is not true in general for
all languages.