### PR TITLE
Switch Windows test shard to vscode 2026

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -617,7 +617,7 @@ jobs:
     needs:
     - classify_changes
     runs-on:
-    - windows-2025
+    - windows-2025-vs2026
     steps:
     - name: Check out code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -494,7 +494,7 @@ class Helper:
                 "run-id=${{ github.run_id }}",
             ]
         elif self.platform == Platform.WINDOWS11_X86_64:
-            ret += ["windows-2025"]
+            ret += ["windows-2025-vs2026"]
         else:
             raise ValueError(f"Unsupported platform: {self.platform_name()}")
         return ret


### PR DESCRIPTION
Forcing the issue now before the `windows-2025` label is migrated to that version, to ensure it doesn't break.