### PR TITLE
Run Linux ARM CI on Depot runners (Cherry-pick of #23363)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,11 +20,7 @@ jobs:
       contents: write
       id-token: write
     runs-on:
-    - self-hosted
-    - runs-on
-    - runner=4cpu-linux-arm64
-    - image=ubuntu22-full-arm64-python3.7-3.13
-    - run-id=${{ github.run_id }}
+    - depot-ubuntu-24.04-arm-8
     steps:
     - name: Free up disk space
       run: |-
@@ -151,7 +147,7 @@ jobs:
       contents: write
       id-token: write
     runs-on:
-    - depot-ubuntu-22.04
+    - depot-ubuntu-22.04-8
     steps:
     - name: Free up disk space
       run: |-

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,11 +22,7 @@ jobs:
     needs:
     - classify_changes
     runs-on:
-    - self-hosted
-    - runs-on
-    - runner=4cpu-linux-arm64
-    - image=ubuntu22-full-arm64-python3.7-3.13
-    - run-id=${{ github.run_id }}
+    - depot-ubuntu-24.04-arm-8
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -42,6 +38,17 @@ jobs:
       uses: actions/checkout@v6
       with:
         fetch-depth: 10
+    - name: Set up Python 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: |-
+          3.8
+          3.9
+          3.10
+          3.11
+          3.12
+          3.13
+          3.14
     - name: Install Protoc
       uses: benjyw/setup-protoc@fa4f90fddf8838036cbdeadf1262b9755f6cfb85
       with:
@@ -123,7 +130,7 @@ jobs:
     needs:
     - classify_changes
     runs-on:
-    - depot-ubuntu-22.04
+    - depot-ubuntu-22.04-8
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -356,11 +363,7 @@ jobs:
       contents: write
       id-token: write
     runs-on:
-    - self-hosted
-    - runs-on
-    - runner=4cpu-linux-arm64
-    - image=ubuntu22-full-arm64-python3.7-3.13
-    - run-id=${{ github.run_id }}
+    - depot-ubuntu-24.04-arm-8
     steps:
     - name: Free up disk space
       run: |-
@@ -440,7 +443,7 @@ jobs:
       contents: write
       id-token: write
     runs-on:
-    - depot-ubuntu-22.04
+    - depot-ubuntu-22.04-8
     steps:
     - name: Free up disk space
       run: |-
@@ -651,7 +654,7 @@ jobs:
     needs:
     - classify_changes
     runs-on:
-    - depot-ubuntu-22.04
+    - depot-ubuntu-22.04-8
     steps:
     - env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -687,7 +690,7 @@ jobs:
       release: ${{ steps.classify.outputs.release }}
       rust: ${{ steps.classify.outputs.rust }}
     runs-on:
-    - depot-ubuntu-22.04
+    - depot-ubuntu-22.04-8
     steps:
     - name: Check out code
       uses: actions/checkout@v6
@@ -730,7 +733,7 @@ jobs:
     - test_python_macos14_arm64
     - classify_changes
     runs-on:
-    - depot-ubuntu-22.04
+    - depot-ubuntu-22.04-8
     steps:
     - uses: coverallsapp/github-action@v2
       with:
@@ -743,7 +746,7 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
-    - depot-ubuntu-22.04
+    - depot-ubuntu-22.04-8
     steps:
     - name: Check out code
       uses: actions/checkout@v6
@@ -814,7 +817,7 @@ jobs:
     needs:
     - set_merge_ok
     runs-on:
-    - depot-ubuntu-22.04
+    - depot-ubuntu-22.04-8
     steps:
     - run: |
         merge_ok="${{ needs.set_merge_ok.outputs.merge_ok }}"
@@ -857,7 +860,7 @@ jobs:
     outputs:
       merge_ok: ${{ steps.set_merge_ok.outputs.merge_ok }}
     runs-on:
-    - depot-ubuntu-22.04
+    - depot-ubuntu-22.04-8
     steps:
     - id: set_merge_ok
       run: echo 'merge_ok=true' >> ${GITHUB_OUTPUT}
@@ -869,11 +872,7 @@ jobs:
     - bootstrap_pants_linux_arm64
     - classify_changes
     runs-on:
-    - self-hosted
-    - runs-on
-    - runner=4cpu-linux-arm64
-    - image=ubuntu22-full-arm64-python3.7-3.13
-    - run-id=${{ github.run_id }}
+    - depot-ubuntu-24.04-arm-8
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -904,6 +903,17 @@ jobs:
       with:
         cache: false
         go-version: 1.24.9
+    - name: Set up Python 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: |-
+          3.8
+          3.9
+          3.10
+          3.11
+          3.12
+          3.13
+          3.14
     - name: Download native binaries
       uses: actions/download-artifact@v7
       with:
@@ -958,7 +968,7 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
-    - depot-ubuntu-22.04
+    - depot-ubuntu-22.04-8
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -1087,7 +1097,7 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
-    - depot-ubuntu-22.04
+    - depot-ubuntu-22.04-8
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -1216,7 +1226,7 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
-    - depot-ubuntu-22.04
+    - depot-ubuntu-22.04-8
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -1345,7 +1355,7 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
-    - depot-ubuntu-22.04
+    - depot-ubuntu-22.04-8
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -1474,7 +1484,7 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
-    - depot-ubuntu-22.04
+    - depot-ubuntu-22.04-8
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -1603,7 +1613,7 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
-    - depot-ubuntu-22.04
+    - depot-ubuntu-22.04-8
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -1732,7 +1742,7 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
-    - depot-ubuntu-22.04
+    - depot-ubuntu-22.04-8
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -1861,7 +1871,7 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
-    - depot-ubuntu-22.04
+    - depot-ubuntu-22.04-8
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -1990,7 +2000,7 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
-    - depot-ubuntu-22.04
+    - depot-ubuntu-22.04-8
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -2119,7 +2129,7 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
-    - depot-ubuntu-22.04
+    - depot-ubuntu-22.04-8
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,7 +39,7 @@ jobs:
       with:
         fetch-depth: 10
     - name: Set up Python 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      uses: actions/setup-python@v6
       with:
         python-version: |-
           3.8
@@ -904,7 +904,7 @@ jobs:
         cache: false
         go-version: 1.24.9
     - name: Set up Python 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      uses: actions/setup-python@v6
       with:
         python-version: |-
           3.8

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -1795,42 +1795,6 @@ def public_repos() -> PublicReposOutput:
     return PublicReposOutput(jobs=jobs, inputs=inputs, run_name=run_name)
 
 
-def clear_self_hosted_persistent_caches_jobs() -> Jobs:
-    jobs = {}
-
-    for platform in sorted(SELF_HOSTED, key=lambda p: p.value):
-        helper = Helper(platform)
-
-        clear_steps = [
-            {
-                "name": f"Deleting {directory}",
-                # squash all errors: this is a best effort thing, so, for instance, it's fine if
-                # there's directories hanging around that this workflow doesn't have permission to
-                # delete
-                "run": f"du -sh {directory} || true; rm -rf {directory} || true",
-            }
-            for directory in [
-                # not all of these will necessarily exist (e.g. ~/Library/Caches is macOS-specific),
-                # but the script is resilient to this
-                "~/Library/Caches",
-                "~/.cache",
-                "~/.nce",
-                "~/.rustup",
-                "~/.pex",
-            ]
-        ]
-        jobs[helper.job_name("clean")] = {
-            "runs-on": helper.runs_on(),
-            "steps": [
-                {"name": "df before", "run": "df -h"},
-                *clear_steps,
-                {"name": "df after", "run": "df -h"},
-            ],
-        }
-
-    return jobs
-
-
 # ----------------------------------------------------------------------
 # Telemetry
 # ----------------------------------------------------------------------
@@ -2040,23 +2004,11 @@ def generate() -> dict[Path, str]:
         },
     )
 
-    clear_self_hosted_persistent_caches = clear_self_hosted_persistent_caches_jobs()
-    clear_self_hosted_persistent_caches_yaml = render_workflow(
-        {
-            "name": "Clear persistent caches on long-lived self-hosted runners",
-            "on": {"workflow_dispatch": {}},
-            "jobs": clear_self_hosted_persistent_caches,
-        }
-    )
-
     return {
         Path(".github/workflows/cache_comparison.yaml"): cache_comparison_yaml,
         Path(".github/workflows/test.yaml"): test_yaml,
         Path(".github/workflows/release.yaml"): release_yaml,
         Path(".github/workflows/public_repos.yaml"): public_repos_yaml,
-        Path(
-            ".github/workflows/clear_self_hosted_persistent_caches.yaml"
-        ): clear_self_hosted_persistent_caches_yaml,
     }
 
 

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -78,20 +78,19 @@ class Platform(Enum):
     WINDOWS11_X86_64 = "Windows11-x86_64"
 
 
-GITHUB_HOSTED = {Platform.LINUX_X86_64, Platform.MACOS14_ARM64}
-SELF_HOSTED = {Platform.LINUX_ARM64}
-
 # We don't specify a patch version so that we get the latest, which comes pre-installed:
 #  https://github.com/actions/setup-python#available-versions-of-python
 # NOTE: The last entry becomes the default
 _BASE_PYTHON_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
-PYTHON_VERSIONS_PER_PLATFORM = {
+PYTHON_VERSIONS_PER_PLATFORM: dict[Platform, list[str]] = {
     Platform.LINUX_X86_64: _BASE_PYTHON_VERSIONS,
+    # Python 3.7 isn't installable by setup-python on ARM64 Ubuntu 24.04.
+    # TODO: Update any tests still relying on 3.7 and 3.8, which have been long EOL'd,
+    #  and then stop requiring them on any platform.
+    Platform.LINUX_ARM64: [v for v in _BASE_PYTHON_VERSIONS if v != "3.7"],
     # Python 3.7 or 3.8 aren't supported directly on arm64 macOS
     Platform.MACOS14_ARM64: [v for v in _BASE_PYTHON_VERSIONS if v not in ("3.7", "3.8")],
-    # These runners have Python already installed
-    Platform.LINUX_ARM64: None,
 }
 
 
@@ -451,21 +450,13 @@ class Helper:
         return name
 
     def runs_on(self) -> list[str]:
-        # GHA strongly recommends targeting the self-hosted label as well as
-        # any platform-specific labels, so we don't run on future GH-hosted
-        # platforms without realizing it.
-        ret = ["self-hosted"] if self.platform in SELF_HOSTED else []
+        ret = []
         if self.platform == Platform.MACOS14_ARM64:
             ret += ["depot-macos-14"]
         elif self.platform == Platform.LINUX_X86_64:
-            ret += ["depot-ubuntu-22.04"]
+            ret += ["depot-ubuntu-22.04-8"]
         elif self.platform == Platform.LINUX_ARM64:
-            ret += [
-                "runs-on",
-                "runner=4cpu-linux-arm64",
-                "image=ubuntu22-full-arm64-python3.7-3.13",
-                "run-id=${{ github.run_id }}",
-            ]
+            ret += ["depot-ubuntu-24.04-arm-8"]
         elif self.platform == Platform.WINDOWS11_X86_64:
             ret += ["windows-2025"]
         else:


### PR DESCRIPTION
RunsOn is deprecating their v2 stack, and rather than migrate to v3
we should use the resources kindly donated by Depot.

GitHub also now has Linux ARM runners, should we need them.


