### PR TITLE
Fix uv index: move indexes to uv.toml, keep sources in pyproject.toml

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex_requirements.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements.py
@@ -520,6 +520,39 @@ class ResolveConfig:
             config_lines.append(f'exclude-newer = "{self.uploaded_prior_to}"')
             config_lines.append("")
 
+        # Indexes must go in uv.toml rather than pyproject.toml because all uv invocations
+        # use --no-config --config-file=uv.toml, which causes [tool.uv] in pyproject.toml
+        # to be ignored.
+        # TOML ordering: [[index]] (array-of-tables) must come after all top-level
+        # key-value pairs, otherwise subsequent keys are absorbed into the last array element.
+        indexes = []
+        for index in self.indexes:
+            part1, _, part2 = index.partition("=")
+            (name, url) = (part1, part2) if part2 else ("", part1)
+            index_data = {"url": url}
+            if name:
+                index_data["name"] = name
+            indexes.append(index_data)
+        if indexes:
+            # To turn off uv's fallback to PyPI we must set some other index to be the default.
+            # In uv the default index has the lowest priority, regardless of its position in the
+            # list of indexes, so we set the last index to be that default, to match user intent.
+            indexes[-1]["default"] = "true"
+            for index_data in indexes:
+                name = index_data.get("name", "")
+                url = index_data.get("url", "")
+                default = index_data.get("default", False)
+                config_lines.append("[[index]]")
+                if name:
+                    config_lines.append(f'name = "{name}"')
+                config_lines.append(f'url = "{url}"')
+                if default:
+                    config_lines.append("default = true")
+                config_lines.append("")
+        else:
+            config_lines.append("no-index = true")
+            config_lines.append("")
+
         return "\n".join(config_lines) + "\n" if config_lines else ""
 
     def validate_for_uv(self, resolve_name: str) -> None:

--- a/src/python/pants/backend/python/util_rules/pex_requirements_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements_test.py
@@ -482,32 +482,23 @@ def _uv_config(
 
 
 def test_uv_config_indexes():
-    ics = InterpreterConstraints([">=3.8"])
+    parsed = _uv_config(indexes=[])
+    assert parsed.get("no-index") is True
+    assert "index" not in parsed
 
-    parsed = tomllib.loads(generate_pyproject_toml("test", ics, [], indexes=[]))
-    assert parsed["tool"]["uv"].get("no-index") is True
-    assert "index" not in parsed["tool"]["uv"]
-
-    parsed = tomllib.loads(
-        generate_pyproject_toml("test", ics, [], indexes=["https://example.com/simple"])
-    )
-    indexes = parsed["tool"]["uv"]["index"]
+    parsed = _uv_config(indexes=["https://example.com/simple"])
+    indexes = parsed["index"]
     assert len(indexes) == 1
     assert indexes[0]["url"] == "https://example.com/simple"
     assert indexes[0]["default"] is True
 
-    parsed = tomllib.loads(
-        generate_pyproject_toml(
-            "test",
-            ics,
-            [],
-            indexes=[
-                "https://primary.example.com/simple",
-                "fallback=https://secondary.example.com/simple",
-            ],
-        )
+    parsed = _uv_config(
+        indexes=[
+            "https://primary.example.com/simple",
+            "fallback=https://secondary.example.com/simple",
+        ],
     )
-    indexes = parsed["tool"]["uv"]["index"]
+    indexes = parsed["index"]
     assert len(indexes) == 2
     assert indexes[0]["url"] == "https://primary.example.com/simple"
     assert "name" not in indexes[0]
@@ -515,6 +506,18 @@ def test_uv_config_indexes():
     assert indexes[1]["url"] == "https://secondary.example.com/simple"
     assert indexes[1].get("name") == "fallback"
     assert indexes[1]["default"] is True
+
+    # Verify TOML ordering: indexes (array-of-tables) coexist correctly with
+    # top-level key-value settings like find-links and no-binary-package.
+    parsed = _uv_config(
+        indexes=["https://example.com/simple"],
+        find_links=["https://example.com/wheels"],
+        no_binary=["somepkg"],
+    )
+    assert parsed["find-links"] == ["https://example.com/wheels"]
+    assert parsed["no-binary-package"] == ["somepkg"]
+    assert len(parsed["index"]) == 1
+    assert parsed["index"][0]["url"] == "https://example.com/simple"
 
 
 def test_uv_config_find_links():
@@ -538,13 +541,27 @@ def test_uv_config_sources():
     assert "sources" not in parsed.get("tool", {}).get("uv", {})
 
     parsed = tomllib.loads(
-        generate_pyproject_toml("test", ics, ["requests"], sources=["myindex=requests>=2.0"])
+        generate_pyproject_toml(
+            "test",
+            ics,
+            ["requests"],
+            indexes=["myindex=https://example.com/simple"],
+            sources=["myindex=requests>=2.0"],
+        )
     )
     assert parsed["tool"]["uv"]["sources"] == {"requests": {"index": "myindex"}}
+    # The referenced index should also be declared in pyproject.toml.
+    assert parsed["tool"]["uv"]["index"] == [
+        {"name": "myindex", "url": "https://example.com/simple"}
+    ]
 
     parsed = tomllib.loads(
         generate_pyproject_toml(
-            "test", ics, ["requests"], sources=['myindex=requests>=2.0; python_version > "3.8"']
+            "test",
+            ics,
+            ["requests"],
+            indexes=["myindex=https://example.com/simple"],
+            sources=['myindex=requests>=2.0; python_version > "3.8"'],
         )
     )
     assert parsed["tool"]["uv"]["sources"]["requests"]["index"] == "myindex"
@@ -555,11 +572,18 @@ def test_uv_config_sources():
             "test",
             ics,
             ["requests", "boto3"],
+            indexes=[
+                "indexa=https://a.example.com/simple",
+                "indexb=https://b.example.com/simple",
+            ],
             sources=["indexa=requests>=2.0", "indexb=boto3>=1.0"],
         )
     )
     assert parsed["tool"]["uv"]["sources"]["requests"] == {"index": "indexa"}
     assert parsed["tool"]["uv"]["sources"]["boto3"] == {"index": "indexb"}
+    # Both referenced indexes should be declared.
+    index_names = {idx["name"] for idx in parsed["tool"]["uv"]["index"]}
+    assert index_names == {"indexa", "indexb"}
 
 
 def test_uv_config_no_binary():

--- a/src/python/pants/backend/python/util_rules/uv.py
+++ b/src/python/pants/backend/python/util_rules/uv.py
@@ -121,7 +121,7 @@ def generate_pyproject_toml(
     resolve: str,
     ics: InterpreterConstraints,
     reqs: Iterable[str],
-    indexes: Iterable[str] | None = None,
+    indexes: Iterable[str] = (),
     sources: Iterable[str] = tuple(),
 ) -> str:
     def escape_double_quotes(s: str) -> str:
@@ -145,30 +145,32 @@ def generate_pyproject_toml(
         """
     ).format(resolve=resolve, requires_python=requires_python, deps_lines=deps_lines)
 
-    if indexes is not None:
+    # Sources map package names to named indexes and must be in pyproject.toml — uv rejects
+    # [sources] in uv.toml.  However, sources reference index names, so the referenced indexes
+    # must also be declared here (as [[tool.uv.index]]) for uv to validate the name references.
+    #
+    # Index definitions for actual package resolution go in uv.toml (via uv_config()) because
+    # all uv invocations use --no-config --config-file=uv.toml, which causes [tool.uv] config
+    # in pyproject.toml to be ignored for resolution purposes.
+    sources = tuple(sources)
+    if sources:
+        # Collect index names referenced by sources so we can declare them in pyproject.toml.
+        referenced_index_names = {source.partition("=")[0] for source in sources}
+
+        # Write [[tool.uv.index]] entries for indexes that sources reference.
         parsed_indexes = []
         for index in indexes:
             part1, _, part2 = index.partition("=")
             (name, url) = (part1, part2) if part2 else ("", part1)
             parsed_indexes.append((name, url))
-        if parsed_indexes:
-            # To turn off uv's fallback to PyPI we must set some other index to be the default.
-            # In uv the default index has the lowest priority, regardless of its position in the
-            # list of indexes, so we set the last index to be that default, to match user intent.
-            for i, (name, url) in enumerate(parsed_indexes):
-                is_default = i == len(parsed_indexes) - 1
-                content += "[[tool.uv.index]]\n"
-                if name:
-                    content += f'name = "{name}"\n'
-                content += f'url = "{url}"\n'
-                if is_default:
-                    content += "default = true\n"
-                content += "\n"
-        else:
-            content += "no-index = true\n\n"
 
-    sources = tuple(sources)
-    if sources:
+        for name, url in parsed_indexes:
+            if name in referenced_index_names:
+                content += "[[tool.uv.index]]\n"
+                content += f'name = "{name}"\n'
+                content += f'url = "{url}"\n'
+                content += "\n"
+
         source_lines = ["[tool.uv.sources]"]
         for source in sources:
             index_name, _, scope = source.partition("=")


### PR DESCRIPTION


All uv invocations use --no-config --config-file=uv.toml, which causes [tool.uv] configuration in pyproject.toml to be silently ignored for resolution purposes. Commit c7359e475b placed both [[tool.uv.index]] and [tool.uv.sources] in pyproject.toml, but indexes there are not used by uv during resolution, causing packages from private indexes to not be found.

The fix splits configuration correctly between the two files:
- [[index]] entries go in uv.toml (via ResolveConfig.uv_config()) where uv actually reads them for package resolution
- [tool.uv.sources] stays in pyproject.toml since uv rejects [sources] in uv.toml
- Indexes referenced by sources are also declared in pyproject.toml so uv can validate the name references