### PR TITLE
Run Linux ARM CI on Depot runners (Cherry-pick of #23363)

### DIFF
--- a/.github/workflows/clear_self_hosted_persistent_caches.yaml
+++ b/.github/workflows/clear_self_hosted_persistent_caches.yaml
@@ -3,29 +3,7 @@
 #   pants run src/python/pants_release/generate_github_workflows.py
 
 
-jobs:
-  clean_linux_arm64:
-    runs-on:
-    - self-hosted
-    - runs-on
-    - runner=4cpu-linux-arm64
-    - image=ubuntu22-full-arm64-python3.7-3.13
-    - run-id=${{ github.run_id }}
-    steps:
-    - name: df before
-      run: df -h
-    - name: Deleting ~/Library/Caches
-      run: du -sh ~/Library/Caches || true; rm -rf ~/Library/Caches || true
-    - name: Deleting ~/.cache
-      run: du -sh ~/.cache || true; rm -rf ~/.cache || true
-    - name: Deleting ~/.nce
-      run: du -sh ~/.nce || true; rm -rf ~/.nce || true
-    - name: Deleting ~/.rustup
-      run: du -sh ~/.rustup || true; rm -rf ~/.rustup || true
-    - name: Deleting ~/.pex
-      run: du -sh ~/.pex || true; rm -rf ~/.pex || true
-    - name: df after
-      run: df -h
+jobs: {}
 name: Clear persistent caches on long-lived self-hosted runners
 'on':
   workflow_dispatch: {}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -146,11 +146,7 @@ jobs:
       contents: write
       id-token: write
     runs-on:
-<<<<<<< HEAD
-    - ubuntu-22.04
-=======
     - depot-ubuntu-22.04-8
->>>>>>> b2edb60735 (Run Linux ARM CI on Depot runners (#23363))
     steps:
     - name: Free up disk space
       run: |-
@@ -295,7 +291,7 @@ jobs:
       contents: write
       id-token: write
     runs-on:
-    - macos-14
+    - depot-macos-14
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,11 +20,7 @@ jobs:
       contents: write
       id-token: write
     runs-on:
-    - self-hosted
-    - runs-on
-    - runner=4cpu-linux-arm64
-    - image=ubuntu22-full-arm64-python3.7-3.13
-    - run-id=${{ github.run_id }}
+    - depot-ubuntu-24.04-arm-8
     steps:
     - name: Free up disk space
       run: |-
@@ -150,7 +146,11 @@ jobs:
       contents: write
       id-token: write
     runs-on:
+<<<<<<< HEAD
     - ubuntu-22.04
+=======
+    - depot-ubuntu-22.04-8
+>>>>>>> b2edb60735 (Run Linux ARM CI on Depot runners (#23363))
     steps:
     - name: Free up disk space
       run: |-

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,11 +22,7 @@ jobs:
     needs:
     - classify_changes
     runs-on:
-    - self-hosted
-    - runs-on
-    - runner=4cpu-linux-arm64
-    - image=ubuntu22-full-arm64-python3.7-3.13
-    - run-id=${{ github.run_id }}
+    - depot-ubuntu-24.04-arm-8
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -42,6 +38,17 @@ jobs:
       uses: actions/checkout@v6
       with:
         fetch-depth: 10
+    - name: Set up Python 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: |-
+          3.8
+          3.9
+          3.10
+          3.11
+          3.12
+          3.13
+          3.14
     - name: Install Protoc
       uses: arduino/setup-protoc@3ea1d70ac22caff0b66ed6cb37d5b7aadebd4623
       with:
@@ -123,7 +130,11 @@ jobs:
     needs:
     - classify_changes
     runs-on:
+<<<<<<< HEAD
     - ubuntu-22.04
+=======
+    - depot-ubuntu-22.04-8
+>>>>>>> b2edb60735 (Run Linux ARM CI on Depot runners (#23363))
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -354,11 +365,7 @@ jobs:
       contents: write
       id-token: write
     runs-on:
-    - self-hosted
-    - runs-on
-    - runner=4cpu-linux-arm64
-    - image=ubuntu22-full-arm64-python3.7-3.13
-    - run-id=${{ github.run_id }}
+    - depot-ubuntu-24.04-arm-8
     steps:
     - name: Free up disk space
       run: |-
@@ -437,7 +444,11 @@ jobs:
       contents: write
       id-token: write
     runs-on:
+<<<<<<< HEAD
     - ubuntu-22.04
+=======
+    - depot-ubuntu-22.04-8
+>>>>>>> b2edb60735 (Run Linux ARM CI on Depot runners (#23363))
     steps:
     - name: Free up disk space
       run: |-
@@ -642,7 +653,11 @@ jobs:
     needs:
     - classify_changes
     runs-on:
+<<<<<<< HEAD
     - ubuntu-22.04
+=======
+    - depot-ubuntu-22.04-8
+>>>>>>> b2edb60735 (Run Linux ARM CI on Depot runners (#23363))
     steps:
     - env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -678,7 +693,11 @@ jobs:
       release: ${{ steps.classify.outputs.release }}
       rust: ${{ steps.classify.outputs.rust }}
     runs-on:
+<<<<<<< HEAD
     - ubuntu-22.04
+=======
+    - depot-ubuntu-22.04-8
+>>>>>>> b2edb60735 (Run Linux ARM CI on Depot runners (#23363))
     steps:
     - name: Check out code
       uses: actions/checkout@v6
@@ -721,7 +740,11 @@ jobs:
     - test_python_macos14_arm64
     - classify_changes
     runs-on:
+<<<<<<< HEAD
     - ubuntu-22.04
+=======
+    - depot-ubuntu-22.04-8
+>>>>>>> b2edb60735 (Run Linux ARM CI on Depot runners (#23363))
     steps:
     - uses: coverallsapp/github-action@v2
       with:
@@ -734,7 +757,11 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
+<<<<<<< HEAD
     - ubuntu-22.04
+=======
+    - depot-ubuntu-22.04-8
+>>>>>>> b2edb60735 (Run Linux ARM CI on Depot runners (#23363))
     steps:
     - name: Check out code
       uses: actions/checkout@v6
@@ -804,7 +831,11 @@ jobs:
     needs:
     - set_merge_ok
     runs-on:
+<<<<<<< HEAD
     - ubuntu-22.04
+=======
+    - depot-ubuntu-22.04-8
+>>>>>>> b2edb60735 (Run Linux ARM CI on Depot runners (#23363))
     steps:
     - run: |
         merge_ok="${{ needs.set_merge_ok.outputs.merge_ok }}"
@@ -847,7 +878,11 @@ jobs:
     outputs:
       merge_ok: ${{ steps.set_merge_ok.outputs.merge_ok }}
     runs-on:
+<<<<<<< HEAD
     - ubuntu-22.04
+=======
+    - depot-ubuntu-22.04-8
+>>>>>>> b2edb60735 (Run Linux ARM CI on Depot runners (#23363))
     steps:
     - id: set_merge_ok
       run: echo 'merge_ok=true' >> ${GITHUB_OUTPUT}
@@ -859,11 +894,7 @@ jobs:
     - bootstrap_pants_linux_arm64
     - classify_changes
     runs-on:
-    - self-hosted
-    - runs-on
-    - runner=4cpu-linux-arm64
-    - image=ubuntu22-full-arm64-python3.7-3.13
-    - run-id=${{ github.run_id }}
+    - depot-ubuntu-24.04-arm-8
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -892,6 +923,17 @@ jobs:
       uses: actions/setup-go@v6
       with:
         go-version: 1.24.9
+    - name: Set up Python 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: |-
+          3.8
+          3.9
+          3.10
+          3.11
+          3.12
+          3.13
+          3.14
     - name: Download native binaries
       uses: actions/download-artifact@v7
       with:
@@ -946,7 +988,11 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
+<<<<<<< HEAD
     - ubuntu-22.04
+=======
+    - depot-ubuntu-22.04-8
+>>>>>>> b2edb60735 (Run Linux ARM CI on Depot runners (#23363))
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -1072,7 +1118,11 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
+<<<<<<< HEAD
     - ubuntu-22.04
+=======
+    - depot-ubuntu-22.04-8
+>>>>>>> b2edb60735 (Run Linux ARM CI on Depot runners (#23363))
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -1198,7 +1248,11 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
+<<<<<<< HEAD
     - ubuntu-22.04
+=======
+    - depot-ubuntu-22.04-8
+>>>>>>> b2edb60735 (Run Linux ARM CI on Depot runners (#23363))
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -1324,7 +1378,11 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
+<<<<<<< HEAD
     - ubuntu-22.04
+=======
+    - depot-ubuntu-22.04-8
+>>>>>>> b2edb60735 (Run Linux ARM CI on Depot runners (#23363))
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -1450,7 +1508,11 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
+<<<<<<< HEAD
     - ubuntu-22.04
+=======
+    - depot-ubuntu-22.04-8
+>>>>>>> b2edb60735 (Run Linux ARM CI on Depot runners (#23363))
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -1576,7 +1638,11 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
+<<<<<<< HEAD
     - ubuntu-22.04
+=======
+    - depot-ubuntu-22.04-8
+>>>>>>> b2edb60735 (Run Linux ARM CI on Depot runners (#23363))
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -1702,7 +1768,11 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
+<<<<<<< HEAD
     - ubuntu-22.04
+=======
+    - depot-ubuntu-22.04-8
+>>>>>>> b2edb60735 (Run Linux ARM CI on Depot runners (#23363))
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -1828,7 +1898,11 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
+<<<<<<< HEAD
     - ubuntu-22.04
+=======
+    - depot-ubuntu-22.04-8
+>>>>>>> b2edb60735 (Run Linux ARM CI on Depot runners (#23363))
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -1954,7 +2028,11 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
+<<<<<<< HEAD
     - ubuntu-22.04
+=======
+    - depot-ubuntu-22.04-8
+>>>>>>> b2edb60735 (Run Linux ARM CI on Depot runners (#23363))
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -2080,7 +2158,11 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
+<<<<<<< HEAD
     - ubuntu-22.04
+=======
+    - depot-ubuntu-22.04-8
+>>>>>>> b2edb60735 (Run Linux ARM CI on Depot runners (#23363))
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,17 +38,16 @@ jobs:
       uses: actions/checkout@v6
       with:
         fetch-depth: 10
-    - name: Set up Python 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+    - name: Set up Python 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
+      uses: actions/setup-python@v6
       with:
         python-version: |-
           3.8
           3.9
           3.10
-          3.11
           3.12
           3.13
-          3.14
+          3.11
     - name: Install Protoc
       uses: arduino/setup-protoc@3ea1d70ac22caff0b66ed6cb37d5b7aadebd4623
       with:
@@ -130,11 +129,7 @@ jobs:
     needs:
     - classify_changes
     runs-on:
-<<<<<<< HEAD
-    - ubuntu-22.04
-=======
     - depot-ubuntu-22.04-8
->>>>>>> b2edb60735 (Run Linux ARM CI on Depot runners (#23363))
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -251,7 +246,7 @@ jobs:
     needs:
     - classify_changes
     runs-on:
-    - macos-14
+    - depot-macos-14
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -444,11 +439,7 @@ jobs:
       contents: write
       id-token: write
     runs-on:
-<<<<<<< HEAD
-    - ubuntu-22.04
-=======
     - depot-ubuntu-22.04-8
->>>>>>> b2edb60735 (Run Linux ARM CI on Depot runners (#23363))
     steps:
     - name: Free up disk space
       run: |-
@@ -531,7 +522,7 @@ jobs:
       contents: write
       id-token: write
     runs-on:
-    - macos-14
+    - depot-macos-14
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -653,11 +644,7 @@ jobs:
     needs:
     - classify_changes
     runs-on:
-<<<<<<< HEAD
-    - ubuntu-22.04
-=======
     - depot-ubuntu-22.04-8
->>>>>>> b2edb60735 (Run Linux ARM CI on Depot runners (#23363))
     steps:
     - env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -693,11 +680,7 @@ jobs:
       release: ${{ steps.classify.outputs.release }}
       rust: ${{ steps.classify.outputs.rust }}
     runs-on:
-<<<<<<< HEAD
-    - ubuntu-22.04
-=======
     - depot-ubuntu-22.04-8
->>>>>>> b2edb60735 (Run Linux ARM CI on Depot runners (#23363))
     steps:
     - name: Check out code
       uses: actions/checkout@v6
@@ -740,11 +723,7 @@ jobs:
     - test_python_macos14_arm64
     - classify_changes
     runs-on:
-<<<<<<< HEAD
-    - ubuntu-22.04
-=======
     - depot-ubuntu-22.04-8
->>>>>>> b2edb60735 (Run Linux ARM CI on Depot runners (#23363))
     steps:
     - uses: coverallsapp/github-action@v2
       with:
@@ -757,11 +736,7 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
-<<<<<<< HEAD
-    - ubuntu-22.04
-=======
     - depot-ubuntu-22.04-8
->>>>>>> b2edb60735 (Run Linux ARM CI on Depot runners (#23363))
     steps:
     - name: Check out code
       uses: actions/checkout@v6
@@ -831,11 +806,7 @@ jobs:
     needs:
     - set_merge_ok
     runs-on:
-<<<<<<< HEAD
-    - ubuntu-22.04
-=======
     - depot-ubuntu-22.04-8
->>>>>>> b2edb60735 (Run Linux ARM CI on Depot runners (#23363))
     steps:
     - run: |
         merge_ok="${{ needs.set_merge_ok.outputs.merge_ok }}"
@@ -878,11 +849,7 @@ jobs:
     outputs:
       merge_ok: ${{ steps.set_merge_ok.outputs.merge_ok }}
     runs-on:
-<<<<<<< HEAD
-    - ubuntu-22.04
-=======
     - depot-ubuntu-22.04-8
->>>>>>> b2edb60735 (Run Linux ARM CI on Depot runners (#23363))
     steps:
     - id: set_merge_ok
       run: echo 'merge_ok=true' >> ${GITHUB_OUTPUT}
@@ -923,17 +890,16 @@ jobs:
       uses: actions/setup-go@v6
       with:
         go-version: 1.24.9
-    - name: Set up Python 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+    - name: Set up Python 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
+      uses: actions/setup-python@v6
       with:
         python-version: |-
           3.8
           3.9
           3.10
-          3.11
           3.12
           3.13
-          3.14
+          3.11
     - name: Download native binaries
       uses: actions/download-artifact@v7
       with:
@@ -988,11 +954,7 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
-<<<<<<< HEAD
-    - ubuntu-22.04
-=======
     - depot-ubuntu-22.04-8
->>>>>>> b2edb60735 (Run Linux ARM CI on Depot runners (#23363))
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -1118,11 +1080,7 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
-<<<<<<< HEAD
-    - ubuntu-22.04
-=======
     - depot-ubuntu-22.04-8
->>>>>>> b2edb60735 (Run Linux ARM CI on Depot runners (#23363))
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -1248,11 +1206,7 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
-<<<<<<< HEAD
-    - ubuntu-22.04
-=======
     - depot-ubuntu-22.04-8
->>>>>>> b2edb60735 (Run Linux ARM CI on Depot runners (#23363))
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -1378,11 +1332,7 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
-<<<<<<< HEAD
-    - ubuntu-22.04
-=======
     - depot-ubuntu-22.04-8
->>>>>>> b2edb60735 (Run Linux ARM CI on Depot runners (#23363))
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -1508,11 +1458,7 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
-<<<<<<< HEAD
-    - ubuntu-22.04
-=======
     - depot-ubuntu-22.04-8
->>>>>>> b2edb60735 (Run Linux ARM CI on Depot runners (#23363))
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -1638,11 +1584,7 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
-<<<<<<< HEAD
-    - ubuntu-22.04
-=======
     - depot-ubuntu-22.04-8
->>>>>>> b2edb60735 (Run Linux ARM CI on Depot runners (#23363))
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -1768,11 +1710,7 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
-<<<<<<< HEAD
-    - ubuntu-22.04
-=======
     - depot-ubuntu-22.04-8
->>>>>>> b2edb60735 (Run Linux ARM CI on Depot runners (#23363))
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -1898,11 +1836,7 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
-<<<<<<< HEAD
-    - ubuntu-22.04
-=======
     - depot-ubuntu-22.04-8
->>>>>>> b2edb60735 (Run Linux ARM CI on Depot runners (#23363))
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -2028,11 +1962,7 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
-<<<<<<< HEAD
-    - ubuntu-22.04
-=======
     - depot-ubuntu-22.04-8
->>>>>>> b2edb60735 (Run Linux ARM CI on Depot runners (#23363))
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -2158,11 +2088,7 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
-<<<<<<< HEAD
-    - ubuntu-22.04
-=======
     - depot-ubuntu-22.04-8
->>>>>>> b2edb60735 (Run Linux ARM CI on Depot runners (#23363))
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -2289,7 +2215,7 @@ jobs:
     - bootstrap_pants_macos14_arm64
     - classify_changes
     runs-on:
-    - macos-14
+    - depot-macos-14
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -75,8 +75,7 @@ class Platform(Enum):
     WINDOWS11_X86_64 = "Windows11-x86_64"
 
 
-GITHUB_HOSTED = {Platform.LINUX_X86_64, Platform.MACOS14_ARM64}
-SELF_HOSTED = {Platform.LINUX_ARM64}
+SELF_HOSTED = {}
 CARGO_AUDIT_IGNORED_ADVISORY_IDS = (
     "RUSTSEC-2020-0128",  # returns a false positive on the cache crate, which is a local crate not a 3rd party crate
 )
@@ -86,12 +85,14 @@ CARGO_AUDIT_IGNORED_ADVISORY_IDS = (
 # NOTE: The last entry becomes the default
 _BASE_PYTHON_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.12", "3.13", "3.11"]
 
-PYTHON_VERSIONS_PER_PLATFORM = {
+PYTHON_VERSIONS_PER_PLATFORM: dict[Platform, list[str]] = {
     Platform.LINUX_X86_64: _BASE_PYTHON_VERSIONS,
+    # Python 3.7 isn't installable by setup-python on ARM64 Ubuntu 24.04.
+    # TODO: Update any tests still relying on 3.7 and 3.8, which have been long EOL'd,
+    #  and then stop requiring them on any platform.
+    Platform.LINUX_ARM64: [v for v in _BASE_PYTHON_VERSIONS if v != "3.7"],
     # Python 3.7 or 3.8 aren't supported directly on arm64 macOS
     Platform.MACOS14_ARM64: [v for v in _BASE_PYTHON_VERSIONS if v not in ("3.7", "3.8")],
-    # These runners have Python already installed
-    Platform.LINUX_ARM64: None,
 }
 
 
@@ -449,21 +450,13 @@ class Helper:
         return name
 
     def runs_on(self) -> list[str]:
-        # GHA strongly recommends targeting the self-hosted label as well as
-        # any platform-specific labels, so we don't run on future GH-hosted
-        # platforms without realizing it.
-        ret = ["self-hosted"] if self.platform in SELF_HOSTED else []
+        ret = []
         if self.platform == Platform.MACOS14_ARM64:
-            ret += ["macos-14"]
+            ret += ["depot-macos-14"]
         elif self.platform == Platform.LINUX_X86_64:
-            ret += ["ubuntu-22.04"]
+            ret += ["depot-ubuntu-22.04-8"]
         elif self.platform == Platform.LINUX_ARM64:
-            ret += [
-                "runs-on",
-                "runner=4cpu-linux-arm64",
-                "image=ubuntu22-full-arm64-python3.7-3.13",
-                "run-id=${{ github.run_id }}",
-            ]
+            ret += ["depot-ubuntu-24.04-arm-8"]
         elif self.platform == Platform.WINDOWS11_X86_64:
             ret += ["windows-2025"]
         else:

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -75,7 +75,6 @@ class Platform(Enum):
     WINDOWS11_X86_64 = "Windows11-x86_64"
 
 
-SELF_HOSTED = {}
 CARGO_AUDIT_IGNORED_ADVISORY_IDS = (
     "RUSTSEC-2020-0128",  # returns a false positive on the cache crate, which is a local crate not a 3rd party crate
 )
@@ -1794,42 +1793,6 @@ def public_repos() -> PublicReposOutput:
     return PublicReposOutput(jobs=jobs, inputs=inputs, run_name=run_name)
 
 
-def clear_self_hosted_persistent_caches_jobs() -> Jobs:
-    jobs = {}
-
-    for platform in sorted(SELF_HOSTED, key=lambda p: p.value):
-        helper = Helper(platform)
-
-        clear_steps = [
-            {
-                "name": f"Deleting {directory}",
-                # squash all errors: this is a best effort thing, so, for instance, it's fine if
-                # there's directories hanging around that this workflow doesn't have permission to
-                # delete
-                "run": f"du -sh {directory} || true; rm -rf {directory} || true",
-            }
-            for directory in [
-                # not all of these will necessarily exist (e.g. ~/Library/Caches is macOS-specific),
-                # but the script is resilient to this
-                "~/Library/Caches",
-                "~/.cache",
-                "~/.nce",
-                "~/.rustup",
-                "~/.pex",
-            ]
-        ]
-        jobs[helper.job_name("clean")] = {
-            "runs-on": helper.runs_on(),
-            "steps": [
-                {"name": "df before", "run": "df -h"},
-                *clear_steps,
-                {"name": "df after", "run": "df -h"},
-            ],
-        }
-
-    return jobs
-
-
 # ----------------------------------------------------------------------
 # Telemetry
 # ----------------------------------------------------------------------
@@ -2067,24 +2030,12 @@ def generate() -> dict[Path, str]:
         },
     )
 
-    clear_self_hosted_persistent_caches = clear_self_hosted_persistent_caches_jobs()
-    clear_self_hosted_persistent_caches_yaml = render_workflow(
-        {
-            "name": "Clear persistent caches on long-lived self-hosted runners",
-            "on": {"workflow_dispatch": {}},
-            "jobs": clear_self_hosted_persistent_caches,
-        }
-    )
-
     return {
         Path(".github/workflows/audit.yaml"): audit_yaml,
         Path(".github/workflows/cache_comparison.yaml"): cache_comparison_yaml,
         Path(".github/workflows/test.yaml"): test_yaml,
         Path(".github/workflows/release.yaml"): release_yaml,
         Path(".github/workflows/public_repos.yaml"): public_repos_yaml,
-        Path(
-            ".github/workflows/clear_self_hosted_persistent_caches.yaml"
-        ): clear_self_hosted_persistent_caches_yaml,
     }
 
 


### PR DESCRIPTION
RunsOn is deprecating their v2 stack, and rather than migrate to v3
we should use the resources kindly donated by Depot.

GitHub also now has Linux ARM runners, should we need them.


