### PR TITLE
Fix uv support under remote caching/execution.

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -34,7 +34,12 @@ from pants.backend.python.util_rules.interpreter_constraints import InterpreterC
 from pants.backend.python.util_rules.lockfile_metadata import (
     LockfileFormat,
 )
-from pants.backend.python.util_rules.pex_cli import PexCliProcess, PexPEX, maybe_log_pex_stderr
+from pants.backend.python.util_rules.pex_cli import (
+    PexCliProcess,
+    PexPEX,
+    maybe_log_pex_stderr,
+    setup_pex_cli_process,
+)
 from pants.backend.python.util_rules.pex_environment import (
     CompletePexEnvironment,
     PexEnvironment,
@@ -73,6 +78,7 @@ from pants.core.util_rules.stripped_source_files import rules as stripped_source
 from pants.core.util_rules.system_binaries import BashBinary
 from pants.engine.addresses import UnparsedAddressInputs
 from pants.engine.collection import Collection, DeduplicatedCollection
+from pants.engine.composite_process import CompositeProcess, composite_process_to_process
 from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.environment import EnvironmentName
 from pants.engine.fs import (
@@ -912,22 +918,29 @@ async def build_pex(
 
     argv.extend(["--layout", request.layout.value])
 
-    result = await fallible_to_exec_result_or_raise(
-        **implicitly(
-            PexCliProcess(
-                interpreter=interpreter,
-                subcommand=(),
-                extra_args=argv,
-                additional_input_digest=merged_digest,
-                description=_build_pex_description(request, req_strings, python_setup.resolves),
-                append_only_caches=venv_repo.append_only_caches() if venv_repo else None,
-                output_files=None,
-                output_directories=[output_chroot],
-                concurrency_available=requirements_setup.concurrency_available,
-                cache_scope=request.cache_scope,
-            )
-        )
+    pex_process = await setup_pex_cli_process(
+        PexCliProcess(
+            interpreter=interpreter,
+            subcommand=(),
+            extra_args=argv,
+            additional_input_digest=merged_digest,
+            description=_build_pex_description(request, req_strings, python_setup.resolves),
+            append_only_caches=venv_repo.append_only_caches() if venv_repo else None,
+            output_files=None,
+            output_directories=[output_chroot],
+            concurrency_available=requirements_setup.concurrency_available,
+            cache_scope=request.cache_scope,
+        ),
+        **implicitly(),
     )
+
+    if venv_repo:
+        composite_process = CompositeProcess.from_process(pex_process).prepend_subprocesses(
+            [venv_repo.creation_subprocess]
+        )
+        pex_process = await composite_process_to_process(composite_process, **implicitly())
+
+    result = await fallible_to_exec_result_or_raise(**implicitly(pex_process))
 
     maybe_log_pex_stderr(result.stderr, pex_subsystem.verbosity)
 

--- a/src/python/pants/backend/python/util_rules/uv.py
+++ b/src/python/pants/backend/python/util_rules/uv.py
@@ -236,33 +236,6 @@ async def create_venv_repository_from_uv_lockfile(
         ),
     )
 
-    # await execute_process_or_raise(
-    #     **implicitly(
-    #         Process(
-    #             argv=(bash_binary.path, "-c", script),
-    #             input_digest=input_digest,
-    #             env=uv_env.env,
-    #             append_only_caches={
-    #                 **downloaded_uv.append_only_caches(),
-    #                 **venv_repository.append_only_caches(),
-    #             },
-    #             level=LogLevel.INFO,
-    #             description=f"Create venv from uv lockfile at {request.lockfile.lockfile_path}",
-    #             # TODO: We might need to set cache_scope=ProcessCacheScope.PER_SESSION if
-    #             #  running in a non-local environment (e.g., a docker environment), as we're
-    #             #  less sure that a venv created by a previous run still exists. For example
-    #             #  the docker container might have been recreated. However this impacts performance
-    #             #  in the overwhelmingly common local run case. Alternatively we can look at
-    #             #  creating the uv venv in the same Process as whatever is consuming it, which
-    #             #  would ensure availability even in a completely ephemeral remote environment
-    #             #  where we can't guarantee that the venv exists even in the same Pants run.
-    #             #  But that is a more general issue and a much bigger change.
-    #         )
-    #     )
-    # )
-
-    # return venv_repository
-
 
 def rules():
     return [

--- a/src/python/pants/backend/python/util_rules/uv.py
+++ b/src/python/pants/backend/python/util_rules/uv.py
@@ -31,7 +31,8 @@ from pants.base.build_root import BuildRoot
 from pants.core.util_rules import system_binaries
 from pants.core.util_rules.env_vars import environment_vars_subset
 from pants.core.util_rules.subprocess_environment import SubprocessEnvironmentVars
-from pants.core.util_rules.system_binaries import BashBinary, RealpathBinary
+from pants.core.util_rules.system_binaries import RealpathBinary
+from pants.engine.composite_process import Subprocess
 from pants.engine.env_vars import EnvironmentVarsRequest
 from pants.engine.fs import (
     CreateDigest,
@@ -43,14 +44,9 @@ from pants.engine.intrinsics import (
     get_digest_contents,
     merge_digests,
 )
-from pants.engine.process import (
-    Process,
-    execute_process_or_raise,
-)
 from pants.engine.rules import collect_rules, concurrently, implicitly, rule
 from pants.util.docutil import bin_name
 from pants.util.frozendict import FrozenDict
-from pants.util.logging import LogLevel
 from pants.util.strutil import softwrap
 
 logger = logging.getLogger(__name__)
@@ -72,6 +68,7 @@ class VenvRepository:
     cache_dir: ClassVar[str] = f".cache/{cache_name}/"
 
     venv_path_suffix: str
+    creation_subprocess: Subprocess
 
     def relpath(self) -> str:
         # The path to the venv in any sandbox that has the venv_cache append-only cache.
@@ -146,7 +143,6 @@ async def create_venv_repository_from_uv_lockfile(
     request: VenvFromUvLockfileRequest,
     downloaded_uv: DownloadedUv,
     uv_env: UvEnvironment,
-    bash_binary: BashBinary,
     realpath_binary: RealpathBinary,
     buildroot: BuildRoot,
 ) -> VenvRepository:
@@ -197,15 +193,11 @@ async def create_venv_repository_from_uv_lockfile(
         )
     )
 
+    # We maintain one cached venv per buildroot+interpreter+resolve. uv will efficiently
+    # incrementally update the venv as the lockfile changes, and will handle concurrency of
+    # `uv sync` with appropriate locking.
     buildroot_entropy = hashlib.sha256(buildroot.path.encode()).hexdigest()
-    venv_repository = VenvRepository(
-        # We maintain one cached venv per buildroot+interpreter+resolve. uv will efficiently incrementally
-        # update the venv as the lockfile changes, and will handle concurrency of `uv sync` with
-        # appropriate locking.
-        venv_path_suffix=os.path.join(
-            buildroot_entropy, metadata.resolve, request.python.fingerprint
-        )
-    )
+    venv_path_suffix = os.path.join(buildroot_entropy, metadata.resolve, request.python.fingerprint)
 
     uv_cmd = shlex.join(
         (
@@ -224,38 +216,52 @@ async def create_venv_repository_from_uv_lockfile(
     # environment this process runs in. This gives uv a stable absolute path for the venv
     # so that any entry point scripts it creates exec a valid path that doesn't reference
     # the sandbox.
-    script = dedent(
+    command = dedent(
         f"""\
-        cache_root="$({realpath_binary.path} {shlex.quote(venv_repository.cache_dir)})"
-        UV_PROJECT_ENVIRONMENT="${{cache_root}}/{venv_repository.venv_path_suffix}" {uv_cmd}
+        cache_root="$({realpath_binary.path} {shlex.quote(VenvRepository.cache_dir)})"
+        UV_PROJECT_ENVIRONMENT="${{cache_root}}/{venv_path_suffix}" {uv_cmd}
         """
     )
-    await execute_process_or_raise(
-        **implicitly(
-            Process(
-                argv=(bash_binary.path, "-c", script),
-                input_digest=input_digest,
-                env=uv_env.env,
-                append_only_caches={
-                    **downloaded_uv.append_only_caches(),
-                    **venv_repository.append_only_caches(),
-                },
-                level=LogLevel.INFO,
-                description=f"Create venv from uv lockfile at {request.lockfile.lockfile_path}",
-                # TODO: We might need to set cache_scope=ProcessCacheScope.PER_SESSION if
-                #  running in a non-local environment (e.g., a docker environment), as we're
-                #  less sure that a venv created by a previous run still exists. For example
-                #  the docker container might have been recreated. However this impacts performance
-                #  in the overwhelmingly common local run case. Alternatively we can look at
-                #  creating the uv venv in the same Process as whatever is consuming it, which
-                #  would ensure availability even in a completely ephemeral remote environment
-                #  where we can't guarantee that the venv exists even in the same Pants run.
-                #  But that is a more general issue and a much bigger change.
-            )
-        )
+
+    return VenvRepository(
+        venv_path_suffix=venv_path_suffix,
+        creation_subprocess=Subprocess(
+            command=command,
+            input_digest=input_digest,
+            env=uv_env.env,
+            append_only_caches={
+                **downloaded_uv.append_only_caches(),
+                **VenvRepository.append_only_caches(),
+            },
+        ),
     )
 
-    return venv_repository
+    # await execute_process_or_raise(
+    #     **implicitly(
+    #         Process(
+    #             argv=(bash_binary.path, "-c", script),
+    #             input_digest=input_digest,
+    #             env=uv_env.env,
+    #             append_only_caches={
+    #                 **downloaded_uv.append_only_caches(),
+    #                 **venv_repository.append_only_caches(),
+    #             },
+    #             level=LogLevel.INFO,
+    #             description=f"Create venv from uv lockfile at {request.lockfile.lockfile_path}",
+    #             # TODO: We might need to set cache_scope=ProcessCacheScope.PER_SESSION if
+    #             #  running in a non-local environment (e.g., a docker environment), as we're
+    #             #  less sure that a venv created by a previous run still exists. For example
+    #             #  the docker container might have been recreated. However this impacts performance
+    #             #  in the overwhelmingly common local run case. Alternatively we can look at
+    #             #  creating the uv venv in the same Process as whatever is consuming it, which
+    #             #  would ensure availability even in a completely ephemeral remote environment
+    #             #  where we can't guarantee that the venv exists even in the same Pants run.
+    #             #  But that is a more general issue and a much bigger change.
+    #         )
+    #     )
+    # )
+
+    # return venv_repository
 
 
 def rules():


### PR DESCRIPTION
As explained in #23344, a remote cache hit on the process that
creates the uv venv will cause venv creation to be skipped,
and pex will not find that venv locally.

With this change uv venv creation and the pex invocation that
uses it run under the same `Process`, ensuring that they are
always run together or cached together.

This fixes not only the remote caching issue but also a
similar issue with remote execution, when we aren't
guaranteed to run the two processes on the same machine.