### PR TITLE
(Re)implement ipex functionality

### DIFF
--- a/src/python/pants/backend/python/goals/package_pex_binary.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary.py
@@ -51,6 +51,7 @@ from pants.backend.python.target_types import (
     ResolvePexEntryPointRequest,
 )
 from pants.backend.python.target_types_rules import resolve_pex_entry_point
+from pants.backend.python.util_rules.ipex import IpexRequest, create_ipex
 from pants.backend.python.util_rules.pex import create_pex, digest_complete_platforms
 from pants.backend.python.util_rules.pex_from_targets import (
     PexFromTargetsRequest,
@@ -67,10 +68,29 @@ from pants.core.goals.run import RunFieldSet, RunInSandboxBehavior
 from pants.engine.intrinsics import digest_to_snapshot
 from pants.engine.rules import collect_rules, implicitly, rule
 from pants.engine.unions import UnionRule
+from pants.option.option_types import BoolOption
+from pants.option.subsystem import Subsystem
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
+from pants.util.strutil import softwrap
 
 logger = logging.getLogger(__name__)
+
+
+class PexCreationOptions(Subsystem):
+    options_scope = "pex-creation"
+    help = "Options for creating PEX files."
+
+    generate_ipex = BoolOption(
+        default=False,
+        help=softwrap(
+            """
+            Generate a dehydrated PEX that resolves and caches its third-party requirements when
+            first executed, instead of embedding those requirements at package time.
+            """
+        ),
+        advanced=True,
+    )
 
 
 @dataclass(frozen=True)
@@ -265,11 +285,17 @@ async def package_pex_binary(
 @rule
 async def built_package_for_pex_from_targets_request(
     field_set: PexBinaryFieldSet,
+    pex_creation_options: PexCreationOptions,
 ) -> BuiltPackage:
     pft_request = await package_pex_binary(field_set, **implicitly())
 
     base_pex_request = await create_pex_from_targets(**implicitly(pft_request.request))
     if field_set.builds_pex_and_scie():
+        if pex_creation_options.generate_ipex:
+            raise ValueError(
+                "The `[pex-creation].generate_ipex` option is not compatible with "
+                "`pex_binary` targets that set `scie`."
+            )
         pex_request = dataclasses.replace(
             base_pex_request,
             additional_args=(*base_pex_request.additional_args, *field_set.generate_scie_args()),
@@ -277,12 +303,15 @@ async def built_package_for_pex_from_targets_request(
     else:
         pex_request = base_pex_request
 
+    if pex_creation_options.generate_ipex:
+        pex_request = await create_ipex(**implicitly(IpexRequest(pex_request)))
+
     pex = await create_pex(**implicitly(pex_request))
     snapshot = await digest_to_snapshot(pex.digest)
 
     # "The" PEX, and not scie, hashes, or future auxiliary files must be first
     artifacts = [BuiltPackageArtifact(pft_request.request.output_filename)]
-    if PexLayout.ZIPAPP == pft_request.request.layout:
+    if PexLayout.ZIPAPP == pex_request.layout:
         artifacts.extend(
             BuiltPackageArtifact(artifact)
             for artifact in snapshot.files

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -48,6 +48,7 @@ from pants.backend.python.target_types import (
 )
 from pants.backend.python.util_rules import (
     ancestor_files,
+    ipex,
     local_dists,
     local_dists_pep660,
     pex,
@@ -78,6 +79,7 @@ def rules():
         # Util rules
         *ancestor_files.rules(),
         *dependency_inference_rules.rules(),
+        *ipex.rules(),
         *local_dists_pep660.rules(),
         *pex.rules(),
         *pex_from_targets.rules(),

--- a/src/python/pants/backend/python/util_rules/ipex.py
+++ b/src/python/pants/backend/python/util_rules/ipex.py
@@ -1,0 +1,178 @@
+# Copyright 2026 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import shlex
+from dataclasses import dataclass
+
+from pants.backend.python.target_types import EntryPoint, Executable, PexLayout
+from pants.backend.python.util_rules.ipex_launcher import APP_CODE_PREFIX
+from pants.backend.python.util_rules.pex import PexRequest, create_pex
+from pants.backend.python.util_rules.pex_cli import PexCli
+from pants.backend.python.util_rules.pex_requirements import (
+    EntireLockfile,
+    PexRequirements,
+    Resolve,
+    ResolveConfigRequest,
+    determine_resolve_config,
+)
+from pants.core.util_rules import system_binaries
+from pants.core.util_rules.stripped_source_files import StrippedFileNameRequest, strip_file_name
+from pants.core.util_rules.system_binaries import UnzipBinary
+from pants.engine.fs import EMPTY_DIGEST, AddPrefix, CreateDigest, FileContent, MergeDigests
+from pants.engine.intrinsics import add_prefix, create_digest, digest_to_snapshot, merge_digests
+from pants.engine.process import Process, fallible_to_exec_result_or_raise
+from pants.engine.rules import collect_rules, concurrently, implicitly, rule
+from pants.util.frozendict import FrozenDict
+from pants.util.resources import read_sibling_resource
+
+
+@dataclass(frozen=True)
+class IpexRequest:
+    underlying_request: PexRequest
+
+
+def _resolve_name(requirements: PexRequirements | EntireLockfile) -> str | None:
+    if isinstance(requirements, EntireLockfile):
+        return requirements.lockfile.resolve_name
+    if isinstance(requirements.from_superset, Resolve):
+        return requirements.from_superset.name
+    return None
+
+
+async def _pex_args_for_hydrated_pex(request: PexRequest) -> tuple[str, ...]:
+    args = []
+    if request.main is not None:
+        if isinstance(request.main, Executable):
+            stripped = await strip_file_name(StrippedFileNameRequest(request.main.spec))
+            args.extend(("--executable", stripped.value))
+        else:
+            args.extend(request.main.iter_pex_args())
+    args.extend(
+        f"--inject-args={shlex.quote(injected_arg)}" for injected_arg in request.inject_args
+    )
+    args.extend(f"--inject-env={key}={value}" for key, value in sorted(request.inject_env.items()))
+    return tuple(args)
+
+
+@rule
+async def create_ipex(request: IpexRequest, unzip: UnzipBinary) -> PexRequest:
+    # 1. Create the original PEX as-is without sources, in order to get the
+    #    transitively-resolved requirements from its PEX-INFO.
+    original_request = request.underlying_request
+
+    # Removing the entry point and sources means this process execution can stay cached even when
+    # the source files change. That matters for large resolves, which can take minutes uncached.
+    requirements_only_request = dataclasses.replace(
+        original_request,
+        layout=PexLayout.ZIPAPP,
+        main=None,
+        sources=None,
+        additional_inputs=EMPTY_DIGEST,
+        inject_args=(),
+        inject_env=FrozenDict(),
+        additional_args=(),
+        pex_path=(),
+        description=f"Resolving requirements for {original_request.output_filename}",
+    )
+    requirements_only_pex = await create_pex(**implicitly(requirements_only_request))
+
+    # 2. Extract its PEX-INFO. The hydrated PEX generated at runtime will use this data to preserve
+    #    the original resolved requirements.
+    pex_info_result = await fallible_to_exec_result_or_raise(
+        **implicitly(
+            Process(
+                argv=(unzip.path, "-p", requirements_only_pex.name, "PEX-INFO"),
+                input_digest=requirements_only_pex.digest,
+                description=f"Extract PEX-INFO from {requirements_only_pex.name}",
+            )
+        )
+    )
+
+    # 3. Add the original source files in a subdirectory and compute the PEX args needed to recreate
+    #    the original entry point and injected args/env.
+    resolve_config, prefixed_sources_digest, pex_args = await concurrently(
+        determine_resolve_config(
+            ResolveConfigRequest(_resolve_name(original_request.requirements)), **implicitly()
+        ),
+        add_prefix(AddPrefix(original_request.sources or EMPTY_DIGEST, APP_CODE_PREFIX)),
+        _pex_args_for_hydrated_pex(original_request),
+    )
+    prefixed_sources = await digest_to_snapshot(prefixed_sources_digest)
+
+    # 4. Create IPEX-INFO, BOOTSTRAP-PEX-INFO, and the launcher.
+    #
+    # IPEX-INFO is interpreted by ipex_launcher.py:
+    # {
+    #   "code": [<source files to add to the hydrated PEX when bootstrapped>],
+    #   "resolver_settings": {<indexes and find-links to use when bootstrapping>},
+    #   "pex_args": [<entry point and injected args/env to apply to the hydrated PEX>],
+    # }
+    ipex_info = {
+        "code": sorted(prefixed_sources.files),
+        "resolver_settings": {
+            "indexes": list(resolve_config.indexes),
+            "find_links": list(resolve_config.find_links),
+        },
+        "pex_args": list(pex_args),
+    }
+
+    pex_version = PexCli.default_version.removeprefix("v")
+    # BOOTSTRAP-PEX-INFO is the original requirements-only PEX-INFO. The hydrated PEX generated
+    # when the ipex first runs uses it to recover the resolved requirement set.
+    #
+    # ipex_launcher.py is the bootstrap script that hydrates the ipex with fully resolved
+    # requirements before executing the hydrated PEX.
+    metadata_digest, launcher_digest = await concurrently(
+        create_digest(
+            CreateDigest(
+                [
+                    FileContent("BOOTSTRAP-PEX-INFO", pex_info_result.stdout),
+                    FileContent("IPEX-INFO", json.dumps(ipex_info).encode()),
+                ]
+            )
+        ),
+        create_digest(
+            CreateDigest(
+                [
+                    FileContent(
+                        "pants/backend/python/util_rules/ipex_launcher.py",
+                        read_sibling_resource(__name__, "ipex_launcher.py"),
+                    )
+                ]
+            )
+        ),
+    )
+
+    # 5. Merge all injected files, along with the prefixed source files, into the final ipex input.
+    ipex_sources = await merge_digests(
+        MergeDigests((prefixed_sources.digest, metadata_digest, launcher_digest))
+    )
+
+    # The final ipex should not contain the original requirements, or its bootstrap PEX would try to
+    # import distributions that are intentionally absent. Instead, it contains only PEX and the
+    # launcher; the hydrated PEX created on first execution resolves the original requirements from
+    # BOOTSTRAP-PEX-INFO.
+    return dataclasses.replace(
+        original_request,
+        layout=PexLayout.ZIPAPP,
+        requirements=PexRequirements((f"pex=={pex_version}",)),
+        main=EntryPoint("pants.backend.python.util_rules.ipex_launcher", "main"),
+        sources=ipex_sources,
+        additional_inputs=EMPTY_DIGEST,
+        inject_args=(),
+        inject_env=FrozenDict(),
+        additional_args=(),
+        pex_path=(),
+        description=f"Building dehydrated ipex {original_request.output_filename}",
+    )
+
+
+def rules():
+    return (
+        *collect_rules(),
+        *system_binaries.rules(),
+    )

--- a/src/python/pants/backend/python/util_rules/ipex_launcher.py
+++ b/src/python/pants/backend/python/util_rules/ipex_launcher.py
@@ -1,0 +1,109 @@
+# Copyright 2026 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+"""Entrypoint script for a dehydrated ipex file.
+
+The script builds a hydrated PEX next to itself on first execution, then execs that PEX.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import zipfile
+
+APP_CODE_PREFIX = "user_files/"
+
+
+def _strip_app_code_prefix(path: str) -> str:
+    if not path.startswith(APP_CODE_PREFIX):
+        raise ValueError(f"Path {path} in IPEX-INFO did not begin with {APP_CODE_PREFIX}.")
+    return path[len(APP_CODE_PREFIX) :]
+
+
+def _log(message: str) -> None:
+    sys.stderr.write(f"{message}\n")
+
+
+def _requirement_from_wheel_filename(filename: str) -> str | None:
+    if not filename.endswith(".whl"):
+        return None
+    parts = filename.split("-")
+    if len(parts) < 2:
+        return None
+    return f"{parts[0].replace('_', '-')}=={parts[1]}"
+
+
+def _requirements_from_pex_info(pex_info: dict) -> tuple[str, ...]:
+    requirements = []
+    distributions = pex_info.get("distributions") or {}
+    for distribution_path in distributions:
+        requirement = _requirement_from_wheel_filename(os.path.basename(distribution_path))
+        if requirement is not None:
+            requirements.append(requirement)
+    if requirements:
+        return tuple(sorted(set(requirements)))
+    return tuple(pex_info.get("requirements") or ())
+
+
+def _hydrate_pex_file(ipex_file: str, hydrated_pex_file: str) -> None:
+    with tempfile.TemporaryDirectory() as td:
+        source_dir = os.path.join(td, "sources")
+        os.makedirs(source_dir)
+        requirements_path = os.path.join(td, "requirements.txt")
+
+        with zipfile.ZipFile(ipex_file) as zf:
+            bootstrap_info = json.loads(zf.read("BOOTSTRAP-PEX-INFO").decode())
+            ipex_info = json.loads(zf.read("IPEX-INFO").decode())
+
+            for path in ipex_info["code"]:
+                output_path = os.path.join(source_dir, _strip_app_code_prefix(path))
+                os.makedirs(os.path.dirname(output_path), exist_ok=True)
+                with zf.open(path) as src, open(output_path, "wb") as dst:
+                    dst.write(src.read())
+
+        with open(requirements_path, "w", encoding="utf-8") as fp:
+            fp.write("\n".join(_requirements_from_pex_info(bootstrap_info)))
+            fp.write("\n")
+
+        resolver_settings = ipex_info["resolver_settings"]
+        argv = [
+            sys.executable,
+            "-m",
+            "pex",
+            "--output-file",
+            hydrated_pex_file,
+            "--sources-directory",
+            source_dir,
+            "--requirement",
+            requirements_path,
+            *ipex_info["pex_args"],
+            "--no-pypi",
+            *(f"--index={index}" for index in resolver_settings["indexes"]),
+            *(f"--find-links={find_link}" for find_link in resolver_settings["find_links"]),
+        ]
+        if bootstrap_info.get("distributions"):
+            argv.append("--no-transitive")
+
+        env = os.environ.copy()
+        env["PYTHONPATH"] = os.pathsep.join(sys.path)
+        subprocess.run(argv, env=env, check=True)
+
+
+def main() -> None:
+    ipex_file = sys.argv[0]
+    filename_base, ext = os.path.splitext(ipex_file)
+    hydrated_pex_file = f"{filename_base}.ipex.pex" if ext == ".pex" else f"{filename_base}.pex"
+
+    if not os.path.exists(hydrated_pex_file):
+        _log(f"Hydrating {ipex_file} to {hydrated_pex_file}...")
+        _hydrate_pex_file(ipex_file, hydrated_pex_file)
+
+    os.execv(sys.executable, [sys.executable, hydrated_pex_file, *sys.argv[1:]])
+
+
+if __name__ == "__main__":
+    main()

--- a/src/python/pants/backend/python/util_rules/ipex_launcher_test.py
+++ b/src/python/pants/backend/python/util_rules/ipex_launcher_test.py
@@ -1,7 +1,65 @@
 # Copyright 2026 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.python.util_rules.ipex_launcher import _requirements_from_pex_info
+from __future__ import annotations
+
+import json
+import subprocess
+import zipfile
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from pants.backend.python.util_rules import ipex_launcher
+from pants.backend.python.util_rules.ipex_launcher import (
+    APP_CODE_PREFIX,
+    _hydrate_pex_file,
+    _requirements_from_pex_info,
+)
+
+
+def _write_ipex(
+    path: Path,
+    *,
+    bootstrap_info: dict[str, Any],
+    ipex_info: dict[str, Any] | None = None,
+) -> None:
+    ipex_info = ipex_info or {
+        "code": [f"{APP_CODE_PREFIX}app.py"],
+        "resolver_settings": {
+            "indexes": ["https://example.invalid/simple"],
+            "find_links": ["file:///example/wheels"],
+        },
+        "pex_args": ["--entry-point", "app:main"],
+    }
+
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr("BOOTSTRAP-PEX-INFO", json.dumps(bootstrap_info))
+        zf.writestr("IPEX-INFO", json.dumps(ipex_info))
+        zf.writestr(f"{APP_CODE_PREFIX}app.py", "def main(): pass\n")
+
+
+def _capture_hydrate_pex_run(
+    monkeypatch: Any, captured: dict[str, Any]
+) -> None:
+    def fake_run(
+        argv: Sequence[str],
+        *,
+        env: dict[str, str],
+        check: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        requirements_path = Path(argv[argv.index("--requirement") + 1])
+        sources_dir = Path(argv[argv.index("--sources-directory") + 1])
+        captured.update(
+            argv=tuple(argv),
+            check=check,
+            env=env,
+            requirements=requirements_path.read_text().splitlines(),
+            app_source=(sources_dir / "app.py").read_text(),
+        )
+        return subprocess.CompletedProcess(argv, 0)
+
+    monkeypatch.setattr(ipex_launcher.subprocess, "run", fake_run)
 
 
 def test_requirements_from_pex_info_distributions() -> None:
@@ -18,3 +76,58 @@ def test_requirements_from_pex_info_distributions() -> None:
 
 def test_requirements_from_pex_info_falls_back_to_requirements() -> None:
     assert _requirements_from_pex_info({"requirements": ["requests>=2"]}) == ("requests>=2",)
+
+
+def test_hydrate_pex_file_uses_full_resolved_distribution_set(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    ipex_file = tmp_path / "app.ipex"
+    hydrated_pex_file = tmp_path / "app.pex"
+    _write_ipex(
+        ipex_file,
+        bootstrap_info={
+            "distributions": {
+                ".deps/requests-2.32.5-py3-none-any.whl": "",
+                ".deps/urllib3-2.5.0-py3-none-any.whl": "",
+                ".deps/certifi-2025.11.12-py3-none-any.whl": "",
+            },
+            "requirements": ["requests==2.32.5"],
+        },
+    )
+    captured: dict[str, Any] = {}
+    _capture_hydrate_pex_run(monkeypatch, captured)
+
+    _hydrate_pex_file(str(ipex_file), str(hydrated_pex_file))
+
+    assert captured["check"] is True
+    assert captured["requirements"] == [
+        "certifi==2025.11.12",
+        "requests==2.32.5",
+        "urllib3==2.5.0",
+    ]
+    assert captured["app_source"] == "def main(): pass\n"
+    assert "--no-transitive" in captured["argv"]
+    assert "--index=https://example.invalid/simple" in captured["argv"]
+    assert "--find-links=file:///example/wheels" in captured["argv"]
+    assert "--entry-point" in captured["argv"]
+    assert "app:main" in captured["argv"]
+
+
+def test_hydrate_pex_file_falls_back_to_requirements_when_no_distributions(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    ipex_file = tmp_path / "app.ipex"
+    hydrated_pex_file = tmp_path / "app.pex"
+    _write_ipex(
+        ipex_file,
+        bootstrap_info={
+            "requirements": ["requests>=2"],
+        },
+    )
+    captured: dict[str, Any] = {}
+    _capture_hydrate_pex_run(monkeypatch, captured)
+
+    _hydrate_pex_file(str(ipex_file), str(hydrated_pex_file))
+
+    assert captured["requirements"] == ["requests>=2"]
+    assert "--no-transitive" not in captured["argv"]

--- a/src/python/pants/backend/python/util_rules/ipex_launcher_test.py
+++ b/src/python/pants/backend/python/util_rules/ipex_launcher_test.py
@@ -1,0 +1,20 @@
+# Copyright 2026 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.backend.python.util_rules.ipex_launcher import _requirements_from_pex_info
+
+
+def test_requirements_from_pex_info_distributions() -> None:
+    assert _requirements_from_pex_info(
+        {
+            "distributions": {
+                "requests-2.32.5-py3-none-any.whl": "",
+                "typing_extensions-4.15.0-py3-none-any.whl": "",
+            },
+            "requirements": ["requests"],
+        }
+    ) == ("requests==2.32.5", "typing-extensions==4.15.0")
+
+
+def test_requirements_from_pex_info_falls_back_to_requirements() -> None:
+    assert _requirements_from_pex_info({"requirements": ["requests>=2"]}) == ("requests>=2",)


### PR DESCRIPTION
**draft mode**. Please don't merge yet - I have some fixes from our plugin to backport to this.

## Problem

We are running into the same problem as https://github.com/pex-tool/pex/issues/789. Ie., we have massive pex artifacts (in this case, pyspark) which are slow to upload, and expensive to store (we don't need 100s of copies of embedded pyspark stored at the same time).

## Solution

(Re)introducing `ipex` - a pex file packaged with sources + a dependencies lockfile. When run, it rehydrates dependencies from whichever requirements file was requested.

Essentially the same as https://github.com/pantsbuild/pants/pull/8940

## Additional Notes

Ths code here is almost entirely codex w/ GPT-5.5 + some manual tweaks by me. I told it to read the changes from https://github.com/pantsbuild/pants/pull/8940 and reimplement it on top of modern pants, then prompted it to add some more unit test cases we care about (full lockfile resoluton).