### PR TITLE
pex: upgrade to v2.95.1 (Cherry-pick of #23355)

### DIFF
--- a/docs/notes/2.32.x.md
+++ b/docs/notes/2.32.x.md
@@ -144,7 +144,7 @@ All version of [Ruff](https://docs.astral.sh/ruff/) from [0.13.1](https://github
 
 The default version of the [Ruff](https://docs.astral.sh/ruff/) tool has been updated to [0.14.14](https://github.com/astral-sh/ruff/releases/tag/0.14.14).
 
-The version of [Pex](https://github.com/pex-tool/pex) used by the Python backend has been upgraded to [`v2.92.2`](https://github.com/pex-tool/pex/releases/tag/v2.92.2). Of particular note for Pants users:
+The version of [Pex](https://github.com/pex-tool/pex) used by the Python backend has been upgraded to [`v2.95.1`](https://github.com/pex-tool/pex/releases/tag/v2.95.1). Of particular note for Pants users:
  - Fixes a bug where wheels built from sdists weren't cached.
  - Support for [pip 26.0.1](https://pip.pypa.io/en/stable/news/#v26-0-1).
  - A new `--interpreter-selection-strategy` option to select the `"oldest"` or `"newest"` interpreter when multiple match constraints.

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -41,9 +41,9 @@ from pants.util.strutil import softwrap
 logger = logging.getLogger(__name__)
 
 
-_PEX_VERSION = "v2.92.2"
-_PEX_BINARY_HASH = "5ccaf151161debe5381d767c7631b39d5516c7106e725c45dbae24aa0e5fe569"
-_PEX_BINARY_SIZE = 5081502
+_PEX_VERSION = "v2.95.1"
+_PEX_BINARY_HASH = "2cc018cf1a112ae7f94e78456f90da2d15c1a3c1327da4c73c98701ab1f8f732"
+_PEX_BINARY_SIZE = 5124990
 
 
 class PexCli(TemplatedExternalTool):


### PR DESCRIPTION
Upgrade to Pex 2.95.1 to consume a fix for "a bug in the `--venv-repository` resolver that ignored extras when determining if a requirement had already been resolved" as reproduced in https://github.com/pantsbuild/pants/pull/23354.

Release notes:
- https://github.com/pex-tool/pex/releases/tag/v2.95.1
- https://github.com/pex-tool/pex/releases/tag/v2.95.0
- https://github.com/pex-tool/pex/releases/tag/v2.94.0
