### PR TITLE
Fix uv lockfile resolver to selectively sync only needed packages

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,120 @@
+# Copilot Instructions for pantsbuild/pants
+
+## Build & Test Commands
+
+Pants is self-hosting — it uses itself (via `./pants`) to build, test, and lint.
+
+```bash
+# Run all Python tests
+./pants test ::
+
+# Run tests for a specific file
+./pants test src/python/pants/backend/python/goals/pytest_runner_test.py
+
+# Run tests for a specific directory
+./pants test src/python/pants/backend/python/goals/
+
+# Run a single test method (pass pytest args after --)
+./pants test src/python/pants/backend/python/goals/pytest_runner_test.py -- -k test_name
+
+# Lint and format (runs all configured tools: ruff, flake8, shellcheck, shfmt, hadolint, etc.)
+./pants lint ::
+./pants fmt ::
+
+# Type-check with mypy
+./pants check ::
+
+# Run against changed files only
+./pants --all-changed test
+
+# Auto-generate BUILD files after adding/removing source files
+./pants tailor ::
+
+# Build/test the Rust native engine
+./cargo test --locked --all --tests
+./cargo test -p fs                    # single crate
+./cargo test -p fs read_file_missing  # single test
+./cargo clippy --locked --all
+./cargo check                         # fast compile check
+./cargo fmt
+```
+
+The `./cargo` wrapper script sets up the correct Python and environment variables before delegating to cargo inside `src/rust/`.
+
+## Architecture
+
+### Dual-language codebase
+
+- **Python** (`src/python/pants/`): Rules, backends, goals, target types, and the plugin API.
+- **Rust** (`src/rust/`): The core execution engine, filesystem, process execution, caching, and the native scheduler. Compiled into `native_engine.so` which Python calls via PyO3.
+- The `./pants` bootstrap script compiles the Rust engine and places the `.so` into the Python source tree before running.
+
+### Rule Engine
+
+The engine is a demand-driven computation graph. Work is defined by **rules** — Python async functions decorated with `@rule`:
+
+```python
+@rule
+async def compile_thing(request: CompileRequest, subsystem: MySubsystem) -> CompileResult:
+    result = await some_other_rule(SomeInput(...), **implicitly())
+    return CompileResult(result.output)
+```
+
+Key concepts:
+- **Rules** (`@rule`): Async functions whose parameter types are automatically resolved by the engine. The return type annotation is the "product" the rule provides.
+- **Goal rules** (`@goal_rule`): Entry points invoked by CLI commands (e.g., `test`, `lint`, `fmt`). Must return a `Goal` subclass.
+- **`await` / `concurrently`**: Inside a rule, you request other computations by calling other rules or using `concurrently()` for parallel execution. There is no `Get()` anymore — use direct `await` on rule calls.
+- **`**implicitly()`**: Pass this when calling a rule to allow the engine to supply implicit parameters.
+- **Unions** (`@union`): Enable polymorphic dispatch — different backends can register implementations for the same abstract request type via `UnionRule`.
+
+### Backend Structure
+
+Each language/tool backend lives under `src/python/pants/backend/<name>/` (stable) or `src/python/pants/backend/experimental/<name>/` (experimental) and follows this structure:
+
+- `register.py` — Entry point exposing `rules()`, `target_types()`, and optionally `build_file_aliases()`. Each function aggregates rules/types from submodules.
+- `target_types.py` — Defines `Target` subclasses and their `Field` classes.
+- `goals/` — Implementations of goals (test, lint, fmt, package, etc.) for that backend.
+- `subsystems/` — Tool configuration (`Subsystem` subclasses with options).
+- `util_rules/` — Shared helper rules.
+
+Backends are enabled in `pants.toml` under `[GLOBAL].backend_packages`.
+
+### Targets and Fields
+
+Targets are declared in `BUILD` files and modeled as frozen collections of typed fields:
+
+```python
+class MyField(StringField):
+    alias = "my_field"
+    help = "Description."
+
+class MyTarget(Target):
+    alias = "my_target"
+    core_fields = (*COMMON_TARGET_FIELDS, MyField, ...)
+    help = "Description."
+```
+
+### Plugin System
+
+Internal plugins live in `pants-plugins/` (added to `pythonpath` in `pants.toml`). Both internal and external plugins follow the same `register.py` pattern with `rules()` and `target_types()` functions.
+
+Use `collect_rules()` at the bottom of a module to gather all `@rule`-decorated functions in that module for export.
+
+## Key Conventions
+
+- **`from __future__ import annotations`** — Used in most Python files; follow the convention of nearby files.
+- **`__init__.py` files must be empty** — Enforced by CI. Notable exceptions: `pants/__init__.py` (namespace package path setup) and `pants/testutil/__init__.py` (pytest assertion rewriting). Do not add exports or side effects to `__init__.py` unless matching an existing exception.
+- **Copyright headers** — Required on all `.py` (except `__init__.py`), `.rs`, and `.js` files:
+  ```
+  # Copyright YYYY Pants project contributors (see CONTRIBUTORS.md).
+  # Licensed under the Apache License, Version 2.0 (see LICENSE).
+  ```
+- **Test files** — Named `*_test.py` (unit) or `*_integration_test.py` (integration). Tests use `RuleRunner` to set up a sandboxed rule graph:
+  ```python
+  rule_runner = RuleRunner(rules=[*my_module.rules(), QueryRule(Output, [Input])])
+  ```
+- **Frozen collections** — Use `FrozenDict` and `FrozenOrderedSet` (from `pants.util`) instead of mutable dicts/sets in rule inputs/outputs, since all rule data must be hashable/immutable.
+- **`@dataclass(frozen=True)`** — Used for all request/response types passed between rules.
+- **Line length** — 100 characters (configured in ruff and enforced by linting).
+- **Python version** — 3.14 (set in `pants.toml` under `[python].interpreter_constraints`).
+- **Skipping tests** — `pytest.skip()` is treated as a test failure (via `--noskip`). Use the `@pytest.mark.no_error_if_skipped` marker if a skip is intentional.

--- a/copilot/problem_definition.md
+++ b/copilot/problem_definition.md
@@ -1,0 +1,19 @@
+## Problem definition
+
+The e8b784f897c4658a365becbc669c384240573b5e commit adds support for uv lockfiles as an alternative
+to pex lockfiles.
+
+However, the implementation of uv support has a known capability regression vs. pex for cold-cache
+builds: the pex resolver subsets the lockfile per target; the uv resolver always materializes the
+full resolve first. For ML-heavy users with large 3rdparty deps, this can lead to out-of-disk issues
+on CI agents when building even small PEX files with only a few dependencies.
+
+Read the Slack conversation in copilot/slack.md for more details on the issue and potential
+workarounds.
+
+Analyze the code changes in the commit and propose a solution to address this capability regression
+in uv support.
+Evaluate the feasibility of the proposed solution in the last message - it involves using uv's
+`--only-group` option and generating an ephemeral dependency group for just the immediate
+dependencies needed for the PEX build. Consider the implementation complexity, potential edge cases,
+and how it would integrate with the existing Pants build system.

--- a/copilot/slack.md
+++ b/copilot/slack.md
@@ -1,0 +1,58 @@
+Yi Cheng  [12:56 AM]
+
+Symptom is that we are seeing out of disk issue on jenkins when building a really small pex with errors like
+```
+ Downloaded nvidia-cufft
+   Building pyspark==3.5.5
+ Downloaded nvidia-cudnn-cu13
+ Downloaded nvidia-cublas
+  × Failed to download `torch==2.12.0`
+  ├─▶ Failed to extract archive:
+  │   torch-2.12.0-cp310-cp310-manylinux_2_28_x86_64.whl
+  ├─▶ I/O operation failed during extraction
+  ╰─▶ failed to write to file
+      `/mnt/data/agent/cache/tmp/pants-sandbox-0Qzbb9/.cache/uv_cache/.tmphW4bpP/torch/lib/libtorch_cpu.so`:
+      No space left on device (os error 28)
+  help: `torch` (v2.12.0) was included because
+        `pants-lockfile-for-python-default` (v0.0.0) depends on `torch`
+```
+
+but that particular pex only has 1-2 small 3rdparty deps transitively.
+
+So I suspected that pants with resolver=uv may be instantiating the entire resolve, and claude seems concur:
+With resolver = "pex" (main branch): When building a PEX for a PexRequirements target (your 2-dep script), Pants calls pex with [*req_strings, "--lock", lockfile_path] (line 700-709). Pex reads the lockfile and only downloads/installs requests, metatron, and their
+ transitive deps — it subsets the lockfile. Never touches torch, CUDA, etc.
+
+```
+ With resolver = "uv" (your branch): When building the same target, Pants hits line 679-682 and punts to create_venv_repository_from_uv_lockfile, which runs uv sync --frozen --all-extras on the entire default_universe.lock. Every package in the resolve — torch (507
+ MB), nvidia-*, ... — gets downloaded and extracted. This exhausts the CI agent's disk at torch.
+
+  The comment in the code at line 618-620 confirms this is a known awkward gap:
+
+  ▎ "The caller will need to set the argv. This is slightly awkward, and due to uv support being tacked on later."
+
+  The design intent is that the full-resolve venv is a shared cached package repository (one per resolve) that amortizes cost across many targets. But for cold CI agents with no persistent venv_cache, it forces a multi-GB download just to build a 2-dep PEX.
+
+  Bottom line: This is a known capability regression in uv support vs. pex for cold-cache builds. The pex resolver subsets the lockfile per target; the uv resolver always materializes the full resolve first. The separate-resolve fix I described earlier is the right
+  workaround until upstream Pants adds selective uv sync --package support for individual PEX builds.
+```
+
+
+Yi Cheng  [12:58 AM]
+cc @Benjy, may not be a blocker for some.
+for us, we are ML heavy (large 3rdparty deps), so had to roll back to resolver=pex
+
+
+Benjy Weinberger  [2:41 AM]
+Yes, currently, by design, uv syncs the entire lockfile to a venv, and pex then treats that venv as a repository from which to consume the required subset of requirements.
+[2:42 AM]Just to confirm: what's killing you is uv creating that venv? i.e., not pex accidentally trying to consume more requirements than it needs
+
+
+Yi Cheng  [2:43 AM]
+that's correct. the failure is still at uv (creating the venv) phase.
+[2:43 AM]thanks for clarifying!
+[2:44 AM]not blocking for the release since this may not be a problem for other users.
+
+
+Benjy Weinberger  [2:45 AM]
+We could use uv's `--only-group` option, and generate an ephemeral dependency group for just the immediate deps you care about

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -819,6 +819,7 @@ async def build_pex(
             VenvFromUvLockfileRequest(
                 lockfile=requirements_setup.uv_lockfile,
                 python=pex_python_setup.python,
+                subset_req_strings=req_strings if req_strings else None,
             ),
             **implicitly(),
         )

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -57,6 +57,7 @@ from pants.backend.python.util_rules.pex_test_utils import (
     create_pex_and_get_pex_info,
     parse_requirements,
 )
+from pants.backend.python.util_rules.uv import generate_pyproject_toml
 from pants.backend.python.util_rules.uv import rules as uv_rules
 from pants.core.goals.generate_lockfiles import GenerateLockfileResult
 from pants.core.register import wrap_as_resources
@@ -534,6 +535,94 @@ def test_build_pex_from_uv_lockfile(rule_runner: RuleRunner) -> None:
     )
     assert res.returncode == 0
     assert b"ok" in res.stdout
+
+
+def test_generate_pyproject_toml_includes_dependency_groups() -> None:
+    """Verify that generate_pyproject_toml produces per-requirement dependency groups."""
+    ic = InterpreterConstraints(["CPython==3.14.*"])
+    content = generate_pyproject_toml("test", ic, ["requests>=2.0", "torch==2.12.0"])
+
+    # Should contain the standard project section.
+    assert '[project]' in content
+    assert 'name = "pants-lockfile-for-test"' in content
+    assert '"requests>=2.0",' in content
+    assert '"torch==2.12.0",' in content
+
+    # Should contain per-requirement dependency groups.
+    assert '[dependency-groups]' in content
+    assert 'requests = ["requests>=2.0"]' in content
+    assert 'torch = ["torch==2.12.0"]' in content
+
+
+def test_generate_pyproject_toml_canonicalizes_group_names() -> None:
+    """Verify that group names are canonicalized (PEP 503)."""
+    ic = InterpreterConstraints(["CPython==3.14.*"])
+    content = generate_pyproject_toml("test", ic, ["Foo-Bar[extra]>=1.0"])
+
+    assert '[dependency-groups]' in content
+    # PEP 503 canonicalization: Foo-Bar -> foo-bar
+    assert 'foo-bar = ["Foo-Bar[extra]>=1.0"]' in content
+
+
+def test_build_pex_subset_from_uv_lockfile(rule_runner: RuleRunner) -> None:
+    """Build a PEX from a uv lockfile requesting only a subset of the locked packages.
+
+    This tests the selective sync path: the lockfile contains multiple packages but
+    the PEX build only needs one of them. With selective sync, only the needed package
+    (and its transitive deps) should be installed.
+    """
+    ic = InterpreterConstraints(["CPython==3.14.*"])
+    rule_runner.set_options(
+        [
+            "--python-resolves={'test': 'test.lock'}",
+            "--python-resolver=uv",
+        ],
+        env_inherit=PYTHON_BOOTSTRAP_ENV,
+    )
+    gen_result = rule_runner.request(
+        GenerateLockfileResult,
+        [
+            GenerateUvLockfile(
+                requirements=FrozenOrderedSet(
+                    [
+                        "ansicolors==1.1.8",
+                        "cowsay @ git+https://github.com/VaasuDevanS/cowsay-python@dcf7236f0b5ece9ed56e91271486e560526049cf",
+                    ]
+                ),
+                find_links=FrozenOrderedSet([]),
+                interpreter_constraints=ic,
+                resolve_name="test",
+                lockfile_dest="test.lock",
+                diff=False,
+            )
+        ],
+    )
+    digest_contents = rule_runner.request(DigestContents, [gen_result.digest])
+    rule_runner.write_files({fc.path: fc.content for fc in digest_contents})
+
+    # Build a PEX requesting only ansicolors (a subset of the lockfile).
+    lock = Lockfile("test.lock", url_description_of_origin="test uv lockfile", resolve_name="test")
+    pex_data = create_pex_and_get_all_data(
+        rule_runner,
+        requirements=PexRequirements(
+            ["ansicolors==1.1.8"],
+            from_superset=Resolve("test", use_entire_lockfile=False),
+        ),
+        interpreter_constraints=ic,
+        layout=PexLayout.ZIPAPP,
+        additional_pants_args=(
+            "--python-resolves={'test': 'test.lock'}",
+            "--python-resolver=uv",
+        ),
+    )
+
+    # The subset PEX should have ansicolors but not cowsay.
+    res = subprocess.run(
+        [pex_data.local_path, "-c", "import colors; print('subset-ok')"],
+        capture_output=True,
+    )
+    assert res.returncode == 0
+    assert b"subset-ok" in res.stdout
 
 
 def test_entry_point(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/backend/python/util_rules/uv.py
+++ b/src/python/pants/backend/python/util_rules/uv.py
@@ -12,6 +12,9 @@ from dataclasses import dataclass
 from textwrap import dedent  # noqa: PNT20
 from typing import ClassVar, cast
 
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name as canonicalize_project_name
+
 from pants.backend.python.subsystems import uv as uv_subsystem
 from pants.backend.python.subsystems.python_native_code import PythonNativeCodeSubsystem
 from pants.backend.python.subsystems.uv import (
@@ -54,10 +57,16 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class VenvFromUvLockfileRequest:
-    """Request to install all packages from a uv lockfile into a virtualenv."""
+    """Request to install packages from a uv lockfile into a virtualenv.
+
+    If subset_req_strings is set, only those requirements (and their transitive deps)
+    will be installed via per-requirement dependency groups. If None, the entire lockfile
+    is synced.
+    """
 
     lockfile: LoadedLockfile
     python: PythonExecutable
+    subset_req_strings: tuple[str, ...] | None = None
 
 
 @dataclass(frozen=True)
@@ -115,12 +124,33 @@ async def get_uv_environment(
 # The synthetic project name (pants-lockfile-for-*) must not collide with any real requirement.
 # uv will include this project as a virtual package in the lockfile, and we set package = false,
 # so it won't try to install it.
+#
+# Per-requirement dependency groups are generated so that `uv sync --only-group <name>` can
+# install a subset of requirements during PEX builds, avoiding downloading the entire resolve.
 def generate_pyproject_toml(resolve: str, ics: InterpreterConstraints, reqs: Iterable[str]) -> str:
     def escape_double_quotes(s: str) -> str:
         return s.replace('"', '\\"')
 
     requires_python = ",".join(str(constraint.specifier) for constraint in ics)
-    deps_lines = "\n".join(f'    "{escape_double_quotes(r)}",' for r in sorted(reqs))
+    sorted_reqs = sorted(reqs)
+    deps_lines = "\n".join(f'    "{escape_double_quotes(r)}",' for r in sorted_reqs)
+
+    # Build per-requirement dependency groups. Each top-level requirement gets its own
+    # group named after the canonicalized package name (PEP 503). This allows selective
+    # install via `uv sync --only-group <name>` during PEX builds.
+    groups: dict[str, str] = {}
+    for r in sorted_reqs:
+        try:
+            parsed = Requirement(r)
+            group_name = canonicalize_project_name(parsed.name)
+            groups[group_name] = f'"{escape_double_quotes(r)}"'
+        except Exception:
+            logger.debug(f"Could not parse requirement {r!r} for dependency group generation")
+
+    groups_section = ""
+    if groups:
+        group_lines = "\n".join(f'{name} = [{dep}]' for name, dep in sorted(groups.items()))
+        groups_section = f"\n[dependency-groups]\n{group_lines}\n"
 
     return dedent(
         """
@@ -135,7 +165,7 @@ def generate_pyproject_toml(resolve: str, ics: InterpreterConstraints, reqs: Ite
         [tool.uv]
         package = false
         """
-    ).format(resolve=resolve, requires_python=requires_python, deps_lines=deps_lines)
+    ).format(resolve=resolve, requires_python=requires_python, deps_lines=deps_lines) + groups_section
 
 
 @rule
@@ -146,7 +176,13 @@ async def create_venv_repository_from_uv_lockfile(
     realpath_binary: RealpathBinary,
     buildroot: BuildRoot,
 ) -> VenvRepository:
-    """Install all packages from a uv lockfile into a virtualenv."""
+    """Install packages from a uv lockfile into a virtualenv.
+
+    When subset_req_strings is provided, only those packages (and their transitive deps)
+    are installed using per-requirement dependency groups and --only-group. The --inexact
+    flag prevents removal of previously-installed packages, allowing the shared venv to
+    accumulate packages across builds.
+    """
     if request.lockfile.lockfile_format != LockfileFormat.UV:
         raise ValueError(f"Expected a uv lockfile, got {request.lockfile.lockfile_format}")
     if request.lockfile.metadata is None:
@@ -193,11 +229,45 @@ async def create_venv_repository_from_uv_lockfile(
         )
     )
 
-    # We maintain one cached venv per buildroot+interpreter+resolve. uv will efficiently
-    # incrementally update the venv as the lockfile changes, and will handle concurrency of
-    # `uv sync` with appropriate locking.
+    # Build the uv sync arguments depending on whether we're doing a full or subset sync.
+    subset_group_args: list[str] = []
+    if request.subset_req_strings:
+        for req_str in request.subset_req_strings:
+            try:
+                parsed = Requirement(req_str)
+                group_name = canonicalize_project_name(parsed.name)
+                subset_group_args.extend(["--only-group", group_name])
+            except Exception:
+                logger.warning(
+                    f"Could not parse requirement {req_str!r} for selective sync; "
+                    "falling back to full sync."
+                )
+                subset_group_args = []
+                break
+
+    if subset_group_args:
+        # Selective sync: install only the requested packages and their transitive deps.
+        # --inexact prevents removal of previously-installed packages, allowing the shared
+        # venv to accumulate packages across different PEX builds.
+        sync_mode_args = ("--inexact", *subset_group_args)
+    else:
+        # Full sync: install everything in the lockfile.
+        # TODO: extras can conflict, so we might need to be more selective.
+        sync_mode_args = ("--all-extras",)
+
+    # When using --inexact, we include a lockfile content hash in the venv path so that
+    # stale packages from old lockfile versions are not visible to Pex.
     buildroot_entropy = hashlib.sha256(buildroot.path.encode()).hexdigest()
-    venv_path_suffix = os.path.join(buildroot_entropy, metadata.resolve, request.python.fingerprint)
+    if subset_group_args:
+        lock_hash = hashlib.sha256(uv_lock_contents[0].content).hexdigest()[:12]
+        venv_path_suffix = os.path.join(
+            buildroot_entropy, metadata.resolve, request.python.fingerprint, lock_hash
+        )
+    else:
+        # Full sync: uv manages the venv contents exactly, so no hash needed.
+        venv_path_suffix = os.path.join(
+            buildroot_entropy, metadata.resolve, request.python.fingerprint
+        )
 
     uv_cmd = shlex.join(
         (
@@ -205,8 +275,7 @@ async def create_venv_repository_from_uv_lockfile(
             "sync",
             "--frozen",
             "--no-install-project",
-            # TODO: extras can conflict, so we might need to be more selective.
-            "--all-extras",
+            *sync_mode_args,
             "--no-progress",
             "--python",
             request.python.path,


### PR DESCRIPTION
## Problem

When building a PEX from a uv lockfile, the uv resolver syncs the **entire** lockfile into a venv (`uv sync --frozen --all-extras`), even when the target only needs a small subset of packages. For ML-heavy resolves with large packages (torch, CUDA libs — 500MB+), this causes out-of-disk failures on CI agents with limited storage.

This is a known capability regression vs. the pex resolver, which subsets the lockfile natively per target. As reported in Slack:

> *"Symptom is that we are seeing out of disk issue on jenkins when building a really small pex [...] but that particular pex only has 1-2 small 3rdparty deps transitively."*

The root cause: `create_venv_repository_from_uv_lockfile` runs `uv sync --frozen --all-extras` which downloads every package in the resolve, then Pex subsets from the venv. On cold CI agents, this forces a multi-GB download just to build a 2-dep PEX.

## Solution

Implements selective sync using uv's `--only-group` and `--inexact` flags, as suggested by @benjyw:

1. **Per-requirement dependency groups**: `generate_pyproject_toml` now emits a `[dependency-groups]` section with one group per top-level requirement, named after the canonicalized package name (PEP 503). Since this function is shared by both lockfile generation and sync, the groups are baked into the lockfile at generation time — required for `--frozen` compatibility.

2. **Selective sync**: When building a PEX with a subset of requirements (the common case), `create_venv_repository_from_uv_lockfile` uses `uv sync --frozen --only-group <name> --inexact` to install only the needed packages and their transitive deps. `--inexact` prevents removal of previously-installed packages, preserving the shared-venv caching model.

3. **Stale cache prevention**: A lockfile content hash is included in the venv cache path for selective syncs, ensuring stale packages from old lockfile versions are not visible to Pex.

The `EntireLockfile` path (tools, `run_against_entire_lockfile`) is unchanged and continues to sync everything via `--all-extras`.

## Changes

- `src/python/pants/backend/python/util_rules/uv.py`: Core implementation — dependency groups in pyproject.toml, selective sync logic, lockfile hash in venv path
- `src/python/pants/backend/python/util_rules/pex.py`: Pass `req_strings` through to `VenvFromUvLockfileRequest`
- `src/python/pants/backend/python/util_rules/pex_test.py`: Unit tests for `generate_pyproject_toml` (groups, canonicalization) and integration test for subset PEX build

## Notes

- Users must regenerate lockfiles after upgrading to pick up the new dependency group structure
- Old lockfiles without groups will continue to work (full sync, no subsetting)
- uv 0.11.6 (the version Pants pins) supports both `--only-group` and `--inexact`