### PR TITLE
drop python3.9 specific tests that use the bundled lockfiles

### DIFF
--- a/build-support/bin/generate_builtin_lockfiles.py
+++ b/build-support/bin/generate_builtin_lockfiles.py
@@ -48,6 +48,7 @@ from pants.backend.python.subsystems.debugpy import DebugPy
 from pants.backend.python.subsystems.ipython import IPython
 from pants.backend.python.subsystems.pytest import PyTest
 from pants.backend.python.subsystems.python_tool_base import PythonToolRequirementsBase
+from pants.backend.python.subsystems.setup import Resolver
 from pants.backend.python.subsystems.setuptools import Setuptools
 from pants.backend.python.subsystems.setuptools_scm import SetuptoolsSCM
 from pants.backend.python.subsystems.twine import TwineSubsystem
@@ -189,6 +190,13 @@ def create_parser() -> argparse.ArgumentParser:
         "--all-jvm", action="store_true", help="Regenerate all builtin JVM tool lockfiles."
     )
     parser.add_argument(
+        "--resolver",
+        type=Resolver,
+        choices=list(Resolver),
+        default=Resolver.pex,
+        help="The Python resolver (pex or uv) used to generate Python tool lockfiles.",
+    )
+    parser.add_argument(
         "--dry-run", action="store_true", help="Show Pants commands that would be run."
     )
     parser.add_argument(
@@ -210,7 +218,7 @@ def create_parser() -> argparse.ArgumentParser:
 
 
 def generate_python_tool_lockfiles(
-    tools: Sequence[PythonTool], dry_run: bool, keep_sandboxes: KeepSandboxes
+    tools: Sequence[PythonTool], resolver: Resolver, dry_run: bool, keep_sandboxes: KeepSandboxes
 ) -> None:
     def req_file(_tool: PythonTool) -> str:
         return f"{_tool.name}-requirements.txt"
@@ -252,7 +260,7 @@ def generate_python_tool_lockfiles(
             "--python-pip-version=latest",
             f"--python-interpreter-constraints=['{default_python_interpreter_constraints}']",
             "--python-enable-resolves",
-            "--python-resolver=uv",
+            f"--python-resolver={resolver.value}",
             # Unset any existing resolve names in the Pants repo, and set to just our temporary ones.
             f"--python-resolves={resolves}",
             f"--python-resolves-to-interpreter-constraints={resolves_to_ics}",
@@ -388,7 +396,9 @@ def main() -> None:
             "or via the --all-python/--all-jvm flags."
         )
     if python_tools:
-        generate_python_tool_lockfiles(python_tools, args.dry_run, args.keep_sandboxes)
+        generate_python_tool_lockfiles(
+            python_tools, args.resolver, args.dry_run, args.keep_sandboxes
+        )
     if jvm_tools:
         generate_jvm_tool_lockfiles(jvm_tools, args.dry_run, args.keep_sandboxes)
 

--- a/src/python/pants/backend/python/lint/black/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/black/rules_integration_test.py
@@ -21,7 +21,6 @@ from pants.engine.target import Target
 from pants.testutil.python_interpreter_selection import (
     all_major_minor_python_versions,
     skip_unless_python38_present,
-    skip_unless_python39_present,
 )
 from pants.testutil.python_rule_runner import PythonRuleRunner
 from pants.testutil.rule_runner import QueryRule
@@ -231,27 +230,6 @@ def test_works_with_python38(rule_runner: PythonRuleRunner) -> None:
             "--black-install-from-resolve=black-py38-testing",
         ],
     )
-    assert "1 file left unchanged" in fmt_result.stderr
-    assert fmt_result.output == rule_runner.make_snapshot({"f.py": content})
-    assert fmt_result.did_change is False
-
-
-@skip_unless_python39_present
-def test_works_with_python39(rule_runner: PythonRuleRunner) -> None:
-    """Black's typed-ast dependency does not understand Python 3.9, so we must instead run Black
-    with Python 3.9 when relevant."""
-    content = dedent(
-        """\
-        @lambda _: int
-        def replaced(x: bool) -> str:
-            return "42" if x is True else "1/137"
-        """
-    )
-    rule_runner.write_files(
-        {"f.py": content, "BUILD": "python_sources(name='t', interpreter_constraints=['>=3.9'])"}
-    )
-    tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.py"))
-    fmt_result = run_black(rule_runner, [tgt], expected_ics=">=3.9")
     assert "1 file left unchanged" in fmt_result.stderr
     assert fmt_result.output == rule_runner.make_snapshot({"f.py": content})
     assert fmt_result.did_change is False

--- a/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
@@ -42,7 +42,6 @@ from pants.testutil.python_interpreter_selection import (
     all_major_minor_python_versions,
     skip_unless_all_pythons_present,
     skip_unless_python38_present,
-    skip_unless_python39_present,
 )
 from pants.testutil.python_rule_runner import PythonRuleRunner
 from pants.util.resources import read_sibling_resource
@@ -355,26 +354,6 @@ def test_works_with_python38(rule_runner: PythonRuleRunner) -> None:
     ]
     tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="f.py"))
     assert_success(rule_runner, tgt, extra_args=extra_args)
-
-
-@skip_unless_python39_present
-def test_works_with_python39(rule_runner: PythonRuleRunner) -> None:
-    """MyPy's typed-ast dependency does not understand Python 3.9, so we must instead run MyPy with
-    Python 3.9 when relevant."""
-    rule_runner.write_files(
-        {
-            f"{PACKAGE}/f.py": dedent(
-                """\
-                @lambda _: int
-                def replaced(x: bool) -> str:
-                    return "42" if x is True else "1/137"
-                """
-            ),
-            f"{PACKAGE}/BUILD": "python_sources(interpreter_constraints=['>=3.9'])",
-        }
-    )
-    tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="f.py"))
-    assert_success(rule_runner, tgt)
 
 
 def test_run_only_on_specified_files(rule_runner: PythonRuleRunner) -> None:

--- a/src/python/pants/base/specs_integration_test.py
+++ b/src/python/pants/base/specs_integration_test.py
@@ -7,7 +7,7 @@ import re
 from textwrap import dedent
 
 from pants.testutil.pants_integration_test import PantsResult, run_pants, setup_tmpdir
-from pants.testutil.python_interpreter_selection import skip_unless_python39_present
+from pants.testutil.python_interpreter_selection import skip_unless_python310_present
 
 SOURCES = {
     # NB: This uses recursive globs for the `python_sources` and `python_tests` target generators,
@@ -65,7 +65,7 @@ def run(args: list[str]) -> PantsResult:
         [
             "--backend-packages=pants.backend.python",
             "--backend-packages=pants.backend.experimental.go",
-            "--python-interpreter-constraints=['==3.9.*']",
+            "--python-interpreter-constraints=['==3.10.*']",
             "--pants-ignore=__pycache__",
             *args,
         ]
@@ -74,7 +74,7 @@ def run(args: list[str]) -> PantsResult:
     return result
 
 
-@skip_unless_python39_present
+@skip_unless_python310_present
 def test_address_literal() -> None:
     """Semantics:
 
@@ -91,7 +91,7 @@ def test_address_literal() -> None:
         assert f"{tmpdir}/py:tests" not in test_result
 
 
-@skip_unless_python39_present
+@skip_unless_python310_present
 def test_sibling_addresses() -> None:
     """Semantics:
 
@@ -127,7 +127,7 @@ def test_sibling_addresses() -> None:
         assert f"{tmpdir}/py:tests" not in test_result
 
 
-@skip_unless_python39_present
+@skip_unless_python310_present
 def test_descendent_addresses() -> None:
     """Semantics are the same as sibling addresses, only recursive."""
     with setup_tmpdir(SOURCES) as tmpdir:
@@ -148,7 +148,7 @@ def test_descendent_addresses() -> None:
         assert f"{tmpdir}/py:tests" not in test_result
 
 
-@skip_unless_python39_present
+@skip_unless_python310_present
 def test_file_arg() -> None:
     """Semantics: find the 'owning' target, using generated target rather than target generator
     when possible (regardless of project introspection vs. "build" goal).


### PR DESCRIPTION
I think these "does black/mypy support Python syntax circa 2020?" tests have outlived their usefulness and removing them makes it easier to drop support for Python 3.9 (EoL since 2025-10-31).

There are still tests that use 3.8 when custom test lockfiles when available, which cover the "Does Pants work with Pythons older than the bundled tool lockfiles?" case.