### PR TITLE
pin all remaining actions/checkout references

### DIFF
--- a/.github/workflows/auto-cherry-picker.yaml
+++ b/.github/workflows/auto-cherry-picker.yaml
@@ -27,7 +27,7 @@ jobs:
         with:
           node-version: 16
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: npm install ./build-support/cherry_pick
       - id: get-prereqs
         name: Get Cherry-Pick prerequisites
@@ -60,7 +60,7 @@ jobs:
         include: ${{ fromJSON(needs.prerequisites.outputs.matrix) }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ secrets.WORKER_PANTS_CHERRY_PICK_PAT }}
       - name: Prepare cherry-pick branch
@@ -113,7 +113,7 @@ jobs:
     if: needs.prerequisites.result == 'success' && (success() || failure())
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: npm install ./build-support/cherry_pick
       - name: Run Script
         uses: actions/github-script@v8

--- a/.github/workflows/build_runson_ami.yaml
+++ b/.github/workflows/build_runson_ami.yaml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 10
       - name: Run packer

--- a/.github/workflows/create-alpha-release-pr.yaml
+++ b/.github/workflows/create-alpha-release-pr.yaml
@@ -65,7 +65,7 @@ jobs:
           echo "::notice::Base branch is: ${base_branch}"
           echo "base-branch=${base_branch}" >> "$GITHUB_OUTPUT"
       
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ steps.validate-version.outputs.base-branch }}
           fetch-depth: 0  # Required for contributors file

--- a/.github/workflows/create-dev-release-pr.yaml
+++ b/.github/workflows/create-dev-release-pr.yaml
@@ -28,7 +28,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0  # Required for contributors file
 

--- a/.github/workflows/create-rc-release-pr.yaml
+++ b/.github/workflows/create-rc-release-pr.yaml
@@ -57,7 +57,7 @@ jobs:
           echo "::notice::Base branch is: ${base_branch}"
           echo "base-branch=${base_branch}" >> "$GITHUB_OUTPUT"
       
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ steps.validate-version.outputs.base-branch }}
           fetch-depth: 0  # Required for contributors file


### PR DESCRIPTION
This should be the same (pinned) version everywhere and satisfy zizmor.  Example:
https://github.com/pantsbuild/pants/security/code-scanning/479