### PR TITLE
Permit vfork fast-path within local `execute_process`

### DIFF
--- a/src/rust/process_execution/children/src/lib.rs
+++ b/src/rust/process_execution/children/src/lib.rs
@@ -37,13 +37,7 @@ impl ManagedChild {
 
         // Adjust the Command to create its own PGID as it starts, to make it safe to kill the PGID
         // later.
-        unsafe {
-            command.pre_exec(|| {
-                nix::unistd::setsid()
-                    .map(|_pgid| ())
-                    .map_err(|e| std::io::Error::other(format!("Could not create new pgid: {e}")))
-            });
-        };
+        command.process_group(0);
 
         // Then spawn.
         let child = command.spawn()?;


### PR DESCRIPTION
Replaces use of `tokio::process::Command::pre_exec()` to establish a new process group for the spawned child instead with `tokio::proces::Command::process_group()`, as the former requires a "slow" `fork -> (pre_exec closures)* -> exec` codepath, and the latter permits a `vfork -> exec`-based fast-path.

This improves local build performance relative to both the resident set size that the Pants process builds up (i.e. through in-memory caching of rule results), and to the number of processes spawned through `execute_process()`.

The "slow" path translates to underlying `clone()` syscalls without the `CLONE_VFORK|CLONE_VM` flags, which suffer latency relative to the parent process resident set size due to duplication of page tables for the child, a cost which can become considerable for parent processes (i.e., `pants`) that have allocated significant memory (e.g., cached rule results), and can become meaningful for local Pants builds spawning many processes.

This change permits the runtime to take the "fast" `vfork`-based path (using `clone()` with `CLONE_VFORK|CLONE_VM`), which has ~constant latency irrespective of parent memory allocation. "Permits", because this code change alone does not ensure the fast path is taken; minimally, the environment must also supply a glibc v2.29+, the earliest version providing another required ingredient for taking the `vfork` fast path (`posix_spawn_file_actions_addchdir_np()`).