### PR TITLE
fix(js): include workspace member node_modules in install sandbox

### DIFF
--- a/docs/notes/2.33.x.md
+++ b/docs/notes/2.33.x.md
@@ -56,6 +56,8 @@ Fixed a bug in Ruff backend where ancestor `__init__.py` files were not included
 
 Fixes caching for `pants run` of a `node_run_script` and `node_build_script` target when using the `pnpm` or `yarn` package managers.
 
+Fixes JavaScript workspace builds where dependencies are installed under members' `node_modules/`. The install sandbox now captures every workspace member's `node_modules/`, not just the build target's. Makes pnpm workspaces usable in pants and also fixes npm/yarn workspaces when a version conflict prevented hoisting.
+
 #### TypeScript
 
 #### Go

--- a/src/python/pants/backend/javascript/nodejs_project_environment.py
+++ b/src/python/pants/backend/javascript/nodejs_project_environment.py
@@ -61,9 +61,18 @@ class NodeJsProjectEnvironment:
 
     @property
     def node_modules_directories(self) -> Iterable[str]:
+        """node_modules paths to capture from the install Process.
+
+        In a project with workspaces enabled, the package manager may install deps under a
+        member's node_modules directory (pnpm does this by default). We capture those paths
+        too so the sandbox match what the package manager actually installs.
+        """
         yield "node_modules"
         if self.package and not self.project.single_workspace:
-            yield os.path.join(self.relative_workspace_directory(), "node_modules")
+            for workspace in self.project.workspaces:
+                if workspace.root_dir != self.project.root_dir:
+                    rel_dir = fast_relpath(workspace.root_dir, self.project.root_dir)
+                    yield os.path.join(rel_dir, "node_modules")
 
     @property
     def target(self) -> Target | None:

--- a/src/python/pants/backend/javascript/nodejs_project_environment_test.py
+++ b/src/python/pants/backend/javascript/nodejs_project_environment_test.py
@@ -1,0 +1,163 @@
+# Copyright 2026 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from pants.backend.javascript import nodejs_project_environment, package_json
+from pants.backend.javascript.nodejs_project import AllNodeJSProjects, NodeJSProject
+from pants.backend.javascript.nodejs_project_environment import (
+    NodeJsProjectEnvironment,
+    NodeJSProjectEnvironmentRequest,
+)
+from pants.backend.javascript.package_json import PackageJsonTarget
+from pants.build_graph.address import Address
+from pants.engine.rules import QueryRule
+from pants.testutil.rule_runner import RuleRunner
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    return RuleRunner(
+        rules=[
+            *nodejs_project_environment.rules(),
+            QueryRule(AllNodeJSProjects, ()),
+            QueryRule(NodeJsProjectEnvironment, (NodeJSProjectEnvironmentRequest,)),
+        ],
+        target_types=[PackageJsonTarget],
+        objects=dict(package_json.build_file_aliases().objects),
+    )
+
+
+def _request_project(rule_runner: RuleRunner) -> NodeJSProject:
+    [project] = rule_runner.request(AllNodeJSProjects, [])
+    return project
+
+
+def test_node_modules_directories_single_workspace(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "src/js/BUILD": "package_json()",
+            "src/js/package.json": json.dumps({"name": "ham", "version": "0.0.1"}),
+        }
+    )
+    project = _request_project(rule_runner)
+    env = rule_runner.request(
+        NodeJsProjectEnvironment,
+        [NodeJSProjectEnvironmentRequest(Address("src/js", generated_name="ham"))],
+    )
+
+    assert project.single_workspace
+    assert tuple(env.node_modules_directories) == ("node_modules",)
+
+
+@pytest.mark.parametrize("package_manager", ["npm", "yarn"])
+def test_node_modules_directories_yields_all_member_paths_for_workspace(
+    rule_runner: RuleRunner, package_manager: str
+) -> None:
+    """Yield root + every member's node_modules, regardless of package manager.
+
+    The path-generation code is the same for npm/yarn/pnpm; the tsc test in
+    check_test.py exercises the pnpm install pipeline end-to-end.
+    """
+    rule_runner.set_options([f"--nodejs-package-manager={package_manager}"])
+    rule_runner.write_files(
+        {
+            "src/js/BUILD": "package_json()",
+            "src/js/package.json": json.dumps(
+                {
+                    "name": "egg",
+                    "version": "1.0.0",
+                    "private": True,
+                    "workspaces": ["foo", "bar"],
+                }
+            ),
+            "src/js/foo/BUILD": "package_json()",
+            "src/js/foo/package.json": json.dumps({"name": "ham", "version": "0.0.1"}),
+            "src/js/bar/BUILD": "package_json()",
+            "src/js/bar/package.json": json.dumps({"name": "spam", "version": "0.0.2"}),
+        }
+    )
+    env = rule_runner.request(
+        NodeJsProjectEnvironment,
+        [NodeJSProjectEnvironmentRequest(Address("src/js/foo", generated_name="ham"))],
+    )
+
+    assert not env.project.single_workspace
+    assert env.package is not None
+    assert set(env.node_modules_directories) == {
+        "node_modules",
+        "foo/node_modules",
+        "bar/node_modules",
+    }
+
+
+def test_node_modules_directories_from_root_yields_only_root(rule_runner: RuleRunner) -> None:
+    """from_root() envs (lockfile generation) yield only the root's node_modules.
+
+    Lockfile generation runs against the project as a whole, not a specific member,
+    so member node_modules paths aren't relevant and shouldn't leak in.
+    """
+    rule_runner.write_files(
+        {
+            "src/js/BUILD": "package_json()",
+            "src/js/package.json": json.dumps(
+                {
+                    "name": "egg",
+                    "version": "1.0.0",
+                    "private": True,
+                    "workspaces": ["foo", "bar"],
+                }
+            ),
+            "src/js/foo/BUILD": "package_json()",
+            "src/js/foo/package.json": json.dumps({"name": "ham", "version": "0.0.1"}),
+            "src/js/bar/BUILD": "package_json()",
+            "src/js/bar/package.json": json.dumps({"name": "spam", "version": "0.0.2"}),
+        }
+    )
+    project = _request_project(rule_runner)
+    env = NodeJsProjectEnvironment.from_root(project)
+
+    assert not project.single_workspace
+    assert env.package is None
+    assert tuple(env.node_modules_directories) == ("node_modules",)
+
+
+def test_node_modules_directories_nested_workspaces(rule_runner: RuleRunner) -> None:
+    """Nested workspace layouts emit relative paths from the project root."""
+    rule_runner.write_files(
+        {
+            "src/js/BUILD": "package_json()",
+            "src/js/package.json": json.dumps(
+                {
+                    "name": "egg",
+                    "version": "1.0.0",
+                    "private": True,
+                    "workspaces": ["foo"],
+                }
+            ),
+            "src/js/foo/BUILD": "package_json()",
+            "src/js/foo/package.json": json.dumps(
+                {
+                    "name": "ham",
+                    "version": "0.0.1",
+                    "private": True,
+                    "workspaces": ["bar"],
+                }
+            ),
+            "src/js/foo/bar/BUILD": "package_json()",
+            "src/js/foo/bar/package.json": json.dumps({"name": "spam", "version": "0.0.2"}),
+        }
+    )
+    env = rule_runner.request(
+        NodeJsProjectEnvironment,
+        [NodeJSProjectEnvironmentRequest(Address("src/js/foo/bar", generated_name="spam"))],
+    )
+
+    assert set(env.node_modules_directories) == {
+        "node_modules",
+        "foo/node_modules",
+        "foo/bar/node_modules",
+    }

--- a/src/python/pants/backend/typescript/goals/check_test.py
+++ b/src/python/pants/backend/typescript/goals/check_test.py
@@ -52,6 +52,11 @@ def pnpm_project_test(request) -> TestProjectAndPackageManager:
     return cast(TestProjectAndPackageManager, request.param)
 
 
+@pytest.fixture(params=[("pnpm_member_dep", "pnpm")])
+def pnpm_member_dep_test(request) -> TestProjectAndPackageManager:
+    return cast(TestProjectAndPackageManager, request.param)
+
+
 def _create_rule_runner(package_manager: str) -> RuleRunner:
     rule_runner = RuleRunner(
         rules=[
@@ -99,6 +104,14 @@ def pnpm_rule_runner(
     pnpm_project_test: TestProjectAndPackageManager,
 ) -> RuleRunnerWithProjectAndPackageManager:
     test_project, package_manager = pnpm_project_test
+    return _create_rule_runner(package_manager), test_project, package_manager
+
+
+@pytest.fixture
+def pnpm_member_dep_rule_runner(
+    pnpm_member_dep_test: TestProjectAndPackageManager,
+) -> RuleRunnerWithProjectAndPackageManager:
+    test_project, package_manager = pnpm_member_dep_test
     return _create_rule_runner(package_manager), test_project, package_manager
 
 
@@ -618,3 +631,34 @@ def test_check_javascript_disabled_via_tsconfig(
     assert len(results.results) == 1
     assert results.results[0].exit_code == 0
     assert "error.js" not in results.results[0].stdout
+
+
+def test_typescript_check_resolves_member_only_deps(
+    pnpm_member_dep_rule_runner: RuleRunnerWithProjectAndPackageManager,
+) -> None:
+    """Regression test: @types/node is declared only on the member, not the root.
+
+    Pre-fix, tsc ran from the workspace root and couldn't see member/node_modules,
+    so it failed with TS2304 (Cannot find name 'process').
+    """
+    rule_runner, test_project, _ = pnpm_member_dep_rule_runner
+    test_files = _load_project_test_files(test_project)
+    rule_runner.write_files(test_files)
+
+    target = rule_runner.get_target(
+        Address(
+            f"{test_project}/member/src",
+            target_name="ts_sources",
+            relative_file_path="node_types.ts",
+        )
+    )
+    field_set = TypeScriptCheckFieldSet.create(target)
+    request = TypeScriptCheckRequest([field_set])
+    results = rule_runner.request(CheckResults, [request])
+
+    assert len(results.results) == 1
+    result = results.results[0]
+    assert result.exit_code == 0, (
+        f"TypeScript check failed — member node_modules likely missing from sandbox:\n"
+        f"{result.stdout}\n{result.stderr}"
+    )

--- a/src/python/pants/backend/typescript/test_resources/pnpm_member_dep/BUILD
+++ b/src/python/pants/backend/typescript/test_resources/pnpm_member_dep/BUILD
@@ -1,0 +1,3 @@
+# Copyright 2026 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+package_json()

--- a/src/python/pants/backend/typescript/test_resources/pnpm_member_dep/member/BUILD
+++ b/src/python/pants/backend/typescript/test_resources/pnpm_member_dep/member/BUILD
@@ -1,0 +1,3 @@
+# Copyright 2026 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+package_json()

--- a/src/python/pants/backend/typescript/test_resources/pnpm_member_dep/member/package.json
+++ b/src/python/pants/backend/typescript/test_resources/pnpm_member_dep/member/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "pnpm-member-dep-member",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "typescript": "5.9.3",
+    "@types/node": "22.15.21"
+  }
+}

--- a/src/python/pants/backend/typescript/test_resources/pnpm_member_dep/member/src/BUILD
+++ b/src/python/pants/backend/typescript/test_resources/pnpm_member_dep/member/src/BUILD
@@ -1,0 +1,3 @@
+# Copyright 2026 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+typescript_sources(name="ts_sources")

--- a/src/python/pants/backend/typescript/test_resources/pnpm_member_dep/member/src/node_types.ts
+++ b/src/python/pants/backend/typescript/test_resources/pnpm_member_dep/member/src/node_types.ts
@@ -1,0 +1,2 @@
+// Needs @types/node to typecheck.
+export const nodeVersion: string = process.version;

--- a/src/python/pants/backend/typescript/test_resources/pnpm_member_dep/member/tsconfig.json
+++ b/src/python/pants/backend/typescript/test_resources/pnpm_member_dep/member/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "composite": true,
+    "declaration": true,
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"]
+}

--- a/src/python/pants/backend/typescript/test_resources/pnpm_member_dep/package.json
+++ b/src/python/pants/backend/typescript/test_resources/pnpm_member_dep/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "pnpm-member-dep-root",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "packageManager": "pnpm@10.19.0",
+  "devDependencies": {
+    "typescript": "5.9.3"
+  }
+}

--- a/src/python/pants/backend/typescript/test_resources/pnpm_member_dep/pnpm-lock.yaml
+++ b/src/python/pants/backend/typescript/test_resources/pnpm_member_dep/pnpm-lock.yaml
@@ -1,0 +1,45 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+
+  member:
+    devDependencies:
+      '@types/node':
+        specifier: 22.15.21
+        version: 22.15.21
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+
+packages:
+
+  '@types/node@22.15.21':
+    resolution: {integrity: sha512-EV/37Td6c+MgKAbkcLG6vqZ2zEYHD7bvSrzqqs2RIhbA6w3x+Dqz8MZM3sP6kGTeLrdoOgKZe+Xja7tUB2DNkQ==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+snapshots:
+
+  '@types/node@22.15.21':
+    dependencies:
+      undici-types: 6.21.0
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}

--- a/src/python/pants/backend/typescript/test_resources/pnpm_member_dep/pnpm-workspace.yaml
+++ b/src/python/pants/backend/typescript/test_resources/pnpm_member_dep/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - 'member'

--- a/src/python/pants/backend/typescript/test_resources/pnpm_member_dep/tsconfig.json
+++ b/src/python/pants/backend/typescript/test_resources/pnpm_member_dep/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./member" }
+  ],
+  "compilerOptions": {
+    "outDir": "./dist"
+  }
+}


### PR DESCRIPTION
# Problem

In a nodejs workspace, each project of the workspace can have its own `node_modules` directory that is populated during installation. Previously, pants was capturing the project's workspace and the top-level workspace but not sibling or descendent projects. This caused certain operations to fail, such as `tsc --build` on a pnpm workspace project since a pnpm project doesn't hoist member deps to the root by default. Outside of pnpm, there are reports of this causing problems with yarn/npm projects where a version conflict prevents hoisting.

# Solution

In `node_modules_directories`, the install sandbox now captures every workspace member's `node_modules/`, not just the build target's.

Note: the new behavior only impacts the install path ( when `self.package` is set). Lockfile generation's codepath (via`NodeJsProjectEnvironment.from_root()`) doesn't set `self.package` and keeps the "root only" behavior. Dropping the `if self.package` check would align with the approach from #23264, but I left out that change to minimize the scope. I added a test to demonstrate this behavior.

# References
* Previous PR that was closed by the contributor https://github.com/pantsbuild/pants/pull/23264

# AI Disclosure

Claude Code was used to diagnose the problem, write the fix with my input, and write
the regression tests