### PR TITLE
remote_cache: don't drop outputs for REv2.0 root-capture actions

### DIFF
--- a/docs/notes/2.32.x.md
+++ b/docs/notes/2.32.x.md
@@ -37,6 +37,8 @@ Fixed the sandboxer daemon inheriting the parent process's stdin/stdout file des
 
 Fixed "Scheduling:" workunits (process execution wrappers) being logged at INFO instead of DEBUG, which caused duplicate log lines like `Completed: Scheduling: Generate lockfile for pytest` alongside the actual `Completed: Generate lockfile for pytest`.
 
+Fixed silent action-cache corruption for actions using REv2.0 root-capture (`output_directories=[""]`, or `output_directories=["."]` after `RelativePath` normalization). Pants's client-side `update_action_cache` was writing back an `ActionResult` with an empty `output_directories` list, which overwrote any correct entry the remote server had auto-written during `Execute`. Subsequent cache hits on the same action digest then deserialized to a "successful action with no outputs", producing missing-file failures in downstream consumers that were difficult to diagnose because the action itself appeared to succeed. Affects all four execution backends behind `remote_cache::CommandRunner` (`local`, `nailgun`, `docker`, remote execution) when `remote_cache_write = true`. REv2.1 `output_paths` is unaffected.
+
 #### Internal Python Upgrade
 
 The version of Python used by Pants itself has been updated to [3.14](https://docs.python.org/3/whatsnew/3.14.html). To support this, the [Pants Launcher Binary](https://www.pantsbuild.org/blog/2023/02/23/the-pants-launcher-binary-a-much-simpler-way-to-install-and-run-pants) (also known as [`scie-pants`](https://github.com/pantsbuild/scie-pants/)) now has a minimum version of `0.13.2`. To update to the latest launcher binary, either:

--- a/src/rust/process_execution/remote/src/remote_cache.rs
+++ b/src/rust/process_execution/remote/src/remote_cache.rs
@@ -133,22 +133,33 @@ impl CommandRunner {
         root_trie: &DigestTrie,
         directory_path: RelativePath,
     ) -> Result<Option<(Tree, Vec<Digest>)>, String> {
-        let sub_trie = match root_trie.entry(&directory_path)? {
-            None => return Ok(None),
-            Some(directory::Entry::Directory(d)) => d.tree(),
-            Some(directory::Entry::Symlink(_)) => {
-                return Err(format!(
-                    "Declared output directory path {directory_path:?} in output \
+        // REv2.0 allows `output_directories=[""]` to mean "capture the entire working
+        // directory as a Tree". `root_trie.entry("")` returns None because the root has
+        // no entry with name "", so without this special case the caller `continue`s
+        // and the output is silently dropped from the ActionResult written to the AC.
+        // This produces a cache entry that looks "successful" but has no outputs, which
+        // then poisons downstream cache hits. Detect the root-capture case explicitly
+        // and use the entire root trie as the sub-trie.
+        let sub_trie = if directory_path.as_os_str().is_empty() {
+            root_trie
+        } else {
+            match root_trie.entry(&directory_path)? {
+                None => return Ok(None),
+                Some(directory::Entry::Directory(d)) => d.tree(),
+                Some(directory::Entry::Symlink(_)) => {
+                    return Err(format!(
+                        "Declared output directory path {directory_path:?} in output \
            digest {trie_digest:?} contained a symlink instead.",
-                    trie_digest = root_trie.compute_root_digest(),
-                ));
-            }
-            Some(directory::Entry::File(_)) => {
-                return Err(format!(
-                    "Declared output directory path {directory_path:?} in output \
+                        trie_digest = root_trie.compute_root_digest(),
+                    ));
+                }
+                Some(directory::Entry::File(_)) => {
+                    return Err(format!(
+                        "Declared output directory path {directory_path:?} in output \
            digest {trie_digest:?} contained a file instead.",
-                    trie_digest = root_trie.compute_root_digest(),
-                ));
+                        trie_digest = root_trie.compute_root_digest(),
+                    ));
+                }
             }
         };
 


### PR DESCRIPTION
make_tree_for_output_directory returned Ok(None) for empty directory_path because DigestTrie::entry("") has no root match. The caller in make_action_result then continued, silently dropping the OutputDirectory from the ActionResult that Pants uploads via UpdateActionResult, overwriting any correct entry the remote server had auto-written during Execute.

This corrupted the AC for every action using REv2.0 output_directories=[""] / ["."] (Pants's normalized root-capture). Subsequent AC hits deserialized to a "successful action with no outputs", producing broken downstream consumers.

Fix: special-case empty directory_path in
make_tree_for_output_directory to walk the entire root_trie instead of asking for a child entry named "". The rest of the function is unchanged.

Affects all four inner runners behind remote_cache::CommandRunner (local, nailgun, docker, remote execution). The remote-execution path was intermittently masked by the server's auto-write surviving when the Pants tail-task didn't.