### PR TITLE
Pin GOTOOLCHAIN=local in Go sandboxes for hermeticity

### DIFF
--- a/docs/docs/go/index.mdx
+++ b/docs/docs/go/index.mdx
@@ -83,6 +83,15 @@ pkg/runner:runner
 Pants does not yet update your `go.mod` and `go.sum` for you; it only reads these files when downloading modules. Run `go mod download all` to make sure these files are correct.
 :::
 
+### Toolchain selection
+
+Pants always builds with the Go SDK it discovers via `[golang].go_search_paths`. Inside every sandbox, `GOTOOLCHAIN=local` is set unconditionally, which disables Go's automatic toolchain download feature (introduced in Go 1.21). This means:
+
+- If your `go.mod` or `go.work` file contains a `go` or `toolchain` directive that demands a newer version than the locally installed SDK, the build fails fast with a clear message: `go: go.mod requires go >= X.Y.Z (running go A.B.C; GOTOOLCHAIN=local)`.
+- There is no silent background download of a different toolchain that Pants has not fingerprinted and cannot cache correctly.
+
+To resolve such a failure, either install a newer Go SDK that is discoverable via `[golang].go_search_paths` (and raise `[golang].minimum_expected_version` to match), or lower the `go` directive in the offending `go.mod`.
+
 ### The `embed` directive and `resource` targets
 
 To use the [`embed` directive](https://pkg.go.dev/embed), you must first teach Pants about the [files](../using-pants/assets-and-archives.mdx) with the `resource` / `resources` targets:

--- a/docs/notes/2.33.x.md
+++ b/docs/notes/2.33.x.md
@@ -85,6 +85,8 @@ Fixes JavaScript workspace builds where dependencies are installed under members
 
 #### Go
 
+The Go backend now pins `GOTOOLCHAIN=local` in every Go subprocess sandbox. Since Go 1.21, the default `GOTOOLCHAIN=auto` causes Go to silently download a different toolchain when a `go.mod` or `go.work` file demands a newer version — one that Pants never fingerprinted, breaking hermeticity and cache correctness. With `GOTOOLCHAIN=local`, builds that require a newer toolchain now fail fast with a clear message (`go: go.mod requires go >= X.Y.Z (running go A.B.C; GOTOOLCHAIN=local)`) instead of silently fetching an untracked binary. Repos whose `go.mod` version is at or below the locally installed SDK are unaffected. One-time process cache invalidation will occur for all Go processes when upgrading to this release. To fix a failure, install a newer Go SDK discoverable via `[golang].go_search_paths` (and bump `[golang].minimum_expected_version`), or lower the `go` directive in the offending `go.mod`.
+
 Third-party module analysis is now deduplicated across `go.mod` files. Previously, a module required by `N` `go.mod` files was downloaded and analyzed `N` times, which caused significant memory and time overhead in monorepos with many overlapping `go.mod` files. On a 3-`go.mod` reproducer, `pants list ::` peak memory dropped from 91 GB to 32 GB (-65%). This is a no-op for repos with a single `go.mod`. See [#20274](https://github.com/pantsbuild/pants/issues/20274).
 
 ### Plugin API changes

--- a/src/python/pants/backend/go/lint/golangci_lint/rules.py
+++ b/src/python/pants/backend/go/lint/golangci_lint/rules.py
@@ -179,6 +179,7 @@ async def run_golangci_lint(
             export GOCACHE="${{sandbox_root}}/gocache"
             export GOLANGCI_LINT_CACHE="$GOCACHE"
             export CGO_ENABLED={1 if cgo_enabled else 0}
+            export GOTOOLCHAIN=local
             /bin/mkdir -p "$GOPATH" "$GOCACHE"
             exec "$@"
             """

--- a/src/python/pants/backend/go/util_rules/sdk.py
+++ b/src/python/pants/backend/go/util_rules/sdk.py
@@ -134,6 +134,12 @@ async def setup_go_sdk_process(
         **request.env,
         GoSdkRunSetup.CHDIR_ENV: request.working_dir or "",
         "__PANTS_GO_SDK_CACHE_KEY": f"{goroot.full_version}/{goroot.goos}/{goroot.goarch}",
+        # Pin toolchain selection so a go.mod/go.work `go` or `toolchain` directive that demands
+        # a newer version fails fast with a clear message instead of silently downloading an
+        # unfingerprinted toolchain (the default `GOTOOLCHAIN=auto` behaviour since Go 1.21).
+        # Placement after **env_vars/**request.env is intentional: it prevents callers who pass
+        # GOTOOLCHAIN via `[golang].subprocess_env_vars` from accidentally re-enabling switching.
+        "GOTOOLCHAIN": "local",
     }
 
     immutable_input_digests: dict[str, Digest] = {}

--- a/src/python/pants/backend/go/util_rules/sdk_test.py
+++ b/src/python/pants/backend/go/util_rules/sdk_test.py
@@ -1,0 +1,51 @@
+# Copyright 2026 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import pytest
+
+from pants.backend.go.util_rules import sdk
+from pants.backend.go.util_rules.sdk import GoSdkProcess
+from pants.engine.process import Process
+from pants.engine.rules import QueryRule
+from pants.testutil.rule_runner import RuleRunner
+from pants.util.frozendict import FrozenDict
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    rule_runner = RuleRunner(
+        rules=[
+            *sdk.rules(),
+            QueryRule(Process, [GoSdkProcess]),
+        ],
+    )
+    rule_runner.set_options([], env_inherit={"PATH"})
+    return rule_runner
+
+
+def test_gotoolchain_local_is_set(rule_runner: RuleRunner) -> None:
+    """GOTOOLCHAIN=local must be present in every GoSdkProcess environment."""
+    process = rule_runner.request(
+        Process,
+        [GoSdkProcess(["version"], description="test: go version")],
+    )
+    assert process.env.get("GOTOOLCHAIN") == "local"
+
+
+def test_gotoolchain_local_cannot_be_overridden(rule_runner: RuleRunner) -> None:
+    """GOTOOLCHAIN=local must survive even when the caller passes a different value via
+    GoSdkProcess(env=...).  The pin is placed after **request.env in the dict literal so
+    caller-supplied values are silently overwritten."""
+    process = rule_runner.request(
+        Process,
+        [
+            GoSdkProcess(
+                ["version"],
+                description="test: override attempt",
+                env=FrozenDict({"GOTOOLCHAIN": "auto"}),
+            )
+        ],
+    )
+    assert process.env.get("GOTOOLCHAIN") == "local"

--- a/src/python/pants/backend/go/util_rules/third_party_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/third_party_pkg_test.py
@@ -738,3 +738,19 @@ def test_parse_go_sum() -> None:
     crlf_parsed = _parse_go_sum(crlf_sum)
     assert ("mod", "v1.0.0") in crlf_parsed
     assert len(crlf_parsed[("mod", "v1.0.0")]) == 2
+
+
+def test_gotoolchain_local_fail_fast(rule_runner: RuleRunner) -> None:
+    """When GOTOOLCHAIN=local is pinned, a go.mod demanding a newer toolchain must fail fast with
+    the deterministic message 'go.mod requires go >= X' rather than silently downloading a
+    toolchain (the old GOTOOLCHAIN=auto behaviour) or emitting an ambiguous network error."""
+    # Use `go 1.99.0` (not `go 99.0`): the latter produces "invalid GOTOOLCHAIN" because Go
+    # parses it as a bare major version, whereas 1.99.0 is parsed as a valid semver and triggers
+    # the expected 'requires go >= 1.99.0' failure path.
+    digest = set_up_go_mod(
+        rule_runner,
+        "module example.com/gotoolchain-test\ngo 1.99.0\n",
+        "",
+    )
+    with engine_error(ProcessExecutionFailure, contains="go.mod requires go >= 1.99.0"):
+        rule_runner.request(ModuleDescriptors, [ModuleDescriptorsRequest(digest, "")])


### PR DESCRIPTION
Disclaimer: Like my previous Go PR, I'm still not primarily a golang developer. However, the fact that Golang doesn't work properly in Pants has been the bane of my existence for like 2 years now. The moment that Mythos/Fable dropped I immediately had it dig deeply into whether the whole road to proper-golang-in-pants could be opened up. So this is all by Claude Code with Fable 5 (xhigh), with consults to GPT 5.5 (xhigh) and Gemini 3.1 Pro. I've had it check and recheck, I ran many different roles over it, and I had it explain and re-explain it to me, and then I checked myself.

So, as much as I dislike AI slop and am worried about AI PR overload, I've done my very best to avoid exactly that while still using AI. I hope we can get this road unblocked.

The rest is Fable talking:

---

Since Go 1.21, the `go` command defaults to `GOTOOLCHAIN=auto`: when a `go.mod` or `go.work` file demands a toolchain newer than the installed SDK, `go` silently downloads that toolchain and re-execs it. Pants never fingerprints the downloaded toolchain, so the same cached process result can be produced by different toolchains on different machines. That is a hermeticity hole in the Go backend.

This PR pins `GOTOOLCHAIN=local` in every Go subprocess sandbox. Builds that demand a newer toolchain now fail fast with a deterministic, actionable message:

```
go: go.mod requires go >= X.Y.Z (running go A.B.C; GOTOOLCHAIN=local)
```

Repos whose `go` directive is at or below the installed SDK version are unaffected.

Changes:

- `sdk.py` (`setup_go_sdk_process`): add `"GOTOOLCHAIN": "local"` to the process env. The entry is placed after `**env_vars` / `**request.env` so a value passed via `[golang].subprocess_env_vars` cannot re-enable toolchain switching.
- `golangci_lint/rules.py`: the lint runner script bypasses `__run_go.sh` and invokes `go` directly, so it exports `GOTOOLCHAIN=local` itself.
- Docs: new "Toolchain selection" section in `docs/docs/go/index.mdx`, plus a release note in `docs/notes/2.33.x.md`.

Why no opt-out option: an opt-out reintroduces an unfingerprinted toolchain and cross-machine cache poisoning. The failure it prevents has a one-line fix (install a newer SDK discoverable via `[golang].go_search_paths`, or lower the `go` directive). The backend already hard-pins hermeticity-relevant env without options (`GOPROXY=off`).

Tests:

- `sdk_test.py` (new): asserts `GOTOOLCHAIN=local` is present in the resolved `Process.env` and survives a caller passing `GOTOOLCHAIN=auto` via `GoSdkProcess(env=...)`.
- `third_party_pkg_test.py::test_gotoolchain_local_fail_fast` (new): a `go.mod` with `go 1.99.0` fails as `ProcessExecutionFailure` containing `go.mod requires go >= 1.99.0`. Without this PR the same setup attempts a network toolchain download.

One caveat: adding the env var changes process digests, so existing cached Go process results are invalidated once on upgrade. The release note calls this out.

