### PR TITLE
Fix: IntrinsicError when a non-directory PATH entry is used with `system_binary` (Cherry-pick of #23327)

### DIFF
--- a/src/python/pants/core/util_rules/system_binaries.py
+++ b/src/python/pants/core/util_rules/system_binaries.py
@@ -613,7 +613,9 @@ async def _find_candidate_paths_via_path_metadata_lookups(
     search_path = [os.path.abspath(path) for path in request.search_path]
 
     metadata_results = await concurrently(
-        path_metadata_request(PathMetadataRequest(path=path, namespace=PathNamespace.SYSTEM))
+        path_metadata_request(
+            PathMetadataRequest(path=path, namespace=PathNamespace.SYSTEM, follow_symlinks=True)
+        )
         for path in search_path
     )
 
@@ -625,7 +627,7 @@ async def _find_candidate_paths_via_path_metadata_lookups(
         if not metadata:
             continue
 
-        if metadata.kind in (PathMetadataKind.DIRECTORY, PathMetadataKind.SYMLINK):
+        if metadata.kind == PathMetadataKind.DIRECTORY:
             file_metadata_request = PathMetadataRequest(
                 path=os.path.join(metadata.path, request.binary_name),
                 namespace=PathNamespace.SYSTEM,

--- a/src/python/pants/core/util_rules/system_binaries_test.py
+++ b/src/python/pants/core/util_rules/system_binaries_test.py
@@ -94,6 +94,50 @@ def test_find_binary_file_path(rule_runner: RuleRunner, tmp_path: Path) -> None:
     assert binary_paths.first_path.path == str(binary_path_abs)
 
 
+def test_find_binary_symlink_to_dir_on_path(rule_runner: RuleRunner, tmp_path: Path) -> None:
+    # A symlink-to-directory on PATH should be followed and the binary found inside it.
+    target_dir = tmp_path / "real_bin_dir"
+    MyBin.create(target_dir)
+    symlink = tmp_path / "link_to_bin_dir"
+    symlink.symlink_to(target_dir)
+
+    binary_paths = rule_runner.request(
+        BinaryPaths,
+        [BinaryPathRequest(binary_name=MyBin.binary_name, search_path=[str(symlink)])],
+    )
+    assert binary_paths.first_path is not None
+    assert binary_paths.first_path.path == str(symlink / MyBin.binary_name)
+
+
+def test_find_binary_symlink_to_file_on_path(rule_runner: RuleRunner, tmp_path: Path) -> None:
+    # Regression test for https://github.com/pantsbuild/pants/issues/21990:
+    # a symlink-to-file on PATH should be skipped gracefully, not crash with IntrinsicError.
+    target_file = tmp_path / "some_file"
+    target_file.touch()
+    symlink = tmp_path / "my_symlink"
+    symlink.symlink_to(target_file)
+
+    binary_paths = rule_runner.request(
+        BinaryPaths,
+        [BinaryPathRequest(binary_name=MyBin.binary_name, search_path=[str(symlink)])],
+    )
+    assert binary_paths.first_path is None
+
+
+def test_find_binary_file_component_on_path(rule_runner: RuleRunner, tmp_path: Path) -> None:
+    # Regression test for https://github.com/pantsbuild/pants/issues/21990:
+    # a path like `foo/bar` where `foo` is a file should be skipped gracefully, not crash.
+    file_component = tmp_path / "not_a_dir"
+    file_component.touch()
+    bogus_path = file_component / "subdir"
+
+    binary_paths = rule_runner.request(
+        BinaryPaths,
+        [BinaryPathRequest(binary_name=MyBin.binary_name, search_path=[str(bogus_path)])],
+    )
+    assert binary_paths.first_path is None
+
+
 def test_find_binary_respects_search_path_order(rule_runner: RuleRunner, tmp_path: Path) -> None:
     binary_path_abs1 = MyBin.create(tmp_path / "bin1")
     binary_path_abs2 = MyBin.create(tmp_path / "bin2")

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -331,11 +331,14 @@ class SnapshotDiff:
 class PathMetadataRequest:
     """Request the full metadata of a single path in the filesystem.
 
-    Note: This API is symlink-aware and will distinguish between symlinks and regular files.
+    Note: By default this API is symlink-aware and will distinguish between symlinks and regular
+    files/directories. Set `follow_symlinks=True` to follow symlinks and report the metadata of
+    the symlink target instead.
     """
 
     path: str
     namespace: PathNamespace = PathNamespace.WORKSPACE
+    follow_symlinks: bool = False
 
 
 @dataclass(frozen=True)

--- a/src/rust/engine/src/intrinsics/digests.rs
+++ b/src/rust/engine/src/intrinsics/digests.rs
@@ -375,7 +375,7 @@ fn digest_subset_to_digest(digest_subset: Value) -> PyGeneratorResponseNativeCal
 #[pyfunction]
 fn path_metadata_request(single_path: Value) -> PyGeneratorResponseNativeCall {
     PyGeneratorResponseNativeCall::new(async move {
-        let subject_path = Python::attach(|py| -> Result<_, String> {
+        let (subject_path, follow_symlinks) = Python::attach(|py| -> Result<_, String> {
             let arg = single_path.bind(py);
             let path = externs::getattr_as_optional_string(arg, "path")
                 .map_err(|e| format!("Failed to get `path` for field: {e}"))?;
@@ -383,7 +383,10 @@ fn path_metadata_request(single_path: Value) -> PyGeneratorResponseNativeCall {
 
             let namespace: PyPathNamespace = externs::getattr(arg, "namespace")
                 .map_err(|e| format!("Failed to get `namespace` for field: {e}"))?;
-            match namespace {
+            let follow_symlinks: bool = externs::getattr(arg, "follow_symlinks")
+                .map_err(|e| format!("Failed to get `follow_symlinks` for field: {e}"))?;
+
+            let subject_path = match namespace {
                 PyPathNamespace::Workspace => SubjectPath::new_workspace(&path).map_err(|_| {
                     format!("path_metadata_request error: path for PathNamespace.WORKSPACE must be a relative path. Instead, got `{path}`")
                 }),
@@ -392,12 +395,13 @@ fn path_metadata_request(single_path: Value) -> PyGeneratorResponseNativeCall {
                         "path_metadata_request error: path for PathNamespace.SYSTEM must be an absolute path. Instead, got `{path}`"
                     )
                 }),
-            }
+            }?;
+            Ok((subject_path, follow_symlinks))
         })?;
 
         let context = task_get_context();
         let metadata_opt = context
-            .get(PathMetadataNode::new(subject_path)?)
+            .get(PathMetadataNode::new(subject_path, follow_symlinks)?)
             .await?
             .map(PyPathMetadata);
 

--- a/src/rust/engine/src/nodes/mod.rs
+++ b/src/rust/engine/src/nodes/mod.rs
@@ -113,12 +113,17 @@ impl Vfs<Failure> for Context {
         self.get(Scandir { dir, subject_path }).await
     }
 
-    async fn path_metadata(&self, path: PathBuf) -> Result<Option<PathMetadata>, Failure> {
+    async fn path_metadata(
+        &self,
+        path: PathBuf,
+        follow_symlinks: bool,
+    ) -> Result<Option<PathMetadata>, Failure> {
         let subject_path = {
             let relpath = RelativePath::new(&path).map_err(|e| Self::mk_error(&e))?;
             SubjectPath::Workspace(relpath)
         };
-        self.get(PathMetadataNode::new(subject_path)?).await
+        self.get(PathMetadataNode::new(subject_path, follow_symlinks)?)
+            .await
     }
 
     fn is_ignored(&self, stat: &fs::Stat) -> bool {

--- a/src/rust/engine/src/nodes/path_metadata.rs
+++ b/src/rust/engine/src/nodes/path_metadata.rs
@@ -16,11 +16,15 @@ use crate::python::throw;
 #[derive(Clone, Debug, DeepSizeOf, Eq, Hash, PartialEq)]
 pub struct PathMetadata {
     pub(super) subject_path: SubjectPath,
+    pub(super) follow_symlinks: bool,
 }
 
 impl PathMetadata {
-    pub fn new(subject_path: SubjectPath) -> Result<Self, String> {
-        Ok(Self { subject_path })
+    pub fn new(subject_path: SubjectPath, follow_symlinks: bool) -> Result<Self, String> {
+        Ok(Self {
+            subject_path,
+            follow_symlinks,
+        })
     }
 
     pub fn path(&self) -> &Path {
@@ -36,7 +40,7 @@ impl PathMetadata {
             SubjectPath::LocalSystem(path) => (&context.core.vfs_system, path.as_path()),
         };
 
-        vfs.path_metadata(path.to_path_buf())
+        vfs.path_metadata(path.to_path_buf(), self.follow_symlinks)
             .await
             .map_err(|e| throw(format!("{e}")))
     }

--- a/src/rust/fs/src/lib.rs
+++ b/src/rust/fs/src/lib.rs
@@ -440,7 +440,11 @@ impl Vfs<String> for DigestTrie {
         )))
     }
 
-    async fn path_metadata(&self, path: PathBuf) -> Result<Option<PathMetadata>, String> {
+    async fn path_metadata(
+        &self,
+        path: PathBuf,
+        _follow_symlinks: bool,
+    ) -> Result<Option<PathMetadata>, String> {
         let entry = match self.entry(&path)? {
             Some(e) => e,
             None => return Ok(None),
@@ -499,7 +503,11 @@ impl Vfs<String> for DigestTrie {
 pub trait Vfs<E: Send + Sync + 'static>: Clone + Send + Sync + 'static {
     async fn read_link(&self, link: &Link) -> Result<PathBuf, E>;
     async fn scandir(&self, dir: Dir) -> Result<Arc<DirectoryListing>, E>;
-    async fn path_metadata(&self, path: PathBuf) -> Result<Option<PathMetadata>, E>;
+    async fn path_metadata(
+        &self,
+        path: PathBuf,
+        follow_symlinks: bool,
+    ) -> Result<Option<PathMetadata>, E>;
     fn is_ignored(&self, stat: &Stat) -> bool;
     fn mk_error(msg: &str) -> E;
 }

--- a/src/rust/fs/src/posixfs.rs
+++ b/src/rust/fs/src/posixfs.rs
@@ -243,9 +243,18 @@ impl PosixFS {
             })
     }
 
-    pub async fn path_metadata(&self, path: PathBuf) -> Result<Option<PathMetadata>, io::Error> {
+    pub async fn path_metadata(
+        &self,
+        path: PathBuf,
+        follow_symlinks: bool,
+    ) -> Result<Option<PathMetadata>, io::Error> {
         let abs_path = self.root.0.join(&path);
-        match tokio::fs::symlink_metadata(&abs_path).await {
+        let raw_metadata = if follow_symlinks {
+            tokio::fs::metadata(&abs_path).await
+        } else {
+            tokio::fs::symlink_metadata(&abs_path).await
+        };
+        match raw_metadata {
             Ok(metadata) => {
                 let (kind, symlink_target) = match metadata.file_type() {
                     ft if ft.is_symlink() => {
@@ -276,6 +285,8 @@ impl PosixFS {
                 }))
             }
             Err(err) if err.kind() == ErrorKind::NotFound => Ok(None),
+            // A path component is a file rather than a directory: treat as not found.
+            Err(err) if err.kind() == ErrorKind::NotADirectory => Ok(None),
             Err(err) => Err(err),
         }
     }
@@ -291,8 +302,12 @@ impl Vfs<io::Error> for Arc<PosixFS> {
         Ok(Arc::new(PosixFS::scandir(self, dir).await?))
     }
 
-    async fn path_metadata(&self, path: PathBuf) -> Result<Option<PathMetadata>, io::Error> {
-        PosixFS::path_metadata(self, path).await
+    async fn path_metadata(
+        &self,
+        path: PathBuf,
+        follow_symlinks: bool,
+    ) -> Result<Option<PathMetadata>, io::Error> {
+        PosixFS::path_metadata(self, path, follow_symlinks).await
     }
 
     fn is_ignored(&self, stat: &Stat) -> bool {


### PR DESCRIPTION
Closes #21990

## Problem

Pants crashed with `IntrinsicError: Not a directory (os error 20)` when a
`system_binary` target (or any binary lookup) included a non-directory entry in
its search path. Two distinct shapes of the same underlying bug:

1. **`foo/bar` on PATH where `foo` is a file**. Calling `path_metadata_request`
   on `foo/bar` hits `ENOTDIR` in the OS. That error was not caught in the Rust
   layer, so it surfaced as an uncaught `IntrinsicError`.

2. **A symlink-to-file on PATH** — the case from the issue report. The first
   `path_metadata_request` succeeds and returns `PathMetadataKind::SYMLINK`,
   but the Python code then tried to look up `symlink/binary_name`, which also
   hits `ENOTDIR`.

## Fix

**`src/rust/fs/src/posixfs.rs`** — `path_metadata` now accepts a `follow_symlinks`
flag. When `true`, it calls `tokio::fs::metadata` (which follows symlinks) instead
of `tokio::fs::symlink_metadata`, so a symlink-to-directory appears as a
`Directory` rather than a `Symlink`. It also continues to treat `ENOTDIR` as absent
(`Ok(None)`), fixing the file-component-on-PATH crash.

**`src/rust/fs/src/lib.rs`** — The `Vfs` trait's `path_metadata` signature is
updated to accept `follow_symlinks: bool`. The in-memory `DigestTrie` implementation
accepts but ignores the flag.

**`src/rust/engine/src/nodes/path_metadata.rs`** — `PathMetadataNode` now carries
`follow_symlinks` and passes it through to the VFS call.

**`src/rust/engine/src/intrinsics/digests.rs`** — The `path_metadata_request`
intrinsic reads `follow_symlinks` from the Python `PathMetadataRequest` object and
passes it to `PathMetadataNode`.

**`src/python/pants/engine/fs.py`** — `PathMetadataRequest` gains a
`follow_symlinks: bool = False` field.

**`src/python/pants/core/util_rules/system_binaries.py`** — The initial lookup of
each PATH entry uses `follow_symlinks=True`. A symlink-to-directory is returned as
`PathMetadataKind::DIRECTORY` and handled correctly; a symlink-to-file is returned
as `PathMetadataKind::FILE` and skipped.

**`src/python/pants/core/util_rules/system_binaries_test.py`** — Three regression
tests alongside the existing `test_find_binary_file_path`:

- `test_find_binary_symlink_to_dir_on_path` — symlink on PATH pointing to a directory containing the binary is found correctly
- `test_find_binary_symlink_to_file_on_path` — symlink on PATH pointing to a file is skipped gracefully
- `test_find_binary_file_component_on_path` — path like `not_a_dir/subdir` where `not_a_dir` is a file is skipped gracefully
