### PR TITLE
Run Linux ARM CI on Depot runners (Cherry-pick of #23363)

### DIFF
--- a/.github/workflows/clear_self_hosted_persistent_caches.yaml
+++ b/.github/workflows/clear_self_hosted_persistent_caches.yaml
@@ -4,28 +4,6 @@
 
 
 jobs:
-  clean_linux_arm64:
-    runs-on:
-    - self-hosted
-    - runs-on
-    - runner=4cpu-linux-arm64
-    - image=ubuntu22-full-arm64-python3.7-3.13
-    - run-id=${{ github.run_id }}
-    steps:
-    - name: df before
-      run: df -h
-    - name: Deleting ~/Library/Caches
-      run: du -sh ~/Library/Caches || true; rm -rf ~/Library/Caches || true
-    - name: Deleting ~/.cache
-      run: du -sh ~/.cache || true; rm -rf ~/.cache || true
-    - name: Deleting ~/.nce
-      run: du -sh ~/.nce || true; rm -rf ~/.nce || true
-    - name: Deleting ~/.rustup
-      run: du -sh ~/.rustup || true; rm -rf ~/.rustup || true
-    - name: Deleting ~/.pex
-      run: du -sh ~/.pex || true; rm -rf ~/.pex || true
-    - name: df after
-      run: df -h
   clean_macos13_x86_64:
     runs-on:
     - self-hosted

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,11 +20,7 @@ jobs:
       contents: write
       id-token: write
     runs-on:
-    - self-hosted
-    - runs-on
-    - runner=4cpu-linux-arm64
-    - image=ubuntu22-full-arm64-python3.7-3.13
-    - run-id=${{ github.run_id }}
+    - depot-ubuntu-24.04-arm-8
     steps:
     - name: Free up disk space
       run: |-
@@ -140,7 +136,7 @@ jobs:
       contents: write
       id-token: write
     runs-on:
-    - ubuntu-22.04
+    - depot-ubuntu-22.04-8
     steps:
     - name: Free up disk space
       run: |-
@@ -401,7 +397,7 @@ jobs:
       contents: write
       id-token: write
     runs-on:
-    - macos-14
+    - depot-macos-14
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,11 +21,7 @@ jobs:
     needs:
     - classify_changes
     runs-on:
-    - self-hosted
-    - runs-on
-    - runner=4cpu-linux-arm64
-    - image=ubuntu22-full-arm64-python3.7-3.13
-    - run-id=${{ github.run_id }}
+    - depot-ubuntu-24.04-arm-8
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -41,6 +37,16 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 10
+    - name: Set up Python 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
+      uses: actions/setup-python@v5
+      with:
+        python-version: |-
+          3.8
+          3.9
+          3.10
+          3.12
+          3.13
+          3.11
     - name: Install Protoc
       uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
       with:
@@ -122,7 +128,7 @@ jobs:
     needs:
     - classify_changes
     runs-on:
-    - ubuntu-22.04
+    - depot-ubuntu-22.04-8
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -338,7 +344,7 @@ jobs:
     needs:
     - classify_changes
     runs-on:
-    - macos-14
+    - depot-macos-14
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -452,11 +458,7 @@ jobs:
       contents: write
       id-token: write
     runs-on:
-    - self-hosted
-    - runs-on
-    - runner=4cpu-linux-arm64
-    - image=ubuntu22-full-arm64-python3.7-3.13
-    - run-id=${{ github.run_id }}
+    - depot-ubuntu-24.04-arm-8
     steps:
     - name: Free up disk space
       run: |-
@@ -535,7 +537,7 @@ jobs:
       contents: write
       id-token: write
     runs-on:
-    - ubuntu-22.04
+    - depot-ubuntu-22.04-8
     steps:
     - name: Free up disk space
       run: |-
@@ -707,7 +709,7 @@ jobs:
       contents: write
       id-token: write
     runs-on:
-    - macos-14
+    - depot-macos-14
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -828,7 +830,7 @@ jobs:
     needs:
     - classify_changes
     runs-on:
-    - ubuntu-22.04
+    - depot-ubuntu-22.04-8
     steps:
     - env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -864,7 +866,7 @@ jobs:
       release: ${{ steps.classify.outputs.release }}
       rust: ${{ steps.classify.outputs.rust }}
     runs-on:
-    - ubuntu-22.04
+    - depot-ubuntu-22.04-8
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -908,7 +910,7 @@ jobs:
     - test_python_macos14_arm64
     - classify_changes
     runs-on:
-    - ubuntu-22.04
+    - depot-ubuntu-22.04-8
     steps:
     - uses: coverallsapp/github-action@v2
       with:
@@ -921,7 +923,7 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
-    - ubuntu-22.04
+    - depot-ubuntu-22.04-8
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -991,7 +993,7 @@ jobs:
     needs:
     - set_merge_ok
     runs-on:
-    - ubuntu-22.04
+    - depot-ubuntu-22.04-8
     steps:
     - run: |
         merge_ok="${{ needs.set_merge_ok.outputs.merge_ok }}"
@@ -1037,7 +1039,7 @@ jobs:
     outputs:
       merge_ok: ${{ steps.set_merge_ok.outputs.merge_ok }}
     runs-on:
-    - ubuntu-22.04
+    - depot-ubuntu-22.04-8
     steps:
     - id: set_merge_ok
       run: echo 'merge_ok=true' >> ${GITHUB_OUTPUT}
@@ -1049,11 +1051,7 @@ jobs:
     - bootstrap_pants_linux_arm64
     - classify_changes
     runs-on:
-    - self-hosted
-    - runs-on
-    - runner=4cpu-linux-arm64
-    - image=ubuntu22-full-arm64-python3.7-3.13
-    - run-id=${{ github.run_id }}
+    - depot-ubuntu-24.04-arm-8
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -1082,6 +1080,16 @@ jobs:
       uses: actions/setup-go@7bc60db215a8b16959b0b5cccfdc95950d697b25
       with:
         go-version: 1.24.9
+    - name: Set up Python 3.8, 3.9, 3.10, 3.12, 3.13, 3.11
+      uses: actions/setup-python@v5
+      with:
+        python-version: |-
+          3.8
+          3.9
+          3.10
+          3.12
+          3.13
+          3.11
     - name: Download native binaries
       uses: actions/download-artifact@v4
       with:
@@ -1136,7 +1144,7 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
-    - ubuntu-22.04
+    - depot-ubuntu-22.04-8
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -1262,7 +1270,7 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
-    - ubuntu-22.04
+    - depot-ubuntu-22.04-8
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -1388,7 +1396,7 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
-    - ubuntu-22.04
+    - depot-ubuntu-22.04-8
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -1514,7 +1522,7 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
-    - ubuntu-22.04
+    - depot-ubuntu-22.04-8
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -1640,7 +1648,7 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
-    - ubuntu-22.04
+    - depot-ubuntu-22.04-8
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -1766,7 +1774,7 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
-    - ubuntu-22.04
+    - depot-ubuntu-22.04-8
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -1892,7 +1900,7 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
-    - ubuntu-22.04
+    - depot-ubuntu-22.04-8
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -2018,7 +2026,7 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
-    - ubuntu-22.04
+    - depot-ubuntu-22.04-8
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -2144,7 +2152,7 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
-    - ubuntu-22.04
+    - depot-ubuntu-22.04-8
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -2270,7 +2278,7 @@ jobs:
     - bootstrap_pants_linux_x86_64
     - classify_changes
     runs-on:
-    - ubuntu-22.04
+    - depot-ubuntu-22.04-8
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -2482,7 +2490,7 @@ jobs:
     - bootstrap_pants_macos14_arm64
     - classify_changes
     runs-on:
-    - macos-14
+    - depot-macos-14
     steps:
     - name: Free up disk space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -94,7 +94,7 @@ PYTHON_VERSIONS_PER_PLATFORM: dict[Platform, list[str]] = {
     # Python 3.7 or 3.8 aren't supported directly on arm64 macOS
     Platform.MACOS14_ARM64: [v for v in _BASE_PYTHON_VERSIONS if v not in ("3.7", "3.8")],
     # These runners have Python already installed
-    Platform.MACOS13_X86_64: None,
+    Platform.MACOS13_X86_64: [],
 }
 
 
@@ -584,7 +584,7 @@ class Helper:
     def setup_pythons(self) -> Sequence[Step]:
         ret = []
         versions = PYTHON_VERSIONS_PER_PLATFORM[self.platform]
-        if versions is not None:
+        if versions:
             ret.append(install_pythons(versions))
         return ret
 

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -75,7 +75,7 @@ class Platform(Enum):
 
 
 GITHUB_HOSTED = {Platform.LINUX_X86_64, Platform.MACOS14_ARM64}
-SELF_HOSTED = {Platform.MACOS13_X86_64, Platform.LINUX_ARM64}
+SELF_HOSTED = {Platform.MACOS13_X86_64}
 CARGO_AUDIT_IGNORED_ADVISORY_IDS = (
     "RUSTSEC-2020-0128",  # returns a false positive on the cache crate, which is a local crate not a 3rd party crate
 )
@@ -85,13 +85,16 @@ CARGO_AUDIT_IGNORED_ADVISORY_IDS = (
 # NOTE: The last entry becomes the default
 _BASE_PYTHON_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.12", "3.13", "3.11"]
 
-PYTHON_VERSIONS_PER_PLATFORM = {
+PYTHON_VERSIONS_PER_PLATFORM: dict[Platform, list[str]] = {
     Platform.LINUX_X86_64: _BASE_PYTHON_VERSIONS,
+    # Python 3.7 isn't installable by setup-python on ARM64 Ubuntu 24.04.
+    # TODO: Update any tests still relying on 3.7 and 3.8, which have been long EOL'd,
+    #  and then stop requiring them on any platform.
+    Platform.LINUX_ARM64: [v for v in _BASE_PYTHON_VERSIONS if v != "3.7"],
     # Python 3.7 or 3.8 aren't supported directly on arm64 macOS
     Platform.MACOS14_ARM64: [v for v in _BASE_PYTHON_VERSIONS if v not in ("3.7", "3.8")],
     # These runners have Python already installed
     Platform.MACOS13_X86_64: None,
-    Platform.LINUX_ARM64: None,
 }
 
 
@@ -455,16 +458,11 @@ class Helper:
         if self.platform == Platform.MACOS13_X86_64:
             ret += ["macos-13"]
         elif self.platform == Platform.MACOS14_ARM64:
-            ret += ["macos-14"]
+            ret += ["depot-macos-14"]
         elif self.platform == Platform.LINUX_X86_64:
-            ret += ["ubuntu-22.04"]
+            ret += ["depot-ubuntu-22.04-8"]
         elif self.platform == Platform.LINUX_ARM64:
-            ret += [
-                "runs-on",
-                "runner=4cpu-linux-arm64",
-                "image=ubuntu22-full-arm64-python3.7-3.13",
-                "run-id=${{ github.run_id }}",
-            ]
+            ret += ["depot-ubuntu-24.04-arm-8"]
         elif self.platform == Platform.WINDOWS11_X86_64:
             ret += ["windows-2025"]
         else:


### PR DESCRIPTION
RunsOn is deprecating their v2 stack, and rather than migrate to v3
we should use the resources kindly donated by Depot.

GitHub also now has Linux ARM runners, should we need them.


