### PR TITLE
bump the minimum version of scie-pants for Python 3.14

### DIFF
--- a/docs/notes/2.32.x.md
+++ b/docs/notes/2.32.x.md
@@ -37,7 +37,7 @@ Completed and canceled workunit log messages now include elapsed time, e.g. `Com
 
 #### Internal Python Upgrade
 
-The version of Python used by Pants itself has been updated to [3.14](https://docs.python.org/3/whatsnew/3.14.html). To support this, the [Pants Launcher Binary](https://www.pantsbuild.org/blog/2023/02/23/the-pants-launcher-binary-a-much-simpler-way-to-install-and-run-pants) (also known as [`scie-pants`](https://github.com/pantsbuild/scie-pants/)) now has a minimum version of `0.13.0`. To update to the latest launcher binary, either:
+The version of Python used by Pants itself has been updated to [3.14](https://docs.python.org/3/whatsnew/3.14.html). To support this, the [Pants Launcher Binary](https://www.pantsbuild.org/blog/2023/02/23/the-pants-launcher-binary-a-much-simpler-way-to-install-and-run-pants) (also known as [`scie-pants`](https://github.com/pantsbuild/scie-pants/)) now has a minimum version of `0.13.2`. To update to the latest launcher binary, either:
 - Use the package manager you used to install Pants. For example, with Homebrew: `brew update && brew upgrade pantsbuild/tap/pants`.
 - Use its built-in self-update functionality: `SCIE_BOOT=update pants`.
 

--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -27,10 +27,9 @@ from pants.util.strutil import softwrap
 
 logger = logging.getLogger(__name__)
 
-# First version with working Python 3.11 support:
-# https://github.com/pantsbuild/scie-pants/releases/tag/v0.12.2
-# TODO: Likely still need to update scie-pants
-MINIMUM_SCIE_PANTS_VERSION = Version("0.12.2")
+# First version with working Python 3.14 support:
+# https://github.com/pantsbuild/scie-pants/releases/tag/v0.13.2
+MINIMUM_SCIE_PANTS_VERSION = Version("0.13.2")
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
This is of minimum help since one can't even get to this code, but better to be explicit than to leave this out of date.