### PR TITLE
plumb thru --validate-entry-point as a field

### DIFF
--- a/docs/notes/2.33.x.md
+++ b/docs/notes/2.33.x.md
@@ -68,6 +68,8 @@ The default version of [Pex](https://github.com/pex-tool/pex) used by the Python
 
  Note that `v2.95.1` is now also the *minimum* required version of Pex. If you're pinning to an earlier version you must upgrade. Pex is very scrupulous about backwards compatibility, so this should not be a problem in general. If the pin was specifically to avoid a bug in Pex, that bug should be [reported](https://github.com/pex-tool/pex/issues/new), after first confirming that there isn't an existing [open issue](https://github.com/pex-tool/pex/issues) for it.
 
+The `pex_binary` target now has a `validate_entry_point` which plumbs through the [`--validate-entry-point`](https://github.com/pex-tool/pex/releases/tag/v1.4.5) flag to Pex.  This validates the entry point by importing it in a separate process at build time.
+
 Fixed a bug in Ruff backend where ancestor `__init__.py` files were not included in `fix` partitions which changed how Ruff's importing sorting logic operated. Thie caused `pants fix` to see no need for import sorting even though `pants lint` flagged the need.
 
 All version of [Ruff](https://docs.astral.sh/ruff/) from [0.15.6](https://github.com/astral-sh/ruff/releases/tag/0.15.14) to [0.15.14](https://github.com/astral-sh/ruff/releases/tag/0.15.14) are now included in `default_known_versions`.

--- a/src/python/pants/backend/python/goals/package_pex_binary.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary.py
@@ -46,6 +46,7 @@ from pants.backend.python.target_types import (
     PexShBootField,
     PexShebangField,
     PexStripEnvField,
+    PexValidateEntryPointField,
     PexVenvHermeticScripts,
     PexVenvSitePackagesCopies,
     ResolvePexEntryPointRequest,
@@ -88,6 +89,7 @@ class PexBinaryFieldSet(PackageFieldSet, RunFieldSet):
     output_path: OutputPathField
     emit_warnings: PexEmitWarningsField
     ignore_errors: PexIgnoreErrorsField
+    validate_entry_point: PexValidateEntryPointField
     inherit_path: PexInheritPathField
     sh_boot: PexShBootField
     shebang: PexShebangField
@@ -137,6 +139,8 @@ class PexBinaryFieldSet(PackageFieldSet, RunFieldSet):
             args.append("--emit-warnings")
         if self.ignore_errors.value is True:
             args.append("--ignore-errors")
+        if self.validate_entry_point.value is True:
+            args.append("--validate-entry-point")
         if self.inherit_path.value is not None:
             args.append(f"--inherit-path={self.inherit_path.value}")
         if self.sh_boot.value is True:

--- a/src/python/pants/backend/python/goals/package_pex_binary_integration_test.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary_integration_test.py
@@ -499,6 +499,65 @@ def test_extra_build_args(rule_runner: PythonRuleRunner) -> None:
     assert additional_args[-1] == "value-goes-here"
 
 
+def test_validate_entry_point_plumb(rule_runner: PythonRuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "src/py/project/app.py": "print('hello')\n",
+            "src/py/project/BUILD": dedent(
+                """\
+                python_sources(name="lib")
+                pex_binary(name="default", entry_point="app.py")
+                pex_binary(name="validate", entry_point="app.py", validate_entry_point=True)
+                """
+            ),
+        }
+    )
+
+    default_args = rule_runner.request(
+        PexFromTargetsRequestForBuiltPackage,
+        [
+            PexBinaryFieldSet.create(
+                rule_runner.get_target(Address("src/py/project", target_name="default"))
+            )
+        ],
+    ).request.additional_args
+    validate_args = rule_runner.request(
+        PexFromTargetsRequestForBuiltPackage,
+        [
+            PexBinaryFieldSet.create(
+                rule_runner.get_target(Address("src/py/project", target_name="validate"))
+            )
+        ],
+    ).request.additional_args
+
+    assert "--validate-entry-point" not in default_args
+    assert "--validate-entry-point" in validate_args
+
+
+def test_validate_entry_point_end_to_end(rule_runner: PythonRuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "src/py/project/BUILD": dedent(
+                """\
+                pex_binary(name="bad", entry_point="does.not.exist:null", validate_entry_point=True)
+                pex_binary(name="bad-unchecked", entry_point="does.not.exist:null")
+                """
+            ),
+        }
+    )
+
+    bad = PexBinaryFieldSet.create(
+        rule_runner.get_target(Address("src/py/project", target_name="bad"))
+    )
+    with pytest.raises(ExecutionError, match="does.not.exist"):
+        rule_runner.request(BuiltPackage, [bad])
+
+    unchecked = PexBinaryFieldSet.create(
+        rule_runner.get_target(Address("src/py/project", target_name="bad-unchecked"))
+    )
+    rule_runner.request(BuiltPackage, [unchecked])
+
+
 def test_package_with_python_provider() -> None:
     # Per https://github.com/pantsbuild/pants/issues/21048, test packaging a local/unconstrained pex
     # binary when using a Python that isn't automatically visible on $PATH (using the PBS provider

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -573,6 +573,19 @@ class PexIgnoreErrorsField(BoolField):
     help = "Should PEX ignore errors when it cannot resolve dependencies?"
 
 
+class PexValidateEntryPointField(BoolField):
+    alias = "validate_entry_point"
+    default = False
+    help = help_text(
+        """
+        Validate the entry point by importing it in a separate process when building the PEX.
+
+        Warning: this could have side effects. For example, the entry point `a.b.c:m` will
+        translate to `from a.b.c import m` during validation. (Pex default: False)
+        """
+    )
+
+
 class PexShBootField(BoolField):
     alias = "sh_boot"
     default = False
@@ -1043,6 +1056,7 @@ _PEX_BINARY_COMMON_FIELDS = (
     PexInheritPathField,
     PexStripEnvField,
     PexIgnoreErrorsField,
+    PexValidateEntryPointField,
     PexShBootField,
     PexShebangField,
     PexEmitWarningsField,


### PR DESCRIPTION
Exposes --validate-entry-point from way back in
https://github.com/pex-tool/pex/pull/521 as a field.

Why? I have a repo with a combination of "vanilla" pex_binary targets as well as ones that follow the "split" pattern described at https://www.pantsbuild.org/blog/2022/08/02/optimizing-python-docker-deploys-using-pants. The split ones can't use --validate-entry-point since the whole point is that neither Pex is complete on its own.  I tried to use extra_args (which has come up in the past for "why add fields?" discussions) but juggling that across __defaults__ and macros really was kinda annoying.  Adding it as a field makes it work just as easily as any other field.

Notice: This was generated by pointing a LLM at the prior field additions for the pattern and then pex `--help` for this specific field.