### PR TITLE
Fix: Defer `validate_resolved_files` in `hydrate_sources` to support …

### DIFF
--- a/docs/notes/2.34.x.md
+++ b/docs/notes/2.34.x.md
@@ -16,6 +16,8 @@ Thank you to [Klaviyo](https://www.klaviyo.com/) for their Platinum tier support
 
 ### General
 
+Fixed a bug where `SingleSourceField` could not be hydrated for generated targets because files were validated before code generation ran.
+
 ### Goals
 
 ### Backends

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -1449,11 +1449,19 @@ async def hydrate_sources(
     # protocol sources to be hydrated.
     path_globs = sources_field.path_globs(unmatched_build_file_globs)
     snapshot = await digest_to_snapshot(**implicitly({path_globs: PathGlobs}))
-    sources_field.validate_resolved_files(snapshot.files)
+
+    input_validation_failure = None
+    try:
+        sources_field.validate_resolved_files(snapshot.files)
+    except InvalidFieldException as e:
+        if not request.enable_codegen or generate_request_type is None:
+            raise
+        input_validation_failure = e
 
     # Finally, return if codegen is not in use; otherwise, run the relevant code generator.
     if not request.enable_codegen or generate_request_type is None:
         return HydratedSources(snapshot, sources_field.filespec, sources_type=sources_type)
+
     wrapped_protocol_target = await resolve_target(
         WrappedTargetRequest(
             sources_field.address,
@@ -1466,6 +1474,13 @@ async def hydrate_sources(
     generated_sources = await generate_sources(
         **implicitly({req: GenerateSourcesRequest, env_name: EnvironmentName})
     )
+
+    # If the input failed, we validate whether the output satisfies the field rule.
+    if input_validation_failure is not None:
+        try:
+            sources_field.validate_resolved_files(generated_sources.snapshot.files)
+        except InvalidFieldException:
+            raise input_validation_failure
 
     return HydratedSources(
         generated_sources.snapshot, sources_field.filespec, sources_type=sources_type

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -2028,6 +2028,48 @@ def test_codegen_works_with_subclass_fields(codegen_rule_runner: RuleRunner) -> 
     assert generated.snapshot.files == ("src/smalltalk/f.st",)
 
 
+class GenerateSmalltalkFromSingleAvroRequest(GenerateSourcesRequest):
+    input = SmalltalkSource
+    output = SmalltalkSource
+
+
+@rule
+async def generate_smalltalk_from_single_avro(
+    request: GenerateSmalltalkFromSingleAvroRequest,
+) -> GeneratedSources:
+    result = await digest_to_snapshot(
+        **implicitly(CreateDigest([FileContent("src/smalltalk/f.st", b"Generated")]))
+    )
+    return GeneratedSources(result)
+
+
+def test_codegen_hydrates_single_source_field_without_validation_error() -> None:
+    rule_runner = RuleRunner(
+        rules=[
+            generate_smalltalk_from_single_avro,
+            QueryRule(HydratedSources, [HydrateSourcesRequest, EnvironmentName]),
+            UnionRule(GenerateSourcesRequest, GenerateSmalltalkFromSingleAvroRequest),
+        ],
+        target_types=[AvroLibrary],
+    )
+
+    addr = setup_codegen_protocol_tgt(rule_runner)
+
+    single_source = SmalltalkSource("f.st", addr)
+
+    generated_via_hydrate_sources = rule_runner.request(
+        HydratedSources,
+        [
+            HydrateSourcesRequest(
+                single_source, for_sources_types=[SmalltalkSource], enable_codegen=True
+            )
+        ],
+    )
+
+    assert generated_via_hydrate_sources.snapshot.files == ("src/smalltalk/f.st",)
+    assert generated_via_hydrate_sources.sources_type == SmalltalkSource
+
+
 def test_codegen_cannot_generate_language(codegen_rule_runner: RuleRunner) -> None:
     addr = setup_codegen_protocol_tgt(codegen_rule_runner)
 


### PR DESCRIPTION
Fixes #23015

### Problem
`SingleSourceField`s that rely on target generation/codegen currently fail to hydrate. This happens because `validate_resolved_files` is called immediately after glob expansion, *before* the actual code generation (`generate_sources`) takes place. Since `SingleSourceField` strictly expects exactly 1 file, this premature validation fails because the generated file doesn't exist yet.

### Solution
Refactored the execution order inside `hydrate_sources` (`src/python/pants/engine/internals/graph.py`) to defer file validation:
- If codegen is not in use, the validation happens normally on the initial `snapshot` as before.
- If codegen is enabled, the validation is skipped initially and only called on `generated_sources.snapshot.files` after the `generate_sources` await completes.

Also added the corresponding release note to `docs/notes/2.34.x.md`.
