### PR TITLE
Pre-compile the Go standard library once per toolchain config instead of per-package

### DIFF
--- a/docs/notes/2.33.x.md
+++ b/docs/notes/2.33.x.md
@@ -87,9 +87,19 @@ Fixes JavaScript workspace builds where dependencies are installed under members
 
 Third-party module analysis is now deduplicated across `go.mod` files. Previously, a module required by `N` `go.mod` files was downloaded and analyzed `N` times, which caused significant memory and time overhead in monorepos with many overlapping `go.mod` files. On a 3-`go.mod` reproducer, `pants list ::` peak memory dropped from 91 GB to 32 GB (-65%). This is a no-op for repos with a single `go.mod`. See [#20274](https://github.com/pantsbuild/pants/issues/20274).
 
+Go package compilation sandboxes now contain only the direct dependencies' package archives, instead of the full transitive dependency closure. Previously, every compiled package merged all transitive archives into its compile sandbox, importcfg, and output digest, causing O(depth × packages) digest-merge work in the Pants engine; the transitive archive set is now merged exactly once per linked binary, where it is actually needed. This significantly reduces engine overhead for `pants check` and compile-heavy builds on deep dependency graphs (benchmark numbers in the PR). See [#20274](https://github.com/pantsbuild/pants/issues/20274).
+
+Fixed a traversal bug that silently dropped prebuilt object files (`.syso`) of transitive dependencies at depth 2 or deeper from cgo linking.
+
 ### Plugin API changes
 
 `FrozenOrderedSet` is now backed by a native Rust implementation and is built in `__new__` rather than `__init__`. Subclasses that customized the set's contents by overriding `__init__` (for example, to transform the input iterable before constructing) must move that logic to `__new__`, since the set is already built and immutable by the time `__init__` runs.
+
+The Go backend's `BuiltGoPackage` type changed shape as part of the compile-sandbox restructure:
+
+- `BuiltGoPackage.digest` (the fully merged transitive archive digest) is replaced by `archive_digest`, which contains only the package's own files, plus `transitive_pkg_archives`, which maps each import path in the closure to its archive path and unmerged digest handle. Use the new `merge_built_go_package_archives` rule to obtain a merged closure digest.
+- `BuiltGoPackage.import_paths_to_pkg_a_files` is removed; the same mapping is available from `merge_built_go_package_archives` (or can be derived from `transitive_pkg_archives`).
+- `GoCodegenBuildRequest` implementations must now declare complete direct dependencies for generated code, including its standard-library imports (for example via `BuildGoPackageRequestForStdlibRequest`). Previously, missing direct dependencies were masked because the entire transitive closure leaked into every compile sandbox.
 
 ## Full Changelog
 

--- a/docs/notes/2.33.x.md
+++ b/docs/notes/2.33.x.md
@@ -91,6 +91,8 @@ Go package compilation sandboxes now contain only the direct dependencies' packa
 
 Fixed a traversal bug that silently dropped prebuilt object files (`.syso`) of transitive dependencies at depth 2 or deeper from cgo linking.
 
+The Go standard library is now pre-compiled with a single `go install std` build action per (Go toolchain, cgo configuration) pair, and packages link against those archives, instead of compiling each standard library package (and its assembly and symabis steps) as separate build actions. This significantly speeds up cold builds (numbers in the PR). Pants automatically falls back to compiling the standard library from source for build configurations that change archive content — the race detector and the other sanitizers, code coverage, and custom compiler or assembler flags — and on Go toolchains older than 1.20. Set the new advanced option `[golang].use_prebuilt_stdlib_archives = false` to always compile the standard library from source.
+
 ### Plugin API changes
 
 `FrozenOrderedSet` is now backed by a native Rust implementation and is built in `__new__` rather than `__init__`. Subclasses that customized the set's contents by overriding `__init__` (for example, to transform the input iterable before constructing) must move that logic to `__new__`, since the set is already built and immutable by the time `__init__` runs.

--- a/src/python/pants/backend/codegen/protobuf/go/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/go/rules.py
@@ -46,12 +46,18 @@ from pants.backend.go.util_rules.build_pkg import (
     FallibleBuildGoPackageRequest,
 )
 from pants.backend.go.util_rules.build_pkg_target import (
+    BuildGoPackageRequestForStdlibRequest,
     BuildGoPackageTargetRequest,
     GoCodegenBuildRequest,
     required_build_go_package_request,
+    setup_build_go_package_target_request_for_stdlib,
 )
 from pants.backend.go.util_rules.first_party_pkg import FallibleFirstPartyPkgAnalysis
 from pants.backend.go.util_rules.go_mod import OwningGoModRequest, find_owning_go_mod
+from pants.backend.go.util_rules.import_analysis import (
+    GoStdLibPackagesRequest,
+    analyze_go_stdlib_packages,
+)
 from pants.backend.go.util_rules.pkg_analyzer import PackageAnalyzerSetup
 from pants.backend.go.util_rules.sdk import GoSdkProcess
 from pants.backend.python.util_rules import pex
@@ -371,10 +377,28 @@ async def setup_full_package_build_request(
         )
     analysis = fallible_analysis.analysis
 
-    # Obtain build requests for third-party dependencies.
+    stdlib_packages = await analyze_go_stdlib_packages(
+        GoStdLibPackagesRequest(
+            with_race_detector=request.build_opts.with_race_detector,
+            cgo_enabled=request.build_opts.cgo_enabled,
+        )
+    )
+
+    # Obtain build requests for standard-library and third-party dependencies.
     # TODO: Consider how to merge this code with existing dependency inference code.
     dep_build_request_addrs: set[Address] = set()
+    stdlib_dep_import_paths: set[str] = set()
     for dep_import_path in (*analysis.imports, *analysis.test_imports, *analysis.xtest_imports):
+        if dep_import_path in ("C", "unsafe", "builtin"):
+            continue
+
+        # The generated code imports standard-library packages directly (e.g., `reflect` and
+        # `sync`). They must be declared as direct dependencies: the compile sandbox/importcfg
+        # contains only direct dependencies' export data.
+        if dep_import_path in stdlib_packages:
+            stdlib_dep_import_paths.add(dep_import_path)
+            continue
+
         # Infer dependencies on other Go packages.
         candidate_addresses = package_mapping.mapping.get(dep_import_path)
         if candidate_addresses:
@@ -404,6 +428,21 @@ async def setup_full_package_build_request(
         for addr in sorted(dep_build_request_addrs)
     )
 
+    fallible_stdlib_dep_build_requests = await concurrently(
+        setup_build_go_package_target_request_for_stdlib(
+            BuildGoPackageRequestForStdlibRequest(
+                import_path=dep_import_path,
+                build_opts=request.build_opts,
+            ),
+            **implicitly(),
+        )
+        for dep_import_path in sorted(stdlib_dep_import_paths)
+    )
+    stdlib_dep_build_requests: list[BuildGoPackageRequest] = []
+    for fallible_stdlib_dep in fallible_stdlib_dep_build_requests:
+        assert fallible_stdlib_dep.request is not None
+        stdlib_dep_build_requests.append(fallible_stdlib_dep.request)
+
     return FallibleBuildGoPackageRequest(
         request=BuildGoPackageRequest(
             import_path=request.import_path,
@@ -412,7 +451,7 @@ async def setup_full_package_build_request(
             dir_path=analysis.dir_path,
             go_files=analysis.go_files,
             s_files=analysis.s_files,
-            direct_dependencies=dep_build_requests,
+            direct_dependencies=(*dep_build_requests, *stdlib_dep_build_requests),
             minimum_go_version=analysis.minimum_go_version,
             build_opts=request.build_opts,
         ),

--- a/src/python/pants/backend/go/go_sources/load_go_binary.py
+++ b/src/python/pants/backend/go/go_sources/load_go_binary.py
@@ -8,7 +8,12 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 
 from pants.backend.go.util_rules.build_opts import GoBuildOptions
-from pants.backend.go.util_rules.build_pkg import BuildGoPackageRequest, required_built_go_package
+from pants.backend.go.util_rules.build_pkg import (
+    BuildGoPackageRequest,
+    MergeBuiltGoPackageArchivesRequest,
+    merge_built_go_package_archives,
+    required_built_go_package,
+)
 from pants.backend.go.util_rules.goroot import GoRoot
 from pants.backend.go.util_rules.import_analysis import (
     GoStdLibPackagesRequest,
@@ -140,14 +145,14 @@ async def setup_go_binary(request: LoadedGoBinaryRequest, goroot: GoRoot) -> Loa
         ),
     )
 
-    main_pkg_a_file_path = built_pkg.import_paths_to_pkg_a_files["main"]
+    merged = await merge_built_go_package_archives(MergeBuiltGoPackageArchivesRequest((built_pkg,)))
 
     binary = await link_go_binary(
         LinkGoBinaryRequest(
-            input_digest=built_pkg.digest,
-            archives=(main_pkg_a_file_path,),
+            input_digest=merged.digest,
+            archives=(built_pkg.pkg_archive_path,),
             build_opts=build_opts,
-            import_paths_to_pkg_a_files=built_pkg.import_paths_to_pkg_a_files,
+            import_paths_to_pkg_a_files=merged.import_paths_to_pkg_a_files,
             output_filename=request.output_name,
             description=f"Link internal Go binary `{request.output_name}`",
         ),

--- a/src/python/pants/backend/go/goals/package_binary.py
+++ b/src/python/pants/backend/go/goals/package_binary.py
@@ -20,7 +20,11 @@ from pants.backend.go.util_rules.build_opts import (
     GoBuildOptionsFromTargetRequest,
     go_extract_build_options_from_target,
 )
-from pants.backend.go.util_rules.build_pkg import required_built_go_package
+from pants.backend.go.util_rules.build_pkg import (
+    MergeBuiltGoPackageArchivesRequest,
+    merge_built_go_package_archives,
+    required_built_go_package,
+)
 from pants.backend.go.util_rules.build_pkg_target import BuildGoPackageTargetRequest
 from pants.backend.go.util_rules.first_party_pkg import (
     FirstPartyPkgAnalysisRequest,
@@ -45,7 +49,6 @@ from pants.engine.internals.selectors import concurrently
 from pants.engine.intrinsics import add_prefix
 from pants.engine.rules import collect_rules, implicitly, rule
 from pants.engine.unions import UnionRule
-from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 
 
@@ -109,16 +112,17 @@ async def package_go_binary(field_set: GoBinaryFieldSet) -> BuiltPackage:
             BuildGoPackageTargetRequest(main_pkg.address, is_main=True, build_opts=build_opts)
         ),
     )
-
-    main_pkg_a_file_path = built_package.import_paths_to_pkg_a_files["main"]
+    merged = await merge_built_go_package_archives(
+        MergeBuiltGoPackageArchivesRequest((built_package,))
+    )
 
     output_filename = PurePath(field_set.output_path.value_or_default(file_ending=None))
     binary = await link_go_binary(
         LinkGoBinaryRequest(
-            input_digest=built_package.digest,
-            archives=(main_pkg_a_file_path,),
+            input_digest=merged.digest,
+            archives=(built_package.pkg_archive_path,),
             build_opts=build_opts,
-            import_paths_to_pkg_a_files=FrozenDict(built_package.import_paths_to_pkg_a_files),
+            import_paths_to_pkg_a_files=merged.import_paths_to_pkg_a_files,
             output_filename=f"./{output_filename.name}",
             description=f"Link Go binary for {field_set.address}",
         ),

--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -29,7 +29,9 @@ from pants.backend.go.util_rules.build_opts import (
 )
 from pants.backend.go.util_rules.build_pkg import (
     BuildGoPackageRequest,
+    MergeBuiltGoPackageArchivesRequest,
     build_go_package,
+    merge_built_go_package_archives,
     required_built_go_package,
 )
 from pants.backend.go.util_rules.build_pkg_target import (
@@ -528,14 +530,16 @@ async def prepare_go_test_binary(
         )
     built_main_pkg = maybe_built_main_pkg.output
 
-    main_pkg_a_file_path = built_main_pkg.import_paths_to_pkg_a_files["main"]
+    merged = await merge_built_go_package_archives(
+        MergeBuiltGoPackageArchivesRequest((built_main_pkg,))
+    )
 
     binary = await link_go_binary(
         LinkGoBinaryRequest(
-            input_digest=built_main_pkg.digest,
-            archives=(main_pkg_a_file_path,),
+            input_digest=merged.digest,
+            archives=(built_main_pkg.pkg_archive_path,),
             build_opts=build_opts,
-            import_paths_to_pkg_a_files=built_main_pkg.import_paths_to_pkg_a_files,
+            import_paths_to_pkg_a_files=merged.import_paths_to_pkg_a_files,
             output_filename="./test_runner",  # TODO: Name test binary the way that `go` does?
             description=f"Link Go test binary for {request.field_set.address}",
         ),

--- a/src/python/pants/backend/go/subsystems/golang.py
+++ b/src/python/pants/backend/go/subsystems/golang.py
@@ -259,6 +259,25 @@ class GolangSubsystem(Subsystem):
         ),
     )
 
+    use_prebuilt_stdlib_archives = BoolOption(
+        default=True,
+        help=softwrap(
+            """
+            If true, pre-compile the entire Go standard library once per Go toolchain configuration
+            (via `go install std`) and link against those archives, instead of compiling each
+            standard library package as a separate build action.
+
+            This is usually significantly faster. Pants automatically falls back to compiling the
+            standard library from source for build configurations that are incompatible with the
+            pre-built archives, such as when using the race detector or other sanitizers, code
+            coverage, or custom compiler/assembler flags.
+
+            Set this to false to always compile standard library packages from source.
+            """
+        ),
+        advanced=True,
+    )
+
     asdf_tool_name = StrOption(
         default="go-sdk",
         help=softwrap(

--- a/src/python/pants/backend/go/util_rules/BUILD
+++ b/src/python/pants/backend/go/util_rules/BUILD
@@ -8,5 +8,6 @@ python_tests(
     overrides={
         "embed_integration_test.py": {"timeout": 240},
         "cgo_test.py": {"timeout": 240},
+        "stdlib_archives_test.py": {"timeout": 240},
     },
 )

--- a/src/python/pants/backend/go/util_rules/build_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg.py
@@ -10,7 +10,8 @@ from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from pathlib import PurePath
 
-from pants.backend.go.util_rules import cgo, coverage
+from pants.backend.go.subsystems.golang import GolangSubsystem
+from pants.backend.go.util_rules import cgo, coverage, import_analysis, stdlib_archives
 from pants.backend.go.util_rules.assembly import (
     AssembleGoAssemblyFilesRequest,
     GenerateAssemblySymabisRequest,
@@ -32,8 +33,17 @@ from pants.backend.go.util_rules.coverage import (
 )
 from pants.backend.go.util_rules.embedcfg import EmbedConfig
 from pants.backend.go.util_rules.goroot import GoRoot
+from pants.backend.go.util_rules.import_analysis import (
+    GoStdLibPackagesRequest,
+    analyze_go_stdlib_packages,
+)
 from pants.backend.go.util_rules.import_config import ImportConfigRequest, generate_import_config
 from pants.backend.go.util_rules.sdk import GoSdkProcess, GoSdkToolIDRequest, compute_go_tool_id
+from pants.backend.go.util_rules.stdlib_archives import (
+    GoStdlibArchivesRequest,
+    harvest_go_stdlib_archives,
+    stdlib_archives_compatible,
+)
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.engine.engine_aware import EngineAwareParameter, EngineAwareReturnType
 from pants.engine.fs import (
@@ -294,11 +304,14 @@ class FallibleBuiltGoPackage(EngineAwareReturnType):
 
 @dataclass(frozen=True)
 class BuiltGoPackage:
-    """A compiled Go package as a `__pkg__.a` file, plus handles to its transitive closure.
+    """A compiled Go package archive, plus handles to its transitive closure.
 
-    `archive_digest` contains ONLY this package's own files, laid out as
-    `__pkgs__/{path_safe(import_path)}/__pkg__.a` (plus this package's module sources when
-    the cgo rules detected a `${SRCDIR}` reference that the linker will need).
+    `archive_digest` contains ONLY this package's own files. Packages compiled from source are
+    laid out as `__pkgs__/{path_safe(import_path)}/__pkg__.a` (plus this package's module
+    sources when the cgo rules detected a `${SRCDIR}` reference that the linker will need);
+    pre-built standard library packages are laid out as `__go_stdlib__/{import_path}.a`.
+    Nothing may assume either layout: `pkg_archive_path` and the paths in
+    `transitive_pkg_archives` are the source of truth.
 
     `transitive_pkg_archives` maps import path -> (archive path, digest-containing-that-archive)
     for this package AND all of its transitive dependencies. The digests are NOT merged;
@@ -609,10 +622,62 @@ async def _gather_transitive_prebuilt_object_files(
 # (triggered by `FallibleBuiltGoPackage` subclassing `EngineAwareReturnType`).
 @rule(desc="Compile with Go", level=LogLevel.DEBUG)
 async def build_go_package(
-    request: BuildGoPackageRequest, go_root: GoRoot
+    request: BuildGoPackageRequest, go_root: GoRoot, golang: GolangSubsystem
 ) -> FallibleBuiltGoPackage:
+    # Standard library packages on compatible build configurations short-circuit to the
+    # pre-compiled archives from the one-shot `go install std` harvest, skipping
+    # compile/symabis/assembly/pack processes entirely. This must use the same gate as
+    # `setup_build_go_package_target_request_for_stdlib`, which constructs "slim" stdlib
+    # requests (no sources, no dependency recursion) whenever the gate passes; both gates are
+    # pure functions of `(build_opts, [golang].use_prebuilt_stdlib_archives)` plus
+    # archive-map membership, so they always agree. Full from-source stdlib requests (e.g.
+    # from `go_sources/load_go_binary.py`) are short-circuited here too. Import paths without
+    # a pre-built archive fall through to from-source compilation.
+    if request.is_stdlib and stdlib_archives_compatible(request.build_opts, golang):
+        archives = await harvest_go_stdlib_archives(
+            GoStdlibArchivesRequest(cgo_enabled=request.build_opts.cgo_enabled), go_root
+        )
+        prebuilt_archive_path = archives.import_paths_to_pkg_a_files.get(request.import_path)
+        if prebuilt_archive_path is not None:
+            stdlib_packages = await analyze_go_stdlib_packages(
+                GoStdLibPackagesRequest(
+                    with_race_detector=False, cgo_enabled=request.build_opts.cgo_enabled
+                )
+            )
+            # The transitive closure comes from `go list` analysis rather than from
+            # `direct_dependencies`: slim requests carry no dependency recursion. Import paths
+            # without an archive (e.g. `unsafe`) have no compiled form and are skipped.
+            closure_archive_paths: dict[str, str] = {request.import_path: prebuilt_archive_path}
+            for dep_import_path in stdlib_packages[request.import_path].deps:
+                dep_archive_path = archives.import_paths_to_pkg_a_files.get(dep_import_path)
+                if dep_archive_path is not None:
+                    closure_archive_paths[dep_import_path] = dep_archive_path
+            # One unmerged digest handle per archive so that consumers' compile sandboxes
+            # (which merge only their DIRECT deps' `archive_digest`s) stay minimal, and the
+            # link step merges the closure exactly once, as with from-source packages.
+            archive_digests = await concurrently(
+                digest_subset_to_digest(DigestSubset(archives.digest, PathGlobs([archive_path])))
+                for archive_path in closure_archive_paths.values()
+            )
+            transitive_archives = {
+                import_path: (archive_path, archive_digest)
+                for (import_path, archive_path), archive_digest in zip(
+                    closure_archive_paths.items(), archive_digests
+                )
+            }
+            return FallibleBuiltGoPackage(
+                BuiltGoPackage(
+                    import_path=request.import_path,
+                    pkg_archive_path=prebuilt_archive_path,
+                    archive_digest=transitive_archives[request.import_path][1],
+                    transitive_pkg_archives=FrozenDict(transitive_archives),
+                ),
+                request.import_path,
+            )
+
     maybe_built_deps = await concurrently(
-        build_go_package(build_request, go_root) for build_request in request.direct_dependencies
+        build_go_package(build_request, **implicitly())
+        for build_request in request.direct_dependencies
     )
 
     direct_dep_archives: dict[str, str] = {}  # importcfg entries: DIRECT deps only
@@ -1053,4 +1118,6 @@ def rules():
         *collect_rules(),
         *cgo.rules(),
         *coverage.rules(),
+        *import_analysis.rules(),
+        *stdlib_archives.rules(),
     )

--- a/src/python/pants/backend/go/util_rules/build_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg.py
@@ -294,14 +294,51 @@ class FallibleBuiltGoPackage(EngineAwareReturnType):
 
 @dataclass(frozen=True)
 class BuiltGoPackage:
-    """A package and its dependencies compiled as `__pkg__.a` files.
+    """A compiled Go package as a `__pkg__.a` file, plus handles to its transitive closure.
 
-    The packages are arranged into `__pkgs__/{path_safe(import_path)}/__pkg__.a`.
+    `archive_digest` contains ONLY this package's own files, laid out as
+    `__pkgs__/{path_safe(import_path)}/__pkg__.a` (plus this package's module sources when
+    the cgo rules detected a `${SRCDIR}` reference that the linker will need).
+
+    `transitive_pkg_archives` maps import path -> (archive path, digest-containing-that-archive)
+    for this package AND all of its transitive dependencies. The digests are NOT merged;
+    top-level consumers (link/test binary) merge them exactly once via
+    `merge_built_go_package_archives`.
     """
 
+    import_path: str
+    pkg_archive_path: str
+    archive_digest: Digest
+    transitive_pkg_archives: FrozenDict[str, tuple[str, Digest]]
+    coverage_metadata: BuiltGoPackageCodeCoverageMetadata | None = None
+
+
+@dataclass(frozen=True)
+class MergeBuiltGoPackageArchivesRequest:
+    """Request a single merged digest of the full transitive archive closure of `packages`."""
+
+    packages: tuple[BuiltGoPackage, ...]
+
+
+@dataclass(frozen=True)
+class MergedGoPackageArchives:
     digest: Digest
     import_paths_to_pkg_a_files: FrozenDict[str, str]
-    coverage_metadata: BuiltGoPackageCodeCoverageMetadata | None = None
+
+
+@rule
+async def merge_built_go_package_archives(
+    request: MergeBuiltGoPackageArchivesRequest,
+) -> MergedGoPackageArchives:
+    import_paths_to_pkg_a_files: dict[str, str] = {}
+    digests: list[Digest] = []
+    for pkg in request.packages:
+        for import_path, (archive_path, digest) in pkg.transitive_pkg_archives.items():
+            if import_path not in import_paths_to_pkg_a_files:
+                import_paths_to_pkg_a_files[import_path] = archive_path
+                digests.append(digest)
+    merged = await merge_digests(MergeDigests(digests))
+    return MergedGoPackageArchives(merged, FrozenDict(import_paths_to_pkg_a_files))
 
 
 @dataclass(frozen=True)
@@ -578,24 +615,27 @@ async def build_go_package(
         build_go_package(build_request, go_root) for build_request in request.direct_dependencies
     )
 
-    import_paths_to_pkg_a_files: dict[str, str] = {}
-    dep_digests = []
+    direct_dep_archives: dict[str, str] = {}  # importcfg entries: DIRECT deps only
+    direct_dep_digests: list[Digest] = []
+    transitive_pkg_archives: dict[str, tuple[str, Digest]] = {}
     for maybe_dep in maybe_built_deps:
         if maybe_dep.output is None:
             return dataclasses.replace(
                 maybe_dep, import_path=request.import_path, dependency_failed=True
             )
         dep = maybe_dep.output
-        for dep_import_path, pkg_archive_path in dep.import_paths_to_pkg_a_files.items():
-            if dep_import_path not in import_paths_to_pkg_a_files:
-                import_paths_to_pkg_a_files[dep_import_path] = pkg_archive_path
-                dep_digests.append(dep.digest)
+        if dep.import_path not in direct_dep_archives:
+            direct_dep_archives[dep.import_path] = dep.pkg_archive_path
+            direct_dep_digests.append(dep.archive_digest)
+        for ip, handle in dep.transitive_pkg_archives.items():
+            if ip not in transitive_pkg_archives:
+                transitive_pkg_archives[ip] = handle
 
     merged_deps_digest, import_config, embedcfg, action_id_result = await concurrently(
-        merge_digests(MergeDigests(dep_digests)),
+        merge_digests(MergeDigests(direct_dep_digests)),
         generate_import_config(
             ImportConfigRequest(
-                FrozenDict(import_paths_to_pkg_a_files),
+                FrozenDict(direct_dep_archives),
                 build_opts=request.build_opts,
                 import_map=request.import_map,
             )
@@ -966,17 +1006,16 @@ async def build_go_package(
         compilation_digest = assembly_link_result.output_digest
 
     path_prefix = os.path.join("__pkgs__", path_safe(request.import_path))
-    import_paths_to_pkg_a_files[request.import_path] = os.path.join(path_prefix, "__pkg__.a")
+    pkg_archive_path = os.path.join(path_prefix, "__pkg__.a")
     output_digest = await add_prefix(AddPrefix(compilation_digest, path_prefix))
-    merged_result_digest = await merge_digests(MergeDigests([*dep_digests, output_digest]))
 
-    # Include the modules sources in the output `Digest` alongside the package archive if the Cgo rules
-    # detected a potential attempt to link against a static archive (or other reference to `${SRCDIR}` in
-    # options) which necessitates the linker needing access to module sources.
+    # Include the module sources alongside the package archive if the cgo rules detected a
+    # potential attempt to link against a static archive (`${SRCDIR}` reference): the LINK step
+    # needs those sources, and they propagate to it via `transitive_pkg_archives`.
     if cgo_compile_result and cgo_compile_result.include_module_sources_with_output:
-        merged_result_digest = await merge_digests(
-            MergeDigests([merged_result_digest, request.digest])
-        )
+        output_digest = await merge_digests(MergeDigests([output_digest, request.digest]))
+
+    transitive_pkg_archives[request.import_path] = (pkg_archive_path, output_digest)
 
     coverage_metadata = (
         BuiltGoPackageCodeCoverageMetadata(
@@ -990,8 +1029,10 @@ async def build_go_package(
     )
 
     output = BuiltGoPackage(
-        digest=merged_result_digest,
-        import_paths_to_pkg_a_files=FrozenDict(import_paths_to_pkg_a_files),
+        import_path=request.import_path,
+        pkg_archive_path=pkg_archive_path,
+        archive_digest=output_digest,
+        transitive_pkg_archives=FrozenDict(transitive_pkg_archives),
         coverage_metadata=coverage_metadata,
     )
     return FallibleBuiltGoPackage(output, request.import_path)

--- a/src/python/pants/backend/go/util_rules/build_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg.py
@@ -350,7 +350,9 @@ async def merge_built_go_package_archives(
             if import_path not in import_paths_to_pkg_a_files:
                 import_paths_to_pkg_a_files[import_path] = archive_path
                 digests.append(digest)
-    merged = await merge_digests(MergeDigests(digests))
+    # Sort so the `MergeDigests` input is canonical and identical archive sets share a
+    # `merge_digests` cache entry regardless of package iteration order.
+    merged = await merge_digests(MergeDigests(sorted(digests, key=lambda d: d.fingerprint)))
     return MergedGoPackageArchives(merged, FrozenDict(import_paths_to_pkg_a_files))
 
 
@@ -697,7 +699,8 @@ async def build_go_package(
                 transitive_pkg_archives[ip] = handle
 
     merged_deps_digest, import_config, embedcfg, action_id_result = await concurrently(
-        merge_digests(MergeDigests(direct_dep_digests)),
+        # Sort for a canonical `MergeDigests` input (see `merge_built_go_package_archives`).
+        merge_digests(MergeDigests(sorted(direct_dep_digests, key=lambda d: d.fingerprint))),
         generate_import_config(
             ImportConfigRequest(
                 FrozenDict(direct_dep_archives),

--- a/src/python/pants/backend/go/util_rules/build_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg.py
@@ -546,7 +546,7 @@ async def _gather_transitive_prebuilt_object_files(
     seen: set[BuildGoPackageRequest] = {build_request}
     while queue:
         pkg = queue.popleft()
-        unseen = [dd for dd in build_request.direct_dependencies if dd not in seen]
+        unseen = [dd for dd in pkg.direct_dependencies if dd not in seen]
         queue.extend(unseen)
         seen.update(unseen)
         if pkg.prebuilt_object_files:

--- a/src/python/pants/backend/go/util_rules/build_pkg_target.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from typing import ClassVar
 
 from pants.backend.go.go_sources.load_go_binary import LoadedGoBinaryRequest, setup_go_binary
+from pants.backend.go.subsystems.golang import GolangSubsystem
 from pants.backend.go.target_type_rules import (
     GoImportPathMappingRequest,
     map_import_paths_to_packages,
@@ -20,7 +21,7 @@ from pants.backend.go.target_types import (
     GoPackageSourcesField,
     GoThirdPartyPackageDependenciesField,
 )
-from pants.backend.go.util_rules import build_opts
+from pants.backend.go.util_rules import build_opts, stdlib_archives
 from pants.backend.go.util_rules.build_opts import GoBuildOptions
 from pants.backend.go.util_rules.build_pkg import (
     BuildGoPackageRequest,
@@ -50,6 +51,11 @@ from pants.backend.go.util_rules.import_analysis import (
     analyze_go_stdlib_packages,
 )
 from pants.backend.go.util_rules.pkg_pattern import match_simple_pattern
+from pants.backend.go.util_rules.stdlib_archives import (
+    GoStdlibArchivesRequest,
+    harvest_go_stdlib_archives,
+    stdlib_archives_compatible,
+)
 from pants.backend.go.util_rules.third_party_pkg import (
     ThirdPartyPkgAnalysisRequest,
     extract_package_info,
@@ -171,7 +177,43 @@ class BuildGoPackageRequestForStdlibRequest:
 async def setup_build_go_package_target_request_for_stdlib(
     request: BuildGoPackageRequestForStdlibRequest,
     goroot: GoRoot,
+    golang: GolangSubsystem,
 ) -> FallibleBuildGoPackageRequest:
+    # Standard library packages on compatible build configurations use the pre-compiled
+    # archives from the one-shot `go install std` harvest. Return a "slim" request: no
+    # sources, no dependency recursion, and no embed-config resolution (the harvested archive
+    # already incorporates embedded files). `build_go_package` short-circuits any stdlib
+    # request passing this same gate to the pre-built archive, so the slim request is never
+    # compiled from source. Import paths without an archive (e.g. `unsafe`) fall through to
+    # the from-source request below, as does everything when the gate is off.
+    if stdlib_archives_compatible(request.build_opts, golang):
+        archives = await harvest_go_stdlib_archives(
+            GoStdlibArchivesRequest(cgo_enabled=request.build_opts.cgo_enabled), goroot
+        )
+        if request.import_path in archives.import_paths_to_pkg_a_files:
+            stdlib_packages = await analyze_go_stdlib_packages(
+                GoStdLibPackagesRequest(
+                    with_race_detector=False, cgo_enabled=request.build_opts.cgo_enabled
+                )
+            )
+            pkg_info = stdlib_packages[request.import_path]
+            return FallibleBuildGoPackageRequest(
+                request=BuildGoPackageRequest(
+                    import_path=pkg_info.import_path,
+                    pkg_name=pkg_info.name,
+                    digest=EMPTY_DIGEST,
+                    dir_path=pkg_info.pkg_source_path,
+                    build_opts=request.build_opts,
+                    go_files=(),
+                    s_files=(),
+                    direct_dependencies=(),
+                    import_map=pkg_info.import_map,
+                    minimum_go_version=goroot.version,
+                    is_stdlib=True,
+                ),
+                import_path=request.import_path,
+            )
+
     stdlib_packages = await analyze_go_stdlib_packages(
         GoStdLibPackagesRequest(
             with_race_detector=request.build_opts.with_race_detector,
@@ -693,4 +735,5 @@ def rules():
     return (
         *collect_rules(),
         *build_opts.rules(),
+        *stdlib_archives.rules(),
     )

--- a/src/python/pants/backend/go/util_rules/build_pkg_target_test.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target_test.py
@@ -713,3 +713,79 @@ def test_stdlib_embed_config(rule_runner: RuleRunner) -> None:
     assert embed_config is not None
     assert embed_config.patterns
     assert embed_config.files
+
+
+def test_stdlib_prebuilt_archives_used(rule_runner: RuleRunner) -> None:
+    """With pre-built stdlib archives enabled (the default), stdlib dependency requests are
+    "slim" (no sources, no dependency recursion) and the built output maps stdlib packages to
+    pre-built archives instead of from-source `__pkgs__/...` archives."""
+    rule_runner.write_files(
+        {
+            "go.mod": dedent(
+                """\
+                module example.com/stdlib-user
+                go 1.17
+                """
+            ),
+            "hasher.go": dedent(
+                """\
+                package hasher
+
+                import (
+                    "crypto/sha256"
+                    "fmt"
+                )
+
+                func Hash(b []byte) string {
+                    return fmt.Sprintf("%x", sha256.Sum256(b))
+                }
+                """
+            ),
+            "BUILD": "go_mod(name='mod')\ngo_package(name='pkg')",
+        }
+    )
+    build_request = rule_runner.request(
+        BuildGoPackageRequest,
+        [BuildGoPackageTargetRequest(Address("", target_name="pkg"), build_opts=GoBuildOptions())],
+    )
+
+    # Structural: every stdlib dependency request in the DAG is slim, so no path exists by
+    # which a stdlib package could be compiled from source.
+    stdlib_dep_requests = [dep for dep in build_request.direct_dependencies if dep.is_stdlib]
+    assert sorted(dep.import_path for dep in stdlib_dep_requests) == ["crypto/sha256", "fmt"]
+    for dep in stdlib_dep_requests:
+        assert dep.go_files == ()
+        assert dep.s_files == ()
+        assert dep.direct_dependencies == ()
+
+    # Output: stdlib archives come from the harvest layout, and the full transitive stdlib
+    # closure (e.g. `runtime`) is available for the link step even though no build request
+    # was ever constructed for it.
+    built_package = rule_runner.request(BuiltGoPackage, [build_request])
+    archive_paths = {ip: path for ip, (path, _) in built_package.transitive_pkg_archives.items()}
+    assert archive_paths["crypto/sha256"] == "__go_stdlib__/crypto/sha256.a"
+    assert archive_paths["fmt"] == "__go_stdlib__/fmt.a"
+    assert archive_paths["runtime"] == "__go_stdlib__/runtime.a"
+    assert archive_paths["example.com/stdlib-user"] == os.path.join(
+        "__pkgs__", path_safe("example.com/stdlib-user"), "__pkg__.a"
+    )
+
+
+def test_build_with_race_detector_falls_back(rule_runner: RuleRunner) -> None:
+    """Build options that change stdlib archive content (e.g. the race detector) must fall
+    back to full from-source stdlib build requests."""
+    build_request = rule_runner.request(
+        BuildGoPackageRequest,
+        [
+            BuildGoPackageRequestForStdlibRequest(
+                # NB: cgo must stay enabled: `-race requires cgo`.
+                "fmt",
+                build_opts=GoBuildOptions(cgo_enabled=True, with_race_detector=True),
+            )
+        ],
+    )
+    assert build_request.is_stdlib
+    assert build_request.go_files, "expected a non-slim request with sources present"
+    assert build_request.direct_dependencies, (
+        "expected a non-slim request with dependency recursion"
+    )

--- a/src/python/pants/backend/go/util_rules/build_pkg_target_test.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target_test.py
@@ -214,17 +214,26 @@ def assert_built(
         "__pkgs__", path_safe(built_package.import_path), "__pkg__.a"
     )
     assert built_package.pkg_archive_path in own_files
+    # Standard library dependencies may resolve to pre-built archives
+    # (`__go_stdlib__/<import_path>.a`) instead of being compiled from source into the
+    # `__pkgs__/...` layout, depending on `[golang].use_prebuilt_stdlib_archives` and build
+    # options.
     expected = {
-        import_path: os.path.join("__pkgs__", path_safe(import_path), "__pkg__.a")
+        import_path: (
+            os.path.join("__pkgs__", path_safe(import_path), "__pkg__.a"),
+            f"__go_stdlib__/{import_path}.a",
+        )
         for import_path in expected_import_paths
     }
     actual = {
         import_path: archive_path
         for import_path, (archive_path, _) in built_package.transitive_pkg_archives.items()
     }
-    for import_path, pkg_archive_path in expected.items():
+    for import_path, acceptable_archive_paths in expected.items():
         assert import_path in actual, f"expected {import_path} to be in build output"
-        assert actual[import_path] == pkg_archive_path, "expected package archive paths to match"
+        assert actual[import_path] in acceptable_archive_paths, (
+            "expected package archive paths to match"
+        )
 
 
 def assert_pkg_target_built(
@@ -668,6 +677,10 @@ def test_xtest_deps(rule_runner: RuleRunner) -> None:
 
 @pytest.mark.no_error_if_skipped
 def test_stdlib_embed_config(rule_runner: RuleRunner) -> None:
+    # This test exercises embed-config resolution on the from-source stdlib path. With
+    # pre-built stdlib archives enabled (the default), stdlib build requests are "slim" and
+    # carry no embed config (the harvested archives already incorporate embedded files).
+    rule_runner.set_options(["--no-golang-use-prebuilt-stdlib-archives"], env_inherit={"PATH"})
     stdlib_packages = rule_runner.request(
         GoStdLibPackages, [GoStdLibPackagesRequest(with_race_detector=False, cgo_enabled=False)]
     )

--- a/src/python/pants/backend/go/util_rules/build_pkg_target_test.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target_test.py
@@ -40,6 +40,7 @@ from pants.backend.go.util_rules.build_pkg_target import (
     BuildGoPackageTargetRequest,
     GoCodegenBuildRequest,
     setup_build_go_package_target_request,
+    setup_build_go_package_target_request_for_stdlib,
 )
 from pants.backend.go.util_rules.go_mod import OwningGoModRequest, find_owning_go_mod
 from pants.backend.go.util_rules.import_analysis import (
@@ -143,6 +144,14 @@ async def generate_from_file(request: GoCodegenBuildFilesRequest) -> FallibleBui
     )
     assert thirdparty_dep.request is not None
 
+    # The generated code imports `fmt` directly, so it must be declared as a direct
+    # dependency: the compile sandbox/importcfg contains only direct deps' export data.
+    fmt_dep = await setup_build_go_package_target_request_for_stdlib(
+        BuildGoPackageRequestForStdlibRequest("fmt", build_opts=GoBuildOptions()),
+        **implicitly(),
+    )
+    assert fmt_dep.request is not None
+
     return FallibleBuildGoPackageRequest(
         request=BuildGoPackageRequest(
             import_path="codegen.com/gen",
@@ -152,7 +161,7 @@ async def generate_from_file(request: GoCodegenBuildFilesRequest) -> FallibleBui
             build_opts=GoBuildOptions(),
             go_files=("f.go",),
             s_files=(),
-            direct_dependencies=(thirdparty_dep.request,),
+            direct_dependencies=(fmt_dep.request, thirdparty_dep.request),
             minimum_go_version=None,
         ),
         import_path="codegen.com/gen",
@@ -200,18 +209,22 @@ def assert_built(
     rule_runner: RuleRunner, request: BuildGoPackageRequest, *, expected_import_paths: list[str]
 ) -> None:
     built_package = rule_runner.request(BuiltGoPackage, [request])
-    result_files = rule_runner.request(Snapshot, [built_package.digest]).files
+    own_files = rule_runner.request(Snapshot, [built_package.archive_digest]).files
+    assert built_package.pkg_archive_path == os.path.join(
+        "__pkgs__", path_safe(built_package.import_path), "__pkg__.a"
+    )
+    assert built_package.pkg_archive_path in own_files
     expected = {
         import_path: os.path.join("__pkgs__", path_safe(import_path), "__pkg__.a")
         for import_path in expected_import_paths
     }
-    actual = dict(built_package.import_paths_to_pkg_a_files)
+    actual = {
+        import_path: archive_path
+        for import_path, (archive_path, _) in built_package.transitive_pkg_archives.items()
+    }
     for import_path, pkg_archive_path in expected.items():
         assert import_path in actual, f"expected {import_path} to be in build output"
-        assert actual[import_path] == expected[import_path], (
-            "expected package archive paths to match"
-        )
-    assert set(expected.values()).issubset(set(result_files))
+        assert actual[import_path] == pkg_archive_path, "expected package archive paths to match"
 
 
 def assert_pkg_target_built(
@@ -579,7 +592,7 @@ def test_build_codegen_target(rule_runner: RuleRunner) -> None:
         expected_import_path="codegen.com/gen",
         expected_dir_path="codegen",
         expected_go_file_names=["f.go"],
-        expected_direct_dependency_import_paths=["github.com/google/uuid"],
+        expected_direct_dependency_import_paths=["fmt", "github.com/google/uuid"],
         expected_transitive_dependency_import_paths=[],
     )
 

--- a/src/python/pants/backend/go/util_rules/build_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_test.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import os.path
+from dataclasses import dataclass
 from textwrap import dedent
 
 import pytest
@@ -25,11 +26,37 @@ from pants.backend.go.util_rules.build_pkg import (
     BuildGoPackageRequest,
     BuiltGoPackage,
     FallibleBuiltGoPackage,
+    _gather_transitive_prebuilt_object_files,
 )
 from pants.engine.fs import Snapshot
-from pants.engine.rules import QueryRule
+from pants.engine.rules import QueryRule, rule
 from pants.testutil.rule_runner import RuleRunner
 from pants.util.strutil import path_safe
+
+
+# ---------------------------------------------------------------------------
+# Test-only rule for probing _gather_transitive_prebuilt_object_files directly.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _GatherPrebuiltObjectFilesResult:
+    object_files: frozenset[str]
+
+
+@rule
+async def _gather_prebuilt_object_files_for_test(
+    request: BuildGoPackageRequest,
+) -> _GatherPrebuiltObjectFilesResult:
+    _, object_files = await _gather_transitive_prebuilt_object_files(request)
+    return _GatherPrebuiltObjectFilesResult(object_files)
+
+
+def _syso_test_rules():
+    return [
+        _gather_prebuilt_object_files_for_test,
+        QueryRule(_GatherPrebuiltObjectFilesResult, [BuildGoPackageRequest]),
+    ]
 
 
 @pytest.fixture
@@ -47,6 +74,28 @@ def rule_runner() -> RuleRunner:
             *target_type_rules.rules(),
             QueryRule(BuiltGoPackage, [BuildGoPackageRequest]),
             QueryRule(FallibleBuiltGoPackage, [BuildGoPackageRequest]),
+        ],
+        target_types=[GoModTarget],
+    )
+    rule_runner.set_options([], env_inherit={"PATH"})
+    return rule_runner
+
+
+@pytest.fixture
+def syso_rule_runner() -> RuleRunner:
+    """Fixture that includes the test-only rule for probing _gather_transitive_prebuilt_object_files."""
+    rule_runner = RuleRunner(
+        rules=[
+            *sdk.rules(),
+            *assembly.rules(),
+            *build_pkg.rules(),
+            *import_analysis.rules(),
+            *go_mod.rules(),
+            *first_party_pkg.rules(),
+            *link.rules(),
+            *third_party_pkg.rules(),
+            *target_type_rules.rules(),
+            *_syso_test_rules(),
         ],
         target_types=[GoModTarget],
     )
@@ -212,4 +261,105 @@ def test_build_invalid_pkg(rule_runner: RuleRunner) -> None:
     assert invalid_dep_result.exit_code == 1
     assert (
         invalid_dep_result.stdout == "dep/f.go:1:1: syntax error: package statement must be first\n"
+    )
+
+
+def test_gather_transitive_prebuilt_object_files_depth2(syso_rule_runner: RuleRunner) -> None:
+    """Regression test for BFS bug in _gather_transitive_prebuilt_object_files.
+
+    Before the fix, line 549 read:
+        unseen = [dd for dd in build_request.direct_dependencies if dd not in seen]
+    which always expanded the *root's* direct deps instead of the *current node's*
+    direct deps.  As a result, the BFS never descended past depth 1 and any
+    `.syso` file belonging to a grandchild (or deeper) dependency was silently
+    dropped from cgo linking.
+
+    This test constructs the minimal chain that exposes the bug:
+        cgo_root → direct_dep → grandchild  (grandchild has prebuilt_object_files)
+
+    With the bug present, `_gather_transitive_prebuilt_object_files(cgo_root)`
+    returns an empty `object_files` set because it only ever enqueues
+    `cgo_root.direct_dependencies` (i.e., `[direct_dep]`) on every iteration
+    rather than the *current* node's deps, so `grandchild` is never visited.
+    With the fix, `pkg.direct_dependencies` correctly enqueues `grandchild`
+    from `direct_dep`, and the `.syso` path is returned.
+    """
+    grandchild = BuildGoPackageRequest(
+        import_path="example.com/foo/grandchild",
+        pkg_name="grandchild",
+        dir_path="grandchild",
+        build_opts=GoBuildOptions(),
+        go_files=("f.go",),
+        digest=syso_rule_runner.make_snapshot(
+            {
+                "grandchild/f.go": dedent(
+                    """\
+                    package grandchild
+
+                    func Value() int { return 1 }
+                    """
+                ),
+                # Fake .syso bytes: the BFS only needs the file path recorded in
+                # prebuilt_object_files; actual content is irrelevant for this test.
+                "grandchild/helper.syso": b"\x00",
+            }
+        ).digest,
+        s_files=(),
+        direct_dependencies=(),
+        minimum_go_version=None,
+        prebuilt_object_files=("helper.syso",),
+    )
+    direct_dep = BuildGoPackageRequest(
+        import_path="example.com/foo/dep",
+        pkg_name="dep",
+        dir_path="dep",
+        build_opts=GoBuildOptions(),
+        go_files=("f.go",),
+        digest=syso_rule_runner.make_snapshot(
+            {
+                "dep/f.go": dedent(
+                    """\
+                    package dep
+
+                    import "example.com/foo/grandchild"
+
+                    func Value() int { return grandchild.Value() }
+                    """
+                )
+            }
+        ).digest,
+        s_files=(),
+        direct_dependencies=(grandchild,),
+        minimum_go_version=None,
+    )
+    cgo_root = BuildGoPackageRequest(
+        import_path="example.com/foo",
+        pkg_name="foo",
+        dir_path="",
+        build_opts=GoBuildOptions(),
+        go_files=("f.go",),
+        digest=syso_rule_runner.make_snapshot(
+            {
+                "f.go": dedent(
+                    """\
+                    package foo
+
+                    import "example.com/foo/dep"
+
+                    func Root() int { return dep.Value() }
+                    """
+                )
+            }
+        ).digest,
+        s_files=(),
+        direct_dependencies=(direct_dep,),
+        minimum_go_version=None,
+    )
+
+    result = syso_rule_runner.request(_GatherPrebuiltObjectFilesResult, [cgo_root])
+
+    # The grandchild's .syso must be present even though it is at depth 2.
+    assert os.path.join("grandchild", "helper.syso") in result.object_files, (
+        f"grandchild/helper.syso missing from collected object_files={result.object_files!r}; "
+        "BFS bug: _gather_transitive_prebuilt_object_files never visited the grandchild node"
     )

--- a/src/python/pants/backend/go/util_rules/build_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_test.py
@@ -26,13 +26,15 @@ from pants.backend.go.util_rules.build_pkg import (
     BuildGoPackageRequest,
     BuiltGoPackage,
     FallibleBuiltGoPackage,
+    MergeBuiltGoPackageArchivesRequest,
+    MergedGoPackageArchives,
     _gather_transitive_prebuilt_object_files,
 )
 from pants.engine.fs import Snapshot
 from pants.engine.rules import QueryRule, rule
 from pants.testutil.rule_runner import RuleRunner
+from pants.util.frozendict import FrozenDict
 from pants.util.strutil import path_safe
-
 
 # ---------------------------------------------------------------------------
 # Test-only rule for probing _gather_transitive_prebuilt_object_files directly.
@@ -74,6 +76,7 @@ def rule_runner() -> RuleRunner:
             *target_type_rules.rules(),
             QueryRule(BuiltGoPackage, [BuildGoPackageRequest]),
             QueryRule(FallibleBuiltGoPackage, [BuildGoPackageRequest]),
+            QueryRule(MergedGoPackageArchives, [MergeBuiltGoPackageArchivesRequest]),
         ],
         target_types=[GoModTarget],
     )
@@ -107,13 +110,16 @@ def assert_built(
     rule_runner: RuleRunner, request: BuildGoPackageRequest, *, expected_import_paths: list[str]
 ) -> None:
     built_package = rule_runner.request(BuiltGoPackage, [request])
-    result_files = rule_runner.request(Snapshot, [built_package.digest]).files
+    own_files = rule_runner.request(Snapshot, [built_package.archive_digest]).files
     expected = {
         import_path: os.path.join("__pkgs__", path_safe(import_path), "__pkg__.a")
         for import_path in expected_import_paths
     }
-    assert dict(built_package.import_paths_to_pkg_a_files) == expected
-    assert sorted(result_files) == sorted(expected.values())
+    assert built_package.pkg_archive_path == os.path.join(
+        "__pkgs__", path_safe(built_package.import_path), "__pkg__.a"
+    )
+    assert sorted(own_files) == [built_package.pkg_archive_path]
+    assert {ip: path for ip, (path, _) in built_package.transitive_pkg_archives.items()} == expected
 
 
 def test_build_pkg(rule_runner: RuleRunner) -> None:
@@ -262,6 +268,207 @@ def test_build_invalid_pkg(rule_runner: RuleRunner) -> None:
     assert (
         invalid_dep_result.stdout == "dep/f.go:1:1: syntax error: package statement must be first\n"
     )
+
+
+def test_build_pkg_deep_chain(rule_runner: RuleRunner) -> None:
+    """A 4-level dependency chain compiles with direct-deps-only compile inputs.
+
+    `a → b → c → d`: `d` defines an exported struct, `c` wraps it, `b` re-exports a function
+    returning the wrapper, and `a` reaches through to the innermost field.  Compiling `a` only
+    has `b`'s export data in its importcfg, so this exercises the self-containedness of gc
+    export data across multiple levels (the canary for the direct-deps-only premise).
+    """
+    pkg_d = BuildGoPackageRequest(
+        import_path="example.com/deep/d",
+        pkg_name="d",
+        dir_path="d",
+        build_opts=GoBuildOptions(),
+        go_files=("f.go",),
+        digest=rule_runner.make_snapshot(
+            {
+                "d/f.go": dedent(
+                    """\
+                    package d
+
+                    type Thing struct {
+                        Value int
+                    }
+
+                    func New() Thing {
+                        return Thing{Value: 42}
+                    }
+                    """
+                )
+            }
+        ).digest,
+        s_files=(),
+        direct_dependencies=(),
+        minimum_go_version=None,
+    )
+    pkg_c = BuildGoPackageRequest(
+        import_path="example.com/deep/c",
+        pkg_name="c",
+        dir_path="c",
+        build_opts=GoBuildOptions(),
+        go_files=("f.go",),
+        digest=rule_runner.make_snapshot(
+            {
+                "c/f.go": dedent(
+                    """\
+                    package c
+
+                    import "example.com/deep/d"
+
+                    type Wrapped struct {
+                        Inner d.Thing
+                    }
+
+                    func Get() Wrapped {
+                        return Wrapped{Inner: d.New()}
+                    }
+                    """
+                )
+            }
+        ).digest,
+        s_files=(),
+        direct_dependencies=(pkg_d,),
+        minimum_go_version=None,
+    )
+    pkg_b = BuildGoPackageRequest(
+        import_path="example.com/deep/b",
+        pkg_name="b",
+        dir_path="b",
+        build_opts=GoBuildOptions(),
+        go_files=("f.go",),
+        digest=rule_runner.make_snapshot(
+            {
+                "b/f.go": dedent(
+                    """\
+                    package b
+
+                    import "example.com/deep/c"
+
+                    func Get() c.Wrapped {
+                        return c.Get()
+                    }
+                    """
+                )
+            }
+        ).digest,
+        s_files=(),
+        direct_dependencies=(pkg_c,),
+        minimum_go_version=None,
+    )
+    pkg_a = BuildGoPackageRequest(
+        import_path="example.com/deep/a",
+        pkg_name="a",
+        dir_path="a",
+        build_opts=GoBuildOptions(),
+        go_files=("f.go",),
+        digest=rule_runner.make_snapshot(
+            {
+                "a/f.go": dedent(
+                    """\
+                    package a
+
+                    import "example.com/deep/b"
+
+                    func Use() int {
+                        return b.Get().Inner.Value
+                    }
+                    """
+                )
+            }
+        ).digest,
+        s_files=(),
+        direct_dependencies=(pkg_b,),
+        minimum_go_version=None,
+    )
+
+    all_import_paths = [
+        "example.com/deep/a",
+        "example.com/deep/b",
+        "example.com/deep/c",
+        "example.com/deep/d",
+    ]
+
+    built_a = rule_runner.request(BuiltGoPackage, [pkg_a])
+
+    # The package's own digest contains only its own archive.
+    own_files = rule_runner.request(Snapshot, [built_a.archive_digest]).files
+    assert sorted(own_files) == [built_a.pkg_archive_path]
+
+    # The transitive handle map covers the full closure.
+    assert set(built_a.transitive_pkg_archives.keys()) == set(all_import_paths)
+
+    # Merging the closure of (a,) yields all four archives, each exactly once.
+    merged = rule_runner.request(
+        MergedGoPackageArchives, [MergeBuiltGoPackageArchivesRequest((built_a,))]
+    )
+    expected_paths = {
+        import_path: os.path.join("__pkgs__", path_safe(import_path), "__pkg__.a")
+        for import_path in all_import_paths
+    }
+    assert dict(merged.import_paths_to_pkg_a_files) == expected_paths
+    merged_files = rule_runner.request(Snapshot, [merged.digest]).files
+    assert sorted(merged_files) == sorted(expected_paths.values())
+
+
+def test_merge_built_go_package_archives(rule_runner: RuleRunner) -> None:
+    """Overlapping transitive maps merge each archive once, first-wins on conflicts."""
+    digest_a = rule_runner.make_snapshot({"__pkgs__/a/__pkg__.a": "a-archive"}).digest
+    digest_b = rule_runner.make_snapshot({"__pkgs__/b/__pkg__.a": "b-archive"}).digest
+    digest_common = rule_runner.make_snapshot({"__pkgs__/common/__pkg__.a": "common"}).digest
+    digest_shared_v1 = rule_runner.make_snapshot({"__pkgs__/shared/__pkg__.a": "shared-v1"}).digest
+    digest_shared_v2 = rule_runner.make_snapshot(
+        {"__pkgs__/shared_v2/__pkg__.a": "shared-v2"}
+    ).digest
+
+    path_a = os.path.join("__pkgs__", "a", "__pkg__.a")
+    path_b = os.path.join("__pkgs__", "b", "__pkg__.a")
+    path_common = os.path.join("__pkgs__", "common", "__pkg__.a")
+    path_shared_v1 = os.path.join("__pkgs__", "shared", "__pkg__.a")
+    path_shared_v2 = os.path.join("__pkgs__", "shared_v2", "__pkg__.a")
+
+    pkg_one = BuiltGoPackage(
+        import_path="example.com/a",
+        pkg_archive_path=path_a,
+        archive_digest=digest_a,
+        transitive_pkg_archives=FrozenDict(
+            {
+                "example.com/a": (path_a, digest_a),
+                "example.com/common": (path_common, digest_common),
+                "example.com/shared": (path_shared_v1, digest_shared_v1),
+            }
+        ),
+    )
+    pkg_two = BuiltGoPackage(
+        import_path="example.com/b",
+        pkg_archive_path=path_b,
+        archive_digest=digest_b,
+        transitive_pkg_archives=FrozenDict(
+            {
+                "example.com/b": (path_b, digest_b),
+                # Identical entry in both packages: must merge cleanly, exactly once.
+                "example.com/common": (path_common, digest_common),
+                # Conflicting entry: pkg_one came first, so its handle must win.
+                "example.com/shared": (path_shared_v2, digest_shared_v2),
+            }
+        ),
+    )
+
+    merged = rule_runner.request(
+        MergedGoPackageArchives, [MergeBuiltGoPackageArchivesRequest((pkg_one, pkg_two))]
+    )
+
+    assert dict(merged.import_paths_to_pkg_a_files) == {
+        "example.com/a": path_a,
+        "example.com/b": path_b,
+        "example.com/common": path_common,
+        "example.com/shared": path_shared_v1,
+    }
+    merged_files = rule_runner.request(Snapshot, [merged.digest]).files
+    assert sorted(merged_files) == sorted([path_a, path_b, path_common, path_shared_v1])
 
 
 def test_gather_transitive_prebuilt_object_files_depth2(syso_rule_runner: RuleRunner) -> None:

--- a/src/python/pants/backend/go/util_rules/implicit_linker_deps.py
+++ b/src/python/pants/backend/go/util_rules/implicit_linker_deps.py
@@ -3,18 +3,19 @@
 
 from __future__ import annotations
 
-from pants.backend.go.util_rules.build_pkg import required_built_go_package
+from pants.backend.go.util_rules.build_pkg import (
+    MergeBuiltGoPackageArchivesRequest,
+    merge_built_go_package_archives,
+    required_built_go_package,
+)
 from pants.backend.go.util_rules.build_pkg_target import BuildGoPackageRequestForStdlibRequest
 from pants.backend.go.util_rules.link_defs import (
     ImplicitLinkerDependencies,
     ImplicitLinkerDependenciesHook,
 )
-from pants.engine.internals.native_engine import MergeDigests
 from pants.engine.internals.selectors import concurrently
-from pants.engine.intrinsics import merge_digests
 from pants.engine.rules import collect_rules, implicitly, rule
 from pants.engine.unions import UnionRule
-from pants.util.frozendict import FrozenDict
 
 
 class SdkImplicitLinkerDependenciesHook(ImplicitLinkerDependenciesHook):
@@ -49,17 +50,13 @@ async def provide_sdk_implicit_linker_dependencies(
         for dep_import_path in implicit_deps_import_paths
     )
 
-    implicit_dep_digests = []
-    import_paths_to_pkg_a_files: dict[str, str] = {}
-    for built_implicit_linker_dep in built_implicit_linker_deps:
-        import_paths_to_pkg_a_files.update(built_implicit_linker_dep.import_paths_to_pkg_a_files)
-        implicit_dep_digests.append(built_implicit_linker_dep.digest)
-
-    digest = await merge_digests(MergeDigests(implicit_dep_digests))
+    merged = await merge_built_go_package_archives(
+        MergeBuiltGoPackageArchivesRequest(tuple(built_implicit_linker_deps))
+    )
 
     return ImplicitLinkerDependencies(
-        digest=digest,
-        import_paths_to_pkg_a_files=FrozenDict(import_paths_to_pkg_a_files),
+        digest=merged.digest,
+        import_paths_to_pkg_a_files=merged.import_paths_to_pkg_a_files,
     )
 
 

--- a/src/python/pants/backend/go/util_rules/import_analysis.py
+++ b/src/python/pants/backend/go/util_rules/import_analysis.py
@@ -25,6 +25,7 @@ class GoStdLibPackage:
     import_path: str
     pkg_source_path: str
     imports: tuple[str, ...]
+    deps: tuple[str, ...]
     import_map: FrozenDict[str, str]
 
     # Analysis for when Pants is able to compile the SDK directly.
@@ -64,7 +65,6 @@ async def analyze_go_stdlib_packages(request: GoStdLibPackagesRequest) -> GoStdL
     list_result = await execute_process_or_raise(
         **implicitly(
             GoSdkProcess(
-                # "-find" skips determining dependencies and imports for each package.
                 command=("list", *maybe_race_arg, "-json", "std"),
                 env={"CGO_ENABLED": "1" if request.cgo_enabled else "0"},
                 description="Ask Go for its available import paths",
@@ -84,6 +84,7 @@ async def analyze_go_stdlib_packages(request: GoStdLibPackagesRequest) -> GoStdL
             import_path=import_path,
             pkg_source_path=pkg_source_path,
             imports=tuple(pkg_json.get("Imports", ())),
+            deps=tuple(pkg_json.get("Deps", ())),
             import_map=FrozenDict(pkg_json.get("ImportMap", {})),
             go_files=tuple(pkg_json.get("GoFiles", ())),
             cgo_files=tuple(pkg_json.get("CgoFiles", ())),

--- a/src/python/pants/backend/go/util_rules/stdlib_archives.py
+++ b/src/python/pants/backend/go/util_rules/stdlib_archives.py
@@ -10,7 +10,9 @@ the entire standard library in a single `go install std` invocation and capture 
 keyed on `(go version, GOOS, GOARCH, cgo_enabled)`, so the harvest runs once per
 configuration and is cached forever.
 
-This mirrors the architecture used by Bazel's rules_go.
+This mirrors the architecture used by Bazel's rules_go, which compiles the standard library
+once per configuration in the same way; see
+https://github.com/bazel-contrib/rules_go/blob/master/go/tools/builders/stdlib.go.
 
 The archives are only usable for build configurations that match how `go install std`
 compiles the standard library; `stdlib_archives_compatible` is the single gate deciding
@@ -47,7 +49,10 @@ class GoStdlibArchivesRequest:
     `cgo_enabled` is a cache-key dimension, not a compatibility gate: the contents of some
     archives (e.g. `net`, `os/user`) differ between the cgo and non-cgo configurations, and
     `runtime/cgo` only exists in the cgo configuration, so each configuration is harvested
-    separately.
+    separately. Other content-affecting options (race/msan/asan, coverage, custom compiler or
+    assembler flags) are deliberately *not* dimensions here: rather than harvest a variant for
+    each, `stdlib_archives_compatible` disqualifies them entirely and the build falls back to
+    compiling the standard library from source package-by-package, as before.
     """
 
     cgo_enabled: bool
@@ -115,6 +120,10 @@ async def harvest_go_stdlib_archives(
             GoSdkProcess(
                 command=("install", "-trimpath", "-pkgdir", PKGDIR_PREFIX, "std"),
                 env={
+                    # The critical setting: `installgoroot=all` makes `go install -pkgdir` write
+                    # an archive for *every* standard library package into `-pkgdir`, rather than
+                    # only the handful not already present in GOROOT. Without it the harvest is
+                    # nearly empty. Introduced in Go 1.20 (gated on the version check above).
                     "GODEBUG": "installgoroot=all",
                     "CGO_ENABLED": "1" if request.cgo_enabled else "0",
                 },

--- a/src/python/pants/backend/go/util_rules/stdlib_archives.py
+++ b/src/python/pants/backend/go/util_rules/stdlib_archives.py
@@ -1,0 +1,151 @@
+# Copyright 2026 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+"""Pre-compiled Go standard library archives.
+
+Instead of compiling each standard library package as its own build action (one or more
+processes per package, ~90+ packages in a typical closure), ask the Go toolchain to compile
+the entire standard library in a single `go install std` invocation and capture the resulting
+`.a` archives. The archives are deterministic for a given toolchain configuration and are
+keyed on `(go version, GOOS, GOARCH, cgo_enabled)`, so the harvest runs once per
+configuration and is cached forever.
+
+This mirrors the architecture used by Bazel's rules_go.
+
+The archives are only usable for build configurations that match how `go install std`
+compiles the standard library; `stdlib_archives_compatible` is the single gate deciding
+whether a given `GoBuildOptions` can use them. Incompatible configurations (race/msan/asan,
+code coverage, custom compiler or assembler flags) fall back to compiling the standard
+library from source, exactly as before.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pants.backend.go.subsystems.golang import GolangSubsystem
+from pants.backend.go.util_rules import sdk
+from pants.backend.go.util_rules.build_opts import GoBuildOptions
+from pants.backend.go.util_rules.goroot import GoRoot
+from pants.backend.go.util_rules.sdk import GoSdkProcess
+from pants.engine.fs import EMPTY_DIGEST, Digest, FileEntry
+from pants.engine.intrinsics import get_digest_entries
+from pants.engine.process import execute_process_or_raise
+from pants.engine.rules import collect_rules, implicitly, rule
+from pants.util.frozendict import FrozenDict
+from pants.util.logging import LogLevel
+
+# Directory within the harvest sandbox (and within consuming sandboxes) under which the
+# standard library archives are laid out, mirroring import paths: `__go_stdlib__/<import_path>.a`.
+PKGDIR_PREFIX = "__go_stdlib__"
+
+
+@dataclass(frozen=True)
+class GoStdlibArchivesRequest:
+    """Request the pre-compiled standard library archives for the current Go toolchain.
+
+    `cgo_enabled` is a cache-key dimension, not a compatibility gate: the contents of some
+    archives (e.g. `net`, `os/user`) differ between the cgo and non-cgo configurations, and
+    `runtime/cgo` only exists in the cgo configuration, so each configuration is harvested
+    separately.
+    """
+
+    cgo_enabled: bool
+
+
+@dataclass(frozen=True)
+class GoStdlibArchives:
+    """Pre-compiled standard library archives, laid out as `__go_stdlib__/<import_path>.a`.
+
+    `import_paths_to_pkg_a_files` maps each import path to its archive path within `digest`,
+    e.g. `"fmt" -> "__go_stdlib__/fmt.a"`. A small number of standard library packages have no
+    archive (e.g. `unsafe`, which has no compiled form): consumers must treat a missing key as
+    "fall back to compiling that package from source".
+
+    The mapping is empty when the toolchain cannot produce archives (Go < 1.20); consumers
+    must then fall back to from-source compilation for all standard library packages.
+    """
+
+    digest: Digest
+    import_paths_to_pkg_a_files: FrozenDict[str, str]
+
+
+def stdlib_archives_compatible(build_opts: GoBuildOptions, golang: GolangSubsystem) -> bool:
+    """Whether `build_opts` can link against pre-compiled standard library archives.
+
+    The archives are compiled by `go install std` with the toolchain's default settings, so
+    any option that changes the *content* of a standard library archive disqualifies them:
+    race/msan/asan instrumentation, code coverage, and custom compiler or assembler flags.
+
+    `cgo_enabled` is deliberately not checked: it is part of the harvest cache key (the cgo
+    and non-cgo archive sets are harvested separately). `linker_flags` is deliberately not
+    checked: linker flags apply at the final link step only and never affect the content of a
+    package archive.
+    """
+    return (
+        golang.use_prebuilt_stdlib_archives
+        and build_opts.coverage_config is None
+        and not build_opts.with_race_detector
+        and not build_opts.with_msan
+        and not build_opts.with_asan
+        and not build_opts.compiler_flags
+        and not build_opts.assembler_flags
+    )
+
+
+@rule(desc="Compile Go standard library archives", level=LogLevel.DEBUG)
+async def harvest_go_stdlib_archives(
+    request: GoStdlibArchivesRequest, goroot: GoRoot
+) -> GoStdlibArchives:
+    if not goroot.is_compatible_version("1.20"):
+        # `GODEBUG=installgoroot=all` (which makes `go install std` write archives for every
+        # standard library package even with `-pkgdir`) was introduced in Go 1.20. Return an
+        # empty mapping; consumers fall back to compiling the standard library from source.
+        return GoStdlibArchives(EMPTY_DIGEST, FrozenDict({}))
+
+    # Note: `-trimpath` keeps the archives free of absolute build paths and `-pkgdir` accepts a
+    # path relative to the sandbox root, so the output is fully deterministic for a given
+    # toolchain configuration (verified byte-identical across separate cold builds in different
+    # directories). The toolchain configuration itself is captured by the
+    # `__PANTS_GO_SDK_CACHE_KEY` (version/GOOS/GOARCH) env var injected by `GoSdkProcess`, plus
+    # `CGO_ENABLED` below, so a toolchain change re-runs the harvest atomically with all
+    # package compiles.
+    result = await execute_process_or_raise(
+        **implicitly(
+            GoSdkProcess(
+                command=("install", "-trimpath", "-pkgdir", PKGDIR_PREFIX, "std"),
+                env={
+                    "GODEBUG": "installgoroot=all",
+                    "CGO_ENABLED": "1" if request.cgo_enabled else "0",
+                },
+                description="Compile Go standard library archives",
+                output_directories=(PKGDIR_PREFIX,),
+            )
+        )
+    )
+
+    entries = await get_digest_entries(result.output_digest)
+    mapping = {
+        # e.g. "__go_stdlib__/crypto/sha256.a" -> import path "crypto/sha256"
+        entry.path[len(PKGDIR_PREFIX) + 1 : -len(".a")]: entry.path
+        for entry in entries
+        if isinstance(entry, FileEntry) and entry.path.endswith(".a")
+    }
+    if not mapping:
+        raise ValueError(
+            "Pants ran `go install -pkgdir ... std` to pre-compile the Go standard library, "
+            "but no archives were produced. This may indicate that the "
+            "`GODEBUG=installgoroot=all` setting is no longer honored by your Go version "
+            f"({goroot.full_version}). Set `[golang].use_prebuilt_stdlib_archives = false` "
+            "in `pants.toml` to fall back to per-package compilation of the standard "
+            "library, and report this issue at https://github.com/pantsbuild/pants/issues/new."
+        )
+
+    return GoStdlibArchives(result.output_digest, FrozenDict(mapping))
+
+
+def rules():
+    return (
+        *collect_rules(),
+        *sdk.rules(),
+    )

--- a/src/python/pants/backend/go/util_rules/stdlib_archives_test.py
+++ b/src/python/pants/backend/go/util_rules/stdlib_archives_test.py
@@ -1,0 +1,120 @@
+# Copyright 2026 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import pytest
+
+from pants.backend.go.subsystems.golang import GolangSubsystem
+from pants.backend.go.util_rules import stdlib_archives
+from pants.backend.go.util_rules.build_opts import GoBuildOptions
+from pants.backend.go.util_rules.coverage import GoCoverageConfig, GoCoverMode
+from pants.backend.go.util_rules.stdlib_archives import (
+    PKGDIR_PREFIX,
+    GoStdlibArchives,
+    GoStdlibArchivesRequest,
+    stdlib_archives_compatible,
+)
+from pants.engine.fs import Snapshot
+from pants.engine.rules import QueryRule
+from pants.testutil.option_util import create_subsystem
+from pants.testutil.rule_runner import RuleRunner
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    rule_runner = RuleRunner(
+        rules=[
+            *stdlib_archives.rules(),
+            QueryRule(GoStdlibArchives, (GoStdlibArchivesRequest,)),
+        ],
+    )
+    rule_runner.set_options([], env_inherit={"PATH"})
+    return rule_runner
+
+
+def test_harvest_stdlib_archives_without_cgo(rule_runner: RuleRunner) -> None:
+    archives = rule_runner.request(GoStdlibArchives, [GoStdlibArchivesRequest(cgo_enabled=False)])
+    mapping = archives.import_paths_to_pkg_a_files
+
+    # The Go standard library has ~350 packages with compiled archives (353 on Go 1.26
+    # without cgo). Use a loose lower bound so the test does not need updating for every
+    # toolchain release.
+    assert len(mapping) > 300
+
+    assert mapping["fmt"] == f"{PKGDIR_PREFIX}/fmt.a"
+    # Packages with assembly sources are archived like any other package.
+    assert mapping["runtime"] == f"{PKGDIR_PREFIX}/runtime.a"
+    assert mapping["internal/cpu"] == f"{PKGDIR_PREFIX}/internal/cpu.a"
+    # cgo-sensitive packages still have (pure-Go) archives in the non-cgo configuration.
+    assert mapping["net"] == f"{PKGDIR_PREFIX}/net.a"
+    assert mapping["os/user"] == f"{PKGDIR_PREFIX}/os/user.a"
+    # The GOROOT-vendored subtree is archived under its visible import path.
+    assert any(ip.startswith("vendor/golang.org/x/") for ip in mapping)
+    # `unsafe` has no compiled form and must not appear: consumers must treat a missing key
+    # as "fall back to compiling from source".
+    assert "unsafe" not in mapping
+
+    # Archive paths mirror import paths under the pkgdir prefix.
+    for import_path, archive_path in mapping.items():
+        assert archive_path == f"{PKGDIR_PREFIX}/{import_path}.a"
+
+    # The digest contains exactly the mapped archives.
+    snapshot = rule_runner.request(Snapshot, [archives.digest])
+    assert set(snapshot.files) == set(mapping.values())
+
+
+def test_harvest_stdlib_archives_with_cgo(rule_runner: RuleRunner) -> None:
+    # Note: like the existing cgo tests, this requires a host C toolchain on PATH.
+    archives = rule_runner.request(GoStdlibArchives, [GoStdlibArchivesRequest(cgo_enabled=True)])
+    mapping = archives.import_paths_to_pkg_a_files
+
+    assert len(mapping) > 300
+    assert mapping["fmt"] == f"{PKGDIR_PREFIX}/fmt.a"
+    assert mapping["net"] == f"{PKGDIR_PREFIX}/net.a"
+    assert mapping["os/user"] == f"{PKGDIR_PREFIX}/os/user.a"
+    # `runtime/cgo` only exists in the cgo configuration.
+    assert mapping["runtime/cgo"] == f"{PKGDIR_PREFIX}/runtime/cgo.a"
+
+
+def _golang(use_prebuilt: bool = True) -> GolangSubsystem:
+    return create_subsystem(GolangSubsystem, use_prebuilt_stdlib_archives=use_prebuilt)
+
+
+def test_stdlib_archives_compatible_default_opts() -> None:
+    assert stdlib_archives_compatible(GoBuildOptions(), _golang())
+
+
+def test_stdlib_archives_compatible_escape_hatch() -> None:
+    assert not stdlib_archives_compatible(GoBuildOptions(), _golang(use_prebuilt=False))
+
+
+@pytest.mark.parametrize(
+    "build_opts",
+    [
+        GoBuildOptions(coverage_config=GoCoverageConfig(cover_mode=GoCoverMode.SET)),
+        GoBuildOptions(with_race_detector=True),
+        GoBuildOptions(with_msan=True),
+        GoBuildOptions(with_asan=True),
+        GoBuildOptions(compiler_flags=("-N",)),
+        GoBuildOptions(assembler_flags=("-S",)),
+    ],
+)
+def test_stdlib_archives_incompatible_with_content_changing_opts(
+    build_opts: GoBuildOptions,
+) -> None:
+    """Any option that changes the content of a stdlib archive must force from-source
+    fallback."""
+    assert not stdlib_archives_compatible(build_opts, _golang())
+
+
+@pytest.mark.parametrize("cgo_enabled", [False, True])
+def test_stdlib_archives_compatible_with_either_cgo_setting(cgo_enabled: bool) -> None:
+    """`cgo_enabled` is a harvest cache-key dimension, not a compatibility gate."""
+    assert stdlib_archives_compatible(GoBuildOptions(cgo_enabled=cgo_enabled), _golang())
+
+
+def test_stdlib_archives_compatible_with_linker_flags() -> None:
+    """Linker flags apply at the final link step only; they never affect the content of a
+    package archive, so they must not force the stdlib to be rebuilt from source."""
+    assert stdlib_archives_compatible(GoBuildOptions(linker_flags=("-s", "-w")), _golang())


### PR DESCRIPTION
Disclaimer: Like my previous Go PR, I'm still not primarily a golang developer. However, the fact that Golang doesn't work properly in Pants has been the bane of my existence for like 2 years now. The moment that Mythos/Fable dropped I immediately had it dig deeply into whether the whole road to proper-golang-in-pants could be opened up. So this is all by Claude Code with Fable 5 (xhigh), with consults to GPT 5.5 (xhigh) and Gemini 3.1 Pro. I've had it check and recheck, I ran many different roles over it, and I had it explain and re-explain it to me, and then I checked myself.

So, as much as I dislike AI slop and am worried about AI PR overload, I've done my very best to avoid exactly that while still using AI. I hope we can get this road unblocked.

The rest is Fable talking:

---

Since Go 1.20, Go distributions no longer ship pre-compiled standard library archives, so Pants compiles every needed stdlib package from source: roughly 200 compile/symabis/assembly/pack build actions on a cold build, repeated for every build-options variant. This PR replaces all of that with a single cached `GODEBUG=installgoroot=all go install -trimpath -pkgdir <sandbox-relative> std` action per `(Go version, GOOS, GOARCH, cgo_enabled)` configuration (~6 s, ~175 MB, ~355 archives), the same architecture Bazel's rules_go uses.

Design: stdlib build requests on compatible configurations become "slim" (no sources, no dependency recursion, no embed-config processes), and `build_go_package` short-circuits them to the harvested archive. Each archive enters the result as its own digest handle in `transitive_pkg_archives`, so compile sandboxes still contain only direct deps' archives and the closure is merged exactly once at link, which preserves the invariant from #23421. The transitive closure comes from a new `deps` field parsed from `go list -json std`. cgo is a cache-key dimension (two harvest variants), not a fallback trigger. Configurations that change archive content (coverage, race/msan/asan, custom compiler or assembler flags) and Go < 1.20 fall back to from-source compilation exactly as before, as do the handful of import paths with no archive (`unsafe`). Escape hatch: `[golang].use_prebuilt_stdlib_archives = false` (advanced, default true); naming bikeshed welcome.

Verification: harvested archives are byte-identical across cold builds in different directories and contain no absolute paths (`-trimpath` + relative `-pkgdir`); the toolchain cache key invalidates the harvest atomically with compiles. On a 3-module gRPC/protobuf reproducer, cold `pants package` went from 213 stdlib compile actions / 65 s to **0 stdlib compile actions** (plus one harvest per cgo config) / 30 s; cold `pants check ::` wall time halved (81 → 43 s, n=2, interleaved A/B). Disabling the option reproduces the old behavior bit-for-bit.

A note on what generalizes, since those wall-clock numbers are from a compile-bound reproducer where stdlib compilation sits on the critical path. The work-reduction (eliminating the 200-plus stdlib build actions per configuration) happens on any build. The wall-clock benefit only appears where compilation is actually on the critical path. On a larger real monorepo whose build is dominated by the rule engine rather than the Go toolchain, I measured wall time flat with this change, while the redundant stdlib compiles were still removed. In a per-lever A/B on a 24-module monorepo this change is also memory-neutral in isolation (cold peak 1.78 GiB to 1.46 GiB on top of #23421). So this helps compile-bound graphs, `check`, and cold CI; it is not a wall-clock win on large orchestration-bound builds. The orchestration-bound analysis is on #20274.

Release note added to `docs/notes/2.33.x.md`. **Depends on #23421 (direct-deps-only compile sandboxes)**: this PR builds on its `BuiltGoPackage` per-archive handle map and should be reviewed/merged after it.
