### PR TITLE
Fix jar-tool repacking for DEFLATED ZIP entries that use data descriptors

### DIFF
--- a/docs/notes/2.33.x.md
+++ b/docs/notes/2.33.x.md
@@ -30,6 +30,8 @@ The `docker_image` target now supports capturing file and directory artifacts fr
 
 #### JVM
 
+Fix jar-tool repacking for DEFLATED ZIP entries that use data descriptors.
+
 #### Python
 
 The `--changed-since` functionality now works correctly in the presence of deleted Python files. I.e., if test.py imports from foo.py and foo.py is deleted from the repo, then `--changed-since=...` with `--changed-dependents=transitive` will detect that test.py "depends" on the deleted file and, e.g., run it.

--- a/src/python/pants/jvm/jar_tool/jar_tool_integration_test.py
+++ b/src/python/pants/jvm/jar_tool/jar_tool_integration_test.py
@@ -1,0 +1,105 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import pytest
+
+from pants.backend.java.dependency_inference.rules import rules as java_dep_inf_rules
+from pants.backend.java.target_types import rules as target_types_rules
+from pants.core.util_rules import archive, system_binaries
+from pants.core.util_rules.archive import ExtractedArchive, MaybeExtractArchiveRequest
+from pants.engine.fs import Digest, Snapshot
+from pants.jvm import compile as jvm_compile
+from pants.jvm import jdk_rules, non_jvm_dependencies
+from pants.jvm.classpath import rules as classpath_rules
+from pants.jvm.compile import ClasspathEntry
+from pants.jvm.jar_tool import jar_tool
+from pants.jvm.jar_tool.jar_tool import JarToolRequest
+from pants.jvm.resolve import coursier_fetch, coursier_setup, jvm_tool
+from pants.jvm.resolve.common import ArtifactRequirement, ArtifactRequirements
+from pants.jvm.resolve.coordinate import Coordinate, Coordinates
+from pants.jvm.resolve.coursier_fetch import CoursierLockfileEntry, CoursierResolvedLockfile
+from pants.jvm.testutil import maybe_skip_jdk_test
+from pants.jvm.util_rules import rules as util_rules
+from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunner
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    rule_runner = RuleRunner(
+        rules=[
+            *system_binaries.rules(),
+            *archive.rules(),
+            *coursier_setup.rules(),
+            *coursier_fetch.rules(),
+            *classpath_rules(),
+            *jvm_tool.rules(),
+            *jar_tool.rules(),
+            *jvm_compile.rules(),
+            *non_jvm_dependencies.rules(),
+            *jdk_rules.rules(),
+            *java_dep_inf_rules(),
+            *util_rules(),
+            *target_types_rules(),
+            QueryRule(Digest, (JarToolRequest,)),
+            QueryRule(ExtractedArchive, (MaybeExtractArchiveRequest,)),
+            QueryRule(CoursierResolvedLockfile, (ArtifactRequirements,)),
+            QueryRule(ClasspathEntry, (CoursierLockfileEntry,)),
+        ],
+    )
+    rule_runner.set_options(args=[], env_inherit=PYTHON_BOOTSTRAP_ENV)
+    return rule_runner
+
+
+@maybe_skip_jdk_test
+def test_repack_exact_iceberg_runtime_jar(rule_runner: RuleRunner) -> None:
+    requirement = ArtifactRequirement(
+        coordinate=Coordinate(
+            group="org.apache.iceberg",
+            artifact="iceberg-spark-runtime-4.0_2.13",
+            version="1.10.1",
+        ),
+        url="https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark-runtime-4.0_2.13/1.10.1/iceberg-spark-runtime-4.0_2.13-1.10.1.jar",
+    )
+    resolved_lockfile = rule_runner.request(
+        CoursierResolvedLockfile,
+        [ArtifactRequirements([requirement])],
+    )
+    assert resolved_lockfile.entries
+    entry = resolved_lockfile.entries[0]
+
+    classpath_entry = rule_runner.request(
+        ClasspathEntry,
+        [
+            CoursierLockfileEntry(
+                coord=entry.coord,
+                file_name=entry.file_name,
+                direct_dependencies=Coordinates([]),
+                dependencies=Coordinates([]),
+                file_digest=entry.file_digest,
+                remote_url=requirement.url,
+            )
+        ],
+    )
+    assert classpath_entry.filenames == (entry.file_name,)
+
+    jar_digest = rule_runner.request(
+        Digest,
+        [
+            JarToolRequest(
+                jar_name="output.jar",
+                digest=classpath_entry.digest,
+                jars=[entry.file_name],
+                compress=True,
+                policies=[("^LICENSE", "replace")],
+            )
+        ],
+    )
+
+    jar_extracted = rule_runner.request(
+        ExtractedArchive, [MaybeExtractArchiveRequest(digest=jar_digest, use_suffix=".zip")]
+    )
+    jar_snapshot = rule_runner.request(Snapshot, [jar_extracted.digest])
+    assert "org/apache/iceberg/spark/SparkCatalog.class" in jar_snapshot.files
+    assert "LICENSE" in jar_snapshot.files

--- a/src/python/pants/jvm/jar_tool/jar_tool_integration_test.py
+++ b/src/python/pants/jvm/jar_tool/jar_tool_integration_test.py
@@ -3,24 +3,23 @@
 
 from __future__ import annotations
 
-from textwrap import dedent
-
 import pytest
 
 from pants.backend.java.dependency_inference.rules import rules as java_dep_inf_rules
 from pants.backend.java.target_types import rules as target_types_rules
 from pants.core.util_rules import archive, system_binaries
 from pants.core.util_rules.archive import ExtractedArchive, MaybeExtractArchiveRequest
-from pants.core.util_rules.system_binaries import BashBinary
-from pants.engine.fs import CreateDigest, Digest, FileContent, Snapshot
-from pants.engine.process import Process, ProcessResult
+from pants.engine.fs import Digest, Snapshot
 from pants.jvm import compile as jvm_compile
 from pants.jvm import jdk_rules, non_jvm_dependencies
 from pants.jvm.classpath import rules as classpath_rules
+from pants.jvm.compile import ClasspathEntry
 from pants.jvm.jar_tool import jar_tool
 from pants.jvm.jar_tool.jar_tool import JarToolRequest
-from pants.jvm.jdk_rules import InternalJdk
 from pants.jvm.resolve import coursier_fetch, coursier_setup, jvm_tool
+from pants.jvm.resolve.common import ArtifactRequirement, ArtifactRequirements
+from pants.jvm.resolve.coordinate import Coordinate, Coordinates
+from pants.jvm.resolve.coursier_fetch import CoursierLockfileEntry, CoursierResolvedLockfile
 from pants.jvm.testutil import maybe_skip_jdk_test
 from pants.jvm.util_rules import rules as util_rules
 from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunner
@@ -45,101 +44,55 @@ def rule_runner() -> RuleRunner:
             *target_types_rules(),
             QueryRule(Digest, (JarToolRequest,)),
             QueryRule(ExtractedArchive, (MaybeExtractArchiveRequest,)),
-            QueryRule(BashBinary, ()),
-            QueryRule(InternalJdk, ()),
-            QueryRule(ProcessResult, (Process,)),
+            QueryRule(CoursierResolvedLockfile, (ArtifactRequirements,)),
+            QueryRule(ClasspathEntry, (CoursierLockfileEntry,)),
         ],
     )
     rule_runner.set_options(args=[], env_inherit=PYTHON_BOOTSTRAP_ENV)
     return rule_runner
 
 
-JAR_FIXTURE_SRC = dedent(
-    """\
-    import java.io.OutputStream;
-    import java.nio.file.Files;
-    import java.nio.file.Path;
-    import java.util.jar.JarEntry;
-    import java.util.jar.JarOutputStream;
+@maybe_skip_jdk_test
+def test_repack_exact_iceberg_runtime_jar(rule_runner: RuleRunner) -> None:
+    requirement = ArtifactRequirement(
+        coordinate=Coordinate(
+            group="org.apache.iceberg",
+            artifact="iceberg-spark-runtime-4.0_2.13",
+            version="1.10.1",
+        ),
+        url="https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark-runtime-4.0_2.13/1.10.1/iceberg-spark-runtime-4.0_2.13-1.10.1.jar",
+    )
+    resolved_lockfile = rule_runner.request(
+        CoursierResolvedLockfile,
+        [ArtifactRequirements([requirement])],
+    )
+    assert resolved_lockfile.entries
+    entry = resolved_lockfile.entries[0]
 
-    public class MakeJarWithDataDescriptor {
-      public static void main(String[] args) throws Exception {
-        Path output = Path.of(args[0]);
-        try (OutputStream os = Files.newOutputStream(output);
-            JarOutputStream jos = new JarOutputStream(os)) {
-          write(jos, "META-INF/", new byte[0]);
-          write(jos, "META-INF/MANIFEST.MF", "Manifest-Version: 1.0\\n".getBytes());
-          write(jos, "org/", new byte[0]);
-          write(jos, "org/apache/", new byte[0]);
-          write(jos, "org/apache/iceberg/", new byte[0]);
-          write(jos, "org/apache/iceberg/spark/", new byte[0]);
-          write(jos, "org/apache/iceberg/spark/SparkCatalog.class", "bytecode".repeat(2000).getBytes());
-          write(jos, "LICENSE", "license-one".getBytes());
-        }
-      }
-
-      private static void write(JarOutputStream jos, String name, byte[] content) throws Exception {
-        JarEntry entry = new JarEntry(name);
-        entry.setMethod(JarEntry.DEFLATED);
-        jos.putNextEntry(entry);
-        jos.write(content);
-        jos.closeEntry();
-      }
-    }
-    """
-)
-
-
-def _create_data_descriptor_jar(rule_runner: RuleRunner) -> Digest:
-    jdk = rule_runner.request(InternalJdk, [])
-    bash = rule_runner.request(BashBinary, [])
-    digest = rule_runner.request(
-        Digest,
+    classpath_entry = rule_runner.request(
+        ClasspathEntry,
         [
-            CreateDigest(
-                [
-                    FileContent("MakeJarWithDataDescriptor.java", JAR_FIXTURE_SRC.encode()),
-                    FileContent("out/input.jar", b""),
-                ]
+            CoursierLockfileEntry(
+                coord=entry.coord,
+                file_name=entry.file_name,
+                direct_dependencies=Coordinates([]),
+                dependencies=Coordinates([]),
+                file_digest=entry.file_digest,
+                remote_url=requirement.url,
             )
         ],
     )
-    compile_and_build = Process(
-        argv=[
-            bash.path,
-            jdk.jdk_preparation_script,
-            bash.path,
-            "-c",
-            " && ".join(
-                [
-                    "__java_home/bin/javac MakeJarWithDataDescriptor.java",
-                    "__java_home/bin/java MakeJarWithDataDescriptor out/input.jar",
-                ]
-            ),
-        ],
-        input_digest=digest,
-        immutable_input_digests=jdk.immutable_input_digests,
-        append_only_caches=jdk.append_only_caches,
-        env={"PANTS_INTERNAL_ABSOLUTE_PREFIX": "", **jdk.env},
-        output_files=("MakeJarWithDataDescriptor.class", "out/input.jar"),
-        description="Build local test jar",
-    )
-    result = rule_runner.request(ProcessResult, [compile_and_build])
-    return result.output_digest
-
-
-@maybe_skip_jdk_test
-def test_repack_jar_with_data_descriptor_entries(rule_runner: RuleRunner) -> None:
-    input_digest = _create_data_descriptor_jar(rule_runner)
+    assert classpath_entry.filenames == (entry.file_name,)
 
     jar_digest = rule_runner.request(
         Digest,
         [
             JarToolRequest(
                 jar_name="output.jar",
-                digest=input_digest,
-                jars=["out/input.jar"],
+                digest=classpath_entry.digest,
+                jars=[entry.file_name],
                 compress=True,
+                policies=[("^LICENSE", "replace")],
             )
         ],
     )

--- a/src/python/pants/jvm/jar_tool/jar_tool_integration_test.py
+++ b/src/python/pants/jvm/jar_tool/jar_tool_integration_test.py
@@ -3,23 +3,24 @@
 
 from __future__ import annotations
 
+from textwrap import dedent
+
 import pytest
 
 from pants.backend.java.dependency_inference.rules import rules as java_dep_inf_rules
 from pants.backend.java.target_types import rules as target_types_rules
 from pants.core.util_rules import archive, system_binaries
 from pants.core.util_rules.archive import ExtractedArchive, MaybeExtractArchiveRequest
-from pants.engine.fs import Digest, Snapshot
+from pants.core.util_rules.system_binaries import BashBinary
+from pants.engine.fs import CreateDigest, Digest, FileContent, Snapshot
+from pants.engine.process import Process, ProcessResult
 from pants.jvm import compile as jvm_compile
 from pants.jvm import jdk_rules, non_jvm_dependencies
 from pants.jvm.classpath import rules as classpath_rules
-from pants.jvm.compile import ClasspathEntry
 from pants.jvm.jar_tool import jar_tool
 from pants.jvm.jar_tool.jar_tool import JarToolRequest
+from pants.jvm.jdk_rules import InternalJdk
 from pants.jvm.resolve import coursier_fetch, coursier_setup, jvm_tool
-from pants.jvm.resolve.common import ArtifactRequirement, ArtifactRequirements
-from pants.jvm.resolve.coordinate import Coordinate, Coordinates
-from pants.jvm.resolve.coursier_fetch import CoursierLockfileEntry, CoursierResolvedLockfile
 from pants.jvm.testutil import maybe_skip_jdk_test
 from pants.jvm.util_rules import rules as util_rules
 from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunner
@@ -44,55 +45,101 @@ def rule_runner() -> RuleRunner:
             *target_types_rules(),
             QueryRule(Digest, (JarToolRequest,)),
             QueryRule(ExtractedArchive, (MaybeExtractArchiveRequest,)),
-            QueryRule(CoursierResolvedLockfile, (ArtifactRequirements,)),
-            QueryRule(ClasspathEntry, (CoursierLockfileEntry,)),
+            QueryRule(BashBinary, ()),
+            QueryRule(InternalJdk, ()),
+            QueryRule(ProcessResult, (Process,)),
         ],
     )
     rule_runner.set_options(args=[], env_inherit=PYTHON_BOOTSTRAP_ENV)
     return rule_runner
 
 
-@maybe_skip_jdk_test
-def test_repack_exact_iceberg_runtime_jar(rule_runner: RuleRunner) -> None:
-    requirement = ArtifactRequirement(
-        coordinate=Coordinate(
-            group="org.apache.iceberg",
-            artifact="iceberg-spark-runtime-4.0_2.13",
-            version="1.10.1",
-        ),
-        url="https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark-runtime-4.0_2.13/1.10.1/iceberg-spark-runtime-4.0_2.13-1.10.1.jar",
-    )
-    resolved_lockfile = rule_runner.request(
-        CoursierResolvedLockfile,
-        [ArtifactRequirements([requirement])],
-    )
-    assert resolved_lockfile.entries
-    entry = resolved_lockfile.entries[0]
+JAR_FIXTURE_SRC = dedent(
+    """\
+    import java.io.OutputStream;
+    import java.nio.file.Files;
+    import java.nio.file.Path;
+    import java.util.jar.JarEntry;
+    import java.util.jar.JarOutputStream;
 
-    classpath_entry = rule_runner.request(
-        ClasspathEntry,
+    public class MakeJarWithDataDescriptor {
+      public static void main(String[] args) throws Exception {
+        Path output = Path.of(args[0]);
+        try (OutputStream os = Files.newOutputStream(output);
+            JarOutputStream jos = new JarOutputStream(os)) {
+          write(jos, "META-INF/", new byte[0]);
+          write(jos, "META-INF/MANIFEST.MF", "Manifest-Version: 1.0\\n".getBytes());
+          write(jos, "org/", new byte[0]);
+          write(jos, "org/apache/", new byte[0]);
+          write(jos, "org/apache/iceberg/", new byte[0]);
+          write(jos, "org/apache/iceberg/spark/", new byte[0]);
+          write(jos, "org/apache/iceberg/spark/SparkCatalog.class", "bytecode".repeat(2000).getBytes());
+          write(jos, "LICENSE", "license-one".getBytes());
+        }
+      }
+
+      private static void write(JarOutputStream jos, String name, byte[] content) throws Exception {
+        JarEntry entry = new JarEntry(name);
+        entry.setMethod(JarEntry.DEFLATED);
+        jos.putNextEntry(entry);
+        jos.write(content);
+        jos.closeEntry();
+      }
+    }
+    """
+)
+
+
+def _create_data_descriptor_jar(rule_runner: RuleRunner) -> Digest:
+    jdk = rule_runner.request(InternalJdk, [])
+    bash = rule_runner.request(BashBinary, [])
+    digest = rule_runner.request(
+        Digest,
         [
-            CoursierLockfileEntry(
-                coord=entry.coord,
-                file_name=entry.file_name,
-                direct_dependencies=Coordinates([]),
-                dependencies=Coordinates([]),
-                file_digest=entry.file_digest,
-                remote_url=requirement.url,
+            CreateDigest(
+                [
+                    FileContent("MakeJarWithDataDescriptor.java", JAR_FIXTURE_SRC.encode()),
+                    FileContent("out/input.jar", b""),
+                ]
             )
         ],
     )
-    assert classpath_entry.filenames == (entry.file_name,)
+    compile_and_build = Process(
+        argv=[
+            bash.path,
+            jdk.jdk_preparation_script,
+            bash.path,
+            "-c",
+            " && ".join(
+                [
+                    "__java_home/bin/javac MakeJarWithDataDescriptor.java",
+                    "__java_home/bin/java MakeJarWithDataDescriptor out/input.jar",
+                ]
+            ),
+        ],
+        input_digest=digest,
+        immutable_input_digests=jdk.immutable_input_digests,
+        append_only_caches=jdk.append_only_caches,
+        env={"PANTS_INTERNAL_ABSOLUTE_PREFIX": "", **jdk.env},
+        output_files=("MakeJarWithDataDescriptor.class", "out/input.jar"),
+        description="Build local test jar",
+    )
+    result = rule_runner.request(ProcessResult, [compile_and_build])
+    return result.output_digest
+
+
+@maybe_skip_jdk_test
+def test_repack_jar_with_data_descriptor_entries(rule_runner: RuleRunner) -> None:
+    input_digest = _create_data_descriptor_jar(rule_runner)
 
     jar_digest = rule_runner.request(
         Digest,
         [
             JarToolRequest(
                 jar_name="output.jar",
-                digest=classpath_entry.digest,
-                jars=[entry.file_name],
+                digest=input_digest,
+                jars=["out/input.jar"],
                 compress=True,
-                policies=[("^LICENSE", "replace")],
             )
         ],
     )

--- a/src/python/pants/jvm/jar_tool/jar_tool_source/JarEntryCopier.java
+++ b/src/python/pants/jvm/jar_tool/jar_tool_source/JarEntryCopier.java
@@ -99,6 +99,11 @@ final class JarEntryCopier {
   private static final FieldAccessor<ZipEntry, String> ZE_NAME =
       FieldAccessor.create(ZipEntry.class, String.class, "name");
 
+  private static final FieldReader<ZipEntry, Integer> ZE_FLAG =
+      FieldReader.create(ZipEntry.class, int.class, "flag");
+
+  private static final int DATA_DESCRIPTOR_FLAG = 1 << 3;
+
   /**
    * Copy a jar entry to an output file without decompressing and re-compressing the entry when it
    * is {@link ZipEntry#DEFLATED}.
@@ -136,6 +141,8 @@ final class JarEntryCopier {
         closer.close();
       }
       jarOut.closeEntry();
+    } else if (usesDataDescriptor(jarEntry)) {
+      copyEntrySlow(jarOut, name, jarIn, jarEntry);
     } else {
       Closer closer = Closer.create();
       try {
@@ -165,6 +172,29 @@ final class JarEntryCopier {
       outEntry.setMethod(ZipEntry.DEFLATED);
       outEntry.setSize(jarEntry.getSize());
     }
+  }
+
+  private static boolean usesDataDescriptor(ZipEntry jarEntry) {
+    return (ZE_FLAG.get(jarEntry) & DATA_DESCRIPTOR_FLAG) != 0;
+  }
+
+  private static void copyEntrySlow(
+      JarOutputStream jarOut, String name, JarFile jarIn, JarEntry jarEntry) throws IOException {
+    JarEntry outEntry = new JarEntry(name);
+    outEntry.setTime(jarEntry.getTime());
+    outEntry.setExtra(jarEntry.getExtra());
+    outEntry.setComment(jarEntry.getComment());
+    Closer closer = Closer.create();
+    try {
+      InputStream is = closer.register(jarIn.getInputStream(jarEntry));
+      jarOut.putNextEntry(outEntry);
+      ByteStreams.copy(is, jarOut);
+    } catch (IOException e) {
+      throw closer.rethrow(e);
+    } finally {
+      closer.close();
+    }
+    jarOut.closeEntry();
   }
 
   private JarEntryCopier() {


### PR DESCRIPTION
Fixes #23316 

## Summary

- fix jar-tool repacking for DEFLATED ZIP entries that use data descriptors
- add a regression test covering the failing repack path

## Why

The old fast path copied raw compressed bytes by temporarily treating DEFLATED entries as STORED and patching metadata afterward. That works for ordinary entries, but it breaks when the source ZIP entry uses a data descriptor, where size and CRC are finalized after the entry data instead of being fully available in the local header.
In that case jar-tool could write inconsistent metadata and fail with ZipException while building deploy jars. This change keeps the fast path for normal DEFLATED entries, but falls back to safe copy/recompression for data-descriptor entries.