### PR TITLE
Restore missing-entry guard in CoursierResolvedLockfile.dependencies() (regression from #22906)

### DIFF
--- a/docs/notes/2.33.x.md
+++ b/docs/notes/2.33.x.md
@@ -38,6 +38,8 @@ Add a new `pants.backend.observability.opentelemetry` backend to report work uni
 
 Fix jar-tool repacking for DEFLATED ZIP entries that use data descriptors.
 
+Fix a `KeyError` regression in `pants check` (and other JVM goals) for resolves whose lockfiles contain a transitive dependency without a corresponding coord entry, by restoring the missing-entry guard removed in [#22906](https://github.com/pantsbuild/pants/pull/22906).
+
 #### Python
 
 The `--changed-since` functionality now works correctly in the presence of deleted Python files. I.e., if test.py imports from foo.py and foo.py is deleted from the repo, then `--changed-since=...` with `--changed-dependents=transitive` will detect that test.py "depends" on the deleted file and, e.g., run it.

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -247,12 +247,17 @@ class CoursierResolvedLockfile:
         return (
             entry,
             tuple(
-                entries[(d.group, d.artifact, d.classifier)]
+                dependency_entry
                 for d in entry.dependencies
-                # Coursier will pass "pom" coords through to us. These coords don't have
-                # a coords entry, but all of their relevant dependencies have already been taken into account
-                # and will appear in the dependencies list
-                if d.classifier != "pom"
+                # Coursier sometimes reports transitive dependencies that don't have a
+                # coord entry of their own — parent POMs with classifier "pom", and
+                # other entries that are dropped by coursier bugs such as
+                # https://github.com/coursier/coursier/issues/2884 (which is still
+                # observable as of v2.1.25-M19, e.g. ("org.apache.curator",
+                # "apache-curator", None) when resolving hive-exec). Skip any such
+                # missing entry rather than raising KeyError.
+                if (dependency_entry := entries.get((d.group, d.artifact, d.classifier)))
+                is not None
             ),
         )
 

--- a/src/python/pants/jvm/resolve/coursier_fetch_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_test.py
@@ -11,10 +11,12 @@ from pants.backend.java.target_types import JavaSourcesGeneratorTarget
 from pants.backend.java.target_types import rules as target_types_rules
 from pants.core.util_rules import config_files, source_files
 from pants.engine.addresses import Address, Addresses
+from pants.engine.fs import EMPTY_DIGEST
 from pants.jvm.resolve.coordinate import Coordinate
-from pants.jvm.resolve.coursier_fetch import NoCompatibleResolve
+from pants.jvm.resolve.coursier_fetch import CoursierResolvedLockfile, NoCompatibleResolve
 from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
 from pants.jvm.resolve.key import CoursierResolveKey
+from pants.jvm.resolve.lockfile_metadata import JVMLockfileMetadata
 from pants.jvm.target_types import DeployJarTarget, JvmArtifactTarget
 from pants.jvm.testutil import maybe_skip_jdk_test
 from pants.jvm.util_rules import rules as util_rules
@@ -124,3 +126,94 @@ def test_no_matching_for_leaf(rule_runner: RuleRunner) -> None:
 )
 def test_from_coord_str(coord_str: str, expected: Coordinate) -> None:
     assert Coordinate.from_coord_str(coord_str) == expected
+
+
+def test_dependencies_skips_transitive_entries_missing_from_lockfile() -> None:
+    # Regression test for the v2.31 KeyError that surfaced after #22906 removed the
+    # `entries.get(...)` guard. Coursier (still as of 2.1.25-M19) sometimes emits
+    # transitive dependencies that have no top-level coord entry of their own — see
+    # https://github.com/coursier/coursier/issues/2884 — so `dependencies()` must
+    # tolerate the missing entry rather than raising KeyError. This fixture is the
+    # one from the original bug report: hive-exec lists arrow-memory as a transitive
+    # dependency, but no arrow-memory entry exists.
+    metadata = JVMLockfileMetadata.new([])
+    lockfile = CoursierResolvedLockfile.from_serialized(
+        metadata.add_header_to_lockfile(
+            dedent(
+                """\
+                [[entries]]
+                file_name = "org.apache.hive_hive-exec_3.1.3.jar"
+
+                [[entries.directDependencies]]
+                group = "commons-codec"
+                artifact = "commons-codec"
+                version = "1.17.0"
+                packaging = "jar"
+
+                [[entries.dependencies]]
+                group = "commons-codec"
+                artifact = "commons-codec"
+                version = "1.17.0"
+                packaging = "jar"
+
+                [[entries.dependencies]]
+                group = "org.apache.arrow"
+                artifact = "arrow-memory"
+                version = "0.8.0"
+                packaging = "jar"
+
+                [entries.coord]
+                group = "org.apache.hive"
+                artifact = "hive-exec"
+                version = "3.1.3"
+                packaging = "jar"
+
+                [entries.file_digest]
+                fingerprint = "a39058a6028ad36a74f97639663c94d9d4c52d9d32fab31032270565d01424af"
+                serialized_bytes_length = 492916
+
+                [[entries]]
+                directDependencies = []
+                dependencies = []
+                file_name = "commons-codec_commons-codec_1.17.0.jar"
+
+                [entries.coord]
+                group = "commons-codec"
+                artifact = "commons-codec"
+                version = "1.17.0"
+                packaging = "jar"
+
+                [entries.file_digest]
+                fingerprint = "0000000000000000000000000000000000000000000000000000000000000000"
+                serialized_bytes_length = 1
+                """
+            ).encode(),
+            regenerate_command="N/A - regression fixture",
+            delimeter="#",
+        )
+    )
+
+    root_entry, transitive_entries = lockfile.dependencies(
+        CoursierResolveKey(
+            name="forge-jvm-spark-3-5",
+            path="lockfiles/jvm-spark-3-5.lock",
+            digest=EMPTY_DIGEST,
+        ),
+        Coordinate(group="org.apache.hive", artifact="hive-exec", version="3.1.3"),
+    )
+
+    assert root_entry.coord == Coordinate(
+        group="org.apache.hive",
+        artifact="hive-exec",
+        version="3.1.3",
+        strict=True,
+    )
+    # arrow-memory has no entry of its own, so it is silently skipped here.
+    assert {(entry.coord.group, entry.coord.artifact) for entry in transitive_entries} == {
+        ("commons-codec", "commons-codec"),
+    }
+    # ...but it still appears in the raw dependency list of hive-exec.
+    assert {(dep.group, dep.artifact) for dep in root_entry.dependencies} == {
+        ("commons-codec", "commons-codec"),
+        ("org.apache.arrow", "arrow-memory"),
+    }


### PR DESCRIPTION
Disclaimer: I used Claude Code to evaluate and confirm comments from #23328. Basically, part of #22906 needs to be reverted.

Okay, now here's Claude:

## Summary

Fixes a `KeyError` regression introduced by #22906 that breaks `pants check` (and other JVM goals) on lockfiles whose entries reference a transitive dependency that has no top-level coord entry of its own.

#22906 bumped Coursier to v2.1.24 to pick up the fix for [coursier#2884](https://github.com/coursier/coursier/issues/2884) and, on the assumption that the only remaining "missing entry" cases would be parent POMs (`classifier="pom"`), simplified `CoursierResolvedLockfile.dependencies()` to do a direct dict lookup instead of an `entries.get(...)` guard. That assumption turns out to be wrong: even fresh resolves with the latest Coursier (verified against v2.1.25-M19) still emit transitive deps without a coord entry — e.g. `("org.apache.curator", "apache-curator", None)` when resolving `org.apache.hive:hive-exec:1.1.0`, or `("org.apache.arrow", "arrow-memory", None)` in the user-reported repro on `hive-exec:3.1.3`. Both have `classifier=None`, so the `if d.classifier != "pom"` filter doesn't catch them, and the unguarded lookup raises `KeyError`.

This restores the pre-#22906 `entries.get(...)` skip and adds the bug-report repro as a regression test.

## Changes

- `src/python/pants/jvm/resolve/coursier_fetch.py`: restore the `entries.get(...)` guard in `dependencies()`; update the comment to reflect that #2884-style missing entries are still observable on current Coursier.
- `src/python/pants/jvm/resolve/coursier_fetch_test.py`: add `test_dependencies_skips_transitive_entries_missing_from_lockfile` — the exact fixture from the bug report. Without the fix it reproduces `KeyError: ('org.apache.arrow', 'arrow-memory', None)`; with the fix it passes.

## Out of scope

- `CoursierResolvedLockfile.direct_dependencies()` has the same unguarded pattern but predates #22906; leaving for a follow-up PR.
- The longer-term transitive-closure rewrite drafted in `plans/20251117_jvm_transitive_dep_bug.md` is also a follow-up.

## Test plan

- [x] New unit test `test_dependencies_skips_transitive_entries_missing_from_lockfile` passes with the fix and fails (with the original `KeyError`) without it.
- [x] `./pants test src/python/pants/jvm/resolve/coursier_fetch_test.py src/python/pants/jvm/resolve/coursier_fetch_integration_test.py` — all pass.
- [x] `./pants fmt lint check` clean on both changed files.
