### PR TITLE
Differentiate types of git changes (Cherry-pick of #23309)

### DIFF
--- a/src/python/pants/vcs/change.py
+++ b/src/python/pants/vcs/change.py
@@ -1,0 +1,19 @@
+# Copyright 2026 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class ChangeType(Enum):
+    ADDED = "A"
+    DELETED = "D"
+    MODIFIED = "M"
+
+
+@dataclass(frozen=True)
+class ChangedFile:
+    path: str
+    change_type: ChangeType

--- a/src/python/pants/vcs/changed.py
+++ b/src/python/pants/vcs/changed.py
@@ -122,14 +122,20 @@ class ChangedOptions:
     def changed_files(self, git_worktree: GitWorktree) -> set[str]:
         """Determines the files changed according to SCM/workspace and options."""
         if self.diffspec:
-            return git_worktree.changes_in(self.diffspec, relative_to=get_buildroot())
+            return {
+                cf.path
+                for cf in git_worktree.changes_in(self.diffspec, relative_to=get_buildroot())
+            }
 
         changes_since = self.since or git_worktree.current_rev_identifier
-        return git_worktree.changed_files(
-            from_commit=changes_since,
-            include_untracked=True,
-            relative_to=get_buildroot(),
-        )
+        return {
+            cf.path
+            for cf in git_worktree.changed_files(
+                from_commit=changes_since,
+                include_untracked=True,
+                relative_to=get_buildroot(),
+            )
+        }
 
     def diff_hunks(
         self, git_worktree: GitWorktree, paths: Iterable[str]

--- a/src/python/pants/vcs/git.py
+++ b/src/python/pants/vcs/git.py
@@ -20,6 +20,7 @@ from pants.core.util_rules.system_binaries import GitBinary, GitBinaryException,
 from pants.engine.engine_aware import EngineAwareReturnType
 from pants.engine.rules import collect_rules, rule
 from pants.util.contextutil import pushd
+from pants.vcs.change import ChangedFile, ChangeType
 from pants.vcs.hunk import Hunk, TextBlock
 
 logger = logging.getLogger(__name__)
@@ -83,28 +84,33 @@ class GitWorktree(EngineAwareReturnType):
         from_commit: str | None = None,
         include_untracked: bool = False,
         relative_to: PurePath | str | None = None,
-    ) -> set[str]:
+    ) -> set[ChangedFile]:
         relative_to = PurePath(relative_to) if relative_to is not None else self.worktree
         rel_suffix = ["--", str(relative_to)]
+
+        files: dict[str, ChangeType] = {}
+
         uncommitted_changes = self._git_binary._invoke_unsandboxed(
             self._create_git_cmdline(
-                ["diff", "--name-only", "HEAD"] + rel_suffix,
+                ["diff", "--name-status", "--no-renames", "HEAD"] + rel_suffix,
             )
         )
+        files.update(self._parse_name_status(uncommitted_changes))
 
-        files = set(uncommitted_changes.decode().splitlines())
         if from_commit:
             # Grab the diff from the merge-base to HEAD using ... syntax.  This ensures we have just
             # the changes that have occurred on the current branch.
             committed_cmd = [
                 "diff",
-                "--name-only",
+                "--name-status",
+                "--no-renames",
                 from_commit + "...HEAD",
             ] + rel_suffix
             committed_changes = self._git_binary._invoke_unsandboxed(
                 self._create_git_cmdline(committed_cmd)
             )
-            files.update(committed_changes.decode().splitlines())
+            files.update(self._parse_name_status(committed_changes))
+
         if include_untracked:
             untracked_cmd = [
                 "ls-files",
@@ -115,9 +121,36 @@ class GitWorktree(EngineAwareReturnType):
             untracked = self._git_binary._invoke_unsandboxed(
                 self._create_git_cmdline(untracked_cmd)
             )
-            files.update(untracked.decode().splitlines())
+            files.update(
+                {path: ChangeType.ADDED for path in untracked.decode().splitlines() if path}
+            )
+
         # git will report changed files relative to the worktree: re-relativize to relative_to
-        return {self._fix_git_relative_path(f, relative_to) for f in files}
+        return {
+            ChangedFile(
+                path=self._fix_git_relative_path(path, relative_to),
+                change_type=change_type,
+            )
+            for path, change_type in files.items()
+        }
+
+    @staticmethod
+    def _parse_name_status(output: bytes) -> dict[str, ChangeType]:
+        """Parse `git diff --name-status` output into a dict of path -> ChangeType."""
+        result = {}
+        for line in output.decode().splitlines():
+            if not line:
+                continue
+            status, _, path = line.partition("\t")
+            letter = status[0].upper() if status else "M"
+            try:
+                change_type = ChangeType(letter)
+            except ValueError:
+                # Git may report various other esoteric statuses.
+                # We treat anything that isn't A, D or M as if it were M.
+                change_type = ChangeType.MODIFIED
+            result[path] = change_type
+        return result
 
     def changed_files_lines(
         self,
@@ -175,15 +208,19 @@ class GitWorktree(EngineAwareReturnType):
         """Run unsandboxed git diff command and parse the diff."""
         return self._diff_parser.parse_unified_diff(self._git("diff", *args))
 
-    def changes_in(self, diffspec: str, relative_to: PurePath | str | None = None) -> set[str]:
+    def changes_in(
+        self, diffspec: str, relative_to: PurePath | str | None = None
+    ) -> set[ChangedFile]:
         relative_to = PurePath(relative_to) if relative_to is not None else self.worktree
-        cmd = ["diff-tree", "--no-commit-id", "--name-only", "-r", diffspec]
-        files = (
-            self._git_binary._invoke_unsandboxed(self._create_git_cmdline(cmd))
-            .decode()
-            .splitlines()
-        )
-        return {self._fix_git_relative_path(f.strip(), relative_to) for f in files}
+        cmd = ["diff-tree", "--no-commit-id", "--name-status", "--no-renames", "-r", diffspec]
+        output = self._git_binary._invoke_unsandboxed(self._create_git_cmdline(cmd))
+        return {
+            ChangedFile(
+                path=self._fix_git_relative_path(path, relative_to),
+                change_type=change_type,
+            )
+            for path, change_type in self._parse_name_status(output).items()
+        }
 
     def _create_git_cmdline(self, args: Iterable[str]) -> list[str]:
         return [f"--git-dir={self._gitdir}", f"--work-tree={self.worktree}", *args]

--- a/src/python/pants/vcs/git_test.py
+++ b/src/python/pants/vcs/git_test.py
@@ -151,7 +151,7 @@ parametrize_changed_files = pytest.mark.parametrize(
     [
         (
             "changed_files",
-            lambda git: git.changed_files,
+            lambda git: lambda **kwargs: {cf.path for cf in git.changed_files(**kwargs)},
             lambda files: set(files.keys()),
         ),
         (
@@ -286,6 +286,10 @@ def test_changes_in(gitdir: PurePath, worktree: Path, git: MutatingGitWorktree) 
     it will pass the diffspec to git diff-tree, but this should serve to at least document the
     functionality we believe works.
     """
+
+    def changes(diffspec: str) -> set[tuple[str, str]]:
+        return {(cf.path, cf.change_type.value) for cf in git.changes_in(diffspec)}
+
     with environment_as(GIT_DIR=str(gitdir), GIT_WORK_TREE=str(worktree)):
 
         def commit_contents_to_files(content: str, *files: str) -> str:
@@ -297,41 +301,46 @@ def test_changes_in(gitdir: PurePath, worktree: Path, git: MutatingGitWorktree) 
 
         # We can get changes in HEAD or by SHA
         c1 = commit_contents_to_files("1", "foo")
-        assert {"foo"} == git.changes_in("HEAD")
-        assert {"foo"} == git.changes_in(c1)
+        assert {("foo", "A")} == changes("HEAD")
+        assert {("foo", "A")} == changes(c1)
 
         # Changes in new HEAD, from old-to-new HEAD, in old HEAD, or from old-old-head to new.
         commit_contents_to_files("2", "bar")
-        assert {"bar"} == git.changes_in("HEAD")
-        assert {"bar"} == git.changes_in("HEAD^..HEAD")
-        assert {"foo"} == git.changes_in("HEAD^")
-        assert {"foo"} == git.changes_in("HEAD~1")
-        assert {"foo", "bar"} == git.changes_in("HEAD^^..HEAD")
+        assert {("bar", "A")} == changes("HEAD")
+        assert {("bar", "A")} == changes("HEAD^..HEAD")
+        assert {("foo", "A")} == changes("HEAD^")
+        assert {("foo", "A")} == changes("HEAD~1")
+        assert {("foo", "A"), ("bar", "A")} == changes("HEAD^^..HEAD")
 
         # New commit doesn't change results-by-sha
-        assert {"foo"} == git.changes_in(c1)
+        assert {("foo", "A")} == changes(c1)
 
-        # Files changed in multiple diffs within a range
+        # Files changed in multiple diffs within a range: foo was added in c1 then modified in c3.
         c3 = commit_contents_to_files("3", "foo")
-        assert {"foo", "bar"} == git.changes_in(f"{c1}..{c3}")
+        assert {("bar", "A"), ("foo", "M")} == changes(f"{c1}..{c3}")
 
-        # Changes in a tag
+        # Changes in a tag; foo was modified in c3
         subprocess.check_call(["git", "tag", "v1"])
-        assert {"foo"} == git.changes_in("v1")
+        assert {("foo", "M")} == changes("v1")
 
         # Introduce a new filename
         c4 = commit_contents_to_files("4", "baz")
-        assert {"baz"} == git.changes_in("HEAD")
+        assert {("baz", "A")} == changes("HEAD")
 
         # Tag-to-sha
-        assert {"baz"} == git.changes_in(f"v1..{c4}")
+        assert {("baz", "A")} == changes(f"v1..{c4}")
 
-        # We can get multiple changes from one ref
+        # We can get multiple changes from one ref: bar was added in c2 then modified in c5.
         commit_contents_to_files("5", "foo", "bar")
-        assert {"foo", "bar"} == git.changes_in("HEAD")
-        assert {"foo", "bar", "baz"} == git.changes_in("HEAD~4..HEAD")
-        assert {"foo", "bar", "baz"} == git.changes_in(f"{c1}..HEAD")
-        assert {"foo", "bar", "baz"} == git.changes_in(f"{c1}..{c4}")
+        assert {("foo", "M"), ("bar", "M")} == changes("HEAD")
+        assert {("foo", "M"), ("bar", "A"), ("baz", "A")} == changes("HEAD~4..HEAD")
+        assert {("foo", "M"), ("bar", "A"), ("baz", "A")} == changes(f"{c1}..HEAD")
+        assert {("bar", "A"), ("foo", "M"), ("baz", "A")} == changes(f"{c1}..{c4}")
+
+        (worktree / "baz").unlink()
+        subprocess.check_call(["git", "rm", "baz"])
+        subprocess.check_call(["git", "commit", "-m", "delete baz"])
+        assert {("baz", "D")} == changes("HEAD")
 
 
 @parametrize_changed_files


### PR DESCRIPTION
When interrogating git to compute `--changed-*`
specs, we now record the type of git change 
(add, modify, delete).

We don't yet do anything with this information.
This is initial work towards fixing #17512/#23240.
