### PR TITLE
Make pex accept prereleases from uv venvs.

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -827,6 +827,9 @@ async def build_pex(
                 *req_strings,
                 "--no-transitive",
                 f"--venv-repository={venv_repo.relpath()}",
+                # If uv decided there should be prereleases in the venv, we
+                # shouldn't refuse to resolve them.
+                "--pre",
             ],
         )
 


### PR DESCRIPTION
When resolving with uv, it handles the resolution
decisions. If it deems it appropriate to have a
prerelease, pex should not refuse to use it.