### PR TITLE
refactor: Parse BUILD-files once

### DIFF
--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -115,6 +115,13 @@ class BuildFileSyntaxError(SyntaxError):
         return first_line
 
 
+def _parse_build_file_ast(content: str | bytes, filepath: str) -> ast.Module:
+    try:
+        return ast.parse(content, filepath)
+    except SyntaxError as e:
+        raise BuildFileSyntaxError.from_syntax_error(e).with_traceback(e.__traceback__)
+
+
 @dataclass(frozen=True)
 class BuildFileOptions:
     patterns: tuple[str, ...]
@@ -164,12 +171,13 @@ async def evaluate_preludes(
     for file_content in prelude_digest_contents:
         try:
             file_content_str = file_content.content.decode()
-            content = compile(file_content_str, file_content.path, "exec", dont_inherit=True)
+            tree = ast.parse(file_content_str, file_content.path)
+            content = compile(tree, file_content.path, "exec", dont_inherit=True)
             exec(content, globals, locals)
         except Exception as e:
             raise Exception(f"Error parsing prelude file {file_content.path}: {e}")
-        error_on_imports(file_content_str, file_content.path)
-        env_vars.update(BUILDFileEnvVarExtractor.get_env_vars(file_content))
+        error_on_imports(file_content_str, tree, file_content.path)
+        env_vars.update(BUILDFileEnvVarExtractor.get_env_vars_from_tree(tree, file_content.path))
     # __builtins__ is a dict, so isn't hashable, and can't be put in a FrozenDict.
     # Fortunately, we don't care about it - preludes should not be able to override builtins, so we just pop it out.
     # TODO: Give a nice error message if a prelude tries to set and expose a non-hashable value.
@@ -270,12 +278,13 @@ class BUILDFileEnvVarExtractor(ast.NodeVisitor):
 
     @classmethod
     def get_env_vars(cls, file_content: FileContent) -> Sequence[str]:
-        obj = cls(file_content.path)
-        try:
-            obj.visit(ast.parse(file_content.content, file_content.path))
-        except SyntaxError as e:
-            raise BuildFileSyntaxError.from_syntax_error(e).with_traceback(e.__traceback__)
+        tree = _parse_build_file_ast(file_content.content, file_content.path)
+        return cls.get_env_vars_from_tree(tree, file_content.path)
 
+    @classmethod
+    def get_env_vars_from_tree(cls, tree: ast.Module, filename: str) -> Sequence[str]:
+        obj = cls(filename)
+        obj.visit(tree)
         return tuple(obj.env_vars)
 
     def visit_Call(self, node: ast.Call):
@@ -379,24 +388,32 @@ async def parse_address_family(
         dependents_rules_parser_state = None
         dependencies_rules_parser_state = None
 
+    parsed_build_files = [
+        (fc, _parse_build_file_ast(fc.content, fc.path)) for fc in digest_contents
+    ]
+
     def _extract_env_vars(
-        file_content: FileContent, extra_env: Sequence[str], env: CompleteEnvironmentVars
+        tree: ast.Module, filename: str, extra_env: Sequence[str], env: CompleteEnvironmentVars
     ) -> Coroutine[Any, Any, EnvironmentVars]:
         """For BUILD file env vars, we only ever consult the local systems env."""
-        env_vars = (*BUILDFileEnvVarExtractor.get_env_vars(file_content), *extra_env)
+        env_vars = (*BUILDFileEnvVarExtractor.get_env_vars_from_tree(tree, filename), *extra_env)
         return environment_vars_subset(EnvironmentVarsRequest(env_vars), env)
 
     all_env_vars = await concurrently(
         _extract_env_vars(
-            fc, prelude_symbols.referenced_env_vars, session_values[CompleteEnvironmentVars]
+            tree,
+            fc.path,
+            prelude_symbols.referenced_env_vars,
+            session_values[CompleteEnvironmentVars],
         )
-        for fc in digest_contents
+        for fc, tree in parsed_build_files
     )
 
     declared_address_maps = [
         AddressMap.parse(
             fc.path,
             fc.content.decode(),
+            tree,
             parser,
             prelude_symbols,
             env_vars,
@@ -405,7 +422,7 @@ async def parse_address_family(
             dependents_rules_parser_state,
             dependencies_rules_parser_state,
         )
-        for fc, env_vars in zip(digest_contents, all_env_vars)
+        for (fc, tree), env_vars in zip(parsed_build_files, all_env_vars)
     ]
     declared_address_maps.sort(key=lambda x: x.path)
 

--- a/src/python/pants/engine/internals/mapper.py
+++ b/src/python/pants/engine/internals/mapper.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import ast
 import os.path
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
@@ -52,6 +53,7 @@ class AddressMap:
         cls,
         filepath: str,
         build_file_content: str,
+        tree: ast.Module,
         parser: Parser,
         extra_symbols: BuildFilePreludeSymbols,
         env_vars: EnvironmentVars,
@@ -69,6 +71,7 @@ class AddressMap:
             target_adaptors = parser.parse(
                 filepath,
                 build_file_content,
+                tree,
                 extra_symbols,
                 env_vars,
                 is_bootstrap,

--- a/src/python/pants/engine/internals/mapper_test.py
+++ b/src/python/pants/engine/internals/mapper_test.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import ast
 import functools
 from textwrap import dedent
 
@@ -44,6 +45,7 @@ def parse_address_map(build_file: str, *, ignore_unrecognized_symbols: bool = Fa
     address_map = AddressMap.parse(
         path,
         build_file,
+        ast.parse(build_file),
         parser,
         BuildFilePreludeSymbols(FrozenDict(), ()),
         EnvironmentVars({}),

--- a/src/python/pants/engine/internals/parser.py
+++ b/src/python/pants/engine/internals/parser.py
@@ -3,19 +3,18 @@
 
 from __future__ import annotations
 
+import ast
 import inspect
 import itertools
 import logging
 import re
 import threading
-import tokenize
 import traceback
 import typing
 from annotationlib import Format, ForwardRef, call_annotate_function
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import InitVar, dataclass, field
 from difflib import get_close_matches
-from io import StringIO
 from pathlib import PurePath
 from typing import Annotated, Any, TypeVar
 
@@ -425,6 +424,7 @@ class Parser:
         self,
         filepath: str,
         build_file_content: str,
+        tree: ast.Module,
         extra_symbols: BuildFilePreludeSymbols,
         env_vars: EnvironmentVars,
         is_bootstrap: bool,
@@ -450,7 +450,7 @@ class Parser:
             defined_symbols = set()
             while True:
                 try:
-                    code = compile(build_file_content, filepath, "exec", dont_inherit=True)
+                    code = compile(tree, filepath, "exec", dont_inherit=True)
                     exec(code, global_symbols)
                 except NameError as e:
                     bad_symbol = _extract_symbol_from_name_error(e)
@@ -473,11 +473,11 @@ class Parser:
                     continue
                 break
 
-            error_on_imports(build_file_content, filepath)
+            error_on_imports(build_file_content, tree, filepath)
             return self._parse_state.parsed_targets()
 
         try:
-            code = compile(build_file_content, filepath, "exec", dont_inherit=True)
+            code = compile(tree, filepath, "exec", dont_inherit=True)
             exec(code, global_symbols)
         except NameError as e:
             frame = traceback.extract_tb(e.__traceback__, limit=-1)[0]
@@ -506,28 +506,31 @@ class Parser:
                 f"{original}.\n\n{help_str}\n\nAll registered symbols: {valid_symbols}"
             )
 
-        error_on_imports(build_file_content, filepath)
+        error_on_imports(build_file_content, tree, filepath)
         return self._parse_state.parsed_targets()
 
 
-def error_on_imports(build_file_content: str, filepath: str) -> None:
+def error_on_imports(build_file_content: str, tree: ast.AST, filepath: str) -> None:
     # This is poor sandboxing; there are many ways to get around this. But it's sufficient to tell
     # users who aren't malicious that they're doing something wrong, and it has a low performance
     # overhead.
     if "import" not in build_file_content:
         return
-    io_wrapped_python = StringIO(build_file_content)
-    for token in tokenize.generate_tokens(io_wrapped_python.readline):
-        token_str = token[1]
-        lineno, _ = token[2]
-        if token_str != "import":
-            continue
-        raise ParseError(
-            f"Import used in {filepath} at line {lineno}. Import statements are banned in "
-            "BUILD files and macros (that act like a normal BUILD file) because they can easily "
-            "break Pants caching and lead to stale results. "
-            f"\n\nInstead, consider writing a plugin ({doc_url('docs/writing-plugins/overview')})."
-        )
+    first_import: ast.Import | ast.ImportFrom | None = None
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Import, ast.ImportFrom)) and (
+            first_import is None
+            or (node.lineno, node.col_offset) < (first_import.lineno, first_import.col_offset)
+        ):
+            first_import = node
+    if first_import is None:
+        return
+    raise ParseError(
+        f"Import used in {filepath} at line {first_import.lineno}. Import statements are banned in "
+        "BUILD files and macros (that act like a normal BUILD file) because they can easily "
+        "break Pants caching and lead to stale results. "
+        f"\n\nInstead, consider writing a plugin ({doc_url('docs/writing-plugins/overview')})."
+    )
 
 
 def _extract_symbol_from_name_error(err: NameError) -> str:

--- a/src/python/pants/engine/internals/parser_test.py
+++ b/src/python/pants/engine/internals/parser_test.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import ast
 import re
 from textwrap import dedent
 from typing import Any
@@ -35,7 +36,18 @@ def defaults_parser_state() -> BuildFileDefaultsParserState:
     )
 
 
-def test_imports_banned(defaults_parser_state: BuildFileDefaultsParserState) -> None:
+@pytest.mark.parametrize(
+    "content, expected_line",
+    [
+        ("\nx = 'hello'\n\nimport os\n", 4),
+        ("\nfrom os import path\n", 2),
+        ("def f():\n    import os\n", 2),
+        ("import os\nfrom sys import argv\n", 1),
+    ],
+)
+def test_imports_banned(
+    content: str, expected_line: int, defaults_parser_state: BuildFileDefaultsParserState
+) -> None:
     parser = Parser(
         build_root="",
         registered_target_types=RegisteredTargetTypes({}),
@@ -46,7 +58,8 @@ def test_imports_banned(defaults_parser_state: BuildFileDefaultsParserState) -> 
     with pytest.raises(ParseError) as exc:
         parser.parse(
             "dir/BUILD",
-            "\nx = 'hello'\n\nimport os\n",
+            content,
+            ast.parse(content),
             BuildFilePreludeSymbols(FrozenDict(), ()),
             EnvironmentVars({}),
             False,
@@ -54,7 +67,31 @@ def test_imports_banned(defaults_parser_state: BuildFileDefaultsParserState) -> 
             dependents_rules=None,
             dependencies_rules=None,
         )
-    assert "Import used in dir/BUILD at line 4" in str(exc.value)
+    assert f"Import used in dir/BUILD at line {expected_line}" in str(exc.value)
+
+
+def test_string_containing_import_is_allowed(
+    defaults_parser_state: BuildFileDefaultsParserState,
+) -> None:
+    parser = Parser(
+        build_root="",
+        registered_target_types=RegisteredTargetTypes({}),
+        union_membership=UnionMembership.empty(),
+        object_aliases=BuildFileAliases(),
+        ignore_unrecognized_symbols=False,
+    )
+    content = "x = 'please import this'\n"
+    parser.parse(
+        "dir/BUILD",
+        content,
+        ast.parse(content),
+        BuildFilePreludeSymbols(FrozenDict(), ()),
+        EnvironmentVars({}),
+        False,
+        defaults_parser_state,
+        dependents_rules=None,
+        dependencies_rules=None,
+    )
 
 
 def test_unrecognized_symbol(defaults_parser_state: BuildFileDefaultsParserState) -> None:
@@ -79,6 +116,7 @@ def test_unrecognized_symbol(defaults_parser_state: BuildFileDefaultsParserState
             parser.parse(
                 "dir/BUILD",
                 "FAKE",
+                ast.parse("FAKE"),
                 prelude_symbols,
                 EnvironmentVars({}),
                 False,
@@ -111,6 +149,7 @@ def test_unrecognized_symbol(defaults_parser_state: BuildFileDefaultsParserState
             parser.parse(
                 "dir/BUILD",
                 "FAKE",
+                ast.parse("FAKE"),
                 prelude_symbols,
                 EnvironmentVars({}),
                 False,
@@ -145,9 +184,11 @@ def test_unrecognized_symbol_during_bootstrap_issue_19156(
         ignore_unrecognized_symbols=True,
     )
     prelude_symbols = BuildFilePreludeSymbols.create({"prelude": 0}, ())
+    content = "tgt(field=fake(42,a=(), b='c'))"
     target_adaptors = parser.parse(
         "dir/BUILD",
-        "tgt(field=fake(42,a=(), b='c'))",
+        content,
+        ast.parse(content),
         prelude_symbols,
         EnvironmentVars({}),
         False,
@@ -181,9 +222,11 @@ def test_unknown_target_for_defaults_during_bootstrap_issue_19445(
         object_aliases=BuildFileAliases(),
         ignore_unrecognized_symbols=True,
     )
+    content = "__defaults__({'type_1': dict(), type_2: dict()})"
     parser.parse(
         "BUILD",
-        "__defaults__({'type_1': dict(), type_2: dict()})",
+        content,
+        ast.parse(content),
         BuildFilePreludeSymbols.create({}, ()),
         EnvironmentVars({}),
         True,
@@ -235,6 +278,7 @@ def test_unrecognized_symbol_in_prelude(
         parser.parse(
             filepath="dir/BUILD",
             build_file_content="macro()",
+            tree=ast.parse("macro()"),
             extra_symbols=prelude_symbols,
             env_vars=EnvironmentVars({}),
             is_bootstrap=False,


### PR DESCRIPTION
Was a theoretical cold-start performance gain that turned out to be minor. I do think this is cleaner though. 