### PR TITLE
Cache Go module downloads in a persistent named cache (GOMODCACHE)

### DIFF
--- a/docs/notes/2.34.x.md
+++ b/docs/notes/2.34.x.md
@@ -64,6 +64,8 @@ Optimized third-party Go package compilation by materializing only the package's
 
 The new advanced option `[golang].third_party_target_granularity` controls how third-party targets are generated. The default `package` keeps one `go_third_party_package` target per third-party package; `module` instead generates one `go_third_party_module` target per module, matching how other backends model third-party dependencies, with transitive resolution owned by `go.mod`/`go.sum`. This dramatically reduces target count and dependency-resolution time on projects with large third-party modules.
 
+Third-party Go module downloads now use a persistent named cache (`go_mod_cache`) for `GOMODCACHE`. Previously every sandbox got a fresh module cache, so any `go.mod`/`go.sum` change caused all modules to be re-downloaded from the network. With the named cache, subsequent builds reuse locally cached module zips even when the engine's content-addressed store is cold. Captured digests remain the source of truth: modules are copied out of the shared cache into the sandbox before capture, so results are byte-identical regardless of whether the cache is warm or cold. Remote-execution users: the named cache is only effective when `--remote-execution-append-only-caches-base-path` is configured; without it the process falls back silently to a per-sandbox download (today's behavior). Note: this change invalidates all previously cached Go process results (one-time invalidation). See [#13390](https://github.com/pantsbuild/pants/issues/13390).
+
 ### Plugin API changes
 
 ## Full Changelog

--- a/docs/notes/2.34.x.md
+++ b/docs/notes/2.34.x.md
@@ -66,6 +66,8 @@ The new advanced option `[golang].third_party_target_granularity` controls how t
 
 Third-party Go module downloads now use a persistent named cache (`go_mod_cache`) for `GOMODCACHE`. Previously every sandbox got a fresh module cache, so any `go.mod`/`go.sum` change caused all modules to be re-downloaded from the network. With the named cache, subsequent builds reuse locally cached module zips even when the engine's content-addressed store is cold. Captured digests remain the source of truth: modules are copied out of the shared cache into the sandbox before capture, so results are byte-identical regardless of whether the cache is warm or cold. Remote-execution users: the named cache is only effective when `--remote-execution-append-only-caches-base-path` is configured; without it the process falls back silently to a per-sandbox download (today's behavior). Note: this change invalidates all previously cached Go process results (one-time invalidation). See [#13390](https://github.com/pantsbuild/pants/issues/13390).
 
+The `go_mod_cache` named cache is partitioned by the checksums a build expects for a module, so builds that disagree about the contents of one `module@version` never share a cache entry. Re-tagging a version, which private modules and internal proxies do, therefore re-downloads instead of leaving a stale entry that fails checksum verification until the cache is wiped by hand. As a consequence the cache holds one copy of a module per distinct set of recorded checksums; like other append-only caches, its size is managed by the user.
+
 ### Plugin API changes
 
 ## Full Changelog

--- a/src/python/pants/backend/go/util_rules/sdk.py
+++ b/src/python/pants/backend/go/util_rules/sdk.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import shlex
 import textwrap
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
@@ -15,6 +16,9 @@ from pants.core.util_rules.env_vars import environment_vars_subset
 from pants.core.util_rules.system_binaries import (
     BashBinary,
     BinaryShimsRequest,
+    CatBinary,
+    CpBinary,
+    MkdirBinary,
     create_binary_shims,
 )
 from pants.engine.env_vars import EnvironmentVarsRequest
@@ -38,6 +42,8 @@ class GoSdkProcess:
     output_directories: tuple[str, ...]
     replace_sandbox_root_in_args: bool
 
+    use_module_cache: bool
+
     def __init__(
         self,
         command: Iterable[str],
@@ -50,6 +56,7 @@ class GoSdkProcess:
         output_directories: Iterable[str] = (),
         allow_downloads: bool = False,
         replace_sandbox_root_in_args: bool = False,
+        use_module_cache: bool = False,
     ) -> None:
         object.__setattr__(self, "command", tuple(command))
         object.__setattr__(self, "description", description)
@@ -67,6 +74,7 @@ class GoSdkProcess:
         object.__setattr__(self, "output_files", tuple(output_files))
         object.__setattr__(self, "output_directories", tuple(output_directories))
         object.__setattr__(self, "replace_sandbox_root_in_args", replace_sandbox_root_in_args)
+        object.__setattr__(self, "use_module_cache", use_module_cache)
 
 
 @dataclass(frozen=True)
@@ -76,13 +84,23 @@ class GoSdkRunSetup:
 
     CHDIR_ENV = "__PANTS_CHDIR_TO"
     SANDBOX_ROOT_ENV = "__PANTS_REPLACE_SANDBOX_ROOT"
+    MODCACHE_ENV = "__PANTS_GO_MODCACHE"
+    FETCH_MODULE_ENV = "__PANTS_GO_FETCH_MODULE"
 
 
 @rule
-async def go_sdk_invoke_setup(goroot: GoRoot) -> GoSdkRunSetup:
+async def go_sdk_invoke_setup(
+    goroot: GoRoot,
+    cat: CatBinary,
+    cp: CpBinary,
+    mkdir: MkdirBinary,
+) -> GoSdkRunSetup:
     # Note: The `go` tool requires GOPATH to be an absolute path which can only be resolved
     # from within the execution sandbox. Thus, this code uses a bash script to be able to resolve
     # absolute paths inside the sandbox.
+    cat_path = shlex.quote(cat.path)
+    cp_path = shlex.quote(cp.path)
+    mkdir_path = shlex.quote(mkdir.path)
     go_run_script = FileContent(
         "__run_go.sh",
         textwrap.dedent(
@@ -91,7 +109,49 @@ async def go_sdk_invoke_setup(goroot: GoRoot) -> GoSdkRunSetup:
             sandbox_root="$(/bin/pwd)"
             export GOPATH="${{sandbox_root}}/gopath"
             export GOCACHE="${{sandbox_root}}/cache"
-            /bin/mkdir -p "$GOPATH" "$GOCACHE"
+            {mkdir_path} -p "$GOPATH" "$GOCACHE"
+            if [ -n "${GoSdkRunSetup.MODCACHE_ENV}" ]; then
+              export GOMODCACHE="${{sandbox_root}}/__gomodcache"
+              export GOFLAGS="${{GOFLAGS:+${{GOFLAGS}} }}-modcacherw"
+              {mkdir_path} -p "$GOMODCACHE"
+            fi
+            if [ -n "${GoSdkRunSetup.FETCH_MODULE_ENV}" ]; then
+              module_version="${GoSdkRunSetup.FETCH_MODULE_ENV}"
+              "{goroot.path}/bin/go" mod download -json "$module_version" > __module_metadata.json
+              download_status=$?
+              {cat_path} __module_metadata.json
+              if [ "$download_status" -ne 0 ]; then
+                exit "$download_status"
+              fi
+              # Parse the Dir/GoMod paths from the metadata with shell string operations only:
+              # the sandbox PATH cannot be assumed to provide grep/sed.
+              dir=""
+              gomod=""
+              while IFS= read -r line; do
+                case "$line" in
+                  *'"Dir": "'*) if [ -z "$dir" ]; then dir=${{line#*'"Dir": "'}}; dir=${{dir%'"'*}}; fi ;;
+                  *'"GoMod": "'*) if [ -z "$gomod" ]; then gomod=${{line#*'"GoMod": "'}}; gomod=${{gomod%'"'*}}; fi ;;
+                esac
+              done < __module_metadata.json
+              marker="__gomodcache/"
+              dir_rel="${{dir#*${{marker}}}}"
+              gomod_rel="${{gomod#*${{marker}}}}"
+              if [ -z "$dir" ] || [ -z "$gomod" ] || [ "$dir_rel" = "$dir" ] || [ "$gomod_rel" = "$gomod" ]; then
+                echo "Failed to locate module $module_version under GOMODCACHE after download." 1>&2
+                exit 1
+              fi
+              dest_dir="$GOPATH/pkg/mod/$dir_rel"
+              dest_gomod="$GOPATH/pkg/mod/$gomod_rel"
+              {mkdir_path} -p "$dest_dir" "${{dest_gomod%/*}}" || exit 1
+              {cp_path} -Rp "$dir/." "$dest_dir/" || exit 1
+              {cp_path} -p "$gomod" "$dest_gomod" || exit 1
+              # Assert the copy produced the exact artifacts the Python rule will capture.
+              if [ ! -f "$dest_gomod" ] || [ ! -d "$dest_dir" ]; then
+                echo "Module $module_version was not copied into GOPATH/pkg/mod as expected." 1>&2
+                exit 1
+              fi
+              exit 0
+            fi
             if [ -n "${GoSdkRunSetup.CHDIR_ENV}" ]; then
               cd "${GoSdkRunSetup.CHDIR_ENV}"
             fi
@@ -164,6 +224,11 @@ async def setup_go_sdk_process(
     if request.replace_sandbox_root_in_args:
         env[GoSdkRunSetup.SANDBOX_ROOT_ENV] = "1"
 
+    append_only_caches: dict[str, str] = {}
+    if request.use_module_cache:
+        env[GoSdkRunSetup.MODCACHE_ENV] = "1"
+        append_only_caches["go_mod_cache"] = "__gomodcache"
+
     # Disable the "coverage redesign" experiment on Go v1.20+ for now since Pants does not yet support it.
     if goroot.is_compatible_version("1.20") and not goroot.is_compatible_version("1.25"):
         exp_str = env.get("GOEXPERIMENT", "")
@@ -181,6 +246,7 @@ async def setup_go_sdk_process(
         description=request.description,
         output_files=request.output_files,
         output_directories=request.output_directories,
+        append_only_caches=append_only_caches,
         level=LogLevel.DEBUG,
     )
 

--- a/src/python/pants/backend/go/util_rules/sdk.py
+++ b/src/python/pants/backend/go/util_rules/sdk.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import re
 import shlex
 import textwrap
 from collections.abc import Iterable, Mapping
@@ -31,6 +33,21 @@ from pants.engine.rules import collect_rules, implicitly, rule
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 
+_MODULE_CACHE_PARTITION_RE = re.compile(r"[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}")
+
+# Environment variables that decide where a module download comes from and whether its contents
+# are checked, and so decide which downloads may share a module cache partition.
+_MODULE_INTEGRITY_ENV_VARS = (
+    "GOAUTH",
+    "GOFLAGS",
+    "GOINSECURE",
+    "GONOPROXY",
+    "GONOSUMDB",
+    "GOPRIVATE",
+    "GOPROXY",
+    "GOSUMDB",
+)
+
 
 @dataclass(frozen=True)
 class GoSdkProcess:
@@ -43,7 +60,7 @@ class GoSdkProcess:
     output_directories: tuple[str, ...]
     replace_sandbox_root_in_args: bool
 
-    use_module_cache: bool
+    module_cache_partition: str | None
 
     def __init__(
         self,
@@ -57,7 +74,7 @@ class GoSdkProcess:
         output_directories: Iterable[str] = (),
         allow_downloads: bool = False,
         replace_sandbox_root_in_args: bool = False,
-        use_module_cache: bool = False,
+        module_cache_partition: str | None = None,
     ) -> None:
         object.__setattr__(self, "command", tuple(command))
         object.__setattr__(self, "description", description)
@@ -75,7 +92,22 @@ class GoSdkProcess:
         object.__setattr__(self, "output_files", tuple(output_files))
         object.__setattr__(self, "output_directories", tuple(output_directories))
         object.__setattr__(self, "replace_sandbox_root_in_args", replace_sandbox_root_in_args)
-        object.__setattr__(self, "use_module_cache", use_module_cache)
+        if module_cache_partition is not None and not _MODULE_CACHE_PARTITION_RE.fullmatch(
+            module_cache_partition
+        ):
+            raise ValueError(
+                "A module cache partition must be a short identifier of letters, digits, `_` and "
+                "`-` starting with a letter or digit (it names a directory inside the shared "
+                f"module cache), got {module_cache_partition!r}."
+            )
+        object.__setattr__(self, "module_cache_partition", module_cache_partition)
+        if GoSdkRunSetup.FETCH_MODULE_ENV in self.env and module_cache_partition is None:
+            # Without a partition there is no shared module cache, and the fetch step would look
+            # for the downloaded module under a path that is never populated.
+            raise ValueError(
+                "Fetching a module through the shared module cache requires a "
+                "`module_cache_partition`."
+            )
 
 
 @dataclass(frozen=True)
@@ -115,8 +147,13 @@ async def go_sdk_invoke_setup(
             export GOPATH="${{sandbox_root}}/gopath"
             export GOCACHE="${{sandbox_root}}/cache"
             {mkdir_path} -p "$GOPATH" "$GOCACHE"
-            if [ -n "${GoSdkRunSetup.MODCACHE_ENV}" ]; then
-              export GOMODCACHE="${{sandbox_root}}/__gomodcache"
+            modcache_partition="${GoSdkRunSetup.MODCACHE_ENV}"
+            if [ -n "$modcache_partition" ]; then
+              # The named cache is partitioned: each partition holds modules whose content
+              # the caller has already pinned (see `module_cache_partition`). Two builds that
+              # disagree about the bytes behind one module@version therefore never share a
+              # cache entry, so a stale entry can never poison a later build.
+              export GOMODCACHE="${{sandbox_root}}/__gomodcache/${{modcache_partition}}"
               export GOFLAGS="${{GOFLAGS:+${{GOFLAGS}} }}-modcacherw"
               {mkdir_path} -p "$GOMODCACHE"
             fi
@@ -138,7 +175,7 @@ async def go_sdk_invoke_setup(
                   *'"GoMod": "'*) if [ -z "$gomod" ]; then gomod=${{line#*'"GoMod": "'}}; gomod=${{gomod%'"'*}}; fi ;;
                 esac
               done < __module_metadata.json
-              marker="__gomodcache/"
+              marker="__gomodcache/${{modcache_partition}}/"
               dir_rel="${{dir#*${{marker}}}}"
               gomod_rel="${{gomod#*${{marker}}}}"
               if [ -z "$dir" ] || [ -z "$gomod" ] || [ "$dir_rel" = "$dir" ] || [ "$gomod_rel" = "$gomod" ]; then
@@ -230,8 +267,19 @@ async def setup_go_sdk_process(
         env[GoSdkRunSetup.SANDBOX_ROOT_ENV] = "1"
 
     append_only_caches: dict[str, str] = {}
-    if request.use_module_cache:
-        env[GoSdkRunSetup.MODCACHE_ENV] = "1"
+    if request.module_cache_partition is not None:
+        # The caller's partition covers the checksums it expects, but where a module has no
+        # recorded checksums the integrity of a download depends on the environment instead: which
+        # proxy served it, and whether the checksum database was consulted at all. Builds
+        # configuring those differently must not share downloads, so the environment is part of the
+        # partition too.
+        integrity_env = "\n".join(
+            f"{name}={env[name]}" for name in _MODULE_INTEGRITY_ENV_VARS if name in env
+        )
+        integrity_fingerprint = hashlib.sha256(integrity_env.encode()).hexdigest()[:16]
+        env[GoSdkRunSetup.MODCACHE_ENV] = (
+            f"{request.module_cache_partition}-{integrity_fingerprint}"
+        )
         append_only_caches["go_mod_cache"] = "__gomodcache"
 
     # Disable the "coverage redesign" experiment on Go v1.20+ for now since Pants does not yet support it.

--- a/src/python/pants/backend/go/util_rules/sdk.py
+++ b/src/python/pants/backend/go/util_rules/sdk.py
@@ -19,6 +19,7 @@ from pants.core.util_rules.system_binaries import (
     CatBinary,
     CpBinary,
     MkdirBinary,
+    PwdBinary,
     create_binary_shims,
 )
 from pants.engine.env_vars import EnvironmentVarsRequest
@@ -94,6 +95,7 @@ async def go_sdk_invoke_setup(
     cat: CatBinary,
     cp: CpBinary,
     mkdir: MkdirBinary,
+    pwd: PwdBinary,
 ) -> GoSdkRunSetup:
     # Note: The `go` tool requires GOPATH to be an absolute path which can only be resolved
     # from within the execution sandbox. Thus, this code uses a bash script to be able to resolve
@@ -101,12 +103,15 @@ async def go_sdk_invoke_setup(
     cat_path = shlex.quote(cat.path)
     cp_path = shlex.quote(cp.path)
     mkdir_path = shlex.quote(mkdir.path)
+    pwd_path = shlex.quote(pwd.path)
     go_run_script = FileContent(
         "__run_go.sh",
         textwrap.dedent(
             f"""\
             export GOROOT={goroot.path}
-            sandbox_root="$(/bin/pwd)"
+            # `-P` is explicit: `go` needs the resolved physical path, and the shell
+            # builtin would otherwise hand back a logical path containing symlinks.
+            sandbox_root="$({pwd_path} -P)"
             export GOPATH="${{sandbox_root}}/gopath"
             export GOCACHE="${{sandbox_root}}/cache"
             {mkdir_path} -p "$GOPATH" "$GOCACHE"

--- a/src/python/pants/backend/go/util_rules/third_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/third_party_pkg.py
@@ -19,7 +19,7 @@ from pants.backend.go.util_rules.build_opts import GoBuildOptions
 from pants.backend.go.util_rules.cgo import CGoCompilerFlags
 from pants.backend.go.util_rules.embedcfg import EmbedConfig
 from pants.backend.go.util_rules.pkg_analyzer import PackageAnalyzerSetup
-from pants.backend.go.util_rules.sdk import GoSdkProcess
+from pants.backend.go.util_rules.sdk import GoSdkProcess, GoSdkRunSetup
 from pants.build_graph.address import Address
 from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.fs import (
@@ -147,11 +147,13 @@ class ThirdPartyPkgAnalysisRequest(EngineAwareParameter):
 
 @dataclass(frozen=True)
 class AllThirdPartyPackages:
-    """All the packages downloaded from a go.mod, along with a digest of the downloaded files.
+    """All the packages downloaded from a go.mod.
 
-    The digest has files in the format `gopath/pkg/mod`, which is what `GoSdkProcess` sets `GOPATH`
-    to. This means that you can include the digest in a process and Go will properly consume it as
-    the `GOPATH`.
+    The top-level ``digest`` is always empty since module downloads were deduplicated
+    across go.mods. Each ``ThirdPartyPkgAnalysis`` instead carries its own module's
+    digest with files in ``gopath/pkg/mod/<module@version>/...`` layout; consumers
+    slice it per package (see ``resolve_third_party_pkg_sources_digest``) or merge
+    whichever digests they need into their own input digest.
     """
 
     digest: Digest
@@ -184,7 +186,6 @@ class ModuleDescriptor:
 @dataclass(frozen=True)
 class ModuleDescriptors:
     modules: FrozenOrderedSet[ModuleDescriptor]
-    go_mods_digest: Digest
 
 
 @dataclass(frozen=True)
@@ -265,17 +266,17 @@ async def analyze_module_dependencies(request: ModuleDescriptorsRequest) -> Modu
             GoSdkProcess(
                 command=["list", "-mod=readonly", "-e", "-m", "-json", "all"],
                 input_digest=request.digest,
-                output_directories=("gopath",),
                 working_dir=request.path if request.path else None,
                 # Allow downloads of the module metadata (i.e., go.mod files).
                 allow_downloads=True,
+                use_module_cache=True,
                 description="Analyze Go module dependencies.",
             )
         )
     )
 
     if len(mod_list_result.stdout) == 0:
-        return ModuleDescriptors(FrozenOrderedSet(), EMPTY_DIGEST)
+        return ModuleDescriptors(FrozenOrderedSet())
 
     descriptors: dict[tuple[str, str], ModuleDescriptor] = {}
 
@@ -309,7 +310,7 @@ async def analyze_module_dependencies(request: ModuleDescriptorsRequest) -> Modu
     # Gazelle does this, mainly to store the sum on the go_repository rule. We could store it (or its
     # absence) to be able to download sums automatically.
 
-    return ModuleDescriptors(FrozenOrderedSet(descriptors.values()), mod_list_result.output_digest)
+    return ModuleDescriptors(FrozenOrderedSet(descriptors.values()))
 
 
 def strip_sandbox_prefix(path: str, marker: str) -> str:
@@ -563,12 +564,21 @@ async def download_and_analyze_module(
         synthetic_files.append(FileContent("go.sum", synthetic_go_sum.encode()))
     synthetic_digest = await create_digest(CreateDigest(synthetic_files))
 
+    # Fetch the module into the named cache and copy to gopath/pkg/mod in one process.
+    # The fetch mode in __run_go.sh handles both steps within a single process invocation:
+    # it runs `go mod download -json`, emits the metadata on stdout, then copies the
+    # extracted tree from __gomodcache into gopath/pkg/mod. Combining the steps means the
+    # copy always reads the cache state the download just produced, rather than a separate
+    # later process observing a cache that may have been wiped in between; an external
+    # wipe during the copy itself still fails closed (the script exits non-zero).
     download_result = await fallible_to_exec_result_or_raise(
         **implicitly(
             GoSdkProcess(
-                ("mod", "download", "-json", f"{request.name}@{request.version}"),
+                (),
+                env={GoSdkRunSetup.FETCH_MODULE_ENV: f"{request.name}@{request.version}"},
                 input_digest=synthetic_digest,
                 allow_downloads=True,
+                use_module_cache=True,
                 output_directories=("gopath",),
                 description=f"Download Go module {request.name}@{request.version}.",
             )
@@ -577,12 +587,30 @@ async def download_and_analyze_module(
 
     if len(download_result.stdout) == 0:
         raise AssertionError(
-            f"Expected output from `go mod download` for {request.name}@{request.version}."
+            f"Expected metadata output from module fetch for {request.name}@{request.version}."
         )
+    module_metadata_json = json.loads(download_result.stdout)
 
-    module_metadata = json.loads(download_result.stdout)
-    module_sources_relpath = strip_sandbox_prefix(module_metadata["Dir"], "gopath/")
-    go_mod_relpath = strip_sandbox_prefix(module_metadata["GoMod"], "gopath/")
+    # Dir/GoMod point into __gomodcache (absolute sandbox paths). Extract the
+    # portion after __gomodcache/ to get the relative path within the cache tree,
+    # then re-prefix with gopath/pkg/mod/ to match where the copy step placed them.
+    # strip_sandbox_prefix returns path[marker_pos:] (includes the marker), so we
+    # strip the marker length to get just the relative tail.
+    _modcache_marker = "__gomodcache/"
+    _dir_from_marker = strip_sandbox_prefix(module_metadata_json["Dir"], _modcache_marker)
+    _gomod_from_marker = strip_sandbox_prefix(module_metadata_json["GoMod"], _modcache_marker)
+    if not _dir_from_marker.startswith(_modcache_marker) or not _gomod_from_marker.startswith(
+        _modcache_marker
+    ):
+        raise AssertionError(
+            f"Module fetch metadata for {request.name}@{request.version} did not point into "
+            f"the module cache: Dir={module_metadata_json['Dir']!r} "
+            f"GoMod={module_metadata_json['GoMod']!r}. This should not happen. Please open an "
+            "issue at https://github.com/pantsbuild/pants/issues/new/choose with this error "
+            "message."
+        )
+    module_sources_relpath = "gopath/pkg/mod/" + _dir_from_marker[len(_modcache_marker) :]
+    go_mod_relpath = "gopath/pkg/mod/" + _gomod_from_marker[len(_modcache_marker) :]
 
     module_sources_snapshot = await digest_to_snapshot(
         **implicitly(
@@ -597,6 +625,13 @@ async def download_and_analyze_module(
             )
         )
     )
+
+    if not any(p.startswith(module_sources_relpath) for p in module_sources_snapshot.files):
+        raise AssertionError(
+            f"The download of Go module {request.name}@{request.version} captured no files "
+            f"under {module_sources_relpath}. This should not happen. Please open an issue at "
+            "https://github.com/pantsbuild/pants/issues/new/choose with this error message."
+        )
 
     candidate_package_dirs = []
     files_by_dir = group_by_dir(

--- a/src/python/pants/backend/go/util_rules/third_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/third_party_pkg.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import dataclasses
+import hashlib
 import json
 import logging
 import os
@@ -269,7 +270,12 @@ async def analyze_module_dependencies(request: ModuleDescriptorsRequest) -> Modu
                 working_dir=request.path if request.path else None,
                 # Allow downloads of the module metadata (i.e., go.mod files).
                 allow_downloads=True,
-                use_module_cache=True,
+                # The `go.mod`/`go.sum` pair in the input digest pins every `go.mod` file this
+                # step may fetch, so it also identifies the cache partition those files belong
+                # in. Editing a dependency moves this module graph to a new partition and
+                # re-fetches the `.mod` files, which is cheap (they are small text files) and
+                # keeps a re-tagged module version from ever reusing the previous bytes.
+                module_cache_partition=_module_cache_partition("graph", request.digest.fingerprint),
                 description="Analyze Go module dependencies.",
             )
         )
@@ -313,6 +319,16 @@ async def analyze_module_dependencies(request: ModuleDescriptorsRequest) -> Modu
     return ModuleDescriptors(FrozenOrderedSet(descriptors.values()))
 
 
+def _module_cache_partition(kind: str, *content: str) -> str:
+    """Name the `go_mod_cache` partition that may hold `content`'s downloads.
+
+    Partitions are directories inside the named cache, so the name has to be short and free of
+    path or shell metacharacters; `content` is therefore hashed rather than used verbatim.
+    """
+    digest = hashlib.sha256("\n".join(content).encode()).hexdigest()
+    return f"{kind}-{digest[:32]}"
+
+
 def strip_sandbox_prefix(path: str, marker: str) -> str:
     """Strip a path prefix from a path using a marker string to find the start of the portion to not
     strip. This is used to strip absolute paths used in the execution sandbox by `go`.
@@ -325,6 +341,25 @@ def strip_sandbox_prefix(path: str, marker: str) -> str:
         return path[marker_pos:]
     else:
         return path
+
+
+_MODULE_CACHE_MARKER = "__gomodcache/"
+
+
+def _module_cache_relpath(path: str) -> str | None:
+    """Return `path` relative to GOMODCACHE, or None if it does not point into the module cache.
+
+    The `go` tool reports absolute sandbox paths, and the shared module cache is mounted at
+    `__gomodcache/<partition>/`. The partition directory is not part of the result: the fetch step
+    copies the tree out of GOMODCACHE itself, so what lands in `gopath/pkg/mod` starts below it.
+    """
+    from_marker = strip_sandbox_prefix(path, _MODULE_CACHE_MARKER)
+    if not from_marker.startswith(_MODULE_CACHE_MARKER):
+        return None
+    partition, _, relpath = from_marker[len(_MODULE_CACHE_MARKER) :].partition("/")
+    if not partition or not relpath:
+        return None
+    return relpath
 
 
 def _parse_go_sum(go_sum_content: bytes) -> dict[tuple[str, str], tuple[str, ...]]:
@@ -564,6 +599,23 @@ async def download_and_analyze_module(
         synthetic_files.append(FileContent("go.sum", synthetic_go_sum.encode()))
     synthetic_digest = await create_digest(CreateDigest(synthetic_files))
 
+    # The module cache partition is derived from the module's identity plus the checksums the
+    # caller expects for it. Go stores an extracted module under `<module>@<version>`, a path
+    # that says nothing about the bytes, so a single shared cache would hand a later build
+    # whatever the first build happened to store there. Whenever that disagrees with the
+    # consumer's `go.sum`, Go refuses to build with a checksum-mismatch SECURITY ERROR that
+    # persists until the cache is wiped by hand. Partitioning by the expected checksums keeps
+    # such builds in separate partitions: re-tagging a private module (or any other change to
+    # the recorded sums) simply lands in a fresh partition and re-downloads. Modules with no
+    # go.sum entries have no checksums to partition by, so they share one partition per
+    # module@version and rely on the checksum database; `setup_go_sdk_process` keeps builds that
+    # configure that database (or the proxy) differently in separate partitions.
+    module_cache_partition = _module_cache_partition(
+        "fetch",
+        f"{request.name}@{request.version}",
+        *sorted(request.go_sum_entries),
+    )
+
     # Fetch the module into the named cache and copy to gopath/pkg/mod in one process.
     # The fetch mode in __run_go.sh handles both steps within a single process invocation:
     # it runs `go mod download -json`, emits the metadata on stdout, then copies the
@@ -578,7 +630,7 @@ async def download_and_analyze_module(
                 env={GoSdkRunSetup.FETCH_MODULE_ENV: f"{request.name}@{request.version}"},
                 input_digest=synthetic_digest,
                 allow_downloads=True,
-                use_module_cache=True,
+                module_cache_partition=module_cache_partition,
                 output_directories=("gopath",),
                 description=f"Download Go module {request.name}@{request.version}.",
             )
@@ -591,17 +643,11 @@ async def download_and_analyze_module(
         )
     module_metadata_json = json.loads(download_result.stdout)
 
-    # Dir/GoMod point into __gomodcache (absolute sandbox paths). Extract the
-    # portion after __gomodcache/ to get the relative path within the cache tree,
-    # then re-prefix with gopath/pkg/mod/ to match where the copy step placed them.
-    # strip_sandbox_prefix returns path[marker_pos:] (includes the marker), so we
-    # strip the marker length to get just the relative tail.
-    _modcache_marker = "__gomodcache/"
-    _dir_from_marker = strip_sandbox_prefix(module_metadata_json["Dir"], _modcache_marker)
-    _gomod_from_marker = strip_sandbox_prefix(module_metadata_json["GoMod"], _modcache_marker)
-    if not _dir_from_marker.startswith(_modcache_marker) or not _gomod_from_marker.startswith(
-        _modcache_marker
-    ):
+    # Dir/GoMod are absolute sandbox paths into the module cache; the copy step placed the same
+    # trees under gopath/pkg/mod, so what is needed is their path relative to GOMODCACHE.
+    _dir_in_cache = _module_cache_relpath(module_metadata_json["Dir"])
+    _gomod_in_cache = _module_cache_relpath(module_metadata_json["GoMod"])
+    if _dir_in_cache is None or _gomod_in_cache is None:
         raise AssertionError(
             f"Module fetch metadata for {request.name}@{request.version} did not point into "
             f"the module cache: Dir={module_metadata_json['Dir']!r} "
@@ -609,8 +655,8 @@ async def download_and_analyze_module(
             "issue at https://github.com/pantsbuild/pants/issues/new/choose with this error "
             "message."
         )
-    module_sources_relpath = "gopath/pkg/mod/" + _dir_from_marker[len(_modcache_marker) :]
-    go_mod_relpath = "gopath/pkg/mod/" + _gomod_from_marker[len(_modcache_marker) :]
+    module_sources_relpath = "gopath/pkg/mod/" + _dir_in_cache
+    go_mod_relpath = "gopath/pkg/mod/" + _gomod_in_cache
 
     module_sources_snapshot = await digest_to_snapshot(
         **implicitly(

--- a/src/python/pants/backend/go/util_rules/third_party_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/third_party_pkg_test.py
@@ -3,7 +3,11 @@
 
 from __future__ import annotations
 
+import os
 import os.path
+import pathlib
+import stat
+import tempfile
 from textwrap import dedent
 
 import pytest
@@ -754,3 +758,214 @@ def test_gotoolchain_local_fail_fast(rule_runner: RuleRunner) -> None:
     )
     with engine_error(ProcessExecutionFailure, contains="go.mod requires go >= 1.99.0"):
         rule_runner.request(ModuleDescriptors, [ModuleDescriptorsRequest(digest, "")])
+
+
+def _make_rule_runner(named_caches_dir: str, local_store_dir: str) -> RuleRunner:
+    """Create a RuleRunner with fixed named-caches and local-store dirs (for named-cache tests).
+
+    An isolated local store is essential: with the developer's shared store, the module
+    fetch process would hit the process cache from a previous test session and never
+    execute, so the named cache under `named_caches_dir` would never be populated and
+    assertions on its contents would fail spuriously.
+    """
+    runner = RuleRunner(
+        rules=[
+            *sdk.rules(),
+            *third_party_pkg.rules(),
+            *first_party_pkg.rules(),
+            *load_go_binary.rules(),
+            *build_pkg.rules(),
+            *import_analysis.rules(),
+            *link.rules(),
+            *assembly.rules(),
+            *target_type_rules.rules(),
+            *go_mod.rules(),
+            QueryRule(AllThirdPartyPackages, [AllThirdPartyPackagesRequest]),
+            QueryRule(ThirdPartyPkgAnalysis, [ThirdPartyPkgAnalysisRequest]),
+            QueryRule(ModuleDescriptors, [ModuleDescriptorsRequest]),
+        ],
+        target_types=[GoModTarget],
+        bootstrap_args=[
+            f"--named-caches-dir={named_caches_dir}",
+            f"--local-store-dir={local_store_dir}",
+        ],
+    )
+    runner.set_options(["--golang-cgo-enabled"], env_inherit={"PATH"})
+    return runner
+
+
+def test_named_cache_digest_equality() -> None:
+    """Digest produced by download_and_analyze_module is identical across cold and warm cache.
+
+    This test is the absolute-path-leak detector: if any sandbox-absolute path leaks
+    into a captured digest, the two digests will differ because the sandbox roots differ.
+    """
+    go_mod_single = dedent(
+        """\
+        module example.com/cache-test
+        go 1.16
+        require github.com/google/uuid v1.3.0
+        """
+    )
+    with tempfile.TemporaryDirectory() as named_caches_dir, tempfile.TemporaryDirectory() as stores:
+        # Run 1: cold cache -- populates go_mod_cache named cache
+        runner1 = _make_rule_runner(named_caches_dir, f"{stores}/1")
+        digest1 = runner1.make_snapshot({"go.mod": go_mod_single, "go.sum": UUID_GO_SUM}).digest
+        result1 = runner1.request(
+            AllThirdPartyPackages,
+            [
+                AllThirdPartyPackagesRequest(
+                    Address("cache-test", target_name="mod"),
+                    digest1,
+                    "go.mod",
+                    build_opts=GoBuildOptions(),
+                )
+            ],
+        )
+        uuid_pkg1 = result1.import_paths_to_pkg_info["github.com/google/uuid"]
+
+        # Run 2: warm named cache, fresh (isolated) local store -- the fetch process
+        # re-executes but finds the module already extracted in GOMODCACHE.
+        runner2 = _make_rule_runner(named_caches_dir, f"{stores}/2")
+        digest2 = runner2.make_snapshot({"go.mod": go_mod_single, "go.sum": UUID_GO_SUM}).digest
+        result2 = runner2.request(
+            AllThirdPartyPackages,
+            [
+                AllThirdPartyPackagesRequest(
+                    Address("cache-test", target_name="mod"),
+                    digest2,
+                    "go.mod",
+                    build_opts=GoBuildOptions(),
+                )
+            ],
+        )
+        uuid_pkg2 = result2.import_paths_to_pkg_info["github.com/google/uuid"]
+
+        # Digests must be byte-identical: cold vs warm cache produces the same sources.
+        assert uuid_pkg1.digest == uuid_pkg2.digest, (
+            "Digest differs between cold and warm named cache runs -- "
+            "likely an absolute sandbox path leaked into the captured digest."
+        )
+        assert uuid_pkg1.dir_path == uuid_pkg2.dir_path
+
+        # The captured digest must contain the exact expected artifacts: the module's
+        # sources and its go.mod, in the gopath/pkg/mod layout.
+        snapshot = runner1.request(Snapshot, [uuid_pkg1.digest])
+        module_dir = "gopath/pkg/mod/github.com/google/uuid@v1.3.0"
+        assert f"{module_dir}/uuid.go" in snapshot.files, (
+            f"Expected {module_dir}/uuid.go in the captured digest; got: {snapshot.files[:10]}"
+        )
+        assert f"{module_dir}/go.mod" in snapshot.files
+        assert (
+            "gopath/pkg/mod/cache/download/github.com/google/uuid/@v/v1.3.0.mod" in snapshot.files
+        ), "Expected the download cache's .mod file (the GoMod metadata path) in the digest."
+
+        # Run 3: independent cache dir -- must still produce equal digest
+        with tempfile.TemporaryDirectory() as named_caches_dir2:
+            runner3 = _make_rule_runner(named_caches_dir2, f"{stores}/3")
+            digest3 = runner3.make_snapshot({"go.mod": go_mod_single, "go.sum": UUID_GO_SUM}).digest
+            result3 = runner3.request(
+                AllThirdPartyPackages,
+                [
+                    AllThirdPartyPackagesRequest(
+                        Address("cache-test", target_name="mod"),
+                        digest3,
+                        "go.mod",
+                        build_opts=GoBuildOptions(),
+                    )
+                ],
+            )
+            uuid_pkg3 = result3.import_paths_to_pkg_info["github.com/google/uuid"]
+            assert uuid_pkg1.digest == uuid_pkg3.digest, (
+                "Digest differs across different named-cache directories -- "
+                "likely an absolute sandbox path leaked into the captured digest."
+            )
+
+
+def test_named_cache_populated_and_writable() -> None:
+    """After a download, the go_mod_cache named cache is populated and owner-writable.
+
+    The -modcacherw flag ensures Go writes the cache with writable permissions so
+    Pants can prune or clear the named cache without permission errors.
+    """
+    go_mod_single = dedent(
+        """\
+        module example.com/cache-writability-test
+        go 1.16
+        require rsc.io/quote v1.5.2
+        """
+    )
+    rsc_quote_go_sum = dedent(
+        """\
+        golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c h1:qgOY6WgZOaTkIIMiVjBQcw93ERBE4m30iBm00nkL0i8=
+        golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+        rsc.io/quote v1.5.2 h1:w5fcysjrx7yqtD/aO+QwRjYZOKnaM9Uh2b40tElTs3Y=
+        rsc.io/quote v1.5.2/go.mod h1:LzX7hefJvL54yjefDEDHNONDjII0t9xZLPXsUe+TKr0=
+        rsc.io/sampler v1.3.0 h1:7uVkIFmeBqHfdjD+gZwtXXI+RODJ2Wc4O7MPEh/QiW4=
+        rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
+        """
+    )
+    with tempfile.TemporaryDirectory() as named_caches_dir, tempfile.TemporaryDirectory() as store:
+        runner = _make_rule_runner(named_caches_dir, store)
+        digest = runner.make_snapshot({"go.mod": go_mod_single, "go.sum": rsc_quote_go_sum}).digest
+        runner.request(
+            AllThirdPartyPackages,
+            [
+                AllThirdPartyPackagesRequest(
+                    Address("cache-writability-test", target_name="mod"),
+                    digest,
+                    "go.mod",
+                    build_opts=GoBuildOptions(),
+                )
+            ],
+        )
+        cache_dir = pathlib.Path(named_caches_dir) / "go_mod_cache"
+        assert cache_dir.exists(), (
+            f"go_mod_cache named cache directory not created at {cache_dir}; "
+            "the named cache may not be mounted or GOMODCACHE not set correctly."
+        )
+        # The exact expected artifacts must be present: the extracted module tree and
+        # the download cache's .mod file.
+        extracted_dir = cache_dir / "rsc.io" / "quote@v1.5.2"
+        assert (extracted_dir / "quote.go").is_file(), (
+            f"Extracted module source rsc.io/quote@v1.5.2/quote.go not found under {cache_dir}."
+        )
+        assert (
+            cache_dir / "cache" / "download" / "rsc.io" / "quote" / "@v" / "v1.5.2.mod"
+        ).is_file(), f"Download cache entry rsc.io/quote/@v/v1.5.2.mod not found under {cache_dir}."
+        # Verify the extracted module directory itself is owner-writable: without
+        # -modcacherw, Go leaves extracted module directories read-only, which would
+        # prevent Pants from pruning or clearing the named cache. (Checking arbitrary
+        # files is not sufficient -- cache metadata files are writable regardless.)
+        assert stat.S_IMODE(extracted_dir.stat().st_mode) & stat.S_IWUSR, (
+            f"Extracted module directory {extracted_dir} is not owner-writable; "
+            "-modcacherw flag may not be reaching the Go process."
+        )
+
+
+def test_analyze_module_dependencies_uses_named_cache() -> None:
+    """analyze_module_dependencies uses the named cache (no output_directories capture).
+
+    Verifies that after running analyze_module_dependencies, the go_mod_cache is
+    populated (named cache is mounted and used), and the returned ModuleDescriptors
+    has the expected modules without a go_mods_digest field.
+    """
+    go_mod_content = dedent(
+        """\
+        module example.com/dep-analysis-test
+        go 1.16
+        require github.com/google/uuid v1.3.0
+        """
+    )
+    with tempfile.TemporaryDirectory() as named_caches_dir, tempfile.TemporaryDirectory() as store:
+        runner = _make_rule_runner(named_caches_dir, store)
+        digest = runner.make_snapshot({"go.mod": go_mod_content, "go.sum": UUID_GO_SUM}).digest
+        result = runner.request(
+            ModuleDescriptors,
+            [ModuleDescriptorsRequest(digest=digest, path="")],
+        )
+        assert any(mod.name == "github.com/google/uuid" for mod in result.modules)
+        # go_mods_digest was removed; verify ModuleDescriptors has only 'modules'.
+        assert not hasattr(result, "go_mods_digest"), (
+            "ModuleDescriptors.go_mods_digest should have been removed in this PR."
+        )

--- a/src/python/pants/backend/go/util_rules/third_party_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/third_party_pkg_test.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import os
 import os.path
 import pathlib
+import shutil
 import stat
 import tempfile
 from textwrap import dedent
@@ -15,6 +16,7 @@ import pytest
 from pants.backend.go import target_type_rules
 from pants.backend.go.go_sources import load_go_binary
 from pants.backend.go.target_types import GoModTarget
+from pants.backend.go.testutil import gen_module_gomodproxy
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -925,14 +927,22 @@ def test_named_cache_populated_and_writable() -> None:
             "the named cache may not be mounted or GOMODCACHE not set correctly."
         )
         # The exact expected artifacts must be present: the extracted module tree and
-        # the download cache's .mod file.
-        extracted_dir = cache_dir / "rsc.io" / "quote@v1.5.2"
-        assert (extracted_dir / "quote.go").is_file(), (
-            f"Extracted module source rsc.io/quote@v1.5.2/quote.go not found under {cache_dir}."
+        # the download cache's .mod file. Both live inside the cache partition that the
+        # module's checksums map to, so look for them under any partition directory.
+        extracted_dirs = list(cache_dir.glob("fetch-*/rsc.io/quote@v1.5.2"))
+        assert len(extracted_dirs) == 1, (
+            f"Expected exactly one cache partition holding rsc.io/quote@v1.5.2 under {cache_dir}, "
+            f"got {extracted_dirs}."
         )
-        assert (
-            cache_dir / "cache" / "download" / "rsc.io" / "quote" / "@v" / "v1.5.2.mod"
-        ).is_file(), f"Download cache entry rsc.io/quote/@v/v1.5.2.mod not found under {cache_dir}."
+        extracted_dir = extracted_dirs[0]
+        assert (extracted_dir / "quote.go").is_file(), (
+            f"Extracted module source rsc.io/quote@v1.5.2/quote.go not found under {extracted_dir}."
+        )
+        download_entry = extracted_dir.parents[1] / "cache/download/rsc.io/quote/@v/v1.5.2.mod"
+        assert download_entry.is_file(), (
+            f"Download cache entry {download_entry} not found; the extracted module and its "
+            "download metadata must live in the same partition."
+        )
         # Verify the extracted module directory itself is owner-writable: without
         # -modcacherw, Go leaves extracted module directories read-only, which would
         # prevent Pants from pruning or clearing the named cache. (Checking arbitrary
@@ -941,6 +951,134 @@ def test_named_cache_populated_and_writable() -> None:
             f"Extracted module directory {extracted_dir} is not owner-writable; "
             "-modcacherw flag may not be reaching the Go process."
         )
+
+
+_PARTITION_TEST_IMPORT_PATH = "pantsbuild.org/go-cache-partition-for-test"
+_PARTITION_TEST_VERSION = "v0.0.1"
+
+
+def _run_module_from_local_proxy(
+    named_caches_dir: str,
+    local_store_dir: str,
+    proxy_dir: str,
+    body: str,
+    *,
+    publish: bool = True,
+) -> ThirdPartyPkgAnalysis:
+    """Resolve a one-package module served by a local proxy, returning the package analysis.
+
+    The proxy lives outside the build root so that several runs can share one `GOPROXY` value:
+    the module cache partition covers the download environment as well as the checksums, and a
+    per-run proxy path would put every run in its own partition regardless of contents.
+
+    With `publish=False` the proxy is left untouched, so the run can only succeed if the module
+    comes out of the shared module cache.
+    """
+    import_path = _PARTITION_TEST_IMPORT_PATH
+    version = _PARTITION_TEST_VERSION
+    files = gen_module_gomodproxy(
+        version,
+        import_path,
+        (("pkg/say/say.go", f"package say\n\nfunc Say() string {{ return {body!r} }}\n"),),
+    )
+    proxy_root = pathlib.Path(proxy_dir)
+    for path, content in files.items():
+        if not path.startswith("go-mod-proxy/"):
+            continue
+        if not publish:
+            continue
+        destination = proxy_root / path[len("go-mod-proxy/") :]
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(content.encode() if isinstance(content, str) else content)
+
+    go_mod_content = dedent(
+        f"""\
+        module example.com/cache-partition-test
+        go 1.17
+
+        require {import_path} {version}
+        """
+    )
+    go_sum_content = files["go.sum"]
+    assert isinstance(go_sum_content, str)
+
+    runner = _make_rule_runner(named_caches_dir, local_store_dir)
+    runner.set_options(
+        [
+            f"--golang-subprocess-env-vars=GOPROXY=file://{proxy_dir}",
+            "--golang-subprocess-env-vars=GOSUMDB=off",
+            "--golang-cgo-enabled",
+        ],
+        env_inherit={"PATH"},
+    )
+    snapshot_digest = runner.make_snapshot(
+        {"go.mod": go_mod_content, "go.sum": go_sum_content}
+    ).digest
+    result = runner.request(
+        AllThirdPartyPackages,
+        [
+            AllThirdPartyPackagesRequest(
+                Address("", target_name="mod"),
+                snapshot_digest,
+                "go.mod",
+                build_opts=GoBuildOptions(),
+            )
+        ],
+    )
+    return result.import_paths_to_pkg_info[f"{import_path}/pkg/say"]
+
+
+def test_module_cache_partition_is_reused_across_runs() -> None:
+    """A second run with an unreachable proxy still resolves, so the cache partition was hit.
+
+    Partitioning would be self-defeating if a partition name were not stable across runs: every
+    build would land in a fresh directory and re-download. Emptying the proxy between the runs
+    makes a re-download impossible, so the second run can only succeed from the cache.
+    """
+    with (
+        tempfile.TemporaryDirectory() as named_caches_dir,
+        tempfile.TemporaryDirectory() as stores,
+        tempfile.TemporaryDirectory() as proxy_dir,
+    ):
+        cold = _run_module_from_local_proxy(named_caches_dir, f"{stores}/1", proxy_dir, "first")
+
+        # Take the module off the proxy. The named cache is the only remaining source, and the
+        # local store is fresh, so every process re-executes rather than replaying a result.
+        shutil.rmtree(pathlib.Path(proxy_dir) / _PARTITION_TEST_IMPORT_PATH.split("/")[0])
+
+        warm = _run_module_from_local_proxy(
+            named_caches_dir, f"{stores}/2", proxy_dir, "first", publish=False
+        )
+
+    assert cold.digest == warm.digest
+
+
+def test_same_module_version_with_different_contents_do_not_collide() -> None:
+    """Two builds that disagree about the bytes behind one module@version both succeed.
+
+    Go stores an extracted module under `<module>@<version>`, a path that says nothing about
+    its contents, so a shared module cache would serve the first build's bytes to the second
+    one and fail its checksum verification with a SECURITY ERROR that survives until the cache
+    is wiped by hand. This happens whenever a version is re-tagged (private modules and
+    internal proxies do this) and, in this test, by construction.
+    """
+    with (
+        tempfile.TemporaryDirectory() as named_caches_dir,
+        tempfile.TemporaryDirectory() as stores,
+        tempfile.TemporaryDirectory() as proxy_dir,
+    ):
+        first = _run_module_from_local_proxy(named_caches_dir, f"{stores}/1", proxy_dir, "first")
+        # The second build has the same module@version but different bytes, and therefore a
+        # different go.sum. It must not be served the first build's cached extraction. Both
+        # builds read from the same proxy path, so the partition is decided by the checksums
+        # and nothing else.
+        second = _run_module_from_local_proxy(named_caches_dir, f"{stores}/2", proxy_dir, "second")
+
+    assert first.digest != second.digest, (
+        "Both builds captured identical sources, so the second one was served the first "
+        "build's cached module instead of its own. (Sharing a partition usually fails louder "
+        "than this, with Go's checksum-mismatch SECURITY ERROR raised out of the second run.)"
+    )
 
 
 def test_analyze_module_dependencies_uses_named_cache() -> None:
@@ -965,6 +1103,12 @@ def test_analyze_module_dependencies_uses_named_cache() -> None:
             [ModuleDescriptorsRequest(digest=digest, path="")],
         )
         assert any(mod.name == "github.com/google/uuid" for mod in result.modules)
+        # The analysis downloads land in their own partition, keyed on the go.mod/go.sum pair
+        # rather than on any single module's checksums.
+        cache_dir = pathlib.Path(named_caches_dir) / "go_mod_cache"
+        assert list(
+            cache_dir.glob("graph-*/cache/download/github.com/google/uuid/@v/v1.3.0.mod")
+        ), f"Module graph analysis did not populate an analysis partition under {cache_dir}."
         # go_mods_digest was removed; verify ModuleDescriptors has only 'modules'.
         assert not hasattr(result, "go_mods_digest"), (
             "ModuleDescriptors.go_mods_digest should have been removed in this PR."


### PR DESCRIPTION
Disclaimer: Like my previous Go PR, I'm still not primarily a golang developer. However, the fact that Golang doesn't work properly in Pants has been the bane of my existence for like 2 years now. The moment that Mythos/Fable dropped I immediately had it dig deeply into whether the whole road to proper-golang-in-pants could be opened up. So this is all by Claude Code with Fable 5 (xhigh), with consults to GPT 5.5 (xhigh) and Gemini 3.1 Pro. I've had it check and recheck, I ran many different roles over it, and I had it explain and re-explain it to me, and then I checked myself. The cache-partitioning commit that fixes the CI failure came later and was written by Claude Opus 5, then reviewed by three separate Fable passes (semantics, security, tests) before I pushed it; same drill of checking and re-checking.

So, as much as I dislike AI slop and am worried about AI PR overload, I've done my very best to avoid exactly that while still using AI. I hope we can get this road unblocked.

The rest is Fable talking:

---

Every Go sandbox currently gets a fresh GOMODCACHE, so a cold build re-downloads every third-party module from the network, and so does any change that invalidates the cached download processes. This is #13390; I posted the design there in https://github.com/pantsbuild/pants/issues/13390#issuecomment-4682110828 and benjyw signed off on it, deferring the Go specifics to tdyas.

This PR gives the two download processes in `third_party_pkg.py` (the only Go processes that run with `allow_downloads=True`) a `go_mod_cache` named cache, used purely as a download accelerator. Captured digests remain the source of truth: modules are copied out of the shared cache into the sandbox's `gopath/pkg/mod` before capture, so process results are byte-identical whether the cache is warm or cold, and compile, link, and vet sandboxes never see the shared cache at all. They keep running with `GOPROXY=off` against captured digests, exactly as today.

Mechanics:

- Download and copy happen in one process: a fetch mode in `__run_go.sh` runs `go mod download -json`, emits the metadata on stdout, and copies the extracted module and its go.mod out of the cache into `gopath/pkg/mod`. Keeping it one process preserves self-healing: wipe the named cache and the next run of the same process repopulates it.
- GOMODCACHE points inside `__gomodcache`, a sibling of the captured `gopath/` tree, so `output_directories=("gopath",)` can never capture the shared cache by accident.
- The cache is partitioned by the checksums the caller expects. Go stores a module at `<module>@<version>`, a path that says nothing about the bytes, so one shared cache would serve whatever the first build stored there to every later build. A disagreement then means a checksum-mismatch SECURITY ERROR that survives until someone wipes the cache by hand, and re-tagging a version (which private modules and internal proxies do) is enough to trigger it. The fetch process therefore uses a partition derived from `<module>@<version>` plus the `go.sum` entries the caller expects for it, and module-graph analysis uses one derived from the `go.mod`/`go.sum` pair in its input digest. Stable checksums mean a stable partition, so builds and repos that agree still share their downloads. Partitions accumulate, as named caches are never garbage collected today, but they stay small: an analysis partition holds only `.mod` text files, and a fetch partition holds the same extracted modules a single shared cache would have held, duplicated only when the recorded checksums for a module actually change. Each partition is a self-contained directory, so pruning by mtime later needs no bookkeeping.

  The partition also covers the environment that decides where a download comes from and whether it gets checked (`GOPROXY`, `GOPRIVATE`, `GOSUMDB` and the rest), which matters for modules with no `go.sum` entries: those have no checksums to partition by, so builds configuring a different proxy or checksum database must not share downloads.
- `-modcacherw` is added via GOFLAGS so the cache can be pruned with plain `rm -rf`.
- Checksum verification is unchanged: downloads are still verified against the synthetic per-module go.sum introduced in #23261, and nothing touches GONOSUMCHECK or GOFLAGS beyond `-modcacherw`. The trust model of the shared cache is the same as the default `~/go/pkg/mod` on a developer machine.
- Remote execution degrades gracefully: without `--remote-execution-append-only-caches-base-path` the cache mount is absent, the fetch falls back to a sandbox-local directory, and behavior is identical to today.
- `ModuleDescriptors.go_mods_digest` is removed; it had no consumers.

On a 3-go.mod / 206-module reproducer with a cold engine store, a warm module cache eliminates all 103 network downloads (the slowest module went from 8.6 s of network fetch to 3.1 s of local copy) and module-graph analysis (`go list -m`) stops hitting the network entirely. Cold wall clock on that reproducer is unchanged within noise, because compile time dominates there and proxy.golang.org is fast from my machine. The practical win is cold CI builds and slow or rate-limited proxies, where today every cold build pays the full download set again.

Tests: warm-vs-cold digest equality (which also catches absolute paths leaking into captured digests), named cache populated and writable after a download, module analysis served from the cache, and two builds publishing the same `module@version` with different contents through a local proxy, which is the collision the partitioning prevents. Release note in `docs/notes/2.34.x.md`, including the one-time invalidation from the `__run_go.sh` change.

Note: this touches the same `__run_go.sh` heredoc as #23420 (GOTOOLCHAIN pin); whichever lands second needs a trivial rebase.

