### PR TITLE
Write uv indexes and sources config to pyproject.toml.

### DIFF
--- a/docs/notes/2.33.x.md
+++ b/docs/notes/2.33.x.md
@@ -56,6 +56,8 @@ The `--changed-since` functionality now works correctly in the presence of delet
 
 The Python Build Standalone backend ([pants.backend.python.providers.experimental.python_build_standalone](https://www.pantsbuild.org/stable/reference/subsystems/python-build-standalone-python-provider)) has release metadata current through PBS release [20260414](https://github.com/astral-sh/python-build-standalone/releases/tag/20260414).
 
+Fixed a bug that prevented using the `uv` resolver with custom indexes.
+
 Fixed a bug where the Python Build Standalone provider used a host interpreter path when building in a `docker_environment`, causing `Failed to find interpreter` in the container.
 
 Fixed dependency validation for Python targets to honor resolve-derived interpreter constraints when `[python].default_to_resolve_interpreter_constraints` is enabled.

--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -353,7 +353,11 @@ async def generate_uv_lockfile(
     resolve_config.validate_for_uv(req.resolve_name)
 
     pyproject_content = generate_pyproject_toml(
-        req.resolve_name, req.interpreter_constraints, req.requirements
+        req.resolve_name,
+        req.interpreter_constraints,
+        req.requirements,
+        indexes=resolve_config.indexes,
+        sources=resolve_config.sources,
     )
 
     if generate_lockfiles_subsystem.sync:

--- a/src/python/pants/backend/python/goals/lockfile_test.py
+++ b/src/python/pants/backend/python/goals/lockfile_test.py
@@ -726,3 +726,38 @@ def test_uv_lockfile_generation(
     expected_only_binary = ["ansicolors"] if only_binary else []
     assert sorted(metadata.get("no_binary", [])) == expected_no_binary
     assert sorted(metadata.get("only_binary", [])) == expected_only_binary
+
+
+def test_uv_lockfile_generation_with_sources(rule_runner: PythonRuleRunner) -> None:
+    # Regression test for https://github.com/pantsbuild/pants/issues/23442.
+    rule_runner.set_options(
+        [
+            "--python-resolves={'test': 'test.lock'}",
+            "--python-repos-indexes=['alt=https://pypi.org/simple/']",
+            "--python-resolves-to-sources={'test': ['alt=ansicolors>=1.0']}",
+        ],
+        env_inherit=PYTHON_BOOTSTRAP_ENV,
+    )
+
+    result = rule_runner.request(
+        GenerateLockfileResult,
+        [
+            GenerateUvLockfile(
+                requirements=FrozenOrderedSet(["ansicolors==1.1.8"]),
+                find_links=FrozenOrderedSet([]),
+                interpreter_constraints=InterpreterConstraints(["CPython>=3.9,<3.15"]),
+                resolve_name="test",
+                lockfile_dest="test.lock",
+                diff=False,
+            )
+        ],
+    )
+    digest_contents = rule_runner.request(DigestContents, [result.digest])
+
+    by_path = {fc.path: fc for fc in digest_contents}
+    assert "test.lock" in by_path
+
+    lock_data = tomllib.loads(by_path["test.lock"].content.decode())
+    packages = {pkg["name"]: pkg for pkg in lock_data.get("package", []) if "version" in pkg}
+    assert "ansicolors" in packages
+    assert packages["ansicolors"]["version"] == "1.1.8"

--- a/src/python/pants/backend/python/subsystems/repos.py
+++ b/src/python/pants/backend/python/subsystems/repos.py
@@ -39,6 +39,7 @@ class PythonRepos(Subsystem):
             """
         )
     )
+
     _repos = StrListOption(
         help=softwrap(
             """
@@ -50,6 +51,7 @@ class PythonRepos(Subsystem):
         removal_version="3.0.0.dev0",
         removal_hint="A deprecated alias for `[python-repos].find_links`.",
     )
+
     indexes = StrListOption(
         default=[pypi_index],
         help=softwrap(

--- a/src/python/pants/backend/python/util_rules/pex_requirements.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements.py
@@ -12,8 +12,6 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
-from packaging.requirements import Requirement
-
 from pants.backend.python.subsystems.repos import PythonRepos
 from pants.backend.python.subsystems.setup import InvalidLockfileBehavior, PythonSetup
 from pants.backend.python.target_types import PythonRequirementsField
@@ -498,16 +496,6 @@ class ResolveConfig:
             config_lines.append("]")
             config_lines.append("")
 
-        if self.sources:
-            config_lines.append("[sources]")
-            for source in self.sources:
-                index_name, _, scope = source.partition("=")
-                req = Requirement(scope)
-                # Markers may contain double-quotes, so we use single quotes in the TOML.
-                marker = f", marker = '{req.marker}'" if req.marker else ""
-                config_lines.append(f'{req.name} = {{ index = "{index_name}"{marker} }}')
-            config_lines.append("")
-
         if self.no_binary:
             if ":all:" in self.no_binary:
                 config_lines.append("no-binary = true")
@@ -530,34 +518,6 @@ class ResolveConfig:
 
         if self.uploaded_prior_to:
             config_lines.append(f'exclude-newer = "{self.uploaded_prior_to}"')
-            config_lines.append("")
-
-        indexes = []
-        for index in self.indexes:
-            part1, _, part2 = index.partition("=")
-            (name, url) = (part1, part2) if part2 else ("", part1)
-            index_data = {"url": url}
-            if name:
-                index_data["name"] = name
-            indexes.append(index_data)
-        if indexes:
-            # To turn off uv's fallback to PyPI we must set some other index to be the default.
-            # In uv the default index has the lowest priority, regardless of its position in the
-            # list of indexes, so we set the last index to be that default, to match user intent.
-            indexes[-1]["default"] = "true"
-            for index_data in indexes:
-                name = index_data.get("name", "")
-                url = index_data.get("url", "")
-                default = index_data.get("default", False)
-                config_lines.append("[[index]]")
-                if name:
-                    config_lines.append(f'name = "{name}"')
-                config_lines.append(f'url = "{url}"')
-                if default:
-                    config_lines.append("default = true")
-                config_lines.append("")
-        else:
-            config_lines.append("no-index = true")
             config_lines.append("")
 
         return "\n".join(config_lines) + "\n" if config_lines else ""

--- a/src/python/pants/backend/python/util_rules/pex_requirements_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements_test.py
@@ -23,6 +23,7 @@ from pants.backend.python.util_rules.pex_requirements import (
     strip_comments_from_pex_json_lockfile,
     validate_metadata,
 )
+from pants.backend.python.util_rules.uv import generate_pyproject_toml
 from pants.core.util_rules.lockfile_metadata import (
     BEGIN_LOCKFILE_HEADER,
     END_LOCKFILE_HEADER,
@@ -481,22 +482,32 @@ def _uv_config(
 
 
 def test_uv_config_indexes():
-    parsed = _uv_config(indexes=[])
-    assert parsed.get("no-index") is True
-    assert "index" not in parsed
+    ics = InterpreterConstraints([">=3.8"])
 
-    parsed = _uv_config(indexes=["https://example.com/simple"])
-    assert len(parsed["index"]) == 1
-    assert parsed["index"][0]["url"] == "https://example.com/simple"
-    assert parsed["index"][0]["default"] is True
+    parsed = tomllib.loads(generate_pyproject_toml("test", ics, [], indexes=[]))
+    assert parsed["tool"]["uv"].get("no-index") is True
+    assert "index" not in parsed["tool"]["uv"]
 
-    parsed = _uv_config(
-        indexes=[
-            "https://primary.example.com/simple",
-            "fallback=https://secondary.example.com/simple",
-        ]
+    parsed = tomllib.loads(
+        generate_pyproject_toml("test", ics, [], indexes=["https://example.com/simple"])
     )
-    indexes = parsed["index"]
+    indexes = parsed["tool"]["uv"]["index"]
+    assert len(indexes) == 1
+    assert indexes[0]["url"] == "https://example.com/simple"
+    assert indexes[0]["default"] is True
+
+    parsed = tomllib.loads(
+        generate_pyproject_toml(
+            "test",
+            ics,
+            [],
+            indexes=[
+                "https://primary.example.com/simple",
+                "fallback=https://secondary.example.com/simple",
+            ],
+        )
+    )
+    indexes = parsed["tool"]["uv"]["index"]
     assert len(indexes) == 2
     assert indexes[0]["url"] == "https://primary.example.com/simple"
     assert "name" not in indexes[0]
@@ -521,19 +532,34 @@ def test_uv_config_find_links():
 
 
 def test_uv_config_sources():
-    parsed = _uv_config(sources=[])
-    assert "sources" not in parsed
+    ics = InterpreterConstraints([">=3.8"])
 
-    parsed = _uv_config(sources=["myindex=requests>=2.0"])
-    assert parsed["sources"] == {"requests": {"index": "myindex"}}
+    parsed = tomllib.loads(generate_pyproject_toml("test", ics, ["requests"], sources=tuple()))
+    assert "sources" not in parsed.get("tool", {}).get("uv", {})
 
-    parsed = _uv_config(sources=['myindex=requests>=2.0; python_version > "3.8"'])
-    assert parsed["sources"]["requests"]["index"] == "myindex"
-    assert "python_version" in parsed["sources"]["requests"]["marker"]
+    parsed = tomllib.loads(
+        generate_pyproject_toml("test", ics, ["requests"], sources=["myindex=requests>=2.0"])
+    )
+    assert parsed["tool"]["uv"]["sources"] == {"requests": {"index": "myindex"}}
 
-    parsed = _uv_config(sources=["indexa=requests>=2.0", "indexb=boto3>=1.0"])
-    assert parsed["sources"]["requests"] == {"index": "indexa"}
-    assert parsed["sources"]["boto3"] == {"index": "indexb"}
+    parsed = tomllib.loads(
+        generate_pyproject_toml(
+            "test", ics, ["requests"], sources=['myindex=requests>=2.0; python_version > "3.8"']
+        )
+    )
+    assert parsed["tool"]["uv"]["sources"]["requests"]["index"] == "myindex"
+    assert "python_version" in parsed["tool"]["uv"]["sources"]["requests"]["marker"]
+
+    parsed = tomllib.loads(
+        generate_pyproject_toml(
+            "test",
+            ics,
+            ["requests", "boto3"],
+            sources=["indexa=requests>=2.0", "indexb=boto3>=1.0"],
+        )
+    )
+    assert parsed["tool"]["uv"]["sources"]["requests"] == {"index": "indexa"}
+    assert parsed["tool"]["uv"]["sources"]["boto3"] == {"index": "indexb"}
 
 
 def test_uv_config_no_binary():

--- a/src/python/pants/backend/python/util_rules/uv.py
+++ b/src/python/pants/backend/python/util_rules/uv.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass
 from textwrap import dedent  # noqa: PNT20
 from typing import ClassVar, cast
 
+from packaging.requirements import Requirement
+
 from pants.backend.python.subsystems import uv as uv_subsystem
 from pants.backend.python.subsystems.python_native_code import PythonNativeCodeSubsystem
 from pants.backend.python.subsystems.uv import (
@@ -115,14 +117,20 @@ async def get_uv_environment(
 # The synthetic project name (pants-lockfile-for-*) must not collide with any real requirement.
 # uv will include this project as a virtual package in the lockfile, and we set package = false,
 # so it won't try to install it.
-def generate_pyproject_toml(resolve: str, ics: InterpreterConstraints, reqs: Iterable[str]) -> str:
+def generate_pyproject_toml(
+    resolve: str,
+    ics: InterpreterConstraints,
+    reqs: Iterable[str],
+    indexes: Iterable[str] | None = None,
+    sources: Iterable[str] = tuple(),
+) -> str:
     def escape_double_quotes(s: str) -> str:
         return s.replace('"', '\\"')
 
     requires_python = ",".join(str(constraint.specifier) for constraint in ics)
     deps_lines = "\n".join(f'    "{escape_double_quotes(r)}",' for r in sorted(reqs))
 
-    return dedent(
+    content = dedent(
         """
         [project]
         name = "pants-lockfile-for-{resolve}"
@@ -136,6 +144,42 @@ def generate_pyproject_toml(resolve: str, ics: InterpreterConstraints, reqs: Ite
         package = false
         """
     ).format(resolve=resolve, requires_python=requires_python, deps_lines=deps_lines)
+
+    if indexes is not None:
+        parsed_indexes = []
+        for index in indexes:
+            part1, _, part2 = index.partition("=")
+            (name, url) = (part1, part2) if part2 else ("", part1)
+            parsed_indexes.append((name, url))
+        if parsed_indexes:
+            # To turn off uv's fallback to PyPI we must set some other index to be the default.
+            # In uv the default index has the lowest priority, regardless of its position in the
+            # list of indexes, so we set the last index to be that default, to match user intent.
+            for i, (name, url) in enumerate(parsed_indexes):
+                is_default = i == len(parsed_indexes) - 1
+                content += "[[tool.uv.index]]\n"
+                if name:
+                    content += f'name = "{name}"\n'
+                content += f'url = "{url}"\n'
+                if is_default:
+                    content += "default = true\n"
+                content += "\n"
+        else:
+            content += "no-index = true\n\n"
+
+    sources = tuple(sources)
+    if sources:
+        source_lines = ["[tool.uv.sources]"]
+        for source in sources:
+            index_name, _, scope = source.partition("=")
+            req = Requirement(scope)
+            # Markers may contain double-quotes, so we use single quotes in the TOML.
+            marker = f", marker = '{req.marker}'" if req.marker else ""
+            source_lines.append(f'{req.name} = {{ index = "{index_name}"{marker} }}')
+        source_lines.append("")
+        content += "\n".join(source_lines) + "\n"
+
+    return content
 
 
 @rule


### PR DESCRIPTION
Previously we wrote them to uv.toml, but unlike
other uv config, which can be in either file,
sources and indexes must be in pyproject.toml.

Fixes #23442