### PR TITLE
Raise the minimum supported pex version to 2.95.1.

### DIFF
--- a/docs/notes/2.33.x.md
+++ b/docs/notes/2.33.x.md
@@ -54,9 +54,11 @@ The `--changed-since` functionality now works correctly in the presence of delet
 
 The Python Build Standalone backend ([pants.backend.python.providers.experimental.python_build_standalone](https://www.pantsbuild.org/stable/reference/subsystems/python-build-standalone-python-provider)) has release metadata current through PBS release [20260414](https://github.com/astral-sh/python-build-standalone/releases/tag/20260414).
 
-The version of [Pex](https://github.com/pex-tool/pex) used by the Python backend has been upgraded to [`v2.95.1`](https://github.com/pex-tool/pex/releases/tag/v2.95.1). Of particular note for Pants users:
+The default version of [Pex](https://github.com/pex-tool/pex) used by the Python backend has been upgraded to [`v2.95.1`](https://github.com/pex-tool/pex/releases/tag/v2.95.1). Of particular note for Pants users:
  - Support for [Pip 26.1](https://pip.pypa.io/en/stable/news/#v26-1).
  - In [some cases](https://github.com/pex-tool/pex/pull/3159) lockfile creation is significantly faster.
+
+ Note that `v2.95.1` is now also the *minimum* required version of Pex. If you're pinning to an earlier version you must upgrade. Pex is very scrupulous about backwards compatibility, so this should not be a problem in general. If the pin was specifically to avoid a bug in Pex, that bug should be [reported](https://github.com/pex-tool/pex/issues/new), after first confirming that there isn't an existing [open issue](https://github.com/pex-tool/pex/issues) for it.
 
 Fixed a bug in Ruff backend where ancestor `__init__.py` files were not included in `fix` partitions which changed how Ruff's importing sorting logic operated. Thie caused `pants fix` to see no need for import sorting even though `pants lint` flagged the need.
 

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -53,7 +53,7 @@ class PexCli(TemplatedExternalTool):
 
     default_version = _PEX_VERSION
     default_url_template = "https://github.com/pex-tool/pex/releases/download/{version}/pex"
-    version_constraints = ">=2.76.0,<3.0"
+    version_constraints = ">=2.95.1,<3.0"
 
     # extra args to be passed to the pex tool; note that they
     # are going to apply to all invocations of the pex tool.


### PR DESCRIPTION
This version contains features and fixes required
by uv support.

Folks pinning to an earlier version of pex will have to upgrade.
Pex is very scrupulous about backwards compatibility, so this
should not be a problem in general.

If the pin was specifically to avoid a bug in pex, that
bug should be reported.