### PR TITLE
add a resolve toggle for bundled lockfiles

### DIFF
--- a/build-support/bin/generate_builtin_lockfiles.py
+++ b/build-support/bin/generate_builtin_lockfiles.py
@@ -48,6 +48,7 @@ from pants.backend.python.subsystems.debugpy import DebugPy
 from pants.backend.python.subsystems.ipython import IPython
 from pants.backend.python.subsystems.pytest import PyTest
 from pants.backend.python.subsystems.python_tool_base import PythonToolRequirementsBase
+from pants.backend.python.subsystems.setup import Resolver
 from pants.backend.python.subsystems.setuptools import Setuptools
 from pants.backend.python.subsystems.setuptools_scm import SetuptoolsSCM
 from pants.backend.python.subsystems.twine import TwineSubsystem
@@ -189,6 +190,13 @@ def create_parser() -> argparse.ArgumentParser:
         "--all-jvm", action="store_true", help="Regenerate all builtin JVM tool lockfiles."
     )
     parser.add_argument(
+        "--resolver",
+        type=Resolver,
+        choices=list(Resolver),
+        default=Resolver.pex,
+        help="The Python resolver (pex or uv) used to generate Python tool lockfiles.",
+    )
+    parser.add_argument(
         "--dry-run", action="store_true", help="Show Pants commands that would be run."
     )
     parser.add_argument(
@@ -210,7 +218,7 @@ def create_parser() -> argparse.ArgumentParser:
 
 
 def generate_python_tool_lockfiles(
-    tools: Sequence[PythonTool], dry_run: bool, keep_sandboxes: KeepSandboxes
+    tools: Sequence[PythonTool], resolver: Resolver, dry_run: bool, keep_sandboxes: KeepSandboxes
 ) -> None:
     def req_file(_tool: PythonTool) -> str:
         return f"{_tool.name}-requirements.txt"
@@ -252,7 +260,7 @@ def generate_python_tool_lockfiles(
             "--python-pip-version=latest",
             f"--python-interpreter-constraints=['{default_python_interpreter_constraints}']",
             "--python-enable-resolves",
-            "--python-resolver=uv",
+            f"--python-resolver={resolver.value}",
             # Unset any existing resolve names in the Pants repo, and set to just our temporary ones.
             f"--python-resolves={resolves}",
             f"--python-resolves-to-interpreter-constraints={resolves_to_ics}",
@@ -388,7 +396,9 @@ def main() -> None:
             "or via the --all-python/--all-jvm flags."
         )
     if python_tools:
-        generate_python_tool_lockfiles(python_tools, args.dry_run, args.keep_sandboxes)
+        generate_python_tool_lockfiles(
+            python_tools, args.resolver, args.dry_run, args.keep_sandboxes
+        )
     if jvm_tools:
         generate_jvm_tool_lockfiles(jvm_tools, args.dry_run, args.keep_sandboxes)
 


### PR DESCRIPTION
This adds a `resolve` toggle to generate_builtin_lockfiles.py so we can split apart "switching to uv" from the next generation.

Originally part of https://github.com/pantsbuild/pants/pull/23440