### PR TITLE
fix: fallback to default width when terminal size is 0 (#17946) (Cherry-pick of #23364)

### DIFF
--- a/src/python/pants/util/docutil.py
+++ b/src/python/pants/util/docutil.py
@@ -13,7 +13,14 @@ from pants.version import MAJOR_MINOR, PANTS_SEMVER
 # NB: This is not memoized because that would cause Pants to not pick up terminal resizing when
 # using pantsd.
 def terminal_width(*, fallback: int = 96, padding: int = 2) -> int:
-    return shutil.get_terminal_size(fallback=(fallback, 24)).columns - padding
+    columns = shutil.get_terminal_size(fallback=(fallback, 24)).columns
+    # Some limited terminals may report a width of 0 even when a fallback is provided
+    # (for example, certain non-interactive environments or misbehaving terminal emulators).
+    # Treat a reported width of 0 as if the fallback was returned to avoid returning
+    # an invalid or negative width after applying padding.
+    if columns == 0:
+        columns = fallback
+    return columns - padding
 
 
 _VERSIONED_PREFIXES = ("docs/", "reference/")

--- a/src/python/pants/util/docutil_test.py
+++ b/src/python/pants/util/docutil_test.py
@@ -3,11 +3,13 @@
 
 from __future__ import annotations
 
+import os
+
 import pytest
 from packaging.version import Version
 
 from pants.util import docutil
-from pants.util.docutil import doc_url, git_url
+from pants.util.docutil import doc_url, git_url, terminal_width
 
 
 @pytest.mark.parametrize(
@@ -49,3 +51,12 @@ def test_git_url(monkeypatch) -> None:
         git_url("some_file.ext")
         == "https://github.com/pantsbuild/pants/blob/release_1.29.0/some_file.ext"
     )
+
+
+def test_terminal_width_falls_back_when_columns_are_zero(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "pants.util.docutil.shutil.get_terminal_size",
+        lambda *args, **kwargs: os.terminal_size((0, 24)),
+    )
+
+    assert terminal_width() == 94


### PR DESCRIPTION
Resolves #17946
# Problem Description
The bug occurred specifically when running help commands (pants help) within the Emacs editor's eshell terminal. Because it is a more limited environment, eshell incorrectly reported the terminal width as 0 columns.
The function responsible for calculating this width (terminal_width), located in the docutil.py file, used the shutil.get_terminal_size() method to capture the value. Upon receiving the value 0, the function simply subtracted a standard padding of 2. This mathematical calculation resulted in a negative width of -2. Consequently, when the system attempted to format the help text to fit on an impossible -2 column screen, the program suffered a total collapse, triggering the fatal error ValueError: invalid width -2 (must be > 0).


# What changed:
Refactored terminal_width in docutil.py to explicitly check if shutil.get_terminal_size().columns returns 0.

If columns == 0 (which happens in limited terminals like Emacs eshell), the function now applies the default fallback value before subtracting the padding, preventing a ValueError with negative widths.

Added a regression test (test_terminal_width_falls_back_when_columns_are_zero) in docutil_test.py to ensure the fallback logic holds via monkeypatching.

