### PR TITLE
[pants_ng] Scaffolding for a pants_ng mode.

### DIFF
--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -10,13 +10,17 @@ from typing import Any
 
 from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE, ExitCode
 from pants.base.specs import Specs
-from pants.base.specs_parser import SpecsParser
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.core.environments.rules import determine_bootstrap_environment
 from pants.engine.env_vars import CompleteEnvironmentVars
 from pants.engine.goal import CurrentExecutingGoals
 from pants.engine.internals import native_engine
-from pants.engine.internals.native_engine import PyExecutor, PySessionCancellationLatch
+from pants.engine.internals.native_engine import (
+    PyExecutor,
+    PyNgInvocation,
+    PyNgOptions,
+    PySessionCancellationLatch,
+)
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.internals.selectors import Params
 from pants.engine.internals.session import SessionValues
@@ -63,6 +67,7 @@ class LocalPantsRunner:
     union_membership: UnionMembership
     is_pantsd_run: bool
     working_dir: str
+    ng_invocation: PyNgInvocation | None
 
     @classmethod
     def create(
@@ -73,6 +78,7 @@ class LocalPantsRunner:
         options_initializer: OptionsInitializer | None = None,
         scheduler: GraphScheduler | None = None,
         cancellation_latch: PySessionCancellationLatch | None = None,
+        ng_invocation: PyNgInvocation | None = None,
     ) -> LocalPantsRunner:
         """Creates a new LocalPantsRunner instance by parsing options.
 
@@ -126,8 +132,18 @@ class LocalPantsRunner:
             )
         with options_initializer.handle_unknown_flags(options_bootstrapper, env, raise_=True):
             global_options = options.for_global_scope()
+            session_values_dict = {
+                OptionsBootstrapper: options_bootstrapper,
+                CompleteEnvironmentVars: env,
+                CurrentExecutingGoals: CurrentExecutingGoals(),
+            }
+            if ng_invocation is not None:
+                session_values_dict[PyNgInvocation] = ng_invocation
+                session_values_dict[PyNgOptions] = PyNgOptions(
+                    ng_invocation, dict(env.items()), include_derivation=False
+                )
         graph_session = scheduler.new_session(
-            run_tracker.run_id,
+            build_id=run_tracker.run_id,
             dynamic_ui=global_options.dynamic_ui,
             ui_use_prodash=global_options.dynamic_ui_renderer
             == DynamicUIRenderer.experimental_prodash,
@@ -140,17 +156,17 @@ class LocalPantsRunner:
                     for level in global_options.log_levels_by_target.values()
                 ),
             ),
-            session_values=SessionValues(
-                {
-                    OptionsBootstrapper: options_bootstrapper,
-                    CompleteEnvironmentVars: env,
-                    CurrentExecutingGoals: CurrentExecutingGoals(),
-                }
-            ),
+            session_values=SessionValues(session_values_dict),
             cancellation_latch=cancellation_latch,
         )
 
+        if ng_invocation:
+            specs_strs = ng_invocation.specs()
+        else:
+            specs_strs = tuple(options.specs)
+
         specs = calculate_specs(
+            specs_strs=specs_strs,
             options_bootstrapper=options_bootstrapper,
             options=options,
             session=graph_session.scheduler_session,
@@ -169,6 +185,7 @@ class LocalPantsRunner:
             union_membership=union_membership,
             is_pantsd_run=is_pantsd_run,
             working_dir=working_dir,
+            ng_invocation=ng_invocation,
         )
 
     def _perform_run(self, goals: tuple[str, ...]) -> ExitCode:
@@ -251,10 +268,12 @@ class LocalPantsRunner:
             )
 
     def _run_inner(self) -> ExitCode:
-        if self.options.builtin_or_auxiliary_goal:
+        if self.ng_invocation:
+            goals = self.ng_invocation.goals()
+        elif self.options.builtin_or_auxiliary_goal:
             return self._run_builtin_or_auxiliary_goal(self.options.builtin_or_auxiliary_goal)
-
-        goals = tuple(self.options.goals)
+        else:
+            goals = tuple(self.options.goals)
         if not goals:
             return PANTS_SUCCEEDED_EXIT_CODE
 
@@ -268,13 +287,8 @@ class LocalPantsRunner:
             return PANTS_FAILED_EXIT_CODE
 
     def run(self, start_time: float) -> ExitCode:
-        spec_parser = SpecsParser(working_dir=self.working_dir)
-        specs = []
-        for spec_str in self.options.specs:
-            spec, is_ignore = spec_parser.parse_spec(spec_str)
-            specs.append(f"-{spec}" if is_ignore else str(spec))
-
-        self.run_tracker.start(run_start_time=start_time, specs=specs)
+        specs_strs = list(self.ng_invocation.specs()) if self.ng_invocation else self.options.specs
+        self.run_tracker.start(run_start_time=start_time, specs=specs_strs)
         global_options = self.options.for_global_scope()
 
         streaming_reporter = StreamingWorkunitHandler(

--- a/src/python/pants/bin/pants_loader.py
+++ b/src/python/pants/bin/pants_loader.py
@@ -4,10 +4,12 @@
 
 import importlib
 import locale
+import logging
 import os
 import sys
 import time
 import warnings
+from datetime import datetime
 
 from pants.base.exiter import PANTS_FAILED_EXIT_CODE
 from pants.bin.pants_env_vars import (
@@ -18,6 +20,9 @@ from pants.bin.pants_env_vars import (
 from pants.bin.pants_runner import PantsRunner
 from pants.engine.internals import native_engine
 from pants.util.strutil import softwrap
+
+# pants: infer-dep(/src/python/pants/backend/**/register.py)
+# pants: infer-dep(/src/python/pants/core/**/*)
 
 
 class PantsLoader:
@@ -118,6 +123,20 @@ class PantsLoader:
 
     @classmethod
     def main(cls) -> None:
+        # Set up logging. This is just temporary, as the PantsRunner will re-initialize logging to
+        # be emitted via Rust, but until that happens we want basic logging to do something useful.
+        # We set it up to be visually compatible with the Rust logging.
+        class HundredthsFormatter(logging.Formatter):
+            def formatTime(self, record, datefmt=None):
+                dt = datetime.fromtimestamp(record.created)
+                formatted_time = dt.strftime(datefmt or "%H:%M:%S")
+                hundredths = str(dt.microsecond // 10000).zfill(2)
+                return f"{formatted_time}.{hundredths}"
+
+        handler = logging.StreamHandler()
+        handler.setFormatter(HundredthsFormatter(fmt="%(asctime)s [%(levelname)s] %(message)s"))
+        logging.basicConfig(level=logging.INFO, handlers=[handler])
+
         native_engine.initialize()
         cls.setup_warnings()
         cls.ensure_locale()

--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -15,6 +15,7 @@ from pants.base.deprecated import warn_or_error
 from pants.base.exception_sink import ExceptionSink
 from pants.base.exiter import ExitCode
 from pants.engine.env_vars import CompleteEnvironmentVars
+from pants.engine.internals.native_engine import PyNgInvocation
 from pants.init.logging import initialize_stdio, stdio_destination
 from pants.init.util import init_workdir
 from pants.option.bootstrap_options import BootstrapOptions
@@ -74,9 +75,27 @@ class PantsRunner:
     def run(self, start_time: float) -> ExitCode:
         self.scrub_pythonpath()
 
-        options_bootstrapper = OptionsBootstrapper.create(
-            args=self.args, env=self.env, allow_pantsrc=True
-        )
+        # Create a transient OptionsBootstrapper with no args, to read the value of pants_ng from
+        # config and env. We can't parse args until we know if we're ng or og.
+        options_bootstrapper = OptionsBootstrapper.create(args=[], env=self.env, allow_pantsrc=True)
+        pants_ng = options_bootstrapper.bootstrap_options.for_global_scope().pants_ng
+
+        if pants_ng:
+            logger.info("PantsRunner running as pants_ng")
+            ng_invocation = PyNgInvocation.from_args(tuple(self.args[1:]))
+            # Allow the existing logic to read flags in global position (note, these can be
+            # prefixed with a scope so they are not necessarily just global options), so
+            # that the engine can configure itself.
+            global_flags = ng_invocation.global_flag_strings()
+            options_bootstrapper = OptionsBootstrapper.create(
+                args=[self.args[0], *global_flags], env=self.env, allow_pantsrc=True
+            )
+        else:
+            ng_invocation = None
+            options_bootstrapper = OptionsBootstrapper.create(
+                args=self.args, env=self.env, allow_pantsrc=True
+            )
+
         with warnings.catch_warnings(record=True):
             bootstrap_options = options_bootstrapper.bootstrap_options
             global_bootstrap_options = bootstrap_options.for_global_scope()
@@ -155,6 +174,7 @@ class PantsRunner:
                 env=CompleteEnvironmentVars(self.env),
                 working_dir=os.getcwd(),
                 options_bootstrapper=options_bootstrapper,
+                ng_invocation=ng_invocation,
             )
             return runner.run(start_time)
 

--- a/src/python/pants/init/extension_loader.py
+++ b/src/python/pants/init/extension_loader.py
@@ -34,18 +34,18 @@ class PluginLoadOrderError(PluginLoadingError):
 def load_backends_and_plugins(
     plugins: list[str],
     backends: list[str],
-    bc_builder: BuildConfiguration.Builder | None = None,
+    bc_builder: BuildConfiguration.Builder,
 ) -> BuildConfiguration:
     """Load named plugins and source backends.
 
-    :param plugins: v2 plugins to load.
-    :param backends: v2 backends to load.
+    :param plugins: plugins to load.
+    :param backends: backends to load.
     :param bc_builder: The BuildConfiguration (for adding aliases).
     """
-    bc_builder = bc_builder or BuildConfiguration.Builder()
     load_build_configuration_from_source(bc_builder, backends)
     load_plugins(bc_builder, plugins)
-    register_builtin_goals(bc_builder)
+    if not bc_builder._pants_ng:
+        register_builtin_goals(bc_builder)
     return bc_builder.create()
 
 

--- a/src/python/pants/init/extension_loader_test.py
+++ b/src/python/pants/init/extension_loader_test.py
@@ -359,7 +359,7 @@ class LoaderTest(unittest.TestCase):
             with self.create_register(build_file_aliases=lambda: aliases) as backend_module:
                 backends = [backend_module]
                 build_configuration = load_backends_and_plugins(
-                    plugins, backends, bc_builder=self.bc_builder
+                    plugins, backends, pants_ng=False, bc_builder=self.bc_builder
                 )
             # The backend should load first, then the plugins, therefore the alias registered in
             # the plugin will override the alias registered by the backend

--- a/src/python/pants/init/extension_loader_test.py
+++ b/src/python/pants/init/extension_loader_test.py
@@ -359,7 +359,7 @@ class LoaderTest(unittest.TestCase):
             with self.create_register(build_file_aliases=lambda: aliases) as backend_module:
                 backends = [backend_module]
                 build_configuration = load_backends_and_plugins(
-                    plugins, backends, pants_ng=False, bc_builder=self.bc_builder
+                    plugins, backends, bc_builder=self.bc_builder
                 )
             # The backend should load first, then the plugins, therefore the alias registered in
             # the plugin will override the alias registered by the backend

--- a/src/python/pants/init/options_initializer.py
+++ b/src/python/pants/init/options_initializer.py
@@ -61,6 +61,7 @@ def _initialize_build_configuration(
     return load_backends_and_plugins(
         bootstrap_options.plugins,
         bootstrap_options.backend_packages,
+        BuildConfiguration.Builder(_pants_ng=bootstrap_options.pants_ng),
     )
 
 

--- a/src/python/pants/init/specs_calculator.py
+++ b/src/python/pants/init/specs_calculator.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import logging
-from typing import cast
+from typing import Iterable, cast
 
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.base.specs import AddressLiteralSpec, FileLiteralSpec, RawSpecs, Specs
@@ -31,6 +31,7 @@ class InvalidSpecConstraint(Exception):
 
 
 def calculate_specs(
+    specs_strs: Iterable[str],
     options_bootstrapper: OptionsBootstrapper,
     options: Options,
     session: SchedulerSession,
@@ -40,7 +41,7 @@ def calculate_specs(
     global_options = options.for_global_scope()
     unmatched_cli_globs = global_options.unmatched_cli_globs
     specs = SpecsParser(working_dir=working_dir).parse_specs(
-        options.specs,
+        specs_strs,
         description_of_origin="CLI arguments",
         unmatched_glob_behavior=unmatched_cli_globs,
     )

--- a/src/python/pants/option/bootstrap_options.py
+++ b/src/python/pants/option/bootstrap_options.py
@@ -1781,6 +1781,19 @@ class BootstrapOptions:
         ),
     )
 
+    pants_ng = BoolOption(
+        default=False,
+        advanced=True,
+        help=softwrap(
+            """
+            Enable the Pants "next generation" mode.
+
+            Note that this is currently under development and is *not* yet useful to end users.
+            Do not set this unless you truly know what you're doing.
+            """
+        ),
+    )
+
     @classmethod
     def validate_instance(cls, opts: OptionValueContainer):
         """Validates an instance of global options for cases that are not prohibited via


### PR DESCRIPTION
In this mode the command line is parsed as an
NG invocation, and dispatched appropriately.

Of course at the moment there are no
implementations to dispatch to. That will follow.

This does expose a new option, `pants_ng` to users. 
There is a big warning not to set it, but we're not trying
to hide that we're working on a new thing, so I am
comfortable with this.