### PR TITLE
pex: upgrade to v2.95.1

### DIFF
--- a/docs/notes/2.32.x.md
+++ b/docs/notes/2.32.x.md
@@ -146,7 +146,7 @@ All version of [Ruff](https://docs.astral.sh/ruff/) from [0.13.1](https://github
 
 The default version of the [Ruff](https://docs.astral.sh/ruff/) tool has been updated to [0.14.14](https://github.com/astral-sh/ruff/releases/tag/0.14.14).
 
-The version of [Pex](https://github.com/pex-tool/pex) used by the Python backend has been upgraded to [`v2.92.2`](https://github.com/pex-tool/pex/releases/tag/v2.92.2). Of particular note for Pants users:
+The version of [Pex](https://github.com/pex-tool/pex) used by the Python backend has been upgraded to [`v2.95.1`](https://github.com/pex-tool/pex/releases/tag/v2.95.1). Of particular note for Pants users:
  - Fixes a bug where wheels built from sdists weren't cached.
  - Support for [pip 26.0.1](https://pip.pypa.io/en/stable/news/#v26-0-1).
  - A new `--interpreter-selection-strategy` option to select the `"oldest"` or `"newest"` interpreter when multiple match constraints.

--- a/docs/notes/2.33.x.md
+++ b/docs/notes/2.33.x.md
@@ -46,7 +46,7 @@ The `--changed-since` functionality now works correctly in the presence of delet
 
 The Python Build Standalone backend ([pants.backend.python.providers.experimental.python_build_standalone](https://www.pantsbuild.org/stable/reference/subsystems/python-build-standalone-python-provider)) has release metadata current through PBS release [20260414](https://github.com/astral-sh/python-build-standalone/releases/tag/20260414).
 
-The version of [Pex](https://github.com/pex-tool/pex) used by the Python backend has been upgraded to [`v2.93.2`](https://github.com/pex-tool/pex/releases/tag/v2.93.2). Of particular note for Pants users:
+The version of [Pex](https://github.com/pex-tool/pex) used by the Python backend has been upgraded to [`v2.95.1`](https://github.com/pex-tool/pex/releases/tag/v2.95.1). Of particular note for Pants users:
  - Support for [Pip 26.1](https://pip.pypa.io/en/stable/news/#v26-1).
  - In [some cases](https://github.com/pex-tool/pex/pull/3159) lockfile creation is significantly faster.
 

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -41,9 +41,9 @@ from pants.util.strutil import softwrap
 logger = logging.getLogger(__name__)
 
 
-_PEX_VERSION = "v2.93.2"
-_PEX_BINARY_HASH = "75222f01b34cbe2bbe0aa9564dbf554d10dd22875ce59b6ea0c16665c92adc33"
-_PEX_BINARY_SIZE = 5116653
+_PEX_VERSION = "v2.95.1"
+_PEX_BINARY_HASH = "2cc018cf1a112ae7f94e78456f90da2d15c1a3c1327da4c73c98701ab1f8f732"
+_PEX_BINARY_SIZE = 5124990
 
 
 class PexCli(TemplatedExternalTool):


### PR DESCRIPTION
Upgrade to Pex 2.95.1 to consume a fix for "a bug in the `--venv-repository` resolver that ignored extras when determining if a requirement had already been resolved" as reproduced in https://github.com/pantsbuild/pants/pull/23354.

Release notes:
- https://github.com/pex-tool/pex/releases/tag/v2.95.1
- https://github.com/pex-tool/pex/releases/tag/v2.95.0
- https://github.com/pex-tool/pex/releases/tag/v2.94.0