### PR TITLE
Fix derived interpreter constraints for spec target when using `[python].default_resolve_to_interpreter_constraints` (Cherry-pick of #23419)

### DIFF
--- a/src/python/pants/backend/python/target_types_rules.py
+++ b/src/python/pants/backend/python/target_types_rules.py
@@ -623,7 +623,6 @@ class DependencyValidationFieldSet(FieldSet):
     required_fields = (InterpreterConstraintsField,)
 
     interpreter_constraints: InterpreterConstraintsField
-    resolve: PythonResolveField | None = None
 
 
 class PythonValidateDependenciesRequest(ValidateDependenciesRequest):
@@ -635,19 +634,31 @@ async def validate_python_dependencies(
     request: PythonValidateDependenciesRequest,
     python_setup: PythonSetup,
 ) -> ValidatedDependencies:
-    dependencies = await concurrently(
+    root_target, dependencies = await concurrently(
         resolve_target(
             WrappedTargetRequest(
-                d, description_of_origin=f"the dependencies of {request.field_set.address}"
+                request.field_set.address,
+                description_of_origin=f"the target {request.field_set.address}",
             ),
             **implicitly(),
-        )
-        for d in request.dependencies
+        ),
+        concurrently(
+            resolve_target(
+                WrappedTargetRequest(
+                    d, description_of_origin=f"the dependencies of {request.field_set.address}"
+                ),
+                **implicitly(),
+            )
+            for d in request.dependencies
+        ),
     )
 
     # Validate that the ICs for dependencies are all compatible with our own.
     target_ics = request.field_set.interpreter_constraints.value_or_configured_default(
-        python_setup, request.field_set.resolve
+        python_setup,
+        root_target.target[PythonResolveField]
+        if root_target.target.has_field(PythonResolveField)
+        else None,
     )
     non_subset_items = []
     for dep in dependencies:

--- a/src/python/pants/backend/python/target_types_test.py
+++ b/src/python/pants/backend/python/target_types_test.py
@@ -25,22 +25,25 @@ from pants.backend.python.target_types import (
     PythonRequirementsField,
     PythonRequirementTarget,
     PythonSourcesGeneratorTarget,
+    PythonSourceTarget,
     ResolvedPexEntryPoint,
     ResolvePexEntryPointRequest,
     ResolvePythonDistributionEntryPointsRequest,
     normalize_module_mapping,
 )
 from pants.backend.python.target_types_rules import (
+    DependencyValidationFieldSet,
     InferPexBinaryEntryPointDependency,
     InferPythonDistributionDependencies,
     PexBinaryEntryPointDependencyInferenceFieldSet,
     PythonDistributionDependenciesInferenceFieldSet,
+    PythonValidateDependenciesRequest,
     resolve_pex_entry_point,
 )
 from pants.backend.python.util_rules import python_sources
 from pants.core.goals.generate_lockfiles import UnrecognizedResolveNamesError
 from pants.core.util_rules.unowned_dependency_behavior import UnownedDependencyError
-from pants.engine.addresses import Address
+from pants.engine.addresses import Address, Addresses
 from pants.engine.internals.graph import _TargetParametrizations, _TargetParametrizationsRequest
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.target import (
@@ -49,6 +52,7 @@ from pants.engine.target import (
     InvalidFieldTypeException,
     InvalidTargetException,
     Tags,
+    ValidatedDependencies,
 )
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 from pants.util.frozendict import FrozenDict
@@ -151,6 +155,222 @@ def test_resolve_pex_binary_entry_point() -> None:
     # Resolving >1 file is an error.
     with pytest.raises(ExecutionError):
         assert_resolved(entry_point="*.py", expected=EntryPoint("doesnt matter"), is_file=True)
+
+
+def _python_dependency_validation_rule_runner(*, options: Iterable[str] = ()) -> RuleRunner:
+    rule_runner = RuleRunner(
+        rules=[
+            *target_types_rules.rules(),
+            QueryRule(ValidatedDependencies, [PythonValidateDependenciesRequest]),
+        ],
+        target_types=[PythonDistribution, PythonSourceTarget],
+        objects={"python_artifact": PythonArtifact},
+    )
+    if options:
+        rule_runner.set_options(list(options))
+    return rule_runner
+
+
+def _validate_python_dependencies(rule_runner: RuleRunner) -> ValidatedDependencies:
+    tgt = rule_runner.get_target(Address("project", target_name="app"))
+    return rule_runner.request(
+        ValidatedDependencies,
+        [
+            PythonValidateDependenciesRequest(
+                DependencyValidationFieldSet.create(tgt),
+                Addresses([Address("project", target_name="dep")]),
+            )
+        ],
+    )
+
+
+def test_validate_python_dependencies_with_manual_interpreter_constraints() -> None:
+    rule_runner = _python_dependency_validation_rule_runner()
+    rule_runner.write_files(
+        {
+            "project/app.py": "",
+            "project/dep.py": "",
+            "project/BUILD": dedent(
+                """\
+                python_source(
+                    name="app",
+                    source="app.py",
+                    dependencies=[":dep"],
+                    interpreter_constraints=["==3.10.*"],
+                )
+                python_source(
+                    name="dep",
+                    source="dep.py",
+                    interpreter_constraints=[">=3.8,<4"],
+                )
+                """
+            ),
+        }
+    )
+
+    assert _validate_python_dependencies(rule_runner) == ValidatedDependencies()
+
+
+def test_validate_python_dependencies_with_matching_manual_interpreter_constraints() -> None:
+    rule_runner = _python_dependency_validation_rule_runner()
+    rule_runner.write_files(
+        {
+            "project/app.py": "",
+            "project/dep.py": "",
+            "project/BUILD": dedent(
+                """\
+                python_source(
+                    name="app",
+                    source="app.py",
+                    dependencies=[":dep"],
+                    interpreter_constraints=["==3.10.*"],
+                )
+                python_source(
+                    name="dep",
+                    source="dep.py",
+                    interpreter_constraints=["==3.10.*"],
+                )
+                """
+            ),
+        }
+    )
+
+    assert _validate_python_dependencies(rule_runner) == ValidatedDependencies()
+
+
+def test_validate_python_dependencies_with_incompatible_manual_interpreter_constraints() -> None:
+    rule_runner = _python_dependency_validation_rule_runner()
+    rule_runner.write_files(
+        {
+            "project/app.py": "",
+            "project/dep.py": "",
+            "project/BUILD": dedent(
+                """\
+                python_source(
+                    name="app",
+                    source="app.py",
+                    dependencies=[":dep"],
+                    interpreter_constraints=[">=3.8,<4"],
+                )
+                python_source(
+                    name="dep",
+                    source="dep.py",
+                    interpreter_constraints=["==3.10.*"],
+                )
+                """
+            ),
+        }
+    )
+
+    with pytest.raises(ExecutionError) as exc:
+        _validate_python_dependencies(rule_runner)
+    assert isinstance(exc.value.wrapped_exceptions[0], InvalidFieldException)
+
+
+def test_validate_python_dependencies_explicit_interpreter_constraints_ignore_resolve_default() -> (
+    None
+):
+    rule_runner = _python_dependency_validation_rule_runner(
+        options=[
+            "--python-enable-resolves",
+            "--python-default-to-resolve-interpreter-constraints",
+            "--python-default-resolve=myresolve",
+            "--python-resolves={'myresolve': 'myresolve.lock'}",
+            "--python-resolves-to-interpreter-constraints={'myresolve': ['==3.11.*']}",
+        ]
+    )
+    rule_runner.write_files(
+        {
+            "project/app.py": "",
+            "project/dep.py": "",
+            "project/BUILD": dedent(
+                """\
+                python_source(
+                    name="app",
+                    source="app.py",
+                    dependencies=[":dep"],
+                    resolve="myresolve",
+                    interpreter_constraints=["==3.10.*"],
+                )
+                python_source(
+                    name="dep",
+                    source="dep.py",
+                    interpreter_constraints=[">=3.8,<4"],
+                )
+                """
+            ),
+        }
+    )
+
+    assert _validate_python_dependencies(rule_runner) == ValidatedDependencies()
+
+
+def test_validate_python_dependencies_with_resolve_interpreter_constraints_default() -> None:
+    rule_runner = _python_dependency_validation_rule_runner(
+        options=[
+            "--python-enable-resolves",
+            "--python-default-to-resolve-interpreter-constraints",
+            "--python-default-resolve=myresolve",
+            "--python-resolves={'myresolve': 'myresolve.lock'}",
+            "--python-resolves-to-interpreter-constraints={'myresolve': ['==3.10.*']}",
+        ]
+    )
+    rule_runner.write_files(
+        {
+            "project/app.py": "",
+            "project/dep.py": "",
+            "project/BUILD": dedent(
+                """\
+                python_source(
+                    name="app",
+                    source="app.py",
+                    dependencies=[":dep"],
+                    resolve="myresolve",
+                )
+                python_source(
+                    name="dep",
+                    source="dep.py",
+                    resolve="myresolve",
+                )
+                """
+            ),
+        }
+    )
+
+    assert _validate_python_dependencies(rule_runner) == ValidatedDependencies()
+
+
+def test_validate_python_dependencies_without_python_resolve_field() -> None:
+    rule_runner = _python_dependency_validation_rule_runner(
+        options=[
+            "--python-enable-resolves",
+            "--python-default-to-resolve-interpreter-constraints",
+            "--python-resolves={'a': 'a.lock', 'b': 'b.lock'}",
+            "--python-resolves-to-interpreter-constraints={'a': ['==3.10.*'], 'b': ['==3.11.*']}",
+        ]
+    )
+    rule_runner.write_files(
+        {
+            "project/dep.py": "",
+            "project/BUILD": dedent(
+                """\
+                python_distribution(
+                    name="app",
+                    dependencies=[":dep"],
+                    provides=python_artifact(name="demo"),
+                )
+                python_source(
+                    name="dep",
+                    source="dep.py",
+                    resolve="a",
+                    interpreter_constraints=[">=3.8,<4"],
+                )
+                """
+            ),
+        }
+    )
+
+    assert _validate_python_dependencies(rule_runner) == ValidatedDependencies()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #23418.

  ## Problem

  When `[python].default_to_resolve_interpreter_constraints` is enabled, `validate_python_dependencies` should derive a target's default interpreter constraints from its configured Python resolve when the
  target does not set `interpreter_constraints` directly.

  The dependency side already did this correctly by reading `PythonResolveField` directly from each dependency target. The root target being validated did not: `DependencyValidationFieldSet` declared
  `resolve` as `PythonResolveField | None`, and `FieldSet.create()` only populates attributes whose annotation is a direct `Field` subclass. Because the union annotation was ignored, the field set kept the
  dataclass default of `None`, causing the root target to fall back to global Python interpreter constraints instead of the resolve-derived constraints.

  That made validation asymmetric: the root target used global interpreter constraints, while dependencies used resolve-derived interpreter constraints.

  ## Solution

  Change `DependencyValidationFieldSet.resolve` to be a direct `PythonResolveField` annotation so `FieldSet.create()` includes it. `PythonResolveField` remains optional for dependency validation because it
  is not part of `required_fields`; this preserves the existing FieldSet optional-field pattern while allowing resolve-capable Python targets to carry their actual resolve into validation.

  The tests now cover manual interpreter constraint validation, explicit target interpreter constraints overriding resolve defaults, and the resolve-derived default case that reproduces the issue.

## Additional

Any chance I can have this cherry-picked into a patch version?
