### PR TITLE
Fix sync for lockfiles with metadata headers.

### DIFF
--- a/docs/notes/2.33.x.md
+++ b/docs/notes/2.33.x.md
@@ -62,6 +62,8 @@ Fixed a bug in Ruff backend where ancestor `__init__.py` files were not included
 
 All version of [Ruff](https://docs.astral.sh/ruff/) from [0.15.6](https://github.com/astral-sh/ruff/releases/tag/0.15.14) to [0.15.14](https://github.com/astral-sh/ruff/releases/tag/0.15.14) are now included in `default_known_versions`.
 
+Fixed a bug where `--sync`-ing a Pex lockfile with legacy metadata headers failed.
+
 #### Protobuf
 
 Upgraded the default version of `buf` to v1.69.0 (previously v1.3.0).

--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -32,6 +32,7 @@ from pants.backend.python.util_rules.pex_requirements import (
     ResolveConfig,
     ResolveConfigRequest,
     determine_resolve_config,
+    strip_comments_from_pex_json_lockfile,
 )
 from pants.backend.python.util_rules.uv import UvEnvironment, generate_pyproject_toml
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
@@ -189,6 +190,16 @@ async def generate_pex_lockfile(
                 conjunction=GlobExpansionConjunction.any_match,
             )
         )
+
+        if existing_lockfile_digest != EMPTY_DIGEST:
+            existing_lockfile_contents = await get_digest_contents(existing_lockfile_digest)
+            if existing_lockfile_contents:
+                stripped = strip_comments_from_pex_json_lockfile(
+                    existing_lockfile_contents[0].content
+                )
+                existing_lockfile_digest = await create_digest(
+                    CreateDigest([FileContent(req.lockfile_dest, stripped)])
+                )
     else:
         existing_lockfile_digest = EMPTY_DIGEST
 

--- a/src/python/pants/backend/python/goals/lockfile_test.py
+++ b/src/python/pants/backend/python/goals/lockfile_test.py
@@ -404,6 +404,69 @@ def test_find_links_scoped_to_resolve() -> None:
     assert result_by_resolve["b"].find_links == FrozenOrderedSet([])
 
 
+def test_sync_strips_embedded_metadata_header(rule_runner: PythonRuleRunner) -> None:
+    """Regression test for https://github.com/pantsbuild/pants/issues/23398."""
+    rule_runner.set_options(
+        [
+            "--python-resolves={'test': 'test.lock'}",
+            "--python-resolver=pex",
+            "--no-python-separate-lockfile-metadata-file",
+        ],
+        env_inherit=PYTHON_BOOTSTRAP_ENV,
+    )
+
+    result = rule_runner.request(
+        GenerateLockfileResult,
+        [
+            GeneratePexLockfile(
+                requirements=FrozenOrderedSet(["ansicolors==1.1.8"]),
+                find_links=FrozenOrderedSet([]),
+                interpreter_constraints=InterpreterConstraints(),
+                resolve_name="test",
+                lockfile_dest="test.lock",
+                diff=False,
+                lock_style="universal",
+                complete_platforms=(),
+            )
+        ],
+    )
+    rule_runner.write_digest(result.digest)
+
+    rule_runner.set_options(
+        [
+            "--python-resolves={'test': 'test.lock'}",
+            "--python-resolver=pex",
+            "--no-python-separate-lockfile-metadata-file",
+            "--generate-lockfiles-sync",
+        ],
+        env_inherit=PYTHON_BOOTSTRAP_ENV,
+    )
+    sync_result = rule_runner.request(
+        GenerateLockfileResult,
+        [
+            GeneratePexLockfile(
+                requirements=FrozenOrderedSet(["ansicolors==1.1.8"]),
+                find_links=FrozenOrderedSet([]),
+                interpreter_constraints=InterpreterConstraints(),
+                resolve_name="test",
+                lockfile_dest="test.lock",
+                diff=False,
+                lock_style="universal",
+                complete_platforms=(),
+            )
+        ],
+    )
+    sync_digest_contents = rule_runner.request(DigestContents, [sync_result.digest])
+    assert len(sync_digest_contents) == 1
+    content = sync_digest_contents[0].content.decode()
+    header, _, body = content.partition("\n\n")
+    assert header.strip() != ""
+    lock_content = json.loads(body)
+    reqs = lock_content["locked_resolves"][0]["locked_requirements"]
+    assert len(reqs) == 1
+    assert reqs[0]["project_name"] == "ansicolors"
+
+
 def test_empty_requirements(rule_runner: PythonRuleRunner) -> None:
     with pytest.raises(ExecutionError) as excinfo:
         json.loads(


### PR DESCRIPTION
Previously, attemping to `--sync` a lockfile with
metadata headers would error.

Fixes #23398

As a reminder: `--sync` does a minimal lockfile update,
keeping as many requirements fixed as possible.
So it requires the previous lockfile as input.