### PR TITLE
mitigate "extra_env" code injection via template expansion

### DIFF
--- a/.github/workflows/public_repos.yaml
+++ b/.github/workflows/public_repos.yaml
@@ -36,55 +36,60 @@ jobs:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `version` with repo-default version (baseline)
-      run: ' pants version'
+      run: pants version
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `tailor --check update-build-files --check ::` with repo-default version (baseline)
-      run: ' pants tailor --check update-build-files --check ::'
+      run: 'pants tailor --check update-build-files --check ::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `lint check ::` with repo-default version (baseline)
-      run: ' pants lint check ::'
+      run: 'pants lint check ::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `test ::` with repo-default version (baseline)
-      run: ' pants test ::'
+      run: 'pants test ::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `package ::` with repo-default version (baseline)
-      run: ' pants package ::'
+      run: 'pants package ::'
     - if: success() || failure()
       name: Kill pantsd
       run: pkill -f pantsd
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `version` with ${{ github.event.inputs.pants_version }}
-      run: ${{ github.event.inputs.extra_env }} pants version
+      run: eval "$EXTRA_ENV pants version"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `tailor --check update-build-files --check ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants tailor --check update-build-files --check ::'
+      run: eval "$EXTRA_ENV pants tailor --check update-build-files --check ::"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `lint check ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants lint check ::'
+      run: eval "$EXTRA_ENV pants lint check ::"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `test ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants test ::'
+      run: eval "$EXTRA_ENV pants test ::"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `package ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants package ::'
+      run: eval "$EXTRA_ENV pants package ::"
   Ars-Linguistica_mlconjug3:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
@@ -117,25 +122,27 @@ jobs:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `version` with repo-default version (baseline)
-      run: ' pants version'
+      run: pants version
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `package ::` with repo-default version (baseline)
-      run: ' pants package ::'
+      run: 'pants package ::'
     - if: success() || failure()
       name: Kill pantsd
       run: pkill -f pantsd
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `version` with ${{ github.event.inputs.pants_version }}
-      run: ${{ github.event.inputs.extra_env }} pants version
+      run: eval "$EXTRA_ENV pants version"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `package ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants package ::'
+      run: eval "$EXTRA_ENV pants package ::"
   OpenSaMD_OpenSaMD:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
@@ -168,55 +175,60 @@ jobs:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `version` with repo-default version (baseline)
-      run: ' pants version'
+      run: pants version
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `tailor --check update-build-files --check ::` with repo-default version (baseline)
-      run: ' pants tailor --check update-build-files --check ::'
+      run: 'pants tailor --check update-build-files --check ::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `lint check ::` with repo-default version (baseline)
-      run: ' pants lint check ::'
+      run: 'pants lint check ::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `test ::` with repo-default version (baseline)
-      run: ' pants test ::'
+      run: 'pants test ::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `package ::` with repo-default version (baseline)
-      run: ' pants package ::'
+      run: 'pants package ::'
     - if: success() || failure()
       name: Kill pantsd
       run: pkill -f pantsd
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `version` with ${{ github.event.inputs.pants_version }}
-      run: ${{ github.event.inputs.extra_env }} pants version
+      run: eval "$EXTRA_ENV pants version"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `tailor --check update-build-files --check ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants tailor --check update-build-files --check ::'
+      run: eval "$EXTRA_ENV pants tailor --check update-build-files --check ::"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `lint check ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants lint check ::'
+      run: eval "$EXTRA_ENV pants lint check ::"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `test ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants test ::'
+      run: eval "$EXTRA_ENV pants test ::"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `package ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants package ::'
+      run: eval "$EXTRA_ENV pants package ::"
   StackStorm_st2:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
@@ -256,55 +268,60 @@ jobs:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `version` with repo-default version (baseline)
-      run: ' pants version'
+      run: pants version
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `tailor --check update-build-files --check ::` with repo-default version (baseline)
-      run: ' pants tailor --check update-build-files --check ::'
+      run: 'pants tailor --check update-build-files --check ::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `lint check ::` with repo-default version (baseline)
-      run: ' pants lint check ::'
+      run: 'pants lint check ::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `test st2client::` with repo-default version (baseline)
-      run: ' pants test st2client::'
+      run: 'pants test st2client::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `package ::` with repo-default version (baseline)
-      run: ' pants package ::'
+      run: 'pants package ::'
     - if: success() || failure()
       name: Kill pantsd
       run: pkill -f pantsd
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `version` with ${{ github.event.inputs.pants_version }}
-      run: ${{ github.event.inputs.extra_env }} pants version
+      run: eval "$EXTRA_ENV pants version"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `tailor --check update-build-files --check ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants tailor --check update-build-files --check ::'
+      run: eval "$EXTRA_ENV pants tailor --check update-build-files --check ::"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `lint check ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants lint check ::'
+      run: eval "$EXTRA_ENV pants lint check ::"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `test st2client::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants test st2client::'
+      run: eval "$EXTRA_ENV pants test st2client::"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `package ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants package ::'
+      run: eval "$EXTRA_ENV pants package ::"
   fucina_treb:
     env:
       GIT_COMMIT: abcdef1234567890
@@ -338,45 +355,49 @@ jobs:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `version` with repo-default version (baseline)
-      run: ' pants version'
+      run: pants version
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `lint check ::` with repo-default version (baseline)
-      run: ' pants lint check ::'
+      run: 'pants lint check ::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `test ::` with repo-default version (baseline)
-      run: ' pants test ::'
+      run: 'pants test ::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `package ::` with repo-default version (baseline)
-      run: ' pants package ::'
+      run: 'pants package ::'
     - if: success() || failure()
       name: Kill pantsd
       run: pkill -f pantsd
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `version` with ${{ github.event.inputs.pants_version }}
-      run: ${{ github.event.inputs.extra_env }} pants version
+      run: eval "$EXTRA_ENV pants version"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `lint check ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants lint check ::'
+      run: eval "$EXTRA_ENV pants lint check ::"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `test ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants test ::'
+      run: eval "$EXTRA_ENV pants test ::"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `package ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants package ::'
+      run: eval "$EXTRA_ENV pants package ::"
   ghandic_jsf:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
@@ -409,35 +430,38 @@ jobs:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `version` with repo-default version (baseline)
-      run: ' pants version'
+      run: pants version
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `test ::` with repo-default version (baseline)
-      run: ' pants test ::'
+      run: 'pants test ::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `package ::` with repo-default version (baseline)
-      run: ' pants package ::'
+      run: 'pants package ::'
     - if: success() || failure()
       name: Kill pantsd
       run: pkill -f pantsd
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `version` with ${{ github.event.inputs.pants_version }}
-      run: ${{ github.event.inputs.extra_env }} pants version
+      run: eval "$EXTRA_ENV pants version"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `test ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants test ::'
+      run: eval "$EXTRA_ENV pants test ::"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `package ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants package ::'
+      run: eval "$EXTRA_ENV pants package ::"
   komprenilo_liga:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
@@ -470,25 +494,27 @@ jobs:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `version` with repo-default version (baseline)
-      run: ' pants version'
+      run: pants version
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `package ::` with repo-default version (baseline)
-      run: ' pants package ::'
+      run: 'pants package ::'
     - if: success() || failure()
       name: Kill pantsd
       run: pkill -f pantsd
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `version` with ${{ github.event.inputs.pants_version }}
-      run: ${{ github.event.inputs.extra_env }} pants version
+      run: eval "$EXTRA_ENV pants version"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `package ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants package ::'
+      run: eval "$EXTRA_ENV pants package ::"
   lablup_backend_ai:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
@@ -523,55 +549,60 @@ jobs:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `version` with repo-default version (baseline)
-      run: ' pants version'
+      run: pants version
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `tailor --check update-build-files --check ::` with repo-default version (baseline)
-      run: ' pants tailor --check update-build-files --check ::'
+      run: 'pants tailor --check update-build-files --check ::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `lint check ::` with repo-default version (baseline)
-      run: ' pants lint check ::'
+      run: 'pants lint check ::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: 'Run `test :: -tests/agent/docker:: -tests/client/integration:: -tests/common/redis_helper::` with repo-default version (baseline)'
-      run: ' pants test :: -tests/agent/docker:: -tests/client/integration:: -tests/common/redis_helper::'
+      run: 'pants test :: -tests/agent/docker:: -tests/client/integration:: -tests/common/redis_helper::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `package ::` with repo-default version (baseline)
-      run: ' pants package ::'
+      run: 'pants package ::'
     - if: success() || failure()
       name: Kill pantsd
       run: pkill -f pantsd
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `version` with ${{ github.event.inputs.pants_version }}
-      run: ${{ github.event.inputs.extra_env }} pants version
+      run: eval "$EXTRA_ENV pants version"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `tailor --check update-build-files --check ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants tailor --check update-build-files --check ::'
+      run: eval "$EXTRA_ENV pants tailor --check update-build-files --check ::"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `lint check ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants lint check ::'
+      run: eval "$EXTRA_ENV pants lint check ::"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: 'Run `test :: -tests/agent/docker:: -tests/client/integration:: -tests/common/redis_helper::` with ${{ github.event.inputs.pants_version }}'
-      run: '${{ github.event.inputs.extra_env }} pants test :: -tests/agent/docker:: -tests/client/integration:: -tests/common/redis_helper::'
+      run: 'eval "$EXTRA_ENV pants test :: -tests/agent/docker:: -tests/client/integration:: -tests/common/redis_helper::"'
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `package ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants package ::'
+      run: eval "$EXTRA_ENV pants package ::"
   mitodl_ol-django:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
@@ -606,25 +637,27 @@ jobs:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `version` with repo-default version (baseline)
-      run: ' pants version'
+      run: pants version
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `package ::` with repo-default version (baseline)
-      run: ' pants package ::'
+      run: 'pants package ::'
     - if: success() || failure()
       name: Kill pantsd
       run: pkill -f pantsd
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `version` with ${{ github.event.inputs.pants_version }}
-      run: ${{ github.event.inputs.extra_env }} pants version
+      run: eval "$EXTRA_ENV pants version"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `package ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants package ::'
+      run: eval "$EXTRA_ENV pants package ::"
   mitodl_ol-infrastructure:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
@@ -657,25 +690,27 @@ jobs:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `version` with repo-default version (baseline)
-      run: ' pants version'
+      run: pants version
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `package ::` with repo-default version (baseline)
-      run: ' pants package ::'
+      run: 'pants package ::'
     - if: success() || failure()
       name: Kill pantsd
       run: pkill -f pantsd
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `version` with ${{ github.event.inputs.pants_version }}
-      run: ${{ github.event.inputs.extra_env }} pants version
+      run: eval "$EXTRA_ENV pants version"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `package ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants package ::'
+      run: eval "$EXTRA_ENV pants package ::"
   naccdata_flywheel-gear-extensions:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
@@ -708,35 +743,38 @@ jobs:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `version` with repo-default version (baseline)
-      run: ' pants version'
+      run: pants version
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `test ::` with repo-default version (baseline)
-      run: ' pants test ::'
+      run: 'pants test ::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: 'Run `package :: -directory_pull::` with repo-default version (baseline)'
-      run: ' pants package :: -directory_pull::'
+      run: 'pants package :: -directory_pull::'
     - if: success() || failure()
       name: Kill pantsd
       run: pkill -f pantsd
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `version` with ${{ github.event.inputs.pants_version }}
-      run: ${{ github.event.inputs.extra_env }} pants version
+      run: eval "$EXTRA_ENV pants version"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `test ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants test ::'
+      run: eval "$EXTRA_ENV pants test ::"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: 'Run `package :: -directory_pull::` with ${{ github.event.inputs.pants_version }}'
-      run: '${{ github.event.inputs.extra_env }} pants package :: -directory_pull::'
+      run: 'eval "$EXTRA_ENV pants package :: -directory_pull::"'
   pantsbuild_example-adhoc:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
@@ -773,35 +811,38 @@ jobs:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `version` with repo-default version (baseline)
-      run: ' pants version'
+      run: pants version
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `lint check ::` with repo-default version (baseline)
-      run: ' pants lint check ::'
+      run: 'pants lint check ::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `test ::` with repo-default version (baseline)
-      run: ' pants test ::'
+      run: 'pants test ::'
     - if: success() || failure()
       name: Kill pantsd
       run: pkill -f pantsd
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `version` with ${{ github.event.inputs.pants_version }}
-      run: ${{ github.event.inputs.extra_env }} pants version
+      run: eval "$EXTRA_ENV pants version"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `lint check ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants lint check ::'
+      run: eval "$EXTRA_ENV pants lint check ::"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `test ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants test ::'
+      run: eval "$EXTRA_ENV pants test ::"
   pantsbuild_example-codegen:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
@@ -841,55 +882,60 @@ jobs:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `version` with repo-default version (baseline)
-      run: ' pants version'
+      run: pants version
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `tailor --check update-build-files --check ::` with repo-default version (baseline)
-      run: ' pants tailor --check update-build-files --check ::'
+      run: 'pants tailor --check update-build-files --check ::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `lint check ::` with repo-default version (baseline)
-      run: ' pants lint check ::'
+      run: 'pants lint check ::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `test ::` with repo-default version (baseline)
-      run: ' pants test ::'
+      run: 'pants test ::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `package ::` with repo-default version (baseline)
-      run: ' pants package ::'
+      run: 'pants package ::'
     - if: success() || failure()
       name: Kill pantsd
       run: pkill -f pantsd
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `version` with ${{ github.event.inputs.pants_version }}
-      run: ${{ github.event.inputs.extra_env }} pants version
+      run: eval "$EXTRA_ENV pants version"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `tailor --check update-build-files --check ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants tailor --check update-build-files --check ::'
+      run: eval "$EXTRA_ENV pants tailor --check update-build-files --check ::"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `lint check ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants lint check ::'
+      run: eval "$EXTRA_ENV pants lint check ::"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `test ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants test ::'
+      run: eval "$EXTRA_ENV pants test ::"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `package ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants package ::'
+      run: eval "$EXTRA_ENV pants package ::"
   pantsbuild_example-django:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
@@ -922,55 +968,60 @@ jobs:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `version` with repo-default version (baseline)
-      run: ' pants version'
+      run: pants version
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `tailor --check update-build-files --check ::` with repo-default version (baseline)
-      run: ' pants tailor --check update-build-files --check ::'
+      run: 'pants tailor --check update-build-files --check ::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `lint check ::` with repo-default version (baseline)
-      run: ' pants lint check ::'
+      run: 'pants lint check ::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `test ::` with repo-default version (baseline)
-      run: ' pants test ::'
+      run: 'pants test ::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `package ::` with repo-default version (baseline)
-      run: ' pants package ::'
+      run: 'pants package ::'
     - if: success() || failure()
       name: Kill pantsd
       run: pkill -f pantsd
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `version` with ${{ github.event.inputs.pants_version }}
-      run: ${{ github.event.inputs.extra_env }} pants version
+      run: eval "$EXTRA_ENV pants version"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `tailor --check update-build-files --check ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants tailor --check update-build-files --check ::'
+      run: eval "$EXTRA_ENV pants tailor --check update-build-files --check ::"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `lint check ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants lint check ::'
+      run: eval "$EXTRA_ENV pants lint check ::"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `test ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants test ::'
+      run: eval "$EXTRA_ENV pants test ::"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `package ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants package ::'
+      run: eval "$EXTRA_ENV pants package ::"
   pantsbuild_example-docker:
     env:
       DYNAMIC_TAG: dynamic-tag-here
@@ -1004,55 +1055,60 @@ jobs:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `version` with repo-default version (baseline)
-      run: ' pants version'
+      run: pants version
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `tailor --check update-build-files --check ::` with repo-default version (baseline)
-      run: ' pants tailor --check update-build-files --check ::'
+      run: 'pants tailor --check update-build-files --check ::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `lint check ::` with repo-default version (baseline)
-      run: ' pants lint check ::'
+      run: 'pants lint check ::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `test ::` with repo-default version (baseline)
-      run: ' pants test ::'
+      run: 'pants test ::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `package ::` with repo-default version (baseline)
-      run: ' pants package ::'
+      run: 'pants package ::'
     - if: success() || failure()
       name: Kill pantsd
       run: pkill -f pantsd
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `version` with ${{ github.event.inputs.pants_version }}
-      run: ${{ github.event.inputs.extra_env }} pants version
+      run: eval "$EXTRA_ENV pants version"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `tailor --check update-build-files --check ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants tailor --check update-build-files --check ::'
+      run: eval "$EXTRA_ENV pants tailor --check update-build-files --check ::"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `lint check ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants lint check ::'
+      run: eval "$EXTRA_ENV pants lint check ::"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `test ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants test ::'
+      run: eval "$EXTRA_ENV pants test ::"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `package ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants package ::'
+      run: eval "$EXTRA_ENV pants package ::"
   pantsbuild_example-golang:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
@@ -1095,55 +1151,60 @@ jobs:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `version` with repo-default version (baseline)
-      run: ' pants version'
+      run: pants version
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `tailor --check update-build-files --check ::` with repo-default version (baseline)
-      run: ' pants tailor --check update-build-files --check ::'
+      run: 'pants tailor --check update-build-files --check ::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `lint check ::` with repo-default version (baseline)
-      run: ' pants lint check ::'
+      run: 'pants lint check ::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `test ::` with repo-default version (baseline)
-      run: ' pants test ::'
+      run: 'pants test ::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `package ::` with repo-default version (baseline)
-      run: ' pants package ::'
+      run: 'pants package ::'
     - if: success() || failure()
       name: Kill pantsd
       run: pkill -f pantsd
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `version` with ${{ github.event.inputs.pants_version }}
-      run: ${{ github.event.inputs.extra_env }} pants version
+      run: eval "$EXTRA_ENV pants version"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `tailor --check update-build-files --check ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants tailor --check update-build-files --check ::'
+      run: eval "$EXTRA_ENV pants tailor --check update-build-files --check ::"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `lint check ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants lint check ::'
+      run: eval "$EXTRA_ENV pants lint check ::"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `test ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants test ::'
+      run: eval "$EXTRA_ENV pants test ::"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `package ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants package ::'
+      run: eval "$EXTRA_ENV pants package ::"
   pantsbuild_example-jvm:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
@@ -1176,55 +1237,60 @@ jobs:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `version` with repo-default version (baseline)
-      run: ' pants version'
+      run: pants version
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `tailor --check update-build-files --check ::` with repo-default version (baseline)
-      run: ' pants tailor --check update-build-files --check ::'
+      run: 'pants tailor --check update-build-files --check ::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `lint check ::` with repo-default version (baseline)
-      run: ' pants lint check ::'
+      run: 'pants lint check ::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `test ::` with repo-default version (baseline)
-      run: ' pants test ::'
+      run: 'pants test ::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `package ::` with repo-default version (baseline)
-      run: ' pants package ::'
+      run: 'pants package ::'
     - if: success() || failure()
       name: Kill pantsd
       run: pkill -f pantsd
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `version` with ${{ github.event.inputs.pants_version }}
-      run: ${{ github.event.inputs.extra_env }} pants version
+      run: eval "$EXTRA_ENV pants version"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `tailor --check update-build-files --check ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants tailor --check update-build-files --check ::'
+      run: eval "$EXTRA_ENV pants tailor --check update-build-files --check ::"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `lint check ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants lint check ::'
+      run: eval "$EXTRA_ENV pants lint check ::"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `test ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants test ::'
+      run: eval "$EXTRA_ENV pants test ::"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `package ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants package ::'
+      run: eval "$EXTRA_ENV pants package ::"
   pantsbuild_example-kotlin:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
@@ -1257,55 +1323,60 @@ jobs:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `version` with repo-default version (baseline)
-      run: ' pants version'
+      run: pants version
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `tailor --check update-build-files --check ::` with repo-default version (baseline)
-      run: ' pants tailor --check update-build-files --check ::'
+      run: 'pants tailor --check update-build-files --check ::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `lint check ::` with repo-default version (baseline)
-      run: ' pants lint check ::'
+      run: 'pants lint check ::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `test ::` with repo-default version (baseline)
-      run: ' pants test ::'
+      run: 'pants test ::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `package ::` with repo-default version (baseline)
-      run: ' pants package ::'
+      run: 'pants package ::'
     - if: success() || failure()
       name: Kill pantsd
       run: pkill -f pantsd
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `version` with ${{ github.event.inputs.pants_version }}
-      run: ${{ github.event.inputs.extra_env }} pants version
+      run: eval "$EXTRA_ENV pants version"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `tailor --check update-build-files --check ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants tailor --check update-build-files --check ::'
+      run: eval "$EXTRA_ENV pants tailor --check update-build-files --check ::"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `lint check ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants lint check ::'
+      run: eval "$EXTRA_ENV pants lint check ::"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `test ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants test ::'
+      run: eval "$EXTRA_ENV pants test ::"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `package ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants package ::'
+      run: eval "$EXTRA_ENV pants package ::"
   pantsbuild_example-python:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
@@ -1338,55 +1409,60 @@ jobs:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `version` with repo-default version (baseline)
-      run: ' pants version'
+      run: pants version
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `tailor --check update-build-files --check ::` with repo-default version (baseline)
-      run: ' pants tailor --check update-build-files --check ::'
+      run: 'pants tailor --check update-build-files --check ::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `lint check ::` with repo-default version (baseline)
-      run: ' pants lint check ::'
+      run: 'pants lint check ::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `test ::` with repo-default version (baseline)
-      run: ' pants test ::'
+      run: 'pants test ::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `package ::` with repo-default version (baseline)
-      run: ' pants package ::'
+      run: 'pants package ::'
     - if: success() || failure()
       name: Kill pantsd
       run: pkill -f pantsd
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `version` with ${{ github.event.inputs.pants_version }}
-      run: ${{ github.event.inputs.extra_env }} pants version
+      run: eval "$EXTRA_ENV pants version"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `tailor --check update-build-files --check ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants tailor --check update-build-files --check ::'
+      run: eval "$EXTRA_ENV pants tailor --check update-build-files --check ::"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `lint check ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants lint check ::'
+      run: eval "$EXTRA_ENV pants lint check ::"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `test ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants test ::'
+      run: eval "$EXTRA_ENV pants test ::"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `package ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants package ::'
+      run: eval "$EXTRA_ENV pants package ::"
   pantsbuild_example-visibility:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
@@ -1419,45 +1495,49 @@ jobs:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `version` with repo-default version (baseline)
-      run: ' pants version'
+      run: pants version
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `tailor --check update-build-files --check ::` with repo-default version (baseline)
-      run: ' pants tailor --check update-build-files --check ::'
+      run: 'pants tailor --check update-build-files --check ::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `lint ::` with repo-default version (baseline)
-      run: ' pants lint ::'
+      run: 'pants lint ::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `test ::` with repo-default version (baseline)
-      run: ' pants test ::'
+      run: 'pants test ::'
     - if: success() || failure()
       name: Kill pantsd
       run: pkill -f pantsd
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `version` with ${{ github.event.inputs.pants_version }}
-      run: ${{ github.event.inputs.extra_env }} pants version
+      run: eval "$EXTRA_ENV pants version"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `tailor --check update-build-files --check ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants tailor --check update-build-files --check ::'
+      run: eval "$EXTRA_ENV pants tailor --check update-build-files --check ::"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `lint ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants lint ::'
+      run: eval "$EXTRA_ENV pants lint ::"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `test ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants test ::'
+      run: eval "$EXTRA_ENV pants test ::"
   pantsbuild_scie-pants:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
@@ -1490,55 +1570,60 @@ jobs:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `version` with repo-default version (baseline)
-      run: ' pants version'
+      run: pants version
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `tailor --check update-build-files --check ::` with repo-default version (baseline)
-      run: ' pants tailor --check update-build-files --check ::'
+      run: 'pants tailor --check update-build-files --check ::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `lint check ::` with repo-default version (baseline)
-      run: ' pants lint check ::'
+      run: 'pants lint check ::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `test ::` with repo-default version (baseline)
-      run: ' pants test ::'
+      run: 'pants test ::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
       name: Run `package ::` with repo-default version (baseline)
-      run: ' pants package ::'
+      run: 'pants package ::'
     - if: success() || failure()
       name: Kill pantsd
       run: pkill -f pantsd
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `version` with ${{ github.event.inputs.pants_version }}
-      run: ${{ github.event.inputs.extra_env }} pants version
+      run: eval "$EXTRA_ENV pants version"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `tailor --check update-build-files --check ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants tailor --check update-build-files --check ::'
+      run: eval "$EXTRA_ENV pants tailor --check update-build-files --check ::"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `lint check ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants lint check ::'
+      run: eval "$EXTRA_ENV pants lint check ::"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `test ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants test ::'
+      run: eval "$EXTRA_ENV pants test ::"
     - env:
+        EXTRA_ENV: ${{ github.event.inputs.extra_env }}
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
       name: Run `package ::` with ${{ github.event.inputs.pants_version }}
-      run: '${{ github.event.inputs.extra_env }} pants package ::'
+      run: eval "$EXTRA_ENV pants package ::"
 name: Public repos tests
 'on':
   workflow_dispatch:

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -1719,8 +1719,7 @@ def public_repos() -> PublicReposOutput:
             ),
             # extra environment variables to pass when running the version under test,
             # e.g. `PANTS_SOME_SUBSYSTEM_SOME_SETTING=abc`.  NB. we use it in a way that's vulnerable to
-            # shell injection (there's no validation that it uses A=1 B=2 syntax, it can easily contain
-            # more commands), but this whole workflow is "run untrusted code as a service", so Pants
+            # shell injection but this whole workflow is "run untrusted code as a service", so Pants
             # maintainers injecting things is the least of our worries
             WorkflowInput(
                 "EXTRA_ENV",
@@ -1740,21 +1739,21 @@ def public_repos() -> PublicReposOutput:
             if use_default_version:
                 name = "repo-default version (baseline)"
                 version = ""
-                env_prefix = ""
+                step_env: dict[str, str] = {"PANTS_VERSION": version}
+                run_tmpl = "pants {goal}"
             else:
                 name = version = env["PANTS_VERSION"]
-                env_prefix = env["EXTRA_ENV"]
+                step_env = {"PANTS_VERSION": version, "EXTRA_ENV": env["EXTRA_ENV"]}
+                run_tmpl = 'eval "$EXTRA_ENV pants {goal}"'
 
             return [
                 {
                     "name": f"Run `{goal}` with {name}",
-                    # injecting the input string as just prefices is easier than turning it into
-                    # arguments for `env`
-                    "run": f"{env_prefix} pants {goal}",
+                    "run": run_tmpl.format(goal=goal),
                     # run all the goals, even if there's an earlier failure, because later goals
                     # might still be interesting (e.g. still run `test` even if `lint` fails)
                     "if": "success() || failure()",
-                    "env": {"PANTS_VERSION": version},
+                    "env": step_env,
                 }
                 for goal in ["version", *repo.goals]
             ]


### PR DESCRIPTION
zizmor does not like any of the places where we allow inputs based template expansion. Example:
https://github.com/pantsbuild/pants/security/code-scanning/102

Per the comment "extra_env" is already limited to maintainers due to its vulnerability to shell injection.  I'm not sure preventing maintainers from doing template injection is that much of an improvement, but fixing it wasn't much more work than getting an ignore comment to propagate through the yaml machinations.

NOTE: LLM assisted for both what zizmor was getting at, and generating the work around.

Test Note: https://github.com/pantsbuild/pants/actions/runs/26538042158/job/78172033584
<img width="784" height="393" alt="image" src="https://github.com/user-attachments/assets/8c6d969d-02d4-4dec-a54f-a3a2d794c7e4" />
