### PR TITLE
Pass the same set of object files when retrying linking for cgo

### DIFF
--- a/docs/notes/2.33.x.md
+++ b/docs/notes/2.33.x.md
@@ -114,6 +114,8 @@ The Go standard library is now pre-compiled with a single `go install std` build
 
 The Go backend now supports CGo directives `nocallback` and `noescape`, which were introduced by Go 1.24.
 
+Fixed a linker error when building CGo packages in some environments.
+
 ### Plugin API changes
 
 `FrozenOrderedSet` is now backed by a native Rust implementation and is built in `__new__` rather than `__init__`. Subclasses that customized the set's contents by overriding `__init__` (for example, to transform the input iterable before constructing) must move that logic to `__new__`, since the set is already built and immutable by the time `__init__` runs.

--- a/src/python/pants/backend/go/util_rules/cgo.py
+++ b/src/python/pants/backend/go/util_rules/cgo.py
@@ -497,17 +497,19 @@ async def _dynimport(
         else golang_env_aware.cgo_gcc_binary_name
     )
 
+    objs_to_link = [
+        *obj_files,
+        os.path.join(obj_dir_path, "_cgo_main.o"),
+        *sorted(transitive_prebuilt_objects),
+    ]
+
     cgo_binary_link_result = await _gccld(
         binary_name=linker_binary_name,
         input_digest=obj_digest,
         dir_path=dir_path,
         outfile=dynobj,
         flags=ldflags,
-        objs=[
-            *obj_files,
-            os.path.join(obj_dir_path, "_cgo_main.o"),
-            *sorted(transitive_prebuilt_objects),
-        ],
+        objs=objs_to_link,
         description=f"Link _cgo_.o ({import_path})",
     )
     if cgo_binary_link_result.exit_code != 0:
@@ -548,7 +550,7 @@ async def _dynimport(
             dir_path=dir_path,
             outfile=dynobj,
             flags=[*ldflags, allow_unresolved_symbols_ldflag],
-            objs=obj_files,
+            objs=objs_to_link,
             description=f"Link _cgo_.o ({import_path})",
         )
         if cgo_binary_link_result.exit_code != 0:


### PR DESCRIPTION
With the latest `main` branch, `pants test src/python/pants/backend/go/util_rules/cgo_test.py:tests` fails in my environment:

```
============================= test session starts ==============================
collecting ... collected 5 items

src/python/pants/backend/go/util_rules/cgo_test.py::test_cgo_compile PASSED [ 20%]
src/python/pants/backend/go/util_rules/cgo_test.py::test_cgo_with_cxx_source FAILED [ 40%]
src/python/pants/backend/go/util_rules/cgo_test.py::test_cgo_with_objc_source FAILED [ 60%]
src/python/pants/backend/go/util_rules/cgo_test.py::test_cgo_with_fortran_source FAILED [ 80%]
src/python/pants/backend/go/util_rules/cgo_test.py::test_cgo_with_embedded_static_library PASSED [100%]

=================================== FAILURES ===================================
```

The 3 tests fail with the same linker error:

```
ValueError: cgo binary link failed:
stdout:

stderr:
Undefined symbols for architecture arm64:
  "_main", referenced from:
      <initial-undefines>
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

(found this issue during playing around the tests in https://github.com/pantsbuild/pants/pull/23439)

In `cgo.py`, linking of object files are retried with additional linker options:
https://github.com/pantsbuild/pants/blob/main/src/python/pants/backend/go/util_rules/cgo.py#L500-L559
For relatively simple case, linking succeeds at the 1st try. In the case of ObjC, C++ and Fortran tests, linking fails (due to lack of the language's stdlib?) and retried. `_main` (cgo-generated dummy function) resides in `_cgo_main.o` file and is required by the linker, but the object file is not included in the linker flags at the 2nd try.

My environment:
- OS: macOS 15.7.7
- gcc: clang-1700.6.4.2
- python: 3.14.6
- go: 1.26.2