### PR TITLE
Build Go compile sandboxes from direct dependencies only; merge transitive closure once at link

### DIFF
--- a/docs/notes/2.33.x.md
+++ b/docs/notes/2.33.x.md
@@ -87,9 +87,19 @@ Fixes JavaScript workspace builds where dependencies are installed under members
 
 Third-party module analysis is now deduplicated across `go.mod` files. Previously, a module required by `N` `go.mod` files was downloaded and analyzed `N` times, which caused significant memory and time overhead in monorepos with many overlapping `go.mod` files. On a 3-`go.mod` reproducer, `pants list ::` peak memory dropped from 91 GB to 32 GB (-65%). This is a no-op for repos with a single `go.mod`. See [#20274](https://github.com/pantsbuild/pants/issues/20274).
 
+Go package compilation sandboxes now contain only the direct dependencies' package archives, instead of the full transitive dependency closure. Previously, every compiled package merged all transitive archives into its compile sandbox, importcfg, and output digest, causing O(depth × packages) digest-merge work in the Pants engine; the transitive archive set is now merged exactly once per linked binary, where it is actually needed. This significantly reduces engine overhead for `pants check` and compile-heavy builds on deep dependency graphs (benchmark numbers in the PR). See [#20274](https://github.com/pantsbuild/pants/issues/20274).
+
+Fixed a traversal bug that silently dropped prebuilt object files (`.syso`) of transitive dependencies at depth 2 or deeper from cgo linking.
+
 ### Plugin API changes
 
 `FrozenOrderedSet` is now backed by a native Rust implementation and is built in `__new__` rather than `__init__`. Subclasses that customized the set's contents by overriding `__init__` (for example, to transform the input iterable before constructing) must move that logic to `__new__`, since the set is already built and immutable by the time `__init__` runs.
+
+The Go backend's `BuiltGoPackage` type changed shape as part of the compile-sandbox restructure:
+
+- `BuiltGoPackage.digest` (the fully merged transitive archive digest) is replaced by `archive_digest`, which contains only the package's own files, plus `transitive_pkg_archives`, which maps each import path in the closure to its archive path and unmerged digest handle. Use the new `merge_built_go_package_archives` rule to obtain a merged closure digest.
+- `BuiltGoPackage.import_paths_to_pkg_a_files` is removed; the same mapping is available from `merge_built_go_package_archives` (or can be derived from `transitive_pkg_archives`).
+- `GoCodegenBuildRequest` implementations must now declare complete direct dependencies for generated code, including its standard-library imports (for example via `BuildGoPackageRequestForStdlibRequest`). Previously, missing direct dependencies were masked because the entire transitive closure leaked into every compile sandbox.
 
 ## Full Changelog
 

--- a/src/python/pants/backend/codegen/protobuf/go/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/go/rules.py
@@ -46,12 +46,18 @@ from pants.backend.go.util_rules.build_pkg import (
     FallibleBuildGoPackageRequest,
 )
 from pants.backend.go.util_rules.build_pkg_target import (
+    BuildGoPackageRequestForStdlibRequest,
     BuildGoPackageTargetRequest,
     GoCodegenBuildRequest,
     required_build_go_package_request,
+    setup_build_go_package_target_request_for_stdlib,
 )
 from pants.backend.go.util_rules.first_party_pkg import FallibleFirstPartyPkgAnalysis
 from pants.backend.go.util_rules.go_mod import OwningGoModRequest, find_owning_go_mod
+from pants.backend.go.util_rules.import_analysis import (
+    GoStdLibPackagesRequest,
+    analyze_go_stdlib_packages,
+)
 from pants.backend.go.util_rules.pkg_analyzer import PackageAnalyzerSetup
 from pants.backend.go.util_rules.sdk import GoSdkProcess
 from pants.backend.python.util_rules import pex
@@ -371,10 +377,28 @@ async def setup_full_package_build_request(
         )
     analysis = fallible_analysis.analysis
 
-    # Obtain build requests for third-party dependencies.
+    stdlib_packages = await analyze_go_stdlib_packages(
+        GoStdLibPackagesRequest(
+            with_race_detector=request.build_opts.with_race_detector,
+            cgo_enabled=request.build_opts.cgo_enabled,
+        )
+    )
+
+    # Obtain build requests for standard-library and third-party dependencies.
     # TODO: Consider how to merge this code with existing dependency inference code.
     dep_build_request_addrs: set[Address] = set()
+    stdlib_dep_import_paths: set[str] = set()
     for dep_import_path in (*analysis.imports, *analysis.test_imports, *analysis.xtest_imports):
+        if dep_import_path in ("C", "unsafe", "builtin"):
+            continue
+
+        # The generated code imports standard-library packages directly (e.g., `reflect` and
+        # `sync`). They must be declared as direct dependencies: the compile sandbox/importcfg
+        # contains only direct dependencies' export data.
+        if dep_import_path in stdlib_packages:
+            stdlib_dep_import_paths.add(dep_import_path)
+            continue
+
         # Infer dependencies on other Go packages.
         candidate_addresses = package_mapping.mapping.get(dep_import_path)
         if candidate_addresses:
@@ -404,6 +428,21 @@ async def setup_full_package_build_request(
         for addr in sorted(dep_build_request_addrs)
     )
 
+    fallible_stdlib_dep_build_requests = await concurrently(
+        setup_build_go_package_target_request_for_stdlib(
+            BuildGoPackageRequestForStdlibRequest(
+                import_path=dep_import_path,
+                build_opts=request.build_opts,
+            ),
+            **implicitly(),
+        )
+        for dep_import_path in sorted(stdlib_dep_import_paths)
+    )
+    stdlib_dep_build_requests: list[BuildGoPackageRequest] = []
+    for fallible_stdlib_dep in fallible_stdlib_dep_build_requests:
+        assert fallible_stdlib_dep.request is not None
+        stdlib_dep_build_requests.append(fallible_stdlib_dep.request)
+
     return FallibleBuildGoPackageRequest(
         request=BuildGoPackageRequest(
             import_path=request.import_path,
@@ -412,7 +451,7 @@ async def setup_full_package_build_request(
             dir_path=analysis.dir_path,
             go_files=analysis.go_files,
             s_files=analysis.s_files,
-            direct_dependencies=dep_build_requests,
+            direct_dependencies=(*dep_build_requests, *stdlib_dep_build_requests),
             minimum_go_version=analysis.minimum_go_version,
             build_opts=request.build_opts,
         ),

--- a/src/python/pants/backend/go/go_sources/load_go_binary.py
+++ b/src/python/pants/backend/go/go_sources/load_go_binary.py
@@ -8,7 +8,12 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 
 from pants.backend.go.util_rules.build_opts import GoBuildOptions
-from pants.backend.go.util_rules.build_pkg import BuildGoPackageRequest, required_built_go_package
+from pants.backend.go.util_rules.build_pkg import (
+    BuildGoPackageRequest,
+    MergeBuiltGoPackageArchivesRequest,
+    merge_built_go_package_archives,
+    required_built_go_package,
+)
 from pants.backend.go.util_rules.goroot import GoRoot
 from pants.backend.go.util_rules.import_analysis import (
     GoStdLibPackagesRequest,
@@ -140,14 +145,14 @@ async def setup_go_binary(request: LoadedGoBinaryRequest, goroot: GoRoot) -> Loa
         ),
     )
 
-    main_pkg_a_file_path = built_pkg.import_paths_to_pkg_a_files["main"]
+    merged = await merge_built_go_package_archives(MergeBuiltGoPackageArchivesRequest((built_pkg,)))
 
     binary = await link_go_binary(
         LinkGoBinaryRequest(
-            input_digest=built_pkg.digest,
-            archives=(main_pkg_a_file_path,),
+            input_digest=merged.digest,
+            archives=(built_pkg.pkg_archive_path,),
             build_opts=build_opts,
-            import_paths_to_pkg_a_files=built_pkg.import_paths_to_pkg_a_files,
+            import_paths_to_pkg_a_files=merged.import_paths_to_pkg_a_files,
             output_filename=request.output_name,
             description=f"Link internal Go binary `{request.output_name}`",
         ),

--- a/src/python/pants/backend/go/goals/package_binary.py
+++ b/src/python/pants/backend/go/goals/package_binary.py
@@ -20,7 +20,11 @@ from pants.backend.go.util_rules.build_opts import (
     GoBuildOptionsFromTargetRequest,
     go_extract_build_options_from_target,
 )
-from pants.backend.go.util_rules.build_pkg import required_built_go_package
+from pants.backend.go.util_rules.build_pkg import (
+    MergeBuiltGoPackageArchivesRequest,
+    merge_built_go_package_archives,
+    required_built_go_package,
+)
 from pants.backend.go.util_rules.build_pkg_target import BuildGoPackageTargetRequest
 from pants.backend.go.util_rules.first_party_pkg import (
     FirstPartyPkgAnalysisRequest,
@@ -45,7 +49,6 @@ from pants.engine.internals.selectors import concurrently
 from pants.engine.intrinsics import add_prefix
 from pants.engine.rules import collect_rules, implicitly, rule
 from pants.engine.unions import UnionRule
-from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 
 
@@ -109,16 +112,17 @@ async def package_go_binary(field_set: GoBinaryFieldSet) -> BuiltPackage:
             BuildGoPackageTargetRequest(main_pkg.address, is_main=True, build_opts=build_opts)
         ),
     )
-
-    main_pkg_a_file_path = built_package.import_paths_to_pkg_a_files["main"]
+    merged = await merge_built_go_package_archives(
+        MergeBuiltGoPackageArchivesRequest((built_package,))
+    )
 
     output_filename = PurePath(field_set.output_path.value_or_default(file_ending=None))
     binary = await link_go_binary(
         LinkGoBinaryRequest(
-            input_digest=built_package.digest,
-            archives=(main_pkg_a_file_path,),
+            input_digest=merged.digest,
+            archives=(built_package.pkg_archive_path,),
             build_opts=build_opts,
-            import_paths_to_pkg_a_files=FrozenDict(built_package.import_paths_to_pkg_a_files),
+            import_paths_to_pkg_a_files=merged.import_paths_to_pkg_a_files,
             output_filename=f"./{output_filename.name}",
             description=f"Link Go binary for {field_set.address}",
         ),

--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -29,7 +29,9 @@ from pants.backend.go.util_rules.build_opts import (
 )
 from pants.backend.go.util_rules.build_pkg import (
     BuildGoPackageRequest,
+    MergeBuiltGoPackageArchivesRequest,
     build_go_package,
+    merge_built_go_package_archives,
     required_built_go_package,
 )
 from pants.backend.go.util_rules.build_pkg_target import (
@@ -528,14 +530,16 @@ async def prepare_go_test_binary(
         )
     built_main_pkg = maybe_built_main_pkg.output
 
-    main_pkg_a_file_path = built_main_pkg.import_paths_to_pkg_a_files["main"]
+    merged = await merge_built_go_package_archives(
+        MergeBuiltGoPackageArchivesRequest((built_main_pkg,))
+    )
 
     binary = await link_go_binary(
         LinkGoBinaryRequest(
-            input_digest=built_main_pkg.digest,
-            archives=(main_pkg_a_file_path,),
+            input_digest=merged.digest,
+            archives=(built_main_pkg.pkg_archive_path,),
             build_opts=build_opts,
-            import_paths_to_pkg_a_files=built_main_pkg.import_paths_to_pkg_a_files,
+            import_paths_to_pkg_a_files=merged.import_paths_to_pkg_a_files,
             output_filename="./test_runner",  # TODO: Name test binary the way that `go` does?
             description=f"Link Go test binary for {request.field_set.address}",
         ),

--- a/src/python/pants/backend/go/util_rules/build_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg.py
@@ -337,7 +337,9 @@ async def merge_built_go_package_archives(
             if import_path not in import_paths_to_pkg_a_files:
                 import_paths_to_pkg_a_files[import_path] = archive_path
                 digests.append(digest)
-    merged = await merge_digests(MergeDigests(digests))
+    # Sort so the `MergeDigests` input is canonical and identical archive sets share a
+    # `merge_digests` cache entry regardless of package iteration order.
+    merged = await merge_digests(MergeDigests(sorted(digests, key=lambda d: d.fingerprint)))
     return MergedGoPackageArchives(merged, FrozenDict(import_paths_to_pkg_a_files))
 
 
@@ -632,7 +634,8 @@ async def build_go_package(
                 transitive_pkg_archives[ip] = handle
 
     merged_deps_digest, import_config, embedcfg, action_id_result = await concurrently(
-        merge_digests(MergeDigests(direct_dep_digests)),
+        # Sort for a canonical `MergeDigests` input (see `merge_built_go_package_archives`).
+        merge_digests(MergeDigests(sorted(direct_dep_digests, key=lambda d: d.fingerprint))),
         generate_import_config(
             ImportConfigRequest(
                 FrozenDict(direct_dep_archives),

--- a/src/python/pants/backend/go/util_rules/build_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg.py
@@ -294,14 +294,51 @@ class FallibleBuiltGoPackage(EngineAwareReturnType):
 
 @dataclass(frozen=True)
 class BuiltGoPackage:
-    """A package and its dependencies compiled as `__pkg__.a` files.
+    """A compiled Go package as a `__pkg__.a` file, plus handles to its transitive closure.
 
-    The packages are arranged into `__pkgs__/{path_safe(import_path)}/__pkg__.a`.
+    `archive_digest` contains ONLY this package's own files, laid out as
+    `__pkgs__/{path_safe(import_path)}/__pkg__.a` (plus this package's module sources when
+    the cgo rules detected a `${SRCDIR}` reference that the linker will need).
+
+    `transitive_pkg_archives` maps import path -> (archive path, digest-containing-that-archive)
+    for this package AND all of its transitive dependencies. The digests are NOT merged;
+    top-level consumers (link/test binary) merge them exactly once via
+    `merge_built_go_package_archives`.
     """
 
+    import_path: str
+    pkg_archive_path: str
+    archive_digest: Digest
+    transitive_pkg_archives: FrozenDict[str, tuple[str, Digest]]
+    coverage_metadata: BuiltGoPackageCodeCoverageMetadata | None = None
+
+
+@dataclass(frozen=True)
+class MergeBuiltGoPackageArchivesRequest:
+    """Request a single merged digest of the full transitive archive closure of `packages`."""
+
+    packages: tuple[BuiltGoPackage, ...]
+
+
+@dataclass(frozen=True)
+class MergedGoPackageArchives:
     digest: Digest
     import_paths_to_pkg_a_files: FrozenDict[str, str]
-    coverage_metadata: BuiltGoPackageCodeCoverageMetadata | None = None
+
+
+@rule
+async def merge_built_go_package_archives(
+    request: MergeBuiltGoPackageArchivesRequest,
+) -> MergedGoPackageArchives:
+    import_paths_to_pkg_a_files: dict[str, str] = {}
+    digests: list[Digest] = []
+    for pkg in request.packages:
+        for import_path, (archive_path, digest) in pkg.transitive_pkg_archives.items():
+            if import_path not in import_paths_to_pkg_a_files:
+                import_paths_to_pkg_a_files[import_path] = archive_path
+                digests.append(digest)
+    merged = await merge_digests(MergeDigests(digests))
+    return MergedGoPackageArchives(merged, FrozenDict(import_paths_to_pkg_a_files))
 
 
 @dataclass(frozen=True)
@@ -578,24 +615,27 @@ async def build_go_package(
         build_go_package(build_request, go_root) for build_request in request.direct_dependencies
     )
 
-    import_paths_to_pkg_a_files: dict[str, str] = {}
-    dep_digests = []
+    direct_dep_archives: dict[str, str] = {}  # importcfg entries: DIRECT deps only
+    direct_dep_digests: list[Digest] = []
+    transitive_pkg_archives: dict[str, tuple[str, Digest]] = {}
     for maybe_dep in maybe_built_deps:
         if maybe_dep.output is None:
             return dataclasses.replace(
                 maybe_dep, import_path=request.import_path, dependency_failed=True
             )
         dep = maybe_dep.output
-        for dep_import_path, pkg_archive_path in dep.import_paths_to_pkg_a_files.items():
-            if dep_import_path not in import_paths_to_pkg_a_files:
-                import_paths_to_pkg_a_files[dep_import_path] = pkg_archive_path
-                dep_digests.append(dep.digest)
+        if dep.import_path not in direct_dep_archives:
+            direct_dep_archives[dep.import_path] = dep.pkg_archive_path
+            direct_dep_digests.append(dep.archive_digest)
+        for ip, handle in dep.transitive_pkg_archives.items():
+            if ip not in transitive_pkg_archives:
+                transitive_pkg_archives[ip] = handle
 
     merged_deps_digest, import_config, embedcfg, action_id_result = await concurrently(
-        merge_digests(MergeDigests(dep_digests)),
+        merge_digests(MergeDigests(direct_dep_digests)),
         generate_import_config(
             ImportConfigRequest(
-                FrozenDict(import_paths_to_pkg_a_files),
+                FrozenDict(direct_dep_archives),
                 build_opts=request.build_opts,
                 import_map=request.import_map,
             )
@@ -966,17 +1006,16 @@ async def build_go_package(
         compilation_digest = assembly_link_result.output_digest
 
     path_prefix = os.path.join("__pkgs__", path_safe(request.import_path))
-    import_paths_to_pkg_a_files[request.import_path] = os.path.join(path_prefix, "__pkg__.a")
+    pkg_archive_path = os.path.join(path_prefix, "__pkg__.a")
     output_digest = await add_prefix(AddPrefix(compilation_digest, path_prefix))
-    merged_result_digest = await merge_digests(MergeDigests([*dep_digests, output_digest]))
 
-    # Include the modules sources in the output `Digest` alongside the package archive if the Cgo rules
-    # detected a potential attempt to link against a static archive (or other reference to `${SRCDIR}` in
-    # options) which necessitates the linker needing access to module sources.
+    # Include the module sources alongside the package archive if the cgo rules detected a
+    # potential attempt to link against a static archive (`${SRCDIR}` reference): the LINK step
+    # needs those sources, and they propagate to it via `transitive_pkg_archives`.
     if cgo_compile_result and cgo_compile_result.include_module_sources_with_output:
-        merged_result_digest = await merge_digests(
-            MergeDigests([merged_result_digest, request.digest])
-        )
+        output_digest = await merge_digests(MergeDigests([output_digest, request.digest]))
+
+    transitive_pkg_archives[request.import_path] = (pkg_archive_path, output_digest)
 
     coverage_metadata = (
         BuiltGoPackageCodeCoverageMetadata(
@@ -990,8 +1029,10 @@ async def build_go_package(
     )
 
     output = BuiltGoPackage(
-        digest=merged_result_digest,
-        import_paths_to_pkg_a_files=FrozenDict(import_paths_to_pkg_a_files),
+        import_path=request.import_path,
+        pkg_archive_path=pkg_archive_path,
+        archive_digest=output_digest,
+        transitive_pkg_archives=FrozenDict(transitive_pkg_archives),
         coverage_metadata=coverage_metadata,
     )
     return FallibleBuiltGoPackage(output, request.import_path)

--- a/src/python/pants/backend/go/util_rules/build_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg.py
@@ -546,7 +546,7 @@ async def _gather_transitive_prebuilt_object_files(
     seen: set[BuildGoPackageRequest] = {build_request}
     while queue:
         pkg = queue.popleft()
-        unseen = [dd for dd in build_request.direct_dependencies if dd not in seen]
+        unseen = [dd for dd in pkg.direct_dependencies if dd not in seen]
         queue.extend(unseen)
         seen.update(unseen)
         if pkg.prebuilt_object_files:

--- a/src/python/pants/backend/go/util_rules/build_pkg_target_test.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target_test.py
@@ -40,6 +40,7 @@ from pants.backend.go.util_rules.build_pkg_target import (
     BuildGoPackageTargetRequest,
     GoCodegenBuildRequest,
     setup_build_go_package_target_request,
+    setup_build_go_package_target_request_for_stdlib,
 )
 from pants.backend.go.util_rules.go_mod import OwningGoModRequest, find_owning_go_mod
 from pants.backend.go.util_rules.import_analysis import (
@@ -143,6 +144,14 @@ async def generate_from_file(request: GoCodegenBuildFilesRequest) -> FallibleBui
     )
     assert thirdparty_dep.request is not None
 
+    # The generated code imports `fmt` directly, so it must be declared as a direct
+    # dependency: the compile sandbox/importcfg contains only direct deps' export data.
+    fmt_dep = await setup_build_go_package_target_request_for_stdlib(
+        BuildGoPackageRequestForStdlibRequest("fmt", build_opts=GoBuildOptions()),
+        **implicitly(),
+    )
+    assert fmt_dep.request is not None
+
     return FallibleBuildGoPackageRequest(
         request=BuildGoPackageRequest(
             import_path="codegen.com/gen",
@@ -152,7 +161,7 @@ async def generate_from_file(request: GoCodegenBuildFilesRequest) -> FallibleBui
             build_opts=GoBuildOptions(),
             go_files=("f.go",),
             s_files=(),
-            direct_dependencies=(thirdparty_dep.request,),
+            direct_dependencies=(fmt_dep.request, thirdparty_dep.request),
             minimum_go_version=None,
         ),
         import_path="codegen.com/gen",
@@ -200,18 +209,22 @@ def assert_built(
     rule_runner: RuleRunner, request: BuildGoPackageRequest, *, expected_import_paths: list[str]
 ) -> None:
     built_package = rule_runner.request(BuiltGoPackage, [request])
-    result_files = rule_runner.request(Snapshot, [built_package.digest]).files
+    own_files = rule_runner.request(Snapshot, [built_package.archive_digest]).files
+    assert built_package.pkg_archive_path == os.path.join(
+        "__pkgs__", path_safe(built_package.import_path), "__pkg__.a"
+    )
+    assert built_package.pkg_archive_path in own_files
     expected = {
         import_path: os.path.join("__pkgs__", path_safe(import_path), "__pkg__.a")
         for import_path in expected_import_paths
     }
-    actual = dict(built_package.import_paths_to_pkg_a_files)
+    actual = {
+        import_path: archive_path
+        for import_path, (archive_path, _) in built_package.transitive_pkg_archives.items()
+    }
     for import_path, pkg_archive_path in expected.items():
         assert import_path in actual, f"expected {import_path} to be in build output"
-        assert actual[import_path] == expected[import_path], (
-            "expected package archive paths to match"
-        )
-    assert set(expected.values()).issubset(set(result_files))
+        assert actual[import_path] == pkg_archive_path, "expected package archive paths to match"
 
 
 def assert_pkg_target_built(
@@ -579,7 +592,7 @@ def test_build_codegen_target(rule_runner: RuleRunner) -> None:
         expected_import_path="codegen.com/gen",
         expected_dir_path="codegen",
         expected_go_file_names=["f.go"],
-        expected_direct_dependency_import_paths=["github.com/google/uuid"],
+        expected_direct_dependency_import_paths=["fmt", "github.com/google/uuid"],
         expected_transitive_dependency_import_paths=[],
     )
 

--- a/src/python/pants/backend/go/util_rules/build_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_test.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import os.path
+from dataclasses import dataclass
 from textwrap import dedent
 
 import pytest
@@ -25,11 +26,37 @@ from pants.backend.go.util_rules.build_pkg import (
     BuildGoPackageRequest,
     BuiltGoPackage,
     FallibleBuiltGoPackage,
+    _gather_transitive_prebuilt_object_files,
 )
 from pants.engine.fs import Snapshot
-from pants.engine.rules import QueryRule
+from pants.engine.rules import QueryRule, rule
 from pants.testutil.rule_runner import RuleRunner
 from pants.util.strutil import path_safe
+
+
+# ---------------------------------------------------------------------------
+# Test-only rule for probing _gather_transitive_prebuilt_object_files directly.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _GatherPrebuiltObjectFilesResult:
+    object_files: frozenset[str]
+
+
+@rule
+async def _gather_prebuilt_object_files_for_test(
+    request: BuildGoPackageRequest,
+) -> _GatherPrebuiltObjectFilesResult:
+    _, object_files = await _gather_transitive_prebuilt_object_files(request)
+    return _GatherPrebuiltObjectFilesResult(object_files)
+
+
+def _syso_test_rules():
+    return [
+        _gather_prebuilt_object_files_for_test,
+        QueryRule(_GatherPrebuiltObjectFilesResult, [BuildGoPackageRequest]),
+    ]
 
 
 @pytest.fixture
@@ -47,6 +74,28 @@ def rule_runner() -> RuleRunner:
             *target_type_rules.rules(),
             QueryRule(BuiltGoPackage, [BuildGoPackageRequest]),
             QueryRule(FallibleBuiltGoPackage, [BuildGoPackageRequest]),
+        ],
+        target_types=[GoModTarget],
+    )
+    rule_runner.set_options([], env_inherit={"PATH"})
+    return rule_runner
+
+
+@pytest.fixture
+def syso_rule_runner() -> RuleRunner:
+    """Fixture that includes the test-only rule for probing _gather_transitive_prebuilt_object_files."""
+    rule_runner = RuleRunner(
+        rules=[
+            *sdk.rules(),
+            *assembly.rules(),
+            *build_pkg.rules(),
+            *import_analysis.rules(),
+            *go_mod.rules(),
+            *first_party_pkg.rules(),
+            *link.rules(),
+            *third_party_pkg.rules(),
+            *target_type_rules.rules(),
+            *_syso_test_rules(),
         ],
         target_types=[GoModTarget],
     )
@@ -212,4 +261,105 @@ def test_build_invalid_pkg(rule_runner: RuleRunner) -> None:
     assert invalid_dep_result.exit_code == 1
     assert (
         invalid_dep_result.stdout == "dep/f.go:1:1: syntax error: package statement must be first\n"
+    )
+
+
+def test_gather_transitive_prebuilt_object_files_depth2(syso_rule_runner: RuleRunner) -> None:
+    """Regression test for BFS bug in _gather_transitive_prebuilt_object_files.
+
+    Before the fix, line 549 read:
+        unseen = [dd for dd in build_request.direct_dependencies if dd not in seen]
+    which always expanded the *root's* direct deps instead of the *current node's*
+    direct deps.  As a result, the BFS never descended past depth 1 and any
+    `.syso` file belonging to a grandchild (or deeper) dependency was silently
+    dropped from cgo linking.
+
+    This test constructs the minimal chain that exposes the bug:
+        cgo_root → direct_dep → grandchild  (grandchild has prebuilt_object_files)
+
+    With the bug present, `_gather_transitive_prebuilt_object_files(cgo_root)`
+    returns an empty `object_files` set because it only ever enqueues
+    `cgo_root.direct_dependencies` (i.e., `[direct_dep]`) on every iteration
+    rather than the *current* node's deps, so `grandchild` is never visited.
+    With the fix, `pkg.direct_dependencies` correctly enqueues `grandchild`
+    from `direct_dep`, and the `.syso` path is returned.
+    """
+    grandchild = BuildGoPackageRequest(
+        import_path="example.com/foo/grandchild",
+        pkg_name="grandchild",
+        dir_path="grandchild",
+        build_opts=GoBuildOptions(),
+        go_files=("f.go",),
+        digest=syso_rule_runner.make_snapshot(
+            {
+                "grandchild/f.go": dedent(
+                    """\
+                    package grandchild
+
+                    func Value() int { return 1 }
+                    """
+                ),
+                # Fake .syso bytes: the BFS only needs the file path recorded in
+                # prebuilt_object_files; actual content is irrelevant for this test.
+                "grandchild/helper.syso": b"\x00",
+            }
+        ).digest,
+        s_files=(),
+        direct_dependencies=(),
+        minimum_go_version=None,
+        prebuilt_object_files=("helper.syso",),
+    )
+    direct_dep = BuildGoPackageRequest(
+        import_path="example.com/foo/dep",
+        pkg_name="dep",
+        dir_path="dep",
+        build_opts=GoBuildOptions(),
+        go_files=("f.go",),
+        digest=syso_rule_runner.make_snapshot(
+            {
+                "dep/f.go": dedent(
+                    """\
+                    package dep
+
+                    import "example.com/foo/grandchild"
+
+                    func Value() int { return grandchild.Value() }
+                    """
+                )
+            }
+        ).digest,
+        s_files=(),
+        direct_dependencies=(grandchild,),
+        minimum_go_version=None,
+    )
+    cgo_root = BuildGoPackageRequest(
+        import_path="example.com/foo",
+        pkg_name="foo",
+        dir_path="",
+        build_opts=GoBuildOptions(),
+        go_files=("f.go",),
+        digest=syso_rule_runner.make_snapshot(
+            {
+                "f.go": dedent(
+                    """\
+                    package foo
+
+                    import "example.com/foo/dep"
+
+                    func Root() int { return dep.Value() }
+                    """
+                )
+            }
+        ).digest,
+        s_files=(),
+        direct_dependencies=(direct_dep,),
+        minimum_go_version=None,
+    )
+
+    result = syso_rule_runner.request(_GatherPrebuiltObjectFilesResult, [cgo_root])
+
+    # The grandchild's .syso must be present even though it is at depth 2.
+    assert os.path.join("grandchild", "helper.syso") in result.object_files, (
+        f"grandchild/helper.syso missing from collected object_files={result.object_files!r}; "
+        "BFS bug: _gather_transitive_prebuilt_object_files never visited the grandchild node"
     )

--- a/src/python/pants/backend/go/util_rules/build_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_test.py
@@ -26,13 +26,15 @@ from pants.backend.go.util_rules.build_pkg import (
     BuildGoPackageRequest,
     BuiltGoPackage,
     FallibleBuiltGoPackage,
+    MergeBuiltGoPackageArchivesRequest,
+    MergedGoPackageArchives,
     _gather_transitive_prebuilt_object_files,
 )
 from pants.engine.fs import Snapshot
 from pants.engine.rules import QueryRule, rule
 from pants.testutil.rule_runner import RuleRunner
+from pants.util.frozendict import FrozenDict
 from pants.util.strutil import path_safe
-
 
 # ---------------------------------------------------------------------------
 # Test-only rule for probing _gather_transitive_prebuilt_object_files directly.
@@ -74,6 +76,7 @@ def rule_runner() -> RuleRunner:
             *target_type_rules.rules(),
             QueryRule(BuiltGoPackage, [BuildGoPackageRequest]),
             QueryRule(FallibleBuiltGoPackage, [BuildGoPackageRequest]),
+            QueryRule(MergedGoPackageArchives, [MergeBuiltGoPackageArchivesRequest]),
         ],
         target_types=[GoModTarget],
     )
@@ -107,13 +110,16 @@ def assert_built(
     rule_runner: RuleRunner, request: BuildGoPackageRequest, *, expected_import_paths: list[str]
 ) -> None:
     built_package = rule_runner.request(BuiltGoPackage, [request])
-    result_files = rule_runner.request(Snapshot, [built_package.digest]).files
+    own_files = rule_runner.request(Snapshot, [built_package.archive_digest]).files
     expected = {
         import_path: os.path.join("__pkgs__", path_safe(import_path), "__pkg__.a")
         for import_path in expected_import_paths
     }
-    assert dict(built_package.import_paths_to_pkg_a_files) == expected
-    assert sorted(result_files) == sorted(expected.values())
+    assert built_package.pkg_archive_path == os.path.join(
+        "__pkgs__", path_safe(built_package.import_path), "__pkg__.a"
+    )
+    assert sorted(own_files) == [built_package.pkg_archive_path]
+    assert {ip: path for ip, (path, _) in built_package.transitive_pkg_archives.items()} == expected
 
 
 def test_build_pkg(rule_runner: RuleRunner) -> None:
@@ -262,6 +268,207 @@ def test_build_invalid_pkg(rule_runner: RuleRunner) -> None:
     assert (
         invalid_dep_result.stdout == "dep/f.go:1:1: syntax error: package statement must be first\n"
     )
+
+
+def test_build_pkg_deep_chain(rule_runner: RuleRunner) -> None:
+    """A 4-level dependency chain compiles with direct-deps-only compile inputs.
+
+    `a → b → c → d`: `d` defines an exported struct, `c` wraps it, `b` re-exports a function
+    returning the wrapper, and `a` reaches through to the innermost field.  Compiling `a` only
+    has `b`'s export data in its importcfg, so this exercises the self-containedness of gc
+    export data across multiple levels (the canary for the direct-deps-only premise).
+    """
+    pkg_d = BuildGoPackageRequest(
+        import_path="example.com/deep/d",
+        pkg_name="d",
+        dir_path="d",
+        build_opts=GoBuildOptions(),
+        go_files=("f.go",),
+        digest=rule_runner.make_snapshot(
+            {
+                "d/f.go": dedent(
+                    """\
+                    package d
+
+                    type Thing struct {
+                        Value int
+                    }
+
+                    func New() Thing {
+                        return Thing{Value: 42}
+                    }
+                    """
+                )
+            }
+        ).digest,
+        s_files=(),
+        direct_dependencies=(),
+        minimum_go_version=None,
+    )
+    pkg_c = BuildGoPackageRequest(
+        import_path="example.com/deep/c",
+        pkg_name="c",
+        dir_path="c",
+        build_opts=GoBuildOptions(),
+        go_files=("f.go",),
+        digest=rule_runner.make_snapshot(
+            {
+                "c/f.go": dedent(
+                    """\
+                    package c
+
+                    import "example.com/deep/d"
+
+                    type Wrapped struct {
+                        Inner d.Thing
+                    }
+
+                    func Get() Wrapped {
+                        return Wrapped{Inner: d.New()}
+                    }
+                    """
+                )
+            }
+        ).digest,
+        s_files=(),
+        direct_dependencies=(pkg_d,),
+        minimum_go_version=None,
+    )
+    pkg_b = BuildGoPackageRequest(
+        import_path="example.com/deep/b",
+        pkg_name="b",
+        dir_path="b",
+        build_opts=GoBuildOptions(),
+        go_files=("f.go",),
+        digest=rule_runner.make_snapshot(
+            {
+                "b/f.go": dedent(
+                    """\
+                    package b
+
+                    import "example.com/deep/c"
+
+                    func Get() c.Wrapped {
+                        return c.Get()
+                    }
+                    """
+                )
+            }
+        ).digest,
+        s_files=(),
+        direct_dependencies=(pkg_c,),
+        minimum_go_version=None,
+    )
+    pkg_a = BuildGoPackageRequest(
+        import_path="example.com/deep/a",
+        pkg_name="a",
+        dir_path="a",
+        build_opts=GoBuildOptions(),
+        go_files=("f.go",),
+        digest=rule_runner.make_snapshot(
+            {
+                "a/f.go": dedent(
+                    """\
+                    package a
+
+                    import "example.com/deep/b"
+
+                    func Use() int {
+                        return b.Get().Inner.Value
+                    }
+                    """
+                )
+            }
+        ).digest,
+        s_files=(),
+        direct_dependencies=(pkg_b,),
+        minimum_go_version=None,
+    )
+
+    all_import_paths = [
+        "example.com/deep/a",
+        "example.com/deep/b",
+        "example.com/deep/c",
+        "example.com/deep/d",
+    ]
+
+    built_a = rule_runner.request(BuiltGoPackage, [pkg_a])
+
+    # The package's own digest contains only its own archive.
+    own_files = rule_runner.request(Snapshot, [built_a.archive_digest]).files
+    assert sorted(own_files) == [built_a.pkg_archive_path]
+
+    # The transitive handle map covers the full closure.
+    assert set(built_a.transitive_pkg_archives.keys()) == set(all_import_paths)
+
+    # Merging the closure of (a,) yields all four archives, each exactly once.
+    merged = rule_runner.request(
+        MergedGoPackageArchives, [MergeBuiltGoPackageArchivesRequest((built_a,))]
+    )
+    expected_paths = {
+        import_path: os.path.join("__pkgs__", path_safe(import_path), "__pkg__.a")
+        for import_path in all_import_paths
+    }
+    assert dict(merged.import_paths_to_pkg_a_files) == expected_paths
+    merged_files = rule_runner.request(Snapshot, [merged.digest]).files
+    assert sorted(merged_files) == sorted(expected_paths.values())
+
+
+def test_merge_built_go_package_archives(rule_runner: RuleRunner) -> None:
+    """Overlapping transitive maps merge each archive once, first-wins on conflicts."""
+    digest_a = rule_runner.make_snapshot({"__pkgs__/a/__pkg__.a": "a-archive"}).digest
+    digest_b = rule_runner.make_snapshot({"__pkgs__/b/__pkg__.a": "b-archive"}).digest
+    digest_common = rule_runner.make_snapshot({"__pkgs__/common/__pkg__.a": "common"}).digest
+    digest_shared_v1 = rule_runner.make_snapshot({"__pkgs__/shared/__pkg__.a": "shared-v1"}).digest
+    digest_shared_v2 = rule_runner.make_snapshot(
+        {"__pkgs__/shared_v2/__pkg__.a": "shared-v2"}
+    ).digest
+
+    path_a = os.path.join("__pkgs__", "a", "__pkg__.a")
+    path_b = os.path.join("__pkgs__", "b", "__pkg__.a")
+    path_common = os.path.join("__pkgs__", "common", "__pkg__.a")
+    path_shared_v1 = os.path.join("__pkgs__", "shared", "__pkg__.a")
+    path_shared_v2 = os.path.join("__pkgs__", "shared_v2", "__pkg__.a")
+
+    pkg_one = BuiltGoPackage(
+        import_path="example.com/a",
+        pkg_archive_path=path_a,
+        archive_digest=digest_a,
+        transitive_pkg_archives=FrozenDict(
+            {
+                "example.com/a": (path_a, digest_a),
+                "example.com/common": (path_common, digest_common),
+                "example.com/shared": (path_shared_v1, digest_shared_v1),
+            }
+        ),
+    )
+    pkg_two = BuiltGoPackage(
+        import_path="example.com/b",
+        pkg_archive_path=path_b,
+        archive_digest=digest_b,
+        transitive_pkg_archives=FrozenDict(
+            {
+                "example.com/b": (path_b, digest_b),
+                # Identical entry in both packages: must merge cleanly, exactly once.
+                "example.com/common": (path_common, digest_common),
+                # Conflicting entry: pkg_one came first, so its handle must win.
+                "example.com/shared": (path_shared_v2, digest_shared_v2),
+            }
+        ),
+    )
+
+    merged = rule_runner.request(
+        MergedGoPackageArchives, [MergeBuiltGoPackageArchivesRequest((pkg_one, pkg_two))]
+    )
+
+    assert dict(merged.import_paths_to_pkg_a_files) == {
+        "example.com/a": path_a,
+        "example.com/b": path_b,
+        "example.com/common": path_common,
+        "example.com/shared": path_shared_v1,
+    }
+    merged_files = rule_runner.request(Snapshot, [merged.digest]).files
+    assert sorted(merged_files) == sorted([path_a, path_b, path_common, path_shared_v1])
 
 
 def test_gather_transitive_prebuilt_object_files_depth2(syso_rule_runner: RuleRunner) -> None:

--- a/src/python/pants/backend/go/util_rules/implicit_linker_deps.py
+++ b/src/python/pants/backend/go/util_rules/implicit_linker_deps.py
@@ -3,18 +3,19 @@
 
 from __future__ import annotations
 
-from pants.backend.go.util_rules.build_pkg import required_built_go_package
+from pants.backend.go.util_rules.build_pkg import (
+    MergeBuiltGoPackageArchivesRequest,
+    merge_built_go_package_archives,
+    required_built_go_package,
+)
 from pants.backend.go.util_rules.build_pkg_target import BuildGoPackageRequestForStdlibRequest
 from pants.backend.go.util_rules.link_defs import (
     ImplicitLinkerDependencies,
     ImplicitLinkerDependenciesHook,
 )
-from pants.engine.internals.native_engine import MergeDigests
 from pants.engine.internals.selectors import concurrently
-from pants.engine.intrinsics import merge_digests
 from pants.engine.rules import collect_rules, implicitly, rule
 from pants.engine.unions import UnionRule
-from pants.util.frozendict import FrozenDict
 
 
 class SdkImplicitLinkerDependenciesHook(ImplicitLinkerDependenciesHook):
@@ -49,17 +50,13 @@ async def provide_sdk_implicit_linker_dependencies(
         for dep_import_path in implicit_deps_import_paths
     )
 
-    implicit_dep_digests = []
-    import_paths_to_pkg_a_files: dict[str, str] = {}
-    for built_implicit_linker_dep in built_implicit_linker_deps:
-        import_paths_to_pkg_a_files.update(built_implicit_linker_dep.import_paths_to_pkg_a_files)
-        implicit_dep_digests.append(built_implicit_linker_dep.digest)
-
-    digest = await merge_digests(MergeDigests(implicit_dep_digests))
+    merged = await merge_built_go_package_archives(
+        MergeBuiltGoPackageArchivesRequest(tuple(built_implicit_linker_deps))
+    )
 
     return ImplicitLinkerDependencies(
-        digest=digest,
-        import_paths_to_pkg_a_files=FrozenDict(import_paths_to_pkg_a_files),
+        digest=merged.digest,
+        import_paths_to_pkg_a_files=merged.import_paths_to_pkg_a_files,
     )
 
 


### PR DESCRIPTION
Disclaimer: Like my previous Go PR, I'm still not primarily a golang developer. However, the fact that Golang doesn't work properly in Pants has been the bane of my existence for like 2 years now. The moment that Mythos/Fable dropped I immediately had it dig deeply into whether the whole road to proper-golang-in-pants could be opened up. So this is all by Claude Code with Fable 5 (xhigh), with consults to GPT 5.5 (xhigh) and Gemini 3.1 Pro. I've had it check and recheck, I ran many different roles over it, and I had it explain and re-explain it to me, and then I checked myself.

So, as much as I dislike AI slop and am worried about AI PR overload, I've done my very best to avoid exactly that while still using AI. I hope we can get this road unblocked.

The rest is Fable talking:

---

Every compiled Go package previously merged its entire transitive dependency closure into its compile sandbox: archives, importcfg entries, and the output digest. On deep dependency graphs this is O(depth × packages) digest-merge work in the engine, repeated at every node, and it is one of the remaining contributors to the engine overhead and LMDB churn reported in #20274.

The Go toolchain doesn't need any of that. `go tool compile` requires only the direct dependencies' export data, because gc export data is self-contained. `cmd/go` itself writes compile importcfgs containing only direct deps (`cmd/go/internal/work/exec.go`); only the link step needs the full transitive archive set. This PR makes Pants match that: compile sandboxes and importcfgs are built from direct deps only, and the transitive closure is merged exactly once per linked binary.

Specifically:

- `BuiltGoPackage` now carries `import_path`, `pkg_archive_path`, `archive_digest` (the package's own files only), and `transitive_pkg_archives`, a map from each import path in the closure to its archive path and *unmerged* digest handle. Handle-map union is a cheap Python dict union; no engine merges happen per node.
- A new memoized rule, `merge_built_go_package_archives`, produces the merged closure digest + path map. The four top-level consumers (binary packaging, test binary, implicit linker deps, internal `go_sources` binaries) call it once each. `pants check` gets the per-node reduction with no merge at all, since it never links.
- cgo `${SRCDIR}` module sources now ride the package's own `archive_digest` and reach the linker through the handle map.

Plugin API changes (release-noted in `docs/notes/2.33.x.md`):

- `BuiltGoPackage.digest` is replaced by `archive_digest` + `transitive_pkg_archives`; use `merge_built_go_package_archives` to obtain a merged closure digest.
- `BuiltGoPackage.import_paths_to_pkg_a_files` is removed; the same mapping is available from the merge rule.
- `GoCodegenBuildRequest` implementations must declare complete direct dependencies for generated code, including stdlib imports (e.g. via `BuildGoPackageRequestForStdlibRequest`). Previously, missing deps were masked because every transitive archive leaked into every compile sandbox. The in-tree protobuf-go codegen rule had exactly this latent bug (it silently skipped stdlib imports such as `reflect` and `sync`) and is fixed here.

A separate first commit fixes a drive-by correctness bug found while preparing this change: `_gather_transitive_prebuilt_object_files` iterated the *root's* direct dependencies on every BFS step instead of the current node's, so prebuilt `.syso` object files at depth ≥ 2 were silently dropped from cgo linking. A regression test is included.

Tests: deep-chain test (`a → b → c → d`, struct type reaching through three levels of export data with direct-only importcfgs); merge-rule unit test (overlap dedup, first-wins conflict semantics); `.syso` depth-2 regression test; updated `assert_built` helpers. Full Go util_rules + goals suites pass (two pre-existing environment-related failures on Go 1.26.4 excepted, unrelated to this change).

Honest benchmark note: on a 3-`go.mod`/206-module reproducer and a synthetic 1000-package deep-chain repro, cold wall time and peak RSS are unchanged within noise (graphs this small don't exhibit the O(depth × packages) blow-up), output is byte-identical, and the content-addressed store comes out consistently ~7.5% smaller from the slimmer per-sandbox trees. The structural reduction grows with dependency depth, package count, and archive size, which is the regime of the #20274 reports. The follow-up PR building on this structure (pre-built stdlib archives, #23422) shows a 47% cold `check` improvement on the same reproducer.

Note on cache invalidation: because per-package importcfg contents change (direct-only instead of full closure), compile process cache keys change, so the first build after upgrading re-runs Go compile processes once. Subsequent builds cache normally.

