### PR TITLE
Compose a Process out of multiple sequential subprocesses

### DIFF
--- a/src/python/pants/engine/composite_process.py
+++ b/src/python/pants/engine/composite_process.py
@@ -1,0 +1,230 @@
+# Copyright 2026 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import shlex
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+
+from pants.core.util_rules.system_binaries import BashBinary
+from pants.engine.fs import EMPTY_DIGEST, Digest
+from pants.engine.internals.native_engine import MergeDigests
+from pants.engine.intrinsics import merge_digests
+from pants.engine.process import Process, ProcessCacheScope, ProcessConcurrency
+from pants.engine.rules import collect_rules, rule
+from pants.util.frozendict import FrozenDict
+from pants.util.logging import LogLevel
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class Subprocess:
+    """One in a list of subprocesses to run sequentially in the same Process invocation."""
+
+    # The subprocess can either provide argv or a pre-joined command string, but not both.
+    command: str | None
+    argv: Iterable[str]
+    input_digest: Digest
+    immutable_input_digests: FrozenDict[str, Digest]
+    env: FrozenDict[str, str]
+    append_only_caches: FrozenDict[str, str]
+    output_files: Iterable[str]
+    output_directories: Iterable[str]
+
+    def __init__(
+        self,
+        *,
+        command: str | None = None,
+        argv: Iterable[str] | None = None,
+        input_digest: Digest = EMPTY_DIGEST,
+        immutable_input_digests: Mapping[str, Digest] | None = None,
+        env: Mapping[str, str] | None = None,
+        append_only_caches: Mapping[str, str] | None = None,
+        output_files: Iterable[str] | None = None,
+        output_directories: Iterable[str] | None = None,
+    ) -> None:
+        if (command is None and argv is None) or (command is not None and argv is not None):
+            raise ValueError("Exactly one of command and argv must be specified.")
+        if isinstance(argv, str):
+            raise ValueError("argv must be a sequence of strings, but was a single string.")
+        object.__setattr__(self, "command", command)
+        object.__setattr__(self, "argv", tuple(argv or []))
+        object.__setattr__(self, "input_digest", input_digest)
+        object.__setattr__(
+            self, "immutable_input_digests", FrozenDict(immutable_input_digests or {})
+        )
+        object.__setattr__(self, "env", FrozenDict(env or {}))
+        object.__setattr__(self, "append_only_caches", FrozenDict(append_only_caches or {}))
+        object.__setattr__(self, "output_files", tuple(output_files or ()))
+        object.__setattr__(self, "output_directories", tuple(output_directories or ()))
+
+    def get_command(self) -> str:
+        if self.command is None:
+            return shlex.join(self.argv)
+        return self.command
+
+
+@dataclass(frozen=True)
+class CompositeProcess:
+    description: str = dataclasses.field(compare=False)
+    level: LogLevel
+    subprocesses: tuple[Subprocess, ...]
+    use_nailgun: tuple[str, ...]
+    working_directory: str | None
+    timeout_seconds: int | float
+    jdk_home: str | None
+    execution_slot_variable: str | None
+    concurrency_available: int
+    concurrency: ProcessConcurrency | None
+    cache_scope: ProcessCacheScope
+    remote_cache_speculation_delay_millis: int
+    attempt: int
+
+    @classmethod
+    def from_process(cls, proc: Process) -> CompositeProcess:
+        """Create a CompositeProcess from a Process.
+
+        The returned CompositeProcess will act exactly as the Process would: the Process's
+        field values will be set on the CompositeProcess's fields or on the fields of its single
+        Subprocess, as appropriate.
+        """
+        return cls(
+            subprocesses=[
+                Subprocess(
+                    argv=proc.argv,
+                    input_digest=proc.input_digest,
+                    immutable_input_digests=proc.immutable_input_digests,
+                    env=proc.env,
+                    append_only_caches=proc.append_only_caches,
+                    output_files=proc.output_files,
+                    output_directories=proc.output_directories,
+                )
+            ],
+            description=proc.description,
+            level=proc.level,
+            use_nailgun=proc.use_nailgun,
+            working_directory=proc.working_directory,
+            timeout_seconds=proc.timeout_seconds,
+            jdk_home=proc.jdk_home,
+            execution_slot_variable=proc.execution_slot_variable,
+            concurrency_available=proc.concurrency_available,
+            concurrency=proc.concurrency,
+            cache_scope=proc.cache_scope,
+            remote_cache_speculation_delay_millis=proc.remote_cache_speculation_delay_millis,
+            attempt=proc.attempt,
+        )
+
+    def __init__(
+        self,
+        subprocesses: Iterable[Subprocess],
+        *,
+        description: str,
+        level: LogLevel = LogLevel.INFO,
+        use_nailgun: Iterable[str] = (),
+        working_directory: str | None = None,
+        timeout_seconds: int | float | None = None,
+        jdk_home: str | None = None,
+        execution_slot_variable: str | None = None,
+        concurrency_available: int = 0,
+        concurrency: ProcessConcurrency | None = None,
+        cache_scope: ProcessCacheScope = ProcessCacheScope.SUCCESSFUL,
+        remote_cache_speculation_delay_millis: int = 0,
+        attempt: int = 0,
+    ) -> None:
+        """A sequence of subprocesses to run serially under a single Process."""
+        object.__setattr__(self, "subprocesses", tuple(subprocesses))
+        object.__setattr__(self, "description", description)
+        object.__setattr__(self, "level", level)
+
+        object.__setattr__(self, "use_nailgun", tuple(use_nailgun))
+        object.__setattr__(self, "working_directory", working_directory)
+        # NB: A negative or None time value is normalized to -1 to ease the transfer to Rust.
+        object.__setattr__(
+            self,
+            "timeout_seconds",
+            timeout_seconds if timeout_seconds and timeout_seconds > 0 else -1,
+        )
+        object.__setattr__(self, "jdk_home", jdk_home)
+        object.__setattr__(self, "execution_slot_variable", execution_slot_variable)
+        object.__setattr__(self, "concurrency_available", concurrency_available)
+        object.__setattr__(self, "concurrency", concurrency)
+        object.__setattr__(self, "cache_scope", cache_scope)
+        object.__setattr__(
+            self, "remote_cache_speculation_delay_millis", remote_cache_speculation_delay_millis
+        )
+        object.__setattr__(self, "attempt", attempt)
+
+    def prepend_subprocesses(self, subprocesses: Iterable[Subprocess]) -> CompositeProcess:
+        return dataclasses.replace(self, subprocesses=(*subprocesses, *self.subprocesses))
+
+    def append_subprocesses(self, subprocesses: Iterable[Subprocess]) -> CompositeProcess:
+        return dataclasses.replace(self, subprocesses=(*self.subprocesses, *subprocesses))
+
+
+@rule
+async def composite_process_to_process(
+    composite_process: CompositeProcess, bash_binary: BashBinary
+) -> Process:
+    subprocs = composite_process.subprocesses
+    command = "\n".join(subproc.get_command() for subproc in subprocs)
+    input_digest = await merge_digests(MergeDigests([subproc.input_digest for subproc in subprocs]))
+
+    immutable_input_digests: dict[str, Digest] = {}
+    for subproc in subprocs:
+        for path, digest in subproc.immutable_input_digests.items():
+            if path in immutable_input_digests and immutable_input_digests[path] != digest:
+                raise ValueError(
+                    "Multiple Subprocess in the same CompositeProcess had "
+                    f"immutable_input_digests with the path {path} and different digests"
+                )
+            immutable_input_digests[path] = digest
+
+    env: dict[str, str] = {}
+    for subproc in subprocs:
+        for name, val in subproc.env.items():
+            if name in env and env[name] != val:
+                raise ValueError(
+                    "Multiple Subprocess in the same CompositeProcess set the env var "
+                    f"{name}, to different values"
+                )
+            env[name] = val
+
+    append_only_caches: dict[str, str] = {}
+    for subproc in subprocs:
+        for cache_name, cache_dir in subproc.append_only_caches.items():
+            if cache_name in append_only_caches and append_only_caches[cache_name] != cache_dir:
+                raise ValueError(
+                    "Multiple Subprocess in the same CompositeProcess had  "
+                    f"append_only_caches with the name {cache_name} and different values"
+                )
+            append_only_caches[cache_name] = cache_dir
+
+    return Process(
+        argv=(bash_binary.path, "-c", command),
+        description=composite_process.description,
+        level=composite_process.level,
+        input_digest=input_digest,
+        immutable_input_digests=immutable_input_digests,
+        use_nailgun=composite_process.use_nailgun,
+        working_directory=composite_process.working_directory,
+        env=env,
+        append_only_caches=append_only_caches,
+        output_files=[of for subproc in subprocs for of in subproc.output_files],
+        output_directories=[od for subproc in subprocs for od in subproc.output_directories],
+        timeout_seconds=composite_process.timeout_seconds,
+        jdk_home=composite_process.jdk_home,
+        execution_slot_variable=composite_process.execution_slot_variable,
+        concurrency_available=composite_process.concurrency_available,
+        concurrency=composite_process.concurrency,
+        cache_scope=composite_process.cache_scope,
+        remote_cache_speculation_delay_millis=composite_process.remote_cache_speculation_delay_millis,
+        attempt=composite_process.attempt,
+    )
+
+
+def rules():
+    return collect_rules()

--- a/src/python/pants/engine/composite_process_test.py
+++ b/src/python/pants/engine/composite_process_test.py
@@ -1,0 +1,176 @@
+# Copyright 2026 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from pants.core.util_rules.system_binaries import CatBinary
+from pants.engine.composite_process import CompositeProcess, Subprocess
+from pants.engine.fs import EMPTY_DIGEST, Digest, DigestContents
+from pants.engine.platform import Platform
+from pants.engine.process import Process, ProcessResult
+from pants.testutil.rule_runner import QueryRule, RuleRunner
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    return RuleRunner(
+        rules=[
+            QueryRule(Process, [CompositeProcess]),
+            QueryRule(ProcessResult, [Process]),
+            QueryRule(DigestContents, [Digest]),
+            QueryRule(CatBinary, []),
+            QueryRule(Platform, []),
+        ],
+    )
+
+
+def test_subprocess_requires_command_or_argv() -> None:
+    with pytest.raises(ValueError, match="Exactly one of command and argv must be specified"):
+        Subprocess()
+
+
+def test_subprocess_rejects_both_command_and_argv() -> None:
+    with pytest.raises(ValueError, match="Exactly one of command and argv must be specified"):
+        Subprocess(command="echo hi", argv=["echo", "hi"])
+
+
+def test_subprocess_defaults() -> None:
+    sub = Subprocess(argv=["cmd"])
+    assert sub.input_digest == EMPTY_DIGEST
+    assert sub.immutable_input_digests == {}
+    assert sub.env == {}
+    assert sub.append_only_caches == {}
+    assert sub.output_files == ()
+    assert sub.output_directories == ()
+
+
+def test_subprocess_get_command() -> None:
+    assert (
+        Subprocess(argv=["my-tool", "--flag", "value with spaces"]).get_command()
+        == "my-tool --flag 'value with spaces'"
+    )
+
+    assert (
+        Subprocess(command="cmd1 && cmd2 | tee out.txt").get_command()
+        == "cmd1 && cmd2 | tee out.txt"
+    )
+
+
+def _mk_composite_proc(**kwargs) -> CompositeProcess:
+    return CompositeProcess(
+        subprocesses=[Subprocess(argv=["cmd"])],
+        description="test",
+        **kwargs,
+    )
+
+
+def test_composite_process_timeout() -> None:
+    assert _mk_composite_proc(timeout_seconds=None).timeout_seconds == -1
+    assert _mk_composite_proc(timeout_seconds=0).timeout_seconds == -1
+    assert _mk_composite_proc(timeout_seconds=-5).timeout_seconds == -1
+    assert _mk_composite_proc(timeout_seconds=30).timeout_seconds == 30
+
+
+def test_to_process_env_same_value_is_allowed(rule_runner: RuleRunner) -> None:
+    cp = CompositeProcess(
+        description="test",
+        subprocesses=[
+            Subprocess(argv=["cmd1"], env={"FOO": "bar"}),
+            Subprocess(argv=["cmd2"], env={"FOO": "bar"}),
+        ],
+    )
+    process = rule_runner.request(Process, [cp])
+    assert process.env.get("FOO") == "bar"
+
+
+def test_to_process_env_conflict_raises(rule_runner: RuleRunner) -> None:
+    cp = CompositeProcess(
+        description="test",
+        subprocesses=[
+            Subprocess(argv=["cmd1"], env={"FOO": "bar"}),
+            Subprocess(argv=["cmd2"], env={"FOO": "baz"}),
+        ],
+    )
+    with pytest.raises(Exception, match="FOO"):
+        rule_runner.request(Process, [cp])
+
+
+def test_to_process_append_only_caches_same_value_is_allowed(rule_runner: RuleRunner) -> None:
+    cp = CompositeProcess(
+        description="test",
+        subprocesses=[
+            Subprocess(argv=["cmd1"], append_only_caches={"my_cache": ".cache"}),
+            Subprocess(argv=["cmd2"], append_only_caches={"my_cache": ".cache"}),
+        ],
+    )
+    process = rule_runner.request(Process, [cp])
+    assert process.append_only_caches.get("my_cache") == ".cache"
+
+
+def test_to_process_append_only_caches_conflict_raises(rule_runner: RuleRunner) -> None:
+    cp = CompositeProcess(
+        description="test",
+        subprocesses=[
+            Subprocess(argv=["cmd1"], append_only_caches={"my_cache": ".cache1"}),
+            Subprocess(argv=["cmd2"], append_only_caches={"my_cache": ".cache2"}),
+        ],
+    )
+    with pytest.raises(Exception, match="my_cache"):
+        rule_runner.request(Process, [cp])
+
+
+def test_to_process_output_files_concatenated(rule_runner: RuleRunner) -> None:
+    cp = CompositeProcess(
+        description="test",
+        subprocesses=[
+            Subprocess(argv=["cmd1"], output_files=["a.txt", "b.txt"]),
+            Subprocess(argv=["cmd2"], output_files=["c.txt"]),
+        ],
+    )
+    process = rule_runner.request(Process, [cp])
+    assert sorted(process.output_files) == ["a.txt", "b.txt", "c.txt"]
+
+
+def test_to_process_output_directories_concatenated(rule_runner: RuleRunner) -> None:
+    cp = CompositeProcess(
+        description="test",
+        subprocesses=[
+            Subprocess(argv=["cmd1"], output_directories=["dist/", "build/"]),
+            Subprocess(argv=["cmd2"], output_directories=["out/"]),
+        ],
+    )
+    process = rule_runner.request(Process, [cp])
+    assert sorted(process.output_directories) == ["build/", "dist/", "out/"]
+
+
+def test_subprocess_command_join(rule_runner: RuleRunner) -> None:
+    cp = CompositeProcess(
+        description="test",
+        subprocesses=[
+            Subprocess(argv=["cmd1", "--flag"]),
+            Subprocess(command="cmd2 arg1 arg2"),
+        ],
+    )
+    process = rule_runner.request(Process, [cp])
+    assert len(process.argv) == 3
+    assert process.argv[2] == "cmd1 --flag\ncmd2 arg1 arg2"
+
+
+def test_composite_process(rule_runner: RuleRunner) -> None:
+    cat = rule_runner.request(CatBinary, [])
+    composite_process = CompositeProcess(
+        description="test CompositeProcess",
+        subprocesses=[
+            Subprocess(
+                argv=[sys.executable, "-c", "with open('hello.txt', 'w') as fp: fp.write('Hello')"]
+            ),
+            Subprocess(command=f"{cat.path} 'hello.txt'"),
+        ],
+    )
+    process = rule_runner.request(Process, [composite_process])
+    result = rule_runner.request(ProcessResult, [process])
+    assert result.stdout.decode() == "Hello"

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -18,7 +18,7 @@ from pants.build_graph.build_configuration import BuildConfiguration
 from pants.core.environments import rules as environments_rules
 from pants.core.environments.rules import determine_bootstrap_environment
 from pants.core.util_rules import system_binaries
-from pants.engine import desktop, download_file, fs, intrinsics, process
+from pants.engine import composite_process, desktop, download_file, fs, intrinsics, process
 from pants.engine.console import Console
 from pants.engine.environment import EnvironmentName
 from pants.engine.fs import PathGlobs, Snapshot, Workspace
@@ -312,6 +312,7 @@ class EngineInitializer:
                 *specs_rules.rules(),
                 *options_parsing.rules(),
                 *process.rules(),
+                *composite_process.rules(),
                 *environments_rules.rules(),
                 *system_binaries.rules(),
                 *platform_rules.rules(),


### PR DESCRIPTION
It is sometimes useful to run multiple processes in a single
Process invocation. 

For example, when creating a pex from a venv repository,
we need to ensure the venv repository exists, and the 
only reliable way to do so in the presence of remote caching/
remote execution is to run the venv creation process 
in the same Process as the pex invocation.

This change introduces a bit of useful plumbing to make
this easy: A `CompositeProcess` holds multiple
`Subprocess` instances, and invokes them sequentially
via a bash command. 
