### PR TITLE
Fix FROM build-arg substitution misalignment with mixed address + literal base images

### DIFF
--- a/src/python/pants/backend/docker/util_rules/docker_build_context.py
+++ b/src/python/pants/backend/docker/util_rules/docker_build_context.py
@@ -357,20 +357,28 @@ async def create_docker_build_context(
         dockerfile_build_args = dockerfile_info.from_image_build_args.with_overrides(
             supplied_build_args
         ).nonempty()
-        # Parse the build args values into Address instances.
-        from_image_addresses = await resolve_unparsed_address_inputs(
-            UnparsedAddressInputs(
-                dockerfile_build_args.values(),
-                owning_address=dockerfile_info.address,
-                description_of_origin=softwrap(
-                    f"""
-                    the FROM arguments from the file {dockerfile_info.source}
-                    from the target {dockerfile_info.address}
-                    """
+        # Parse each build arg value into an Address independently, so that a value which does
+        # not resolve to an in-repo target (e.g. a plain image ref such as
+        # `registry.example.com/base:1.0`) is skipped in place rather than shifting the
+        # positional alignment of the remaining args. Resolving the whole batch at once and
+        # then zipping the result against the arg names silently mispairs args whenever a
+        # non-last value is dropped by `skip_invalid_addresses`.
+        from_image_addresses = await concurrently(
+            resolve_unparsed_address_inputs(
+                UnparsedAddressInputs(
+                    [value],
+                    owning_address=dockerfile_info.address,
+                    description_of_origin=softwrap(
+                        f"""
+                        the FROM arguments from the file {dockerfile_info.source}
+                        from the target {dockerfile_info.address}
+                        """
+                    ),
+                    skip_invalid_addresses=True,
                 ),
-                skip_invalid_addresses=True,
-            ),
-            **implicitly(),
+                **implicitly(),
+            )
+            for value in dockerfile_build_args.values()
         )
         # Map those addresses to the corresponding built image ref (tag).
         address_to_built_image_tag = {
@@ -385,10 +393,12 @@ async def create_docker_build_context(
             for image in built.artifacts
             if isinstance(image, BuiltDockerImage)
         ]
-        # Create the FROM image build args.
+        # Create the FROM image build args. Each arg is paired with its own resolution result,
+        # so a skipped (non-address) value can never be substituted onto the wrong arg name.
         from_image_build_args = [
-            f"{arg_name}={address_to_built_image_tag[addr]}"
-            for arg_name, addr in zip(dockerfile_build_args.keys(), from_image_addresses)
+            f"{arg_name}={address_to_built_image_tag[addresses[0]]}"
+            for arg_name, addresses in zip(dockerfile_build_args.keys(), from_image_addresses)
+            if addresses and addresses[0] in address_to_built_image_tag
         ]
         build_args = build_args.extended(from_image_build_args)
 

--- a/src/python/pants/backend/docker/util_rules/docker_build_context_test.py
+++ b/src/python/pants/backend/docker/util_rules/docker_build_context_test.py
@@ -337,6 +337,58 @@ def test_from_image_build_arg_not_in_repo_issue_15585(rule_runner: RuleRunner) -
     )
 
 
+def test_from_image_build_arg_mixed_address_and_literal(rule_runner: RuleRunner) -> None:
+    """A Dockerfile with two `FROM $ARG` base images: one Pants address, one plain image ref.
+
+    Only the address-valued arg should be substituted with the built upstream image; the
+    literal-valued arg should be left untouched (as in the `..._not_in_repo_issue_15585` test).
+
+    Both args are classified as "from image" build args, since the literal registry ref also
+    matches the loose address regex. The build args are stored sorted by "NAME=VALUE", so
+    `AAA_LITERAL` comes first. At resolution the literal is dropped (`skip_invalid_addresses`),
+    which shortens the resolved-address list; `zip(build_args.keys(), resolved_addresses)` then
+    pairs the first key (`AAA_LITERAL`) with the only upstream image and silently drops
+    `ZZZ_UPSTREAM` -- so the real address-valued arg is never substituted.
+    """
+    rule_runner.write_files(
+        {
+            "src/upstream/BUILD": dedent(
+                """\
+                docker_image(
+                  name="image",
+                  repository="upstream/{name}",
+                  image_tags=["1.0"],
+                  instructions=["FROM alpine:3.16.1"],
+                )
+                """
+            ),
+            "src/downstream/BUILD": "docker_image(name='image')",
+            "src/downstream/Dockerfile": dedent(
+                """\
+                ARG AAA_LITERAL=registry.example.com/base:1.0
+                ARG ZZZ_UPSTREAM=src/upstream:image
+                FROM $AAA_LITERAL AS first
+                FROM $ZZZ_UPSTREAM
+                """
+            ),
+        }
+    )
+
+    context = assert_build_context(
+        rule_runner,
+        Address("src/downstream", target_name="image"),
+        expected_files=["src/downstream/Dockerfile", "src.upstream/image.docker-info.json"],
+        build_upstream_images=True,
+        expected_num_upstream_images=1,
+    )
+
+    build_args = context.build_args.to_dict()
+    # The address-valued arg must be substituted with the built upstream image ref.
+    assert build_args.get("ZZZ_UPSTREAM") == "upstream/image:1.0"
+    # The literal-valued arg must not be hijacked with the upstream image ref.
+    assert "AAA_LITERAL" not in build_args
+
+
 def test_build_args_for_copy(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {


### PR DESCRIPTION
Fixes #23470.

## Summary

Fixes a base-image build-arg substitution bug in the Docker backend, and adds a reproducer test for it.

When a single Dockerfile declares **two** `FROM $ARG` base images — one whose default is an in-repo `docker_image` target address, and one whose default is a plain registry reference — Pants substitutes the built image onto the **wrong** build arg and leaves the real address-valued arg unsubstituted. Its literal `//path:target` default then leaks to the Docker build:

```
failed to parse stage name "//path:target": invalid reference format
```

## Root cause

In `create_docker_build_context`:

1. Both args are classified as "from image" build args — the literal registry ref (e.g. `registry.example.com/base:1.0`) also matches the loose `valid_address` regex in `dockerfile_wrapper_script.py`.
2. `from_image_build_args` is stored **sorted by `"NAME=VALUE"`** (`KeyValueSequenceUtil.from_strings` → `sorted(...)`), so an arg like `AAA_LITERAL` sorts before `ZZZ_UPSTREAM`.
3. `resolve_unparsed_address_inputs(..., skip_invalid_addresses=True)` **drops** the non-resolvable literal, shortening the resolved-address list.
4. The code then zipped that shortened list against the full, sorted arg names:
   ```python
   from_image_build_args = [
       f"{arg_name}={address_to_built_image_tag[addr]}"
       for arg_name, addr in zip(dockerfile_build_args.keys(), from_image_addresses)
   ]
   ```
   Because a **non-last** value was dropped, `zip` mispaired: it substituted the upstream image onto the sorted-first `AAA_LITERAL` and silently dropped `ZZZ_UPSTREAM`.

## The fix

Resolve each build-arg value **independently** (via `concurrently`) so a skipped value stays in place instead of shifting the alignment, and build the substitutions keyed by name with a membership guard:

```python
from_image_build_args = [
    f"{arg_name}={address_to_built_image_tag[addresses[0]]}"
    for arg_name, addresses in zip(dockerfile_build_args.keys(), from_image_addresses)
    if addresses and addresses[0] in address_to_built_image_tag
]
```

Arg names and resolutions now stay aligned regardless of which values are dropped.

## Reproducer / test

`test_from_image_build_arg_mixed_address_and_literal` in `docker_build_context_test.py` builds the context and asserts the address-valued arg resolves to the built upstream image while the literal-valued arg is left untouched.

- **Before the fix** it failed on the substitution assertion (`ZZZ_UPSTREAM` came back `None`).
- **After the fix** the full file is `28 passed, 1 deselected` (the deselected `test_packaged_pex_environment` is a pre-existing macOS-only `arm64`-vs-`aarch64` skip, unrelated to this change). No regressions.

## Note (out of scope)

The COPY-args path (`fill_args_from_copy`) uses the same `zip(keys(), resolved_addresses)` pattern and has the same latent misalignment. It is left unchanged here since no test exercises it; happy to follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

