### PR TITLE
Docs: Fix broken troubleshooting links

### DIFF
--- a/docs/notes/2.33.x.md
+++ b/docs/notes/2.33.x.md
@@ -20,6 +20,8 @@ Thank you to [Klaviyo](https://www.klaviyo.com/) for their Platinum tier support
 
 The thread used by the [`workunit-logger`](https://www.pantsbuild.org/2.33/reference/subsystems/workunit-logger) is now named.
 
+Fix broken troubleshooting documentation links.
+
 ### Goals
 
 ### Backends

--- a/src/rust/engine/src/nodes/mod.rs
+++ b/src/rust/engine/src/nodes/mod.rs
@@ -233,7 +233,7 @@ pub fn unmatched_globs_additional_context() -> Option<String> {
     let url = Python::attach(|py| {
         externs::doc_url(
             py,
-            "troubleshooting#pants-cannot-find-a-file-in-your-project",
+            "docs/using-pants/troubleshooting-common-issues#pants-cannot-find-a-file-in-your-project",
         )
     });
     Some(format!(

--- a/src/rust/fs/src/lib.rs
+++ b/src/rust/fs/src/lib.rs
@@ -573,7 +573,7 @@ pub fn increase_limits() -> Result<String, String> {
         if cur < TARGET_NOFILE_LIMIT {
             let err_suffix = format!(
                 "To avoid 'too many open file handle' errors, we recommend a limit of at least {TARGET_NOFILE_LIMIT}: \
-        please see https://www.pantsbuild.org/docs/troubleshooting#too-many-open-files-error \
+        please see https://www.pantsbuild.org/stable/docs/using-pants/troubleshooting-common-issues#too-many-open-files-error \
         for more information."
             );
             // If we might be able to increase the soft limit, try to.

--- a/src/rust/watch/src/lib.rs
+++ b/src/rust/watch/src/lib.rs
@@ -331,7 +331,7 @@ fn maybe_enrich_notify_error(path: &Path, e: notify::Error) -> String {
             format!(
                 "\n\nOn Linux, this can be caused by a `max_user_watches` setting that is lower \
               than the number of files and directories in your repository ({limit_value}). Please see \
-              https://www.pantsbuild.org/docs/troubleshooting#no-space-left-on-device-error-while-watching-files \
+              https://www.pantsbuild.org/stable/docs/using-pants/troubleshooting-common-issues#no-space-left-on-device-error-while-watching-files \
               for more information."
             )
         }


### PR DESCRIPTION
The pants engine printed certain troubleshooting links in warning and error scenarios that navigated to sections in https://www.pantsbuild.org/troubleshooting, which has moved. This change updates the docs to direct to the https://www.pantsbuild.org/stable/docs/using-pants/troubleshooting-common-issues page that has this troubleshooting content.