### PR TITLE
Support configuring nailgun server jar and add support for java agent implemention

### DIFF
--- a/docs/notes/2.33.x.md
+++ b/docs/notes/2.33.x.md
@@ -54,6 +54,8 @@ Fix a `KeyError` regression in `pants check` (and other JVM goals) for resolves 
 
 Add the `[jvm].intermediate_jars_remote_cache` option to enable remote caching of intermediate JAR artifacts. This can significantly reduce local process overhead in environments with a low-latency remote cache, such as CI.
 
+Add support for configuring which nailgun server artifact to run. As well as supporting Java Agent based nailgun server implementations.
+
 #### Python
 
 The `--changed-since` functionality now works correctly in the presence of deleted Python files. I.e., if test.py imports from foo.py and foo.py is deleted from the repo, then `--changed-since=...` with `--changed-dependents=transitive` will detect that test.py "depends" on the deleted file and, e.g., run it.

--- a/src/python/pants/jvm/jdk_rules.py
+++ b/src/python/pants/jvm/jdk_rules.py
@@ -164,16 +164,21 @@ def parse_jre_major_version(version_lines: str) -> int | None:
 
 
 @rule
-async def fetch_nailgun() -> Nailgun:
+async def fetch_nailgun(jvm: JvmSubsystem) -> Nailgun:
+    group = jvm.nailgun_group
+    artifact = jvm.nailgun_artifact
+    version = jvm.nailgun_version
+    coord_str = f"{group}:{artifact}:{version}"
+    file_name = f"{group}_{artifact}_{version}.jar"
     nailgun = await coursier_fetch_one_coord(
         CoursierLockfileEntry(
-            coord=Coordinate.from_coord_str("com.martiansoftware:nailgun-server:0.9.1"),
-            file_name="com.martiansoftware_nailgun-server_0.9.1.jar",
+            coord=Coordinate.from_coord_str(coord_str),
+            file_name=file_name,
             direct_dependencies=Coordinates(),
             dependencies=Coordinates(),
             file_digest=FileDigest(
-                fingerprint="4518faa6bf4bd26fccdc4d85e1625dc679381a08d56872d8ad12151dda9cef25",
-                serialized_bytes_length=32927,
+                fingerprint=jvm.nailgun_sha256,
+                serialized_bytes_length=jvm.nailgun_size,
             ),
         )
     )
@@ -437,6 +442,9 @@ async def jvm_process(
     use_nailgun = []
     if request.use_nailgun:
         use_nailgun = [*jdk.immutable_input_digests, *request.extra_nailgun_keys]
+        if jvm.nailgun_enable_agent:
+            jvm_options.append(f"-javaagent:{request.jdk.nailgun_jar}")
+        env["PANTS_NAILGUN_MAIN_CLASS"] = jvm.nailgun_main_class
 
     remote_cache_speculation_delay_millis = 0
     if request.remote_cache_speculation_delay is not None:

--- a/src/python/pants/jvm/jdk_rules.py
+++ b/src/python/pants/jvm/jdk_rules.py
@@ -16,13 +16,13 @@ from typing import ClassVar
 
 from pants.core.environments.target_types import EnvironmentTarget
 from pants.core.util_rules.system_binaries import BashBinary, LnBinary
-from pants.engine.fs import CreateDigest, Digest, FileContent, FileDigest, MergeDigests
+from pants.engine.fs import CreateDigest, Digest, FileContent, MergeDigests
 from pants.engine.intrinsics import create_digest, execute_process, merge_digests
 from pants.engine.process import Process, ProcessCacheScope
 from pants.engine.rules import collect_rules, implicitly, rule
 from pants.engine.target import CoarsenedTarget
 from pants.jvm.compile import ClasspathEntry
-from pants.jvm.resolve.coordinate import Coordinate, Coordinates
+from pants.jvm.resolve.coordinate import Coordinates
 from pants.jvm.resolve.coursier_fetch import CoursierLockfileEntry, coursier_fetch_one_coord
 from pants.jvm.resolve.coursier_setup import Coursier
 from pants.jvm.subsystems import JvmSubsystem
@@ -165,21 +165,13 @@ def parse_jre_major_version(version_lines: str) -> int | None:
 
 @rule
 async def fetch_nailgun(jvm: JvmSubsystem) -> Nailgun:
-    group = jvm.nailgun_group
-    artifact = jvm.nailgun_artifact
-    version = jvm.nailgun_version
-    coord_str = f"{group}:{artifact}:{version}"
-    file_name = f"{group}_{artifact}_{version}.jar"
     nailgun = await coursier_fetch_one_coord(
         CoursierLockfileEntry(
-            coord=Coordinate.from_coord_str(coord_str),
-            file_name=file_name,
+            coord=jvm.nailgun_server.coordinate,
+            file_name=jvm.nailgun_server.file_name,
             direct_dependencies=Coordinates(),
             dependencies=Coordinates(),
-            file_digest=FileDigest(
-                fingerprint=jvm.nailgun_sha256,
-                serialized_bytes_length=jvm.nailgun_size,
-            ),
+            file_digest=jvm.nailgun_server.file_digest,
         )
     )
 
@@ -444,7 +436,7 @@ async def jvm_process(
         use_nailgun = [*jdk.immutable_input_digests, *request.extra_nailgun_keys]
         if jvm.nailgun_enable_agent:
             jvm_options.append(f"-javaagent:{request.jdk.nailgun_jar}")
-        env["PANTS_NAILGUN_MAIN_CLASS"] = jvm.nailgun_main_class
+        env["PANTS_NAILGUN_MAIN_CLASS"] = jvm.nailgun_server.main_class
 
     remote_cache_speculation_delay_millis = 0
     if request.remote_cache_speculation_delay is not None:

--- a/src/python/pants/jvm/subsystems.py
+++ b/src/python/pants/jvm/subsystems.py
@@ -175,3 +175,45 @@ class JvmSubsystem(Subsystem):
         if eligible and self.intermediate_jars_remote_cache:
             return ProcessCacheScope.SUCCESSFUL
         return ProcessCacheScope.LOCAL_SUCCESSFUL
+
+    nailgun_group = StrOption(
+        default="com.martiansoftware",
+        help="The Maven group ID for the Nailgun server.",
+        advanced=True,
+    )
+
+    nailgun_artifact = StrOption(
+        default="nailgun-server",
+        help="The Maven artifact ID for the Nailgun server.",
+        advanced=True,
+    )
+
+    nailgun_version = StrOption(
+        default="0.9.1",
+        help="The Maven version for the Nailgun server.",
+        advanced=True,
+    )
+
+    nailgun_main_class = StrOption(
+        default="com.martiansoftware.nailgun.NGServer",
+        help="The main class entry point for the Nailgun server.",
+        advanced=True,
+    )
+
+    nailgun_enable_agent = BoolOption(
+        default=False,
+        help="If enabled, start the Nailgun server with itself as a Java Agent.",
+        advanced=True,
+    )
+
+    nailgun_sha256 = StrOption(
+        default="4518faa6bf4bd26fccdc4d85e1625dc679381a08d56872d8ad12151dda9cef25",
+        help="The SHA256 fingerprint of the Nailgun server JAR.",
+        advanced=True,
+    )
+
+    nailgun_size = IntOption(
+        default=32927,
+        help="The size in bytes of the Nailgun server JAR.",
+        advanced=True,
+    )

--- a/src/python/pants/jvm/subsystems.py
+++ b/src/python/pants/jvm/subsystems.py
@@ -3,10 +3,27 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
+from pants.engine.fs import FileDigest
 from pants.engine.process import ProcessCacheScope
+from pants.jvm.resolve.coordinate import Coordinate, InvalidCoordinateString
 from pants.option.option_types import BoolOption, DictOption, IntOption, StrListOption, StrOption
 from pants.option.subsystem import Subsystem
+from pants.util.memo import memoized_property
 from pants.util.strutil import help_text, softwrap
+
+
+@dataclass(frozen=True)
+class NailgunServer:
+    coordinate: Coordinate
+    main_class: str
+    file_digest: FileDigest
+
+    @property
+    def file_name(self) -> str:
+        c = self.coordinate
+        return f"{c.group}_{c.artifact}_{c.version}.jar"
 
 
 class JvmSubsystem(Subsystem):
@@ -176,27 +193,27 @@ class JvmSubsystem(Subsystem):
             return ProcessCacheScope.SUCCESSFUL
         return ProcessCacheScope.LOCAL_SUCCESSFUL
 
-    nailgun_group = StrOption(
-        default="com.martiansoftware",
-        help="The Maven group ID for the Nailgun server.",
+    _nailgun_server = StrOption(
+        default="com.martiansoftware:nailgun-server:0.9.1#com.martiansoftware.nailgun.NGServer",
+        help=softwrap(
+            """
+            The Nailgun server artifact to run, as `group:artifact:version#main.class.Name`.
+
+            The portion before `#` is a standard Maven coordinate; the portion after `#`
+            is the fully-qualified main class used to start the server.
+            """
+        ),
         advanced=True,
     )
 
-    nailgun_artifact = StrOption(
-        default="nailgun-server",
-        help="The Maven artifact ID for the Nailgun server.",
-        advanced=True,
-    )
-
-    nailgun_version = StrOption(
-        default="0.9.1",
-        help="The Maven version for the Nailgun server.",
-        advanced=True,
-    )
-
-    nailgun_main_class = StrOption(
-        default="com.martiansoftware.nailgun.NGServer",
-        help="The main class entry point for the Nailgun server.",
+    nailgun_jar_digest = StrOption(
+        default="4518faa6bf4bd26fccdc4d85e1625dc679381a08d56872d8ad12151dda9cef25:32927",
+        help=softwrap(
+            """
+            The digest of the Nailgun server JAR, as `sha256:length_in_bytes`,
+            used to verify the artifact fetched for `[jvm].nailgun_server`.
+            """
+        ),
         advanced=True,
     )
 
@@ -206,14 +223,46 @@ class JvmSubsystem(Subsystem):
         advanced=True,
     )
 
-    nailgun_sha256 = StrOption(
-        default="4518faa6bf4bd26fccdc4d85e1625dc679381a08d56872d8ad12151dda9cef25",
-        help="The SHA256 fingerprint of the Nailgun server JAR.",
-        advanced=True,
-    )
+    @memoized_property
+    def nailgun_server(self) -> NailgunServer:
+        raw = self._nailgun_server
+        coord_str, sep, main_class = raw.partition("#")
+        main_class = main_class.strip()
+        if not sep or not main_class:
+            raise ValueError(
+                softwrap(
+                    f"""
+                    The `[jvm].nailgun_server` option value {raw!r} is missing the main class.
+                    Expected the form `group:artifact:version#main.class.Name`.
+                    """
+                )
+            )
+        try:
+            coordinate = Coordinate.from_coord_str(coord_str)
+        except InvalidCoordinateString as e:
+            raise ValueError(
+                softwrap(
+                    f"""
+                    The `[jvm].nailgun_server` option value {raw!r} is invalid: {e}.
+                    Expected the form `group:artifact:version#main.class.Name`.
+                    """
+                )
+            ) from e
 
-    nailgun_size = IntOption(
-        default=32927,
-        help="The size in bytes of the Nailgun server JAR.",
-        advanced=True,
-    )
+        digest = self.nailgun_jar_digest
+        fingerprint, dsep, length = digest.partition(":")
+        if not fingerprint or not dsep or not length.isdigit():
+            raise ValueError(
+                softwrap(
+                    f"""
+                    The `[jvm].nailgun_jar_digest` option value {digest!r} is invalid.
+                    Expected the form `sha256:length_in_bytes`.
+                    """
+                )
+            )
+
+        return NailgunServer(
+            coordinate=coordinate,
+            main_class=main_class,
+            file_digest=FileDigest(fingerprint=fingerprint, serialized_bytes_length=int(length)),
+        )

--- a/src/python/pants/jvm/subsystems_test.py
+++ b/src/python/pants/jvm/subsystems_test.py
@@ -1,0 +1,63 @@
+# Copyright 2026 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import pytest
+
+from pants.engine.fs import FileDigest
+from pants.jvm.resolve.coordinate import Coordinate
+from pants.jvm.subsystems import JvmSubsystem, NailgunServer
+from pants.testutil.option_util import create_subsystem
+
+_DEFAULT_SERVER = "com.martiansoftware:nailgun-server:0.9.1#com.martiansoftware.nailgun.NGServer"
+_DEFAULT_DIGEST = "4518faa6bf4bd26fccdc4d85e1625dc679381a08d56872d8ad12151dda9cef25:32927"
+
+
+def test_nailgun_server_parses() -> None:
+    jvm = create_subsystem(
+        JvmSubsystem, nailgun_server=_DEFAULT_SERVER, nailgun_jar_digest=_DEFAULT_DIGEST
+    )
+    assert jvm.nailgun_server == NailgunServer(
+        coordinate=Coordinate(
+            group="com.martiansoftware", artifact="nailgun-server", version="0.9.1"
+        ),
+        main_class="com.martiansoftware.nailgun.NGServer",
+        file_digest=FileDigest(
+            fingerprint="4518faa6bf4bd26fccdc4d85e1625dc679381a08d56872d8ad12151dda9cef25",
+            serialized_bytes_length=32927,
+        ),
+    )
+    assert jvm.nailgun_server.file_name == "com.martiansoftware_nailgun-server_0.9.1.jar"
+
+
+def test_nailgun_server_missing_main_class() -> None:
+    jvm = create_subsystem(
+        JvmSubsystem,
+        nailgun_server="com.martiansoftware:nailgun-server:0.9.1",
+        nailgun_jar_digest="ab:1",
+    )
+    with pytest.raises(ValueError, match="missing the main class"):
+        _ = jvm.nailgun_server
+
+
+def test_nailgun_server_invalid_coordinate() -> None:
+    jvm = create_subsystem(
+        JvmSubsystem, nailgun_server="not-a-coordinate#Main", nailgun_jar_digest="ab:1"
+    )
+    with pytest.raises(ValueError) as exc:
+        _ = jvm.nailgun_server
+
+    assert "[jvm].nailgun_server" in str(exc.value)
+    assert "not-a-coordinate" in str(exc.value)
+
+
+@pytest.mark.parametrize("digest", ["no-colon", "ab:notanumber", ":123", "ab:"])
+def test_nailgun_jar_digest_invalid(digest: str) -> None:
+    jvm = create_subsystem(
+        JvmSubsystem,
+        nailgun_server="com.martiansoftware:nailgun-server:0.9.1#Main",
+        nailgun_jar_digest=digest,
+    )
+    with pytest.raises(ValueError, match="nailgun_jar_digest"):
+        _ = jvm.nailgun_server

--- a/src/rust/process_execution/pe_nailgun/src/lib.rs
+++ b/src/rust/process_execution/pe_nailgun/src/lib.rs
@@ -47,7 +47,13 @@ fn construct_nailgun_server_request(
     args_for_the_jvm: Vec<String>,
 ) -> Process {
     let mut full_args = args_for_the_jvm;
-    full_args.push(NAILGUN_MAIN_CLASS.to_string());
+    let main_class = client_request
+        .env
+        .get("PANTS_NAILGUN_MAIN_CLASS")
+        .map(|s| s.as_str())
+        .unwrap_or(NAILGUN_MAIN_CLASS);
+
+    full_args.push(main_class.to_string());
     full_args.extend(ARGS_TO_START_NAILGUN.iter().map(|&a| a.to_string()));
 
     Process {


### PR DESCRIPTION
Nailgun is deprecated and will not work for Java versions past 17. This is because the SecurityManager API has been deprecated and removed from recent Java versions, which is used for a fundamental mechanism in Nailgun to avoid exiting the server when user code exits.

Some previous mentions on this issue:
https://github.com/pantsbuild/pants/issues/20603
https://github.com/pantsbuild/pants/issues/22580
https://github.com/pantsbuild/pants/pull/22533

I went ahead and forked Nailgun over at https://github.com/soundtrackyourbrand/nailgun and reworked the deprecated mechanism which adds support for all modern Java versions without requiring any structural changes to the client side in Pants. The fork uses a light weight Java Agent that rewrites the bytecode to trap exit calls, which allows removing all use of the SecurityManager.

However, instead of just swapping over, it would make sense to be able to test it out for a while. So I've suggested adding some options here to make it configurable which nailgun-server to use. It also includes an option to run a Java Agent with the nailgun server which is required for the fixed implementation of nailgun itself.

I've made the fork public, but it's only on GitHub packages at the moment. To make use of it in Pants there is some configuration needed
```
[jvm]
nailgun_enable_agent = true
nailgun_group = "com.soundtrackyourbrand"
nailgun_artifact = "nailgun-server"
nailgun_version = "1.1.0"
nailgun_main_class = "com.facebook.nailgun.NGServer"
nailgun_sha256 = "8c70e8a8155fe7da1f004dfc65d8dc6cbbcb9a61189833aff8e4c1595f60d3cd"
nailgun_size = 203910

[coursier]
repos = [
  ...
  "https://maven.pkg.github.com/soundtrackyourbrand/nailgun",
]
```

If it turns out looking good I'm thinking it could be published to Maven Central and be more of a default replacement.