### PR TITLE
Run pants under free threaded python

### DIFF
--- a/.github/workflows/cache_comparison.yaml
+++ b/.github/workflows/cache_comparison.yaml
@@ -11,7 +11,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 10
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14, 3.14t
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: |-
@@ -23,6 +23,7 @@ jobs:
           3.12
           3.13
           3.14
+          3.14t
     - env:
         BASE_REF: ${{ github.event.inputs.base_ref }}
         BUILD_COMMIT: ${{ github.event.inputs.build_commit }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -287,21 +287,6 @@ jobs:
             -H "Content-Type: application/octet-stream" \
             "${{ needs.release_info.outputs.release-asset-upload-url }}?name=$(basename $WHL)" \
             --data-binary "@$WHL";
-    - if: needs.release_info.outputs.is-release == 'true'
-      name: Attest the pantsbuild.pants.testutil wheel
-      uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
-      with:
-        subject-path: dist/deploy/wheels/pantsbuild.pants/**/pantsbuild_pants_testutil*.whl
-    - if: needs.release_info.outputs.is-release == 'true'
-      name: Upload testutil Wheel
-      run: |
-        WHL=$(find dist/deploy/wheels/pantsbuild.pants -type f -name "pantsbuild_pants_testutil*.whl")
-        curl -L --fail \
-            -X POST \
-            -H "Authorization: Bearer ${{ github.token }}" \
-            -H "Content-Type: application/octet-stream" \
-            "${{ needs.release_info.outputs.release-asset-upload-url }}?name=$(basename $WHL)" \
-            --data-binary "@$WHL";
     timeout-minutes: 90
   build_wheels_cp314_macos14_arm64:
     env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,7 +83,7 @@ jobs:
         HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY || '--DISABLED--' }}
         PANTS_OPENTELEMETRY_ENABLED: ${{ vars.OPENTELEMETRY_ENABLED || 'False' }}
       name: Build Pants PEX
-      run: ./pants package src/python/pants:pants-pex@scie_pbs_free_threaded=cp314
+      run: ./pants package src/python/pants:pants-pex@parametrize=cp314
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -100,14 +100,15 @@ jobs:
     - if: needs.release_info.outputs.is-release == 'true'
       name: Rename the Pants Pex to its final name for upload
       run: |
-        PANTS_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import pants.version;print(pants.version.VERSION)")
-        PY_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import sys;print(f'cp{sys.version_info[0]}{sys.version_info[1]}{sys.abiflags}')")
-        PLAT=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import os;print(f'{os.uname().sysname.lower()}_{os.uname().machine.lower()}')")
+        PEX_STEM=dist/src.python.pants/pants-pex-cp314
+        PANTS_VER=$(PEX_INTERPRETER=1 $PEX_STEM.pex -c "import pants.version;print(pants.version.VERSION)")
+        PY_VER=$(PEX_INTERPRETER=1 $PEX_STEM.pex -c "import sys;print(f'cp{sys.version_info[0]}{sys.version_info[1]}{sys.abiflags}')")
+        PLAT=$(PEX_INTERPRETER=1 $PEX_STEM.pex -c "import os;print(f'{os.uname().sysname.lower()}_{os.uname().machine.lower()}')")
         PEX_FILENAME=pants.$PANTS_VER-$PY_VER-$PLAT.pex
         PEX_SCIE_FILENAME=pants.$PANTS_VER-$PY_VER-$PLAT
 
-        mv dist/src.python.pants/pants-pex.pex dist/src.python.pants/$PEX_FILENAME
-        mv dist/src.python.pants/pants-pex dist/src.python.pants/$PEX_SCIE_FILENAME
+        mv $PEX_STEM.pex dist/src.python.pants/$PEX_FILENAME
+        mv $PEX_STEM dist/src.python.pants/$PEX_SCIE_FILENAME
         echo "PEX_FILENAME=$PEX_FILENAME" | tee -a "$GITHUB_ENV"
         echo "PEX_SCIE_FILENAME=$PEX_SCIE_FILENAME" | tee -a "$GITHUB_ENV"
     - if: needs.release_info.outputs.is-release == 'true'
@@ -231,7 +232,7 @@ jobs:
         PANTS_OPENTELEMETRY_ENABLED: ${{ vars.OPENTELEMETRY_ENABLED || 'False' }}
         PANTS_PROCESS_EXECUTION_LOCAL_PARALLELISM: '1'
       name: Build Pants PEX
-      run: ./pants package src/python/pants:pants-pex@scie_pbs_free_threaded=cp314
+      run: ./pants package src/python/pants:pants-pex@parametrize=cp314
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -248,14 +249,15 @@ jobs:
     - if: needs.release_info.outputs.is-release == 'true'
       name: Rename the Pants Pex to its final name for upload
       run: |
-        PANTS_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import pants.version;print(pants.version.VERSION)")
-        PY_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import sys;print(f'cp{sys.version_info[0]}{sys.version_info[1]}{sys.abiflags}')")
-        PLAT=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import os;print(f'{os.uname().sysname.lower()}_{os.uname().machine.lower()}')")
+        PEX_STEM=dist/src.python.pants/pants-pex-cp314
+        PANTS_VER=$(PEX_INTERPRETER=1 $PEX_STEM.pex -c "import pants.version;print(pants.version.VERSION)")
+        PY_VER=$(PEX_INTERPRETER=1 $PEX_STEM.pex -c "import sys;print(f'cp{sys.version_info[0]}{sys.version_info[1]}{sys.abiflags}')")
+        PLAT=$(PEX_INTERPRETER=1 $PEX_STEM.pex -c "import os;print(f'{os.uname().sysname.lower()}_{os.uname().machine.lower()}')")
         PEX_FILENAME=pants.$PANTS_VER-$PY_VER-$PLAT.pex
         PEX_SCIE_FILENAME=pants.$PANTS_VER-$PY_VER-$PLAT
 
-        mv dist/src.python.pants/pants-pex.pex dist/src.python.pants/$PEX_FILENAME
-        mv dist/src.python.pants/pants-pex dist/src.python.pants/$PEX_SCIE_FILENAME
+        mv $PEX_STEM.pex dist/src.python.pants/$PEX_FILENAME
+        mv $PEX_STEM dist/src.python.pants/$PEX_SCIE_FILENAME
         echo "PEX_FILENAME=$PEX_FILENAME" | tee -a "$GITHUB_ENV"
         echo "PEX_SCIE_FILENAME=$PEX_SCIE_FILENAME" | tee -a "$GITHUB_ENV"
     - if: needs.release_info.outputs.is-release == 'true'
@@ -389,7 +391,7 @@ jobs:
         PANTS_OPENTELEMETRY_ENABLED: ${{ vars.OPENTELEMETRY_ENABLED || 'False' }}
         _PYTHON_HOST_PLATFORM: macosx-14.0-arm64
       name: Build Pants PEX
-      run: ./pants package src/python/pants:pants-pex@scie_pbs_free_threaded=cp314
+      run: ./pants package src/python/pants:pants-pex@parametrize=cp314
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -406,14 +408,15 @@ jobs:
     - if: needs.release_info.outputs.is-release == 'true'
       name: Rename the Pants Pex to its final name for upload
       run: |
-        PANTS_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import pants.version;print(pants.version.VERSION)")
-        PY_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import sys;print(f'cp{sys.version_info[0]}{sys.version_info[1]}{sys.abiflags}')")
-        PLAT=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import os;print(f'{os.uname().sysname.lower()}_{os.uname().machine.lower()}')")
+        PEX_STEM=dist/src.python.pants/pants-pex-cp314
+        PANTS_VER=$(PEX_INTERPRETER=1 $PEX_STEM.pex -c "import pants.version;print(pants.version.VERSION)")
+        PY_VER=$(PEX_INTERPRETER=1 $PEX_STEM.pex -c "import sys;print(f'cp{sys.version_info[0]}{sys.version_info[1]}{sys.abiflags}')")
+        PLAT=$(PEX_INTERPRETER=1 $PEX_STEM.pex -c "import os;print(f'{os.uname().sysname.lower()}_{os.uname().machine.lower()}')")
         PEX_FILENAME=pants.$PANTS_VER-$PY_VER-$PLAT.pex
         PEX_SCIE_FILENAME=pants.$PANTS_VER-$PY_VER-$PLAT
 
-        mv dist/src.python.pants/pants-pex.pex dist/src.python.pants/$PEX_FILENAME
-        mv dist/src.python.pants/pants-pex dist/src.python.pants/$PEX_SCIE_FILENAME
+        mv $PEX_STEM.pex dist/src.python.pants/$PEX_FILENAME
+        mv $PEX_STEM dist/src.python.pants/$PEX_SCIE_FILENAME
         echo "PEX_FILENAME=$PEX_FILENAME" | tee -a "$GITHUB_ENV"
         echo "PEX_SCIE_FILENAME=$PEX_SCIE_FILENAME" | tee -a "$GITHUB_ENV"
     - if: needs.release_info.outputs.is-release == 'true'
@@ -525,7 +528,7 @@ jobs:
         HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY || '--DISABLED--' }}
         PANTS_OPENTELEMETRY_ENABLED: ${{ vars.OPENTELEMETRY_ENABLED || 'False' }}
       name: Build Pants PEX
-      run: ./pants package src/python/pants:pants-pex@scie_pbs_free_threaded=cp314t
+      run: ./pants package src/python/pants:pants-pex@parametrize=cp314t
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -542,14 +545,15 @@ jobs:
     - if: needs.release_info.outputs.is-release == 'true'
       name: Rename the Pants Pex to its final name for upload
       run: |
-        PANTS_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import pants.version;print(pants.version.VERSION)")
-        PY_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import sys;print(f'cp{sys.version_info[0]}{sys.version_info[1]}{sys.abiflags}')")
-        PLAT=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import os;print(f'{os.uname().sysname.lower()}_{os.uname().machine.lower()}')")
+        PEX_STEM=dist/src.python.pants/pants-pex-cp314t
+        PANTS_VER=$(PEX_INTERPRETER=1 $PEX_STEM.pex -c "import pants.version;print(pants.version.VERSION)")
+        PY_VER=$(PEX_INTERPRETER=1 $PEX_STEM.pex -c "import sys;print(f'cp{sys.version_info[0]}{sys.version_info[1]}{sys.abiflags}')")
+        PLAT=$(PEX_INTERPRETER=1 $PEX_STEM.pex -c "import os;print(f'{os.uname().sysname.lower()}_{os.uname().machine.lower()}')")
         PEX_FILENAME=pants.$PANTS_VER-$PY_VER-$PLAT.pex
         PEX_SCIE_FILENAME=pants.$PANTS_VER-$PY_VER-$PLAT
 
-        mv dist/src.python.pants/pants-pex.pex dist/src.python.pants/$PEX_FILENAME
-        mv dist/src.python.pants/pants-pex dist/src.python.pants/$PEX_SCIE_FILENAME
+        mv $PEX_STEM.pex dist/src.python.pants/$PEX_FILENAME
+        mv $PEX_STEM dist/src.python.pants/$PEX_SCIE_FILENAME
         echo "PEX_FILENAME=$PEX_FILENAME" | tee -a "$GITHUB_ENV"
         echo "PEX_SCIE_FILENAME=$PEX_SCIE_FILENAME" | tee -a "$GITHUB_ENV"
     - if: needs.release_info.outputs.is-release == 'true'
@@ -673,7 +677,7 @@ jobs:
         PANTS_OPENTELEMETRY_ENABLED: ${{ vars.OPENTELEMETRY_ENABLED || 'False' }}
         PANTS_PROCESS_EXECUTION_LOCAL_PARALLELISM: '1'
       name: Build Pants PEX
-      run: ./pants package src/python/pants:pants-pex@scie_pbs_free_threaded=cp314t
+      run: ./pants package src/python/pants:pants-pex@parametrize=cp314t
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -690,14 +694,15 @@ jobs:
     - if: needs.release_info.outputs.is-release == 'true'
       name: Rename the Pants Pex to its final name for upload
       run: |
-        PANTS_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import pants.version;print(pants.version.VERSION)")
-        PY_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import sys;print(f'cp{sys.version_info[0]}{sys.version_info[1]}{sys.abiflags}')")
-        PLAT=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import os;print(f'{os.uname().sysname.lower()}_{os.uname().machine.lower()}')")
+        PEX_STEM=dist/src.python.pants/pants-pex-cp314t
+        PANTS_VER=$(PEX_INTERPRETER=1 $PEX_STEM.pex -c "import pants.version;print(pants.version.VERSION)")
+        PY_VER=$(PEX_INTERPRETER=1 $PEX_STEM.pex -c "import sys;print(f'cp{sys.version_info[0]}{sys.version_info[1]}{sys.abiflags}')")
+        PLAT=$(PEX_INTERPRETER=1 $PEX_STEM.pex -c "import os;print(f'{os.uname().sysname.lower()}_{os.uname().machine.lower()}')")
         PEX_FILENAME=pants.$PANTS_VER-$PY_VER-$PLAT.pex
         PEX_SCIE_FILENAME=pants.$PANTS_VER-$PY_VER-$PLAT
 
-        mv dist/src.python.pants/pants-pex.pex dist/src.python.pants/$PEX_FILENAME
-        mv dist/src.python.pants/pants-pex dist/src.python.pants/$PEX_SCIE_FILENAME
+        mv $PEX_STEM.pex dist/src.python.pants/$PEX_FILENAME
+        mv $PEX_STEM dist/src.python.pants/$PEX_SCIE_FILENAME
         echo "PEX_FILENAME=$PEX_FILENAME" | tee -a "$GITHUB_ENV"
         echo "PEX_SCIE_FILENAME=$PEX_SCIE_FILENAME" | tee -a "$GITHUB_ENV"
     - if: needs.release_info.outputs.is-release == 'true'
@@ -846,7 +851,7 @@ jobs:
         PANTS_OPENTELEMETRY_ENABLED: ${{ vars.OPENTELEMETRY_ENABLED || 'False' }}
         _PYTHON_HOST_PLATFORM: macosx-14.0-arm64
       name: Build Pants PEX
-      run: ./pants package src/python/pants:pants-pex@scie_pbs_free_threaded=cp314t
+      run: ./pants package src/python/pants:pants-pex@parametrize=cp314t
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -863,14 +868,15 @@ jobs:
     - if: needs.release_info.outputs.is-release == 'true'
       name: Rename the Pants Pex to its final name for upload
       run: |
-        PANTS_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import pants.version;print(pants.version.VERSION)")
-        PY_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import sys;print(f'cp{sys.version_info[0]}{sys.version_info[1]}{sys.abiflags}')")
-        PLAT=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import os;print(f'{os.uname().sysname.lower()}_{os.uname().machine.lower()}')")
+        PEX_STEM=dist/src.python.pants/pants-pex-cp314t
+        PANTS_VER=$(PEX_INTERPRETER=1 $PEX_STEM.pex -c "import pants.version;print(pants.version.VERSION)")
+        PY_VER=$(PEX_INTERPRETER=1 $PEX_STEM.pex -c "import sys;print(f'cp{sys.version_info[0]}{sys.version_info[1]}{sys.abiflags}')")
+        PLAT=$(PEX_INTERPRETER=1 $PEX_STEM.pex -c "import os;print(f'{os.uname().sysname.lower()}_{os.uname().machine.lower()}')")
         PEX_FILENAME=pants.$PANTS_VER-$PY_VER-$PLAT.pex
         PEX_SCIE_FILENAME=pants.$PANTS_VER-$PY_VER-$PLAT
 
-        mv dist/src.python.pants/pants-pex.pex dist/src.python.pants/$PEX_FILENAME
-        mv dist/src.python.pants/pants-pex dist/src.python.pants/$PEX_SCIE_FILENAME
+        mv $PEX_STEM.pex dist/src.python.pants/$PEX_FILENAME
+        mv $PEX_STEM dist/src.python.pants/$PEX_SCIE_FILENAME
         echo "PEX_FILENAME=$PEX_FILENAME" | tee -a "$GITHUB_ENV"
         echo "PEX_SCIE_FILENAME=$PEX_SCIE_FILENAME" | tee -a "$GITHUB_ENV"
     - if: needs.release_info.outputs.is-release == 'true'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -315,7 +315,7 @@ jobs:
       with:
         fetch-depth: 10
         ref: ${{ needs.release_info.outputs.build-ref }}
-    - name: Set up Python 3.9, 3.10, 3.11, 3.12, 3.13, 3.14
+    - name: Set up Python 3.9, 3.10, 3.11, 3.12, 3.13, 3.14, 3.14t
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: |-
@@ -325,6 +325,7 @@ jobs:
           3.12
           3.13
           3.14
+          3.14t
     - name: Install Protoc
       uses: benjyw/setup-protoc@fa4f90fddf8838036cbdeadf1262b9755f6cfb85
       with:
@@ -448,7 +449,7 @@ jobs:
         fetch-depth: '0'
         fetch-tags: true
         ref: ${{ needs.release_info.outputs.build-ref }}
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14, 3.14t
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: |-
@@ -460,6 +461,7 @@ jobs:
           3.12
           3.13
           3.14
+          3.14t
     - name: Install Protoc
       uses: benjyw/setup-protoc@fa4f90fddf8838036cbdeadf1262b9755f6cfb85
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,7 @@
 
 
 jobs:
-  build_wheels_linux_arm64:
+  build_wheels_cp314_linux_arm64:
     container:
       image: quay.io/pypa/manylinux_2_28_aarch64:latest
     env:
@@ -13,7 +13,7 @@ jobs:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
     if: github.repository_owner == 'pantsbuild'
-    name: Build wheels (Linux-ARM64)
+    name: Build wheels (Linux-ARM64, cp314)
     needs:
     - release_info
     permissions:
@@ -57,6 +57,7 @@ jobs:
         echo "/opt/python/cp312-cp312/bin" >> $GITHUB_PATH
         echo "/opt/python/cp313-cp313/bin" >> $GITHUB_PATH
         echo "/opt/python/cp314-cp314/bin" >> $GITHUB_PATH
+        echo "/opt/python/cp314-cp314t/bin" >> $GITHUB_PATH
     - name: Install Protoc
       uses: benjyw/setup-protoc@fa4f90fddf8838036cbdeadf1262b9755f6cfb85
       with:
@@ -64,6 +65,15 @@ jobs:
         version: 23.x
     - name: Install Python headers
       run: echo 'no-op'
+    - name: Select the distribution interpreter
+      run: |
+        curl -fL -o /tmp/pex.pex \
+        https://github.com/pex-tool/pex/releases/download/v2.98.4/pex
+        echo "78d4bae9f6f4d7e63465e79aff2bd9b199a18340f1d6624cb5af236aa90218b6  /tmp/pex.pex" | sha256sum -c -
+        PY="$(python3.14 /tmp/pex.pex --interpreter-constraint 'CPython[gil]==3.14.*' \
+        -- -c 'import os, sys; print(os.path.realpath(sys.executable))')"
+        echo "PY=$PY" >> "$GITHUB_ENV"
+        echo "PANTS_PYTHON_INTERPRETER_CONSTRAINTS=['CPython[gil]==3.14.*']" >> "$GITHUB_ENV"
     - env:
         HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY || '--DISABLED--' }}
         PANTS_OPENTELEMETRY_ENABLED: ${{ vars.OPENTELEMETRY_ENABLED || 'False' }}
@@ -73,7 +83,464 @@ jobs:
         HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY || '--DISABLED--' }}
         PANTS_OPENTELEMETRY_ENABLED: ${{ vars.OPENTELEMETRY_ENABLED || 'False' }}
       name: Build Pants PEX
-      run: ./pants package src/python/pants:pants-pex
+      run: ./pants package src/python/pants:pants-pex@scie_pbs_free_threaded=cp314
+    - continue-on-error: true
+      if: always()
+      name: Upload pants.log
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+      with:
+        name: logs-wheels-and-pex-Linux-ARM64
+        overwrite: 'true'
+        path: .pants.d/workdir/*.log
+    - if: needs.release_info.outputs.is-release == 'true'
+      name: Attest the pantsbuild.pants wheel
+      uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
+      with:
+        subject-path: dist/deploy/wheels/pantsbuild.pants/**/pantsbuild_pants-*.whl
+    - if: needs.release_info.outputs.is-release == 'true'
+      name: Rename the Pants Pex to its final name for upload
+      run: |
+        PANTS_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import pants.version;print(pants.version.VERSION)")
+        PY_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import sys;print(f'cp{sys.version_info[0]}{sys.version_info[1]}{sys.abiflags}')")
+        PLAT=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import os;print(f'{os.uname().sysname.lower()}_{os.uname().machine.lower()}')")
+        PEX_FILENAME=pants.$PANTS_VER-$PY_VER-$PLAT.pex
+        PEX_SCIE_FILENAME=pants.$PANTS_VER-$PY_VER-$PLAT
+
+        mv dist/src.python.pants/pants-pex.pex dist/src.python.pants/$PEX_FILENAME
+        mv dist/src.python.pants/pants-pex dist/src.python.pants/$PEX_SCIE_FILENAME
+        echo "PEX_FILENAME=$PEX_FILENAME" | tee -a "$GITHUB_ENV"
+        echo "PEX_SCIE_FILENAME=$PEX_SCIE_FILENAME" | tee -a "$GITHUB_ENV"
+    - if: needs.release_info.outputs.is-release == 'true'
+      name: Attest the Pants Pex artifact
+      uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
+      with:
+        subject-path: dist/src.python.pants/*
+    - if: needs.release_info.outputs.is-release == 'true'
+      name: Upload Wheel and Pex
+      run: |
+        curl -L --fail \
+            -X POST \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            -H "Content-Type: application/octet-stream" \
+            ${{ needs.release_info.outputs.release-asset-upload-url }}?name=$PEX_FILENAME \
+            --data-binary "@dist/src.python.pants/$PEX_FILENAME"
+
+        curl -L --fail \
+            -X POST \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            -H "Content-Type: application/octet-stream" \
+            ${{ needs.release_info.outputs.release-asset-upload-url }}?name=$PEX_SCIE_FILENAME \
+            --data-binary "@dist/src.python.pants/$PEX_SCIE_FILENAME"
+
+        WHL=$(find dist/deploy/wheels/pantsbuild.pants -type f -name "pantsbuild_pants-*.whl")
+        curl -L --fail \
+            -X POST \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            -H "Content-Type: application/octet-stream" \
+            "${{ needs.release_info.outputs.release-asset-upload-url }}?name=$(basename $WHL)" \
+            --data-binary "@$WHL";
+    timeout-minutes: 90
+  build_wheels_cp314_linux_x86_64:
+    container:
+      image: quay.io/pypa/manylinux_2_28_x86_64:latest
+      volumes:
+      - /:/mnt/host-root
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+      MODE: dist
+      PANTS_REMOTE_CACHE_READ: 'false'
+      PANTS_REMOTE_CACHE_WRITE: 'false'
+    if: github.repository_owner == 'pantsbuild'
+    name: Build wheels (Linux-x86_64, cp314)
+    needs:
+    - release_info
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
+    runs-on:
+    - depot-ubuntu-22.04-8
+    steps:
+    - name: Free up disk space
+      run: |-
+        df -h
+        rm -rf /mnt/host-root/usr/share/dotnet || true
+        rm -rf /mnt/host-root/usr/local/lib/android || true
+        rm -rf /mnt/host-root/opt/ghc || true
+        rm -rf /mnt/host-root/usr/local/.ghcup || true
+        df -h
+    - name: Check out code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        fetch-depth: 10
+        ref: ${{ needs.release_info.outputs.build-ref }}
+    - name: Configure Git
+      run: git config --global safe.directory "$GITHUB_WORKSPACE"
+    - name: Install rustup
+      run: |
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -v -y --default-toolchain none
+        echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
+    - name: Install Rust toolchain
+      run: |
+        # Set the default toolchain. Installs the toolchain if it is not already installed.
+        rustup default 1.97.1
+        cargo version
+    - name: Expose Pythons
+      run: |
+        echo "/opt/python/cp37-cp37m/bin" >> $GITHUB_PATH
+        echo "/opt/python/cp38-cp38/bin" >> $GITHUB_PATH
+        echo "/opt/python/cp39-cp39/bin" >> $GITHUB_PATH
+        echo "/opt/python/cp310-cp310/bin" >> $GITHUB_PATH
+        echo "/opt/python/cp311-cp311/bin" >> $GITHUB_PATH
+        echo "/opt/python/cp312-cp312/bin" >> $GITHUB_PATH
+        echo "/opt/python/cp313-cp313/bin" >> $GITHUB_PATH
+        echo "/opt/python/cp314-cp314/bin" >> $GITHUB_PATH
+        echo "/opt/python/cp314-cp314t/bin" >> $GITHUB_PATH
+    - name: Install Protoc
+      uses: benjyw/setup-protoc@fa4f90fddf8838036cbdeadf1262b9755f6cfb85
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        version: 23.x
+    - name: Install Go 1.25.3
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      with:
+        cache: false
+        go-version: 1.25.3
+    - name: Install Go 1.24.9
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      with:
+        cache: false
+        go-version: 1.24.9
+    - name: Select the distribution interpreter
+      run: |
+        curl -fL -o /tmp/pex.pex \
+        https://github.com/pex-tool/pex/releases/download/v2.98.4/pex
+        echo "78d4bae9f6f4d7e63465e79aff2bd9b199a18340f1d6624cb5af236aa90218b6  /tmp/pex.pex" | sha256sum -c -
+        PY="$(python3.14 /tmp/pex.pex --interpreter-constraint 'CPython[gil]==3.14.*' \
+        -- -c 'import os, sys; print(os.path.realpath(sys.executable))')"
+        echo "PY=$PY" >> "$GITHUB_ENV"
+        echo "PANTS_PYTHON_INTERPRETER_CONSTRAINTS=['CPython[gil]==3.14.*']" >> "$GITHUB_ENV"
+    - env:
+        HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY || '--DISABLED--' }}
+        PANTS_OPENTELEMETRY_ENABLED: ${{ vars.OPENTELEMETRY_ENABLED || 'False' }}
+        PANTS_PROCESS_EXECUTION_LOCAL_PARALLELISM: '1'
+      name: Build wheels
+      run: ./pants run src/python/pants_release/release.py -- build-wheels
+    - env:
+        HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY || '--DISABLED--' }}
+        PANTS_OPENTELEMETRY_ENABLED: ${{ vars.OPENTELEMETRY_ENABLED || 'False' }}
+        PANTS_PROCESS_EXECUTION_LOCAL_PARALLELISM: '1'
+      name: Build Pants PEX
+      run: ./pants package src/python/pants:pants-pex@scie_pbs_free_threaded=cp314
+    - continue-on-error: true
+      if: always()
+      name: Upload pants.log
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+      with:
+        name: logs-wheels-and-pex-Linux-x86_64
+        overwrite: 'true'
+        path: .pants.d/workdir/*.log
+    - if: needs.release_info.outputs.is-release == 'true'
+      name: Attest the pantsbuild.pants wheel
+      uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
+      with:
+        subject-path: dist/deploy/wheels/pantsbuild.pants/**/pantsbuild_pants-*.whl
+    - if: needs.release_info.outputs.is-release == 'true'
+      name: Rename the Pants Pex to its final name for upload
+      run: |
+        PANTS_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import pants.version;print(pants.version.VERSION)")
+        PY_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import sys;print(f'cp{sys.version_info[0]}{sys.version_info[1]}{sys.abiflags}')")
+        PLAT=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import os;print(f'{os.uname().sysname.lower()}_{os.uname().machine.lower()}')")
+        PEX_FILENAME=pants.$PANTS_VER-$PY_VER-$PLAT.pex
+        PEX_SCIE_FILENAME=pants.$PANTS_VER-$PY_VER-$PLAT
+
+        mv dist/src.python.pants/pants-pex.pex dist/src.python.pants/$PEX_FILENAME
+        mv dist/src.python.pants/pants-pex dist/src.python.pants/$PEX_SCIE_FILENAME
+        echo "PEX_FILENAME=$PEX_FILENAME" | tee -a "$GITHUB_ENV"
+        echo "PEX_SCIE_FILENAME=$PEX_SCIE_FILENAME" | tee -a "$GITHUB_ENV"
+    - if: needs.release_info.outputs.is-release == 'true'
+      name: Attest the Pants Pex artifact
+      uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
+      with:
+        subject-path: dist/src.python.pants/*
+    - if: needs.release_info.outputs.is-release == 'true'
+      name: Upload Wheel and Pex
+      run: |
+        curl -L --fail \
+            -X POST \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            -H "Content-Type: application/octet-stream" \
+            ${{ needs.release_info.outputs.release-asset-upload-url }}?name=$PEX_FILENAME \
+            --data-binary "@dist/src.python.pants/$PEX_FILENAME"
+
+        curl -L --fail \
+            -X POST \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            -H "Content-Type: application/octet-stream" \
+            ${{ needs.release_info.outputs.release-asset-upload-url }}?name=$PEX_SCIE_FILENAME \
+            --data-binary "@dist/src.python.pants/$PEX_SCIE_FILENAME"
+
+        WHL=$(find dist/deploy/wheels/pantsbuild.pants -type f -name "pantsbuild_pants-*.whl")
+        curl -L --fail \
+            -X POST \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            -H "Content-Type: application/octet-stream" \
+            "${{ needs.release_info.outputs.release-asset-upload-url }}?name=$(basename $WHL)" \
+            --data-binary "@$WHL";
+    - if: needs.release_info.outputs.is-release == 'true'
+      name: Attest the pantsbuild.pants.testutil wheel
+      uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
+      with:
+        subject-path: dist/deploy/wheels/pantsbuild.pants/**/pantsbuild_pants_testutil*.whl
+    - if: needs.release_info.outputs.is-release == 'true'
+      name: Upload testutil Wheel
+      run: |
+        WHL=$(find dist/deploy/wheels/pantsbuild.pants -type f -name "pantsbuild_pants_testutil*.whl")
+        curl -L --fail \
+            -X POST \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            -H "Content-Type: application/octet-stream" \
+            "${{ needs.release_info.outputs.release-asset-upload-url }}?name=$(basename $WHL)" \
+            --data-binary "@$WHL";
+    timeout-minutes: 90
+  build_wheels_cp314_macos14_arm64:
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: false
+      MODE: dist
+      PANTS_REMOTE_CACHE_READ: 'false'
+      PANTS_REMOTE_CACHE_WRITE: 'false'
+    if: github.repository_owner == 'pantsbuild'
+    name: Build wheels (macOS14-ARM64, cp314)
+    needs:
+    - release_info
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
+    runs-on:
+    - depot-macos-14
+    steps:
+    - name: Free up disk space
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+      with:
+        android: true
+        docker-images: false
+        dotnet: true
+        haskell: true
+        large-packages: false
+        swap-storage: false
+        tool-cache: false
+    - name: Check out code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        fetch-depth: 10
+        ref: ${{ needs.release_info.outputs.build-ref }}
+    - name: Set up Python 3.9, 3.10, 3.11, 3.12, 3.13, 3.14, 3.14t
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: |-
+          3.9
+          3.10
+          3.11
+          3.12
+          3.13
+          3.14
+          3.14t
+    - name: Install Protoc
+      uses: benjyw/setup-protoc@fa4f90fddf8838036cbdeadf1262b9755f6cfb85
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        version: 23.x
+    - name: Set rustup profile
+      run: rustup set profile default
+    - name: Cache Rust toolchain
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        key: macOS14-ARM64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
+        path: |
+          ~/.rustup/toolchains/1.97.1-*
+          ~/.rustup/update-hashes
+          ~/.rustup/settings.toml
+    - name: Cache Cargo
+      uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
+      with:
+        cache-bin: 'false'
+        shared-key: engine
+        workspaces: src/rust
+    - name: Install Protoc
+      uses: benjyw/setup-protoc@fa4f90fddf8838036cbdeadf1262b9755f6cfb85
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        version: 23.x
+    - name: Install Go 1.25.3
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      with:
+        cache: false
+        go-version: 1.25.3
+    - name: Install Go 1.24.9
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      with:
+        cache: false
+        go-version: 1.24.9
+    - name: Select the distribution interpreter
+      run: |
+        curl -fL -o /tmp/pex.pex \
+        https://github.com/pex-tool/pex/releases/download/v2.98.4/pex
+        echo "78d4bae9f6f4d7e63465e79aff2bd9b199a18340f1d6624cb5af236aa90218b6  /tmp/pex.pex" | shasum -a 256 -c -
+        PY="$(python3.14 /tmp/pex.pex --interpreter-constraint 'CPython[gil]==3.14.*' \
+        -- -c 'import os, sys; print(os.path.realpath(sys.executable))')"
+        echo "PY=$PY" >> "$GITHUB_ENV"
+        echo "PANTS_PYTHON_INTERPRETER_CONSTRAINTS=['CPython[gil]==3.14.*']" >> "$GITHUB_ENV"
+    - env:
+        ARCHFLAGS: -arch arm64
+        HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY || '--DISABLED--' }}
+        PANTS_OPENTELEMETRY_ENABLED: ${{ vars.OPENTELEMETRY_ENABLED || 'False' }}
+        _PYTHON_HOST_PLATFORM: macosx-14.0-arm64
+      name: Build wheels
+      run: ./pants run src/python/pants_release/release.py -- build-wheels
+    - env:
+        ARCHFLAGS: -arch arm64
+        HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY || '--DISABLED--' }}
+        PANTS_OPENTELEMETRY_ENABLED: ${{ vars.OPENTELEMETRY_ENABLED || 'False' }}
+        _PYTHON_HOST_PLATFORM: macosx-14.0-arm64
+      name: Build Pants PEX
+      run: ./pants package src/python/pants:pants-pex@scie_pbs_free_threaded=cp314
+    - continue-on-error: true
+      if: always()
+      name: Upload pants.log
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+      with:
+        name: logs-wheels-and-pex-macOS14-ARM64
+        overwrite: 'true'
+        path: .pants.d/workdir/*.log
+    - if: needs.release_info.outputs.is-release == 'true'
+      name: Attest the pantsbuild.pants wheel
+      uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
+      with:
+        subject-path: dist/deploy/wheels/pantsbuild.pants/**/pantsbuild_pants-*.whl
+    - if: needs.release_info.outputs.is-release == 'true'
+      name: Rename the Pants Pex to its final name for upload
+      run: |
+        PANTS_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import pants.version;print(pants.version.VERSION)")
+        PY_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import sys;print(f'cp{sys.version_info[0]}{sys.version_info[1]}{sys.abiflags}')")
+        PLAT=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import os;print(f'{os.uname().sysname.lower()}_{os.uname().machine.lower()}')")
+        PEX_FILENAME=pants.$PANTS_VER-$PY_VER-$PLAT.pex
+        PEX_SCIE_FILENAME=pants.$PANTS_VER-$PY_VER-$PLAT
+
+        mv dist/src.python.pants/pants-pex.pex dist/src.python.pants/$PEX_FILENAME
+        mv dist/src.python.pants/pants-pex dist/src.python.pants/$PEX_SCIE_FILENAME
+        echo "PEX_FILENAME=$PEX_FILENAME" | tee -a "$GITHUB_ENV"
+        echo "PEX_SCIE_FILENAME=$PEX_SCIE_FILENAME" | tee -a "$GITHUB_ENV"
+    - if: needs.release_info.outputs.is-release == 'true'
+      name: Attest the Pants Pex artifact
+      uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
+      with:
+        subject-path: dist/src.python.pants/*
+    - if: needs.release_info.outputs.is-release == 'true'
+      name: Upload Wheel and Pex
+      run: |
+        curl -L --fail \
+            -X POST \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            -H "Content-Type: application/octet-stream" \
+            ${{ needs.release_info.outputs.release-asset-upload-url }}?name=$PEX_FILENAME \
+            --data-binary "@dist/src.python.pants/$PEX_FILENAME"
+
+        curl -L --fail \
+            -X POST \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            -H "Content-Type: application/octet-stream" \
+            ${{ needs.release_info.outputs.release-asset-upload-url }}?name=$PEX_SCIE_FILENAME \
+            --data-binary "@dist/src.python.pants/$PEX_SCIE_FILENAME"
+
+        WHL=$(find dist/deploy/wheels/pantsbuild.pants -type f -name "pantsbuild_pants-*.whl")
+        curl -L --fail \
+            -X POST \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            -H "Content-Type: application/octet-stream" \
+            "${{ needs.release_info.outputs.release-asset-upload-url }}?name=$(basename $WHL)" \
+            --data-binary "@$WHL";
+    timeout-minutes: 90
+  build_wheels_linux_arm64:
+    container:
+      image: quay.io/pypa/manylinux_2_28_aarch64:latest
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+      MODE: dist
+      PANTS_REMOTE_CACHE_READ: 'false'
+      PANTS_REMOTE_CACHE_WRITE: 'false'
+    if: github.repository_owner == 'pantsbuild'
+    name: Build wheels (Linux-ARM64, cp314t)
+    needs:
+    - release_info
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
+    runs-on:
+    - depot-ubuntu-24.04-arm-8
+    steps:
+    - name: Free up disk space
+      run: |-
+        df -h
+        rm -rf /mnt/host-root/usr/share/dotnet || true
+        rm -rf /mnt/host-root/usr/local/lib/android || true
+        rm -rf /mnt/host-root/opt/ghc || true
+        rm -rf /mnt/host-root/usr/local/.ghcup || true
+        df -h
+    - name: Check out code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        fetch-depth: 10
+        ref: ${{ needs.release_info.outputs.build-ref }}
+    - name: Configure Git
+      run: git config --global safe.directory "$GITHUB_WORKSPACE"
+    - name: Install rustup
+      run: |
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -v -y --default-toolchain none
+        echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
+    - name: Install Rust toolchain
+      run: |
+        # Set the default toolchain. Installs the toolchain if it is not already installed.
+        rustup default 1.97.1
+        cargo version
+    - name: Expose Pythons
+      run: |
+        echo "/opt/python/cp37-cp37m/bin" >> $GITHUB_PATH
+        echo "/opt/python/cp38-cp38/bin" >> $GITHUB_PATH
+        echo "/opt/python/cp39-cp39/bin" >> $GITHUB_PATH
+        echo "/opt/python/cp310-cp310/bin" >> $GITHUB_PATH
+        echo "/opt/python/cp311-cp311/bin" >> $GITHUB_PATH
+        echo "/opt/python/cp312-cp312/bin" >> $GITHUB_PATH
+        echo "/opt/python/cp313-cp313/bin" >> $GITHUB_PATH
+        echo "/opt/python/cp314-cp314/bin" >> $GITHUB_PATH
+        echo "/opt/python/cp314-cp314t/bin" >> $GITHUB_PATH
+    - name: Install Protoc
+      uses: benjyw/setup-protoc@fa4f90fddf8838036cbdeadf1262b9755f6cfb85
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        version: 23.x
+    - name: Install Python headers
+      run: echo 'no-op'
+    - name: Select the distribution interpreter
+      run: |
+        curl -fL -o /tmp/pex.pex \
+        https://github.com/pex-tool/pex/releases/download/v2.98.4/pex
+        echo "78d4bae9f6f4d7e63465e79aff2bd9b199a18340f1d6624cb5af236aa90218b6  /tmp/pex.pex" | sha256sum -c -
+        PY="$(python3.14 /tmp/pex.pex --interpreter-constraint 'CPython[free-threaded]==3.14.*' \
+        -- -c 'import os, sys; print(os.path.realpath(sys.executable))')"
+        echo "PY=$PY" >> "$GITHUB_ENV"
+        echo "PANTS_PYTHON_INTERPRETER_CONSTRAINTS=['CPython[free-threaded]==3.14.*']" >> "$GITHUB_ENV"
+    - env:
+        HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY || '--DISABLED--' }}
+        PANTS_OPENTELEMETRY_ENABLED: ${{ vars.OPENTELEMETRY_ENABLED || 'False' }}
+      name: Build wheels
+      run: ./pants run src/python/pants_release/release.py -- build-wheels
+    - env:
+        HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY || '--DISABLED--' }}
+        PANTS_OPENTELEMETRY_ENABLED: ${{ vars.OPENTELEMETRY_ENABLED || 'False' }}
+      name: Build Pants PEX
+      run: ./pants package src/python/pants:pants-pex@scie_pbs_free_threaded=cp314t
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -141,7 +608,7 @@ jobs:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
     if: github.repository_owner == 'pantsbuild'
-    name: Build wheels (Linux-x86_64)
+    name: Build wheels (Linux-x86_64, cp314t)
     needs:
     - release_info
     permissions:
@@ -185,6 +652,7 @@ jobs:
         echo "/opt/python/cp312-cp312/bin" >> $GITHUB_PATH
         echo "/opt/python/cp313-cp313/bin" >> $GITHUB_PATH
         echo "/opt/python/cp314-cp314/bin" >> $GITHUB_PATH
+        echo "/opt/python/cp314-cp314t/bin" >> $GITHUB_PATH
     - name: Install Protoc
       uses: benjyw/setup-protoc@fa4f90fddf8838036cbdeadf1262b9755f6cfb85
       with:
@@ -200,6 +668,15 @@ jobs:
       with:
         cache: false
         go-version: 1.24.9
+    - name: Select the distribution interpreter
+      run: |
+        curl -fL -o /tmp/pex.pex \
+        https://github.com/pex-tool/pex/releases/download/v2.98.4/pex
+        echo "78d4bae9f6f4d7e63465e79aff2bd9b199a18340f1d6624cb5af236aa90218b6  /tmp/pex.pex" | sha256sum -c -
+        PY="$(python3.14 /tmp/pex.pex --interpreter-constraint 'CPython[free-threaded]==3.14.*' \
+        -- -c 'import os, sys; print(os.path.realpath(sys.executable))')"
+        echo "PY=$PY" >> "$GITHUB_ENV"
+        echo "PANTS_PYTHON_INTERPRETER_CONSTRAINTS=['CPython[free-threaded]==3.14.*']" >> "$GITHUB_ENV"
     - env:
         HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY || '--DISABLED--' }}
         PANTS_OPENTELEMETRY_ENABLED: ${{ vars.OPENTELEMETRY_ENABLED || 'False' }}
@@ -211,7 +688,7 @@ jobs:
         PANTS_OPENTELEMETRY_ENABLED: ${{ vars.OPENTELEMETRY_ENABLED || 'False' }}
         PANTS_PROCESS_EXECUTION_LOCAL_PARALLELISM: '1'
       name: Build Pants PEX
-      run: ./pants package src/python/pants:pants-pex
+      run: ./pants package src/python/pants:pants-pex@scie_pbs_free_threaded=cp314t
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -290,7 +767,7 @@ jobs:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
     if: github.repository_owner == 'pantsbuild'
-    name: Build wheels (macOS14-ARM64)
+    name: Build wheels (macOS14-ARM64, cp314t)
     needs:
     - release_info
     permissions:
@@ -362,6 +839,15 @@ jobs:
       with:
         cache: false
         go-version: 1.24.9
+    - name: Select the distribution interpreter
+      run: |
+        curl -fL -o /tmp/pex.pex \
+        https://github.com/pex-tool/pex/releases/download/v2.98.4/pex
+        echo "78d4bae9f6f4d7e63465e79aff2bd9b199a18340f1d6624cb5af236aa90218b6  /tmp/pex.pex" | shasum -a 256 -c -
+        PY="$(python3.14 /tmp/pex.pex --interpreter-constraint 'CPython[free-threaded]==3.14.*' \
+        -- -c 'import os, sys; print(os.path.realpath(sys.executable))')"
+        echo "PY=$PY" >> "$GITHUB_ENV"
+        echo "PANTS_PYTHON_INTERPRETER_CONSTRAINTS=['CPython[free-threaded]==3.14.*']" >> "$GITHUB_ENV"
     - env:
         ARCHFLAGS: -arch arm64
         HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY || '--DISABLED--' }}
@@ -375,7 +861,7 @@ jobs:
         PANTS_OPENTELEMETRY_ENABLED: ${{ vars.OPENTELEMETRY_ENABLED || 'False' }}
         _PYTHON_HOST_PLATFORM: macosx-14.0-arm64
       name: Build Pants PEX
-      run: ./pants package src/python/pants:pants-pex
+      run: ./pants package src/python/pants:pants-pex@scie_pbs_free_threaded=cp314t
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -440,6 +926,9 @@ jobs:
     - build_wheels_linux_x86_64
     - build_wheels_linux_arm64
     - build_wheels_macos14_arm64
+    - build_wheels_cp314_linux_x86_64
+    - build_wheels_cp314_linux_arm64
+    - build_wheels_cp314_macos14_arm64
     - release_info
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,7 +38,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 10
-    - name: Set up Python 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14
+    - name: Set up Python 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14, 3.14t
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: |-
@@ -49,6 +49,7 @@ jobs:
           3.12
           3.13
           3.14
+          3.14t
     - name: Install Protoc
       uses: benjyw/setup-protoc@fa4f90fddf8838036cbdeadf1262b9755f6cfb85
       with:
@@ -148,7 +149,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 10
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14, 3.14t
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: |-
@@ -160,6 +161,7 @@ jobs:
           3.12
           3.13
           3.14
+          3.14t
     - name: Install Protoc
       uses: benjyw/setup-protoc@fa4f90fddf8838036cbdeadf1262b9755f6cfb85
       with:
@@ -267,7 +269,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 10
-    - name: Set up Python 3.9, 3.10, 3.11, 3.12, 3.13, 3.14
+    - name: Set up Python 3.9, 3.10, 3.11, 3.12, 3.13, 3.14, 3.14t
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: |-
@@ -277,6 +279,7 @@ jobs:
           3.12
           3.13
           3.14
+          3.14t
     - name: Install Protoc
       uses: benjyw/setup-protoc@fa4f90fddf8838036cbdeadf1262b9755f6cfb85
       with:
@@ -550,7 +553,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 10
-    - name: Set up Python 3.9, 3.10, 3.11, 3.12, 3.13, 3.14
+    - name: Set up Python 3.9, 3.10, 3.11, 3.12, 3.13, 3.14, 3.14t
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: |-
@@ -560,6 +563,7 @@ jobs:
           3.12
           3.13
           3.14
+          3.14t
     - name: Install Protoc
       uses: benjyw/setup-protoc@fa4f90fddf8838036cbdeadf1262b9755f6cfb85
       with:
@@ -782,7 +786,7 @@ jobs:
         echo "PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092" >> "$GITHUB_ENV"
         echo "PANTS_REMOTE_CACHE_READ=true" >> "$GITHUB_ENV"
         echo "PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}" >> "$GITHUB_ENV"
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14, 3.14t
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: |-
@@ -794,6 +798,7 @@ jobs:
           3.12
           3.13
           3.14
+          3.14t
     - name: Download native binaries
       uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:
@@ -908,7 +913,7 @@ jobs:
       with:
         cache: false
         go-version: 1.24.9
-    - name: Set up Python 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14
+    - name: Set up Python 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14, 3.14t
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: |-
@@ -919,6 +924,7 @@ jobs:
           3.12
           3.13
           3.14
+          3.14t
     - name: Download native binaries
       uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:
@@ -1036,7 +1042,7 @@ jobs:
         curl --fail -L https://binaries.pantsbuild.org/bin/thrift/linux/x86_64/0.15.0/thrift -o "${HOME}/.thrift/thrift"
         chmod +x "${HOME}/.thrift/thrift"
         echo "${HOME}/.thrift" >> $GITHUB_PATH
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14, 3.14t
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: |-
@@ -1048,6 +1054,7 @@ jobs:
           3.12
           3.13
           3.14
+          3.14t
     - name: Download native binaries
       uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:
@@ -1165,7 +1172,7 @@ jobs:
         curl --fail -L https://binaries.pantsbuild.org/bin/thrift/linux/x86_64/0.15.0/thrift -o "${HOME}/.thrift/thrift"
         chmod +x "${HOME}/.thrift/thrift"
         echo "${HOME}/.thrift" >> $GITHUB_PATH
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14, 3.14t
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: |-
@@ -1177,6 +1184,7 @@ jobs:
           3.12
           3.13
           3.14
+          3.14t
     - name: Download native binaries
       uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:
@@ -1294,7 +1302,7 @@ jobs:
         curl --fail -L https://binaries.pantsbuild.org/bin/thrift/linux/x86_64/0.15.0/thrift -o "${HOME}/.thrift/thrift"
         chmod +x "${HOME}/.thrift/thrift"
         echo "${HOME}/.thrift" >> $GITHUB_PATH
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14, 3.14t
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: |-
@@ -1306,6 +1314,7 @@ jobs:
           3.12
           3.13
           3.14
+          3.14t
     - name: Download native binaries
       uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:
@@ -1423,7 +1432,7 @@ jobs:
         curl --fail -L https://binaries.pantsbuild.org/bin/thrift/linux/x86_64/0.15.0/thrift -o "${HOME}/.thrift/thrift"
         chmod +x "${HOME}/.thrift/thrift"
         echo "${HOME}/.thrift" >> $GITHUB_PATH
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14, 3.14t
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: |-
@@ -1435,6 +1444,7 @@ jobs:
           3.12
           3.13
           3.14
+          3.14t
     - name: Download native binaries
       uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:
@@ -1552,7 +1562,7 @@ jobs:
         curl --fail -L https://binaries.pantsbuild.org/bin/thrift/linux/x86_64/0.15.0/thrift -o "${HOME}/.thrift/thrift"
         chmod +x "${HOME}/.thrift/thrift"
         echo "${HOME}/.thrift" >> $GITHUB_PATH
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14, 3.14t
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: |-
@@ -1564,6 +1574,7 @@ jobs:
           3.12
           3.13
           3.14
+          3.14t
     - name: Download native binaries
       uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:
@@ -1681,7 +1692,7 @@ jobs:
         curl --fail -L https://binaries.pantsbuild.org/bin/thrift/linux/x86_64/0.15.0/thrift -o "${HOME}/.thrift/thrift"
         chmod +x "${HOME}/.thrift/thrift"
         echo "${HOME}/.thrift" >> $GITHUB_PATH
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14, 3.14t
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: |-
@@ -1693,6 +1704,7 @@ jobs:
           3.12
           3.13
           3.14
+          3.14t
     - name: Download native binaries
       uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:
@@ -1810,7 +1822,7 @@ jobs:
         curl --fail -L https://binaries.pantsbuild.org/bin/thrift/linux/x86_64/0.15.0/thrift -o "${HOME}/.thrift/thrift"
         chmod +x "${HOME}/.thrift/thrift"
         echo "${HOME}/.thrift" >> $GITHUB_PATH
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14, 3.14t
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: |-
@@ -1822,6 +1834,7 @@ jobs:
           3.12
           3.13
           3.14
+          3.14t
     - name: Download native binaries
       uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:
@@ -1939,7 +1952,7 @@ jobs:
         curl --fail -L https://binaries.pantsbuild.org/bin/thrift/linux/x86_64/0.15.0/thrift -o "${HOME}/.thrift/thrift"
         chmod +x "${HOME}/.thrift/thrift"
         echo "${HOME}/.thrift" >> $GITHUB_PATH
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14, 3.14t
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: |-
@@ -1951,6 +1964,7 @@ jobs:
           3.12
           3.13
           3.14
+          3.14t
     - name: Download native binaries
       uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:
@@ -2068,7 +2082,7 @@ jobs:
         curl --fail -L https://binaries.pantsbuild.org/bin/thrift/linux/x86_64/0.15.0/thrift -o "${HOME}/.thrift/thrift"
         chmod +x "${HOME}/.thrift/thrift"
         echo "${HOME}/.thrift" >> $GITHUB_PATH
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14, 3.14t
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: |-
@@ -2080,6 +2094,7 @@ jobs:
           3.12
           3.13
           3.14
+          3.14t
     - name: Download native binaries
       uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:
@@ -2197,7 +2212,7 @@ jobs:
         curl --fail -L https://binaries.pantsbuild.org/bin/thrift/linux/x86_64/0.15.0/thrift -o "${HOME}/.thrift/thrift"
         chmod +x "${HOME}/.thrift/thrift"
         echo "${HOME}/.thrift" >> $GITHUB_PATH
-    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14
+    - name: Set up Python 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14, 3.14t
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: |-
@@ -2209,6 +2224,7 @@ jobs:
           3.12
           3.13
           3.14
+          3.14t
     - name: Download native binaries
       uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:
@@ -2295,7 +2311,7 @@ jobs:
       with:
         cache: false
         go-version: 1.24.9
-    - name: Set up Python 3.9, 3.10, 3.11, 3.12, 3.13, 3.14
+    - name: Set up Python 3.9, 3.10, 3.11, 3.12, 3.13, 3.14, 3.14t
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: |-
@@ -2305,6 +2321,7 @@ jobs:
           3.12
           3.13
           3.14
+          3.14t
     - name: Download native binaries
       uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -354,7 +354,7 @@ jobs:
       name: Test Rust
       run: ./cargo test --locked --tests -- --nocapture
     timeout-minutes: 60
-  build_wheels_linux_arm64:
+  build_wheels_cp314_linux_arm64:
     container:
       image: quay.io/pypa/manylinux_2_28_aarch64:latest
     env:
@@ -363,7 +363,7 @@ jobs:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
     if: ((github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.release == 'true' || needs.classify_changes.outputs.ci_config == 'true')) && (needs.classify_changes.outputs.no_code != 'true')
-    name: Build wheels (Linux-ARM64)
+    name: Build wheels (Linux-ARM64, cp314)
     needs:
     - classify_changes
     permissions:
@@ -406,6 +406,7 @@ jobs:
         echo "/opt/python/cp312-cp312/bin" >> $GITHUB_PATH
         echo "/opt/python/cp313-cp313/bin" >> $GITHUB_PATH
         echo "/opt/python/cp314-cp314/bin" >> $GITHUB_PATH
+        echo "/opt/python/cp314-cp314t/bin" >> $GITHUB_PATH
     - name: Install Protoc
       uses: benjyw/setup-protoc@fa4f90fddf8838036cbdeadf1262b9755f6cfb85
       with:
@@ -413,6 +414,15 @@ jobs:
         version: 23.x
     - name: Install Python headers
       run: echo 'no-op'
+    - name: Select the distribution interpreter
+      run: |
+        curl -fL -o /tmp/pex.pex \
+        https://github.com/pex-tool/pex/releases/download/v2.98.4/pex
+        echo "78d4bae9f6f4d7e63465e79aff2bd9b199a18340f1d6624cb5af236aa90218b6  /tmp/pex.pex" | sha256sum -c -
+        PY="$(python3.14 /tmp/pex.pex --interpreter-constraint 'CPython[gil]==3.14.*' \
+        -- -c 'import os, sys; print(os.path.realpath(sys.executable))')"
+        echo "PY=$PY" >> "$GITHUB_ENV"
+        echo "PANTS_PYTHON_INTERPRETER_CONSTRAINTS=['CPython[gil]==3.14.*']" >> "$GITHUB_ENV"
     - env:
         HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY || '--DISABLED--' }}
         PANTS_OPENTELEMETRY_ENABLED: ${{ vars.OPENTELEMETRY_ENABLED || 'False' }}
@@ -422,7 +432,7 @@ jobs:
         HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY || '--DISABLED--' }}
         PANTS_OPENTELEMETRY_ENABLED: ${{ vars.OPENTELEMETRY_ENABLED || 'False' }}
       name: Build Pants PEX
-      run: ./pants package src/python/pants:pants-pex
+      run: ./pants package src/python/pants:pants-pex@scie_pbs_free_threaded=cp314
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -432,7 +442,7 @@ jobs:
         overwrite: 'true'
         path: .pants.d/workdir/*.log
     timeout-minutes: 90
-  build_wheels_linux_x86_64:
+  build_wheels_cp314_linux_x86_64:
     container:
       image: quay.io/pypa/manylinux_2_28_x86_64:latest
       volumes:
@@ -443,7 +453,7 @@ jobs:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
     if: ((github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.release == 'true' || needs.classify_changes.outputs.ci_config == 'true')) && (needs.classify_changes.outputs.no_code != 'true')
-    name: Build wheels (Linux-x86_64)
+    name: Build wheels (Linux-x86_64, cp314)
     needs:
     - classify_changes
     permissions:
@@ -486,6 +496,7 @@ jobs:
         echo "/opt/python/cp312-cp312/bin" >> $GITHUB_PATH
         echo "/opt/python/cp313-cp313/bin" >> $GITHUB_PATH
         echo "/opt/python/cp314-cp314/bin" >> $GITHUB_PATH
+        echo "/opt/python/cp314-cp314t/bin" >> $GITHUB_PATH
     - name: Install Protoc
       uses: benjyw/setup-protoc@fa4f90fddf8838036cbdeadf1262b9755f6cfb85
       with:
@@ -501,6 +512,15 @@ jobs:
       with:
         cache: false
         go-version: 1.24.9
+    - name: Select the distribution interpreter
+      run: |
+        curl -fL -o /tmp/pex.pex \
+        https://github.com/pex-tool/pex/releases/download/v2.98.4/pex
+        echo "78d4bae9f6f4d7e63465e79aff2bd9b199a18340f1d6624cb5af236aa90218b6  /tmp/pex.pex" | sha256sum -c -
+        PY="$(python3.14 /tmp/pex.pex --interpreter-constraint 'CPython[gil]==3.14.*' \
+        -- -c 'import os, sys; print(os.path.realpath(sys.executable))')"
+        echo "PY=$PY" >> "$GITHUB_ENV"
+        echo "PANTS_PYTHON_INTERPRETER_CONSTRAINTS=['CPython[gil]==3.14.*']" >> "$GITHUB_ENV"
     - env:
         HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY || '--DISABLED--' }}
         PANTS_OPENTELEMETRY_ENABLED: ${{ vars.OPENTELEMETRY_ENABLED || 'False' }}
@@ -512,7 +532,7 @@ jobs:
         PANTS_OPENTELEMETRY_ENABLED: ${{ vars.OPENTELEMETRY_ENABLED || 'False' }}
         PANTS_PROCESS_EXECUTION_LOCAL_PARALLELISM: '1'
       name: Build Pants PEX
-      run: ./pants package src/python/pants:pants-pex
+      run: ./pants package src/python/pants:pants-pex@scie_pbs_free_threaded=cp314
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -522,14 +542,14 @@ jobs:
         overwrite: 'true'
         path: .pants.d/workdir/*.log
     timeout-minutes: 90
-  build_wheels_macos14_arm64:
+  build_wheels_cp314_macos14_arm64:
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: false
       MODE: debug
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
     if: ((github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.release == 'true' || needs.classify_changes.outputs.ci_config == 'true')) && (needs.classify_changes.outputs.no_code != 'true')
-    name: Build wheels (macOS14-ARM64)
+    name: Build wheels (macOS14-ARM64, cp314)
     needs:
     - classify_changes
     permissions:
@@ -600,6 +620,15 @@ jobs:
       with:
         cache: false
         go-version: 1.24.9
+    - name: Select the distribution interpreter
+      run: |
+        curl -fL -o /tmp/pex.pex \
+        https://github.com/pex-tool/pex/releases/download/v2.98.4/pex
+        echo "78d4bae9f6f4d7e63465e79aff2bd9b199a18340f1d6624cb5af236aa90218b6  /tmp/pex.pex" | shasum -a 256 -c -
+        PY="$(python3.14 /tmp/pex.pex --interpreter-constraint 'CPython[gil]==3.14.*' \
+        -- -c 'import os, sys; print(os.path.realpath(sys.executable))')"
+        echo "PY=$PY" >> "$GITHUB_ENV"
+        echo "PANTS_PYTHON_INTERPRETER_CONSTRAINTS=['CPython[gil]==3.14.*']" >> "$GITHUB_ENV"
     - env:
         ARCHFLAGS: -arch arm64
         HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY || '--DISABLED--' }}
@@ -613,7 +642,305 @@ jobs:
         PANTS_OPENTELEMETRY_ENABLED: ${{ vars.OPENTELEMETRY_ENABLED || 'False' }}
         _PYTHON_HOST_PLATFORM: macosx-14.0-arm64
       name: Build Pants PEX
-      run: ./pants package src/python/pants:pants-pex
+      run: ./pants package src/python/pants:pants-pex@scie_pbs_free_threaded=cp314
+    - continue-on-error: true
+      if: always()
+      name: Upload pants.log
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+      with:
+        name: logs-wheels-and-pex-macOS14-ARM64
+        overwrite: 'true'
+        path: .pants.d/workdir/*.log
+    timeout-minutes: 90
+  build_wheels_linux_arm64:
+    container:
+      image: quay.io/pypa/manylinux_2_28_aarch64:latest
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+      MODE: debug
+      PANTS_REMOTE_CACHE_READ: 'false'
+      PANTS_REMOTE_CACHE_WRITE: 'false'
+    if: ((github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.release == 'true' || needs.classify_changes.outputs.ci_config == 'true')) && (needs.classify_changes.outputs.no_code != 'true')
+    name: Build wheels (Linux-ARM64, cp314t)
+    needs:
+    - classify_changes
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
+    runs-on:
+    - depot-ubuntu-24.04-arm-8
+    steps:
+    - name: Free up disk space
+      run: |-
+        df -h
+        rm -rf /mnt/host-root/usr/share/dotnet || true
+        rm -rf /mnt/host-root/usr/local/lib/android || true
+        rm -rf /mnt/host-root/opt/ghc || true
+        rm -rf /mnt/host-root/usr/local/.ghcup || true
+        df -h
+    - name: Check out code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        fetch-depth: 10
+    - name: Configure Git
+      run: git config --global safe.directory "$GITHUB_WORKSPACE"
+    - name: Install rustup
+      run: |
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -v -y --default-toolchain none
+        echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
+    - name: Install Rust toolchain
+      run: |
+        # Set the default toolchain. Installs the toolchain if it is not already installed.
+        rustup default 1.97.1
+        cargo version
+    - name: Expose Pythons
+      run: |
+        echo "/opt/python/cp37-cp37m/bin" >> $GITHUB_PATH
+        echo "/opt/python/cp38-cp38/bin" >> $GITHUB_PATH
+        echo "/opt/python/cp39-cp39/bin" >> $GITHUB_PATH
+        echo "/opt/python/cp310-cp310/bin" >> $GITHUB_PATH
+        echo "/opt/python/cp311-cp311/bin" >> $GITHUB_PATH
+        echo "/opt/python/cp312-cp312/bin" >> $GITHUB_PATH
+        echo "/opt/python/cp313-cp313/bin" >> $GITHUB_PATH
+        echo "/opt/python/cp314-cp314/bin" >> $GITHUB_PATH
+        echo "/opt/python/cp314-cp314t/bin" >> $GITHUB_PATH
+    - name: Install Protoc
+      uses: benjyw/setup-protoc@fa4f90fddf8838036cbdeadf1262b9755f6cfb85
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        version: 23.x
+    - name: Install Python headers
+      run: echo 'no-op'
+    - name: Select the distribution interpreter
+      run: |
+        curl -fL -o /tmp/pex.pex \
+        https://github.com/pex-tool/pex/releases/download/v2.98.4/pex
+        echo "78d4bae9f6f4d7e63465e79aff2bd9b199a18340f1d6624cb5af236aa90218b6  /tmp/pex.pex" | sha256sum -c -
+        PY="$(python3.14 /tmp/pex.pex --interpreter-constraint 'CPython[free-threaded]==3.14.*' \
+        -- -c 'import os, sys; print(os.path.realpath(sys.executable))')"
+        echo "PY=$PY" >> "$GITHUB_ENV"
+        echo "PANTS_PYTHON_INTERPRETER_CONSTRAINTS=['CPython[free-threaded]==3.14.*']" >> "$GITHUB_ENV"
+    - env:
+        HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY || '--DISABLED--' }}
+        PANTS_OPENTELEMETRY_ENABLED: ${{ vars.OPENTELEMETRY_ENABLED || 'False' }}
+      name: Build wheels
+      run: ./pants run src/python/pants_release/release.py -- build-wheels
+    - env:
+        HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY || '--DISABLED--' }}
+        PANTS_OPENTELEMETRY_ENABLED: ${{ vars.OPENTELEMETRY_ENABLED || 'False' }}
+      name: Build Pants PEX
+      run: ./pants package src/python/pants:pants-pex@scie_pbs_free_threaded=cp314t
+    - continue-on-error: true
+      if: always()
+      name: Upload pants.log
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+      with:
+        name: logs-wheels-and-pex-Linux-ARM64
+        overwrite: 'true'
+        path: .pants.d/workdir/*.log
+    timeout-minutes: 90
+  build_wheels_linux_x86_64:
+    container:
+      image: quay.io/pypa/manylinux_2_28_x86_64:latest
+      volumes:
+      - /:/mnt/host-root
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+      MODE: debug
+      PANTS_REMOTE_CACHE_READ: 'false'
+      PANTS_REMOTE_CACHE_WRITE: 'false'
+    if: ((github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.release == 'true' || needs.classify_changes.outputs.ci_config == 'true')) && (needs.classify_changes.outputs.no_code != 'true')
+    name: Build wheels (Linux-x86_64, cp314t)
+    needs:
+    - classify_changes
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
+    runs-on:
+    - depot-ubuntu-22.04-8
+    steps:
+    - name: Free up disk space
+      run: |-
+        df -h
+        rm -rf /mnt/host-root/usr/share/dotnet || true
+        rm -rf /mnt/host-root/usr/local/lib/android || true
+        rm -rf /mnt/host-root/opt/ghc || true
+        rm -rf /mnt/host-root/usr/local/.ghcup || true
+        df -h
+    - name: Check out code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        fetch-depth: 10
+    - name: Configure Git
+      run: git config --global safe.directory "$GITHUB_WORKSPACE"
+    - name: Install rustup
+      run: |
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -v -y --default-toolchain none
+        echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
+    - name: Install Rust toolchain
+      run: |
+        # Set the default toolchain. Installs the toolchain if it is not already installed.
+        rustup default 1.97.1
+        cargo version
+    - name: Expose Pythons
+      run: |
+        echo "/opt/python/cp37-cp37m/bin" >> $GITHUB_PATH
+        echo "/opt/python/cp38-cp38/bin" >> $GITHUB_PATH
+        echo "/opt/python/cp39-cp39/bin" >> $GITHUB_PATH
+        echo "/opt/python/cp310-cp310/bin" >> $GITHUB_PATH
+        echo "/opt/python/cp311-cp311/bin" >> $GITHUB_PATH
+        echo "/opt/python/cp312-cp312/bin" >> $GITHUB_PATH
+        echo "/opt/python/cp313-cp313/bin" >> $GITHUB_PATH
+        echo "/opt/python/cp314-cp314/bin" >> $GITHUB_PATH
+        echo "/opt/python/cp314-cp314t/bin" >> $GITHUB_PATH
+    - name: Install Protoc
+      uses: benjyw/setup-protoc@fa4f90fddf8838036cbdeadf1262b9755f6cfb85
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        version: 23.x
+    - name: Install Go 1.25.3
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      with:
+        cache: false
+        go-version: 1.25.3
+    - name: Install Go 1.24.9
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      with:
+        cache: false
+        go-version: 1.24.9
+    - name: Select the distribution interpreter
+      run: |
+        curl -fL -o /tmp/pex.pex \
+        https://github.com/pex-tool/pex/releases/download/v2.98.4/pex
+        echo "78d4bae9f6f4d7e63465e79aff2bd9b199a18340f1d6624cb5af236aa90218b6  /tmp/pex.pex" | sha256sum -c -
+        PY="$(python3.14 /tmp/pex.pex --interpreter-constraint 'CPython[free-threaded]==3.14.*' \
+        -- -c 'import os, sys; print(os.path.realpath(sys.executable))')"
+        echo "PY=$PY" >> "$GITHUB_ENV"
+        echo "PANTS_PYTHON_INTERPRETER_CONSTRAINTS=['CPython[free-threaded]==3.14.*']" >> "$GITHUB_ENV"
+    - env:
+        HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY || '--DISABLED--' }}
+        PANTS_OPENTELEMETRY_ENABLED: ${{ vars.OPENTELEMETRY_ENABLED || 'False' }}
+        PANTS_PROCESS_EXECUTION_LOCAL_PARALLELISM: '1'
+      name: Build wheels
+      run: ./pants run src/python/pants_release/release.py -- build-wheels
+    - env:
+        HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY || '--DISABLED--' }}
+        PANTS_OPENTELEMETRY_ENABLED: ${{ vars.OPENTELEMETRY_ENABLED || 'False' }}
+        PANTS_PROCESS_EXECUTION_LOCAL_PARALLELISM: '1'
+      name: Build Pants PEX
+      run: ./pants package src/python/pants:pants-pex@scie_pbs_free_threaded=cp314t
+    - continue-on-error: true
+      if: always()
+      name: Upload pants.log
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+      with:
+        name: logs-wheels-and-pex-Linux-x86_64
+        overwrite: 'true'
+        path: .pants.d/workdir/*.log
+    timeout-minutes: 90
+  build_wheels_macos14_arm64:
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: false
+      MODE: debug
+      PANTS_REMOTE_CACHE_READ: 'false'
+      PANTS_REMOTE_CACHE_WRITE: 'false'
+    if: ((github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.release == 'true' || needs.classify_changes.outputs.ci_config == 'true')) && (needs.classify_changes.outputs.no_code != 'true')
+    name: Build wheels (macOS14-ARM64, cp314t)
+    needs:
+    - classify_changes
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
+    runs-on:
+    - depot-macos-14
+    steps:
+    - name: Free up disk space
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+      with:
+        android: true
+        docker-images: false
+        dotnet: true
+        haskell: true
+        large-packages: false
+        swap-storage: false
+        tool-cache: false
+    - name: Check out code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        fetch-depth: 10
+    - name: Set up Python 3.9, 3.10, 3.11, 3.12, 3.13, 3.14, 3.14t
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: |-
+          3.9
+          3.10
+          3.11
+          3.12
+          3.13
+          3.14
+          3.14t
+    - name: Install Protoc
+      uses: benjyw/setup-protoc@fa4f90fddf8838036cbdeadf1262b9755f6cfb85
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        version: 23.x
+    - name: Set rustup profile
+      run: rustup set profile default
+    - name: Cache Rust toolchain
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        key: macOS14-ARM64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
+        path: |
+          ~/.rustup/toolchains/1.97.1-*
+          ~/.rustup/update-hashes
+          ~/.rustup/settings.toml
+    - name: Cache Cargo
+      uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
+      with:
+        cache-bin: 'false'
+        shared-key: engine
+        workspaces: src/rust
+    - name: Install Protoc
+      uses: benjyw/setup-protoc@fa4f90fddf8838036cbdeadf1262b9755f6cfb85
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        version: 23.x
+    - name: Install Go 1.25.3
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      with:
+        cache: false
+        go-version: 1.25.3
+    - name: Install Go 1.24.9
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      with:
+        cache: false
+        go-version: 1.24.9
+    - name: Select the distribution interpreter
+      run: |
+        curl -fL -o /tmp/pex.pex \
+        https://github.com/pex-tool/pex/releases/download/v2.98.4/pex
+        echo "78d4bae9f6f4d7e63465e79aff2bd9b199a18340f1d6624cb5af236aa90218b6  /tmp/pex.pex" | shasum -a 256 -c -
+        PY="$(python3.14 /tmp/pex.pex --interpreter-constraint 'CPython[free-threaded]==3.14.*' \
+        -- -c 'import os, sys; print(os.path.realpath(sys.executable))')"
+        echo "PY=$PY" >> "$GITHUB_ENV"
+        echo "PANTS_PYTHON_INTERPRETER_CONSTRAINTS=['CPython[free-threaded]==3.14.*']" >> "$GITHUB_ENV"
+    - env:
+        ARCHFLAGS: -arch arm64
+        HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY || '--DISABLED--' }}
+        PANTS_OPENTELEMETRY_ENABLED: ${{ vars.OPENTELEMETRY_ENABLED || 'False' }}
+        _PYTHON_HOST_PLATFORM: macosx-14.0-arm64
+      name: Build wheels
+      run: ./pants run src/python/pants_release/release.py -- build-wheels
+    - env:
+        ARCHFLAGS: -arch arm64
+        HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY || '--DISABLED--' }}
+        PANTS_OPENTELEMETRY_ENABLED: ${{ vars.OPENTELEMETRY_ENABLED || 'False' }}
+        _PYTHON_HOST_PLATFORM: macosx-14.0-arm64
+      name: Build Pants PEX
+      run: ./pants package src/python/pants:pants-pex@scie_pbs_free_threaded=cp314t
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -847,6 +1174,9 @@ jobs:
     - bootstrap_pants_linux_arm64
     - bootstrap_pants_linux_x86_64
     - bootstrap_pants_macos14_arm64
+    - build_wheels_cp314_linux_arm64
+    - build_wheels_cp314_linux_x86_64
+    - build_wheels_cp314_macos14_arm64
     - build_wheels_linux_arm64
     - build_wheels_linux_x86_64
     - build_wheels_macos14_arm64

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -432,7 +432,7 @@ jobs:
         HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY || '--DISABLED--' }}
         PANTS_OPENTELEMETRY_ENABLED: ${{ vars.OPENTELEMETRY_ENABLED || 'False' }}
       name: Build Pants PEX
-      run: ./pants package src/python/pants:pants-pex@scie_pbs_free_threaded=cp314
+      run: ./pants package src/python/pants:pants-pex@parametrize=cp314
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -532,7 +532,7 @@ jobs:
         PANTS_OPENTELEMETRY_ENABLED: ${{ vars.OPENTELEMETRY_ENABLED || 'False' }}
         PANTS_PROCESS_EXECUTION_LOCAL_PARALLELISM: '1'
       name: Build Pants PEX
-      run: ./pants package src/python/pants:pants-pex@scie_pbs_free_threaded=cp314
+      run: ./pants package src/python/pants:pants-pex@parametrize=cp314
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -642,7 +642,7 @@ jobs:
         PANTS_OPENTELEMETRY_ENABLED: ${{ vars.OPENTELEMETRY_ENABLED || 'False' }}
         _PYTHON_HOST_PLATFORM: macosx-14.0-arm64
       name: Build Pants PEX
-      run: ./pants package src/python/pants:pants-pex@scie_pbs_free_threaded=cp314
+      run: ./pants package src/python/pants:pants-pex@parametrize=cp314
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -730,7 +730,7 @@ jobs:
         HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY || '--DISABLED--' }}
         PANTS_OPENTELEMETRY_ENABLED: ${{ vars.OPENTELEMETRY_ENABLED || 'False' }}
       name: Build Pants PEX
-      run: ./pants package src/python/pants:pants-pex@scie_pbs_free_threaded=cp314t
+      run: ./pants package src/python/pants:pants-pex@parametrize=cp314t
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -830,7 +830,7 @@ jobs:
         PANTS_OPENTELEMETRY_ENABLED: ${{ vars.OPENTELEMETRY_ENABLED || 'False' }}
         PANTS_PROCESS_EXECUTION_LOCAL_PARALLELISM: '1'
       name: Build Pants PEX
-      run: ./pants package src/python/pants:pants-pex@scie_pbs_free_threaded=cp314t
+      run: ./pants package src/python/pants:pants-pex@parametrize=cp314t
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -940,7 +940,7 @@ jobs:
         PANTS_OPENTELEMETRY_ENABLED: ${{ vars.OPENTELEMETRY_ENABLED || 'False' }}
         _PYTHON_HOST_PLATFORM: macosx-14.0-arm64
       name: Build Pants PEX
-      run: ./pants package src/python/pants:pants-pex@scie_pbs_free_threaded=cp314t
+      run: ./pants package src/python/pants:pants-pex@parametrize=cp314t
     - continue-on-error: true
       if: always()
       name: Upload pants.log

--- a/build-support/common.sh
+++ b/build-support/common.sh
@@ -52,7 +52,7 @@ function determine_python() {
     which "${PY}" && return 0
   fi
 
-  version='3.14'
+  version='3.14t'
   interpreter_path="$(command -v "python${version}")"
   if [[ -z "${interpreter_path}" ]]; then
     echo "pants: Failed to find a Python ${version} interpreter" 1>&2 && return 1

--- a/docs/notes/2.34.x.md
+++ b/docs/notes/2.34.x.md
@@ -12,7 +12,8 @@ Thank you to [Klaviyo](https://www.klaviyo.com/) for their Platinum tier support
 
 ### Highlights
 
-- Pants now runs on free-threaded CPython 3.14t. The Pants engine and Pants' own Python code are thread-safe without the GIL.
+- Pants now runs on free-threaded CPython 3.14t by default. The Pants engine and Pants' own Python code are thread-safe without the GIL.
+  Each release also ships a regular (GIL) CPython 3.14 distribution as an escape hatch: set `[GLOBAL].pants_free_threaded = false` in `pants.toml` (or the `PANTS_FREE_THREADED` env var) to select it.
   Release artifacts are named with the full ABI tag (e.g. `cp314t`). Launching via `scie-pants` requires a launcher release with free-threaded interpreter support; older launchers will fail to locate the release asset and must be updated.
 
 

--- a/docs/notes/2.34.x.md
+++ b/docs/notes/2.34.x.md
@@ -12,6 +12,10 @@ Thank you to [Klaviyo](https://www.klaviyo.com/) for their Platinum tier support
 
 ### Highlights
 
+- Pants now runs on free-threaded CPython 3.14t. The Pants engine and Pants' own Python code are thread-safe without the GIL.
+  Release artifacts are named with the full ABI tag (e.g. `cp314t`). Launching via `scie-pants` requires a launcher release with free-threaded interpreter support; older launchers will fail to locate the release asset and must be updated.
+
+
 ### Deprecations
 
 ### General

--- a/pants
+++ b/pants
@@ -4,7 +4,7 @@
 
 # This bootstrap script runs pants from the live sources in this repo.
 #
-# The script defaults to running with Python 3.11. To use another Python version,
+# The script defaults to running with Python 3.14t. To use another Python version,
 # prefix the script with `PY=python3.14`.
 
 set -eo pipefail

--- a/src/python/pants/BUILD
+++ b/src/python/pants/BUILD
@@ -70,7 +70,16 @@ pex_binary(
     scie_env=["NO_SCIE_WARNING=true", "_PANTS_SERVER_EXE={scie.env.VIRTUAL_ENV}/bin/pants"],
     # The scie interpreter must match the wheels: each release lane builds one
     # parametrization with the corresponding CPython (PY=python3.14t or python3.14).
-    scie_pbs_free_threaded=parametrize(cp314t=True, cp314=False),
+    **parametrize(
+        "cp314t",
+        scie_pbs_free_threaded=True,
+        output_path="${spec_path_normalized}/pants-pex-cp314t${file_suffix}",
+    ),
+    **parametrize(
+        "cp314",
+        scie_pbs_free_threaded=False,
+        output_path="${spec_path_normalized}/pants-pex-cp314${file_suffix}",
+    ),
 )
 
 # NB: we use `dummy.c` to avoid clang/gcc complaining `error: no input files` when building

--- a/src/python/pants/BUILD
+++ b/src/python/pants/BUILD
@@ -68,7 +68,9 @@ pex_binary(
     scie_bind_resource_path=["PANTS_NATIVE_CLIENT=pants/bin/native_client"],
     scie_exe="{scie.env.PANTS_NATIVE_CLIENT}",
     scie_env=["NO_SCIE_WARNING=true", "_PANTS_SERVER_EXE={scie.env.VIRTUAL_ENV}/bin/pants"],
-    scie_pbs_free_threaded=True,
+    # The scie interpreter must match the wheels: each release lane builds one
+    # parametrization with the corresponding CPython (PY=python3.14t or python3.14).
+    scie_pbs_free_threaded=parametrize(cp314t=True, cp314=False),
 )
 
 # NB: we use `dummy.c` to avoid clang/gcc complaining `error: no input files` when building

--- a/src/python/pants/BUILD
+++ b/src/python/pants/BUILD
@@ -68,6 +68,7 @@ pex_binary(
     scie_bind_resource_path=["PANTS_NATIVE_CLIENT=pants/bin/native_client"],
     scie_exe="{scie.env.PANTS_NATIVE_CLIENT}",
     scie_env=["NO_SCIE_WARNING=true", "_PANTS_SERVER_EXE={scie.env.VIRTUAL_ENV}/bin/pants"],
+    scie_pbs_free_threaded=True,
 )
 
 # NB: we use `dummy.c` to avoid clang/gcc complaining `error: no input files` when building

--- a/src/python/pants/backend/BUILD
+++ b/src/python/pants/backend/BUILD
@@ -19,6 +19,8 @@ DEFAULT_DEPENDENTS_RULES = (
     "//tests/**",
     # Allow build-support to use what ever.
     "//build-support/**",
+    # Allow release and CI tooling to use what ever.
+    "//src/python/pants_release/**",
     # Allow testprojects to use any backend.
     "//testprojects/**",
     # Deny all others.

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -41,8 +41,8 @@ from pants.util.strutil import softwrap
 logger = logging.getLogger(__name__)
 
 
-_PEX_VERSION = "v2.98.4"
-_PEX_BINARY_HASH = "78d4bae9f6f4d7e63465e79aff2bd9b199a18340f1d6624cb5af236aa90218b6"
+PEX_VERSION = "v2.98.4"
+PEX_BINARY_HASH = "78d4bae9f6f4d7e63465e79aff2bd9b199a18340f1d6624cb5af236aa90218b6"
 _PEX_BINARY_SIZE = 5129912
 
 
@@ -51,7 +51,7 @@ class PexCli(TemplatedExternalTool):
     name = "pex"
     help = "The PEX (Python EXecutable) tool (https://github.com/pex-tool/pex)."
 
-    default_version = _PEX_VERSION
+    default_version = PEX_VERSION
     default_url_template = "https://github.com/pex-tool/pex/releases/download/{version}/pex"
     version_constraints = ">=2.97.1,<3.0"
 
@@ -68,7 +68,7 @@ class PexCli(TemplatedExternalTool):
     )
 
     default_known_versions = [
-        f"{_PEX_VERSION}|{platform}|{_PEX_BINARY_HASH}|{_PEX_BINARY_SIZE}"
+        f"{PEX_VERSION}|{platform}|{PEX_BINARY_HASH}|{_PEX_BINARY_SIZE}"
         for platform in ["macos_x86_64", "macos_arm64", "linux_x86_64", "linux_arm64"]
     ]
 

--- a/src/python/pants/base/exception_sink_integration_test.py
+++ b/src/python/pants/base/exception_sink_integration_test.py
@@ -128,13 +128,18 @@ class ExceptionSinkIntegrationTest(PantsDaemonIntegrationTestBase):
 
             # Check that the logs show an abort signal and the beginning of a traceback.
             pid_specific_log_file, shared_log_file = get_log_file_paths(ctx.workdir, pid)
-            regex_str = """\
-Fatal Python error: Aborted
+            # On free-threaded CPython, faulthandler can't enumerate all threads, so it emits a
+            # different header than the GIL-enabled per-thread traceback format.
+            regex_str = (
+                "Fatal Python error: Aborted\n\n"
+                "(?:Thread [^\n]+ \\(most recent call first\\):"
+                "|<Cannot show all threads while the GIL is disabled>\n"
+                "Stack \\(most recent call first\\):)\n"
+            )
 
-Thread [^\n]+ \\(most recent call first\\):
-"""
-
-            assert re.search(regex_str, read_file(pid_specific_log_file))
+            pid_specific_log_contents = read_file(pid_specific_log_file)
+            assert re.search(regex_str, pid_specific_log_contents)
+            assert '  File "' in pid_specific_log_contents
 
             # faulthandler.enable() only allows use of a single logging file at once for fatal tracebacks.
             assert "" == read_file(shared_log_file)

--- a/src/python/pants/core/subsystems/python_bootstrap.py
+++ b/src/python/pants/core/subsystems/python_bootstrap.py
@@ -30,7 +30,7 @@ from pants.util.strutil import help_text, softwrap
 
 logger = logging.getLogger(__name__)
 
-_PBS_URL_TEMPLATE = "https://github.com/astral-sh/python-build-standalone/releases/download/20251014/cpython-3.14.0+20251014-{}-install_only_stripped.tar.gz"
+_PBS_URL_TEMPLATE = "https://github.com/astral-sh/python-build-standalone/releases/download/20260610/cpython-3.14.6+20260610-{}-freethreaded-install_only_stripped.tar.gz"
 
 
 class PythonBootstrapSubsystem(Subsystem):
@@ -49,23 +49,23 @@ class PythonBootstrapSubsystem(Subsystem):
         default={
             "linux_arm64": (
                 _PBS_URL_TEMPLATE.format("aarch64-unknown-linux-gnu"),
-                "7dbb43b742c040835a277318355fb359b41e509dbf4fbb614da38005a9290e16",
-                29297561,
+                "3d82c130c647988c0cb83fbf6b69637024dfa184da0b4d25c1498a3e9655b2f1",
+                30304472,
             ),
             "linux_x86_64": (
                 _PBS_URL_TEMPLATE.format("x86_64-unknown-linux-gnu"),
-                "493c477b4a88bb1ea2f6c6f57fa0e88ffbe55d9e7b1405c4699f2d41c04eb154",
-                34580370,
+                "d4872b127c641aadb0846a0a4f2c3f6377393a34e89de7668274ec2434d50c00",
+                36178201,
             ),
             "macos_arm64": (
                 _PBS_URL_TEMPLATE.format("aarch64-apple-darwin"),
-                "057476264b07222a2baeff68a733647f91a9d61c94f79beba46a44eb42101749",
-                16923076,
+                "f47f0d5b02fc634385bdc630dd293678cfbdbc009de2b04403ce04c92473b483",
+                26071097,
             ),
             "macos_x86_64": (
                 _PBS_URL_TEMPLATE.format("x86_64-apple-darwin"),
-                "56dcb0cdafabac9d6d976690fb05d9ee92d20ce798c3aabe9049259ebe7d3e0d",
-                16905036,
+                "f8daa286f7315afc2fc1d51e3f6169ef133bd030f344d182f5f24849439aa4be",
+                26138236,
             ),
         },
         help=softwrap(

--- a/src/python/pants/option/bootstrap_options.py
+++ b/src/python/pants/option/bootstrap_options.py
@@ -903,6 +903,17 @@ class BootstrapOptions:
             """
         ),
     )
+    pants_free_threaded = BoolOption(
+        advanced=True,
+        default=True,
+        help=softwrap(
+            f"""
+            Run Pants on a free-threaded CPython interpreter. Like `pants_version`, this is
+            consumed by the `{bin_name()}` launcher to select which Pants distribution to
+            install and has no effect once Pants is running.
+            """
+        ),
+    )
     pants_bin_name = StrOption(
         advanced=True,
         default="pants",

--- a/src/python/pants/option/bootstrap_options.py
+++ b/src/python/pants/option/bootstrap_options.py
@@ -40,6 +40,7 @@ from pants.option.option_types import (
 )
 from pants.option.option_value_container import OptionValueContainer
 from pants.option.options import Options
+from pants.option.ranked_value import Rank
 from pants.util.docutil import bin_name, doc_url
 from pants.util.logging import LogLevel
 from pants.util.osutil import CPU_COUNT
@@ -1934,6 +1935,55 @@ class BootstrapOptions:
                     """
                 )
             )
+
+        advisory = cls._free_threaded_advisory(
+            requested=opts.pants_free_threaded,
+            explicitly_set=opts.get_rank("pants_free_threaded") > Rank.HARDCODED,
+            abiflags=sys.abiflags,
+            scie_pants_version=os.environ.get("SCIE_PANTS_VERSION"),
+        )
+        if advisory:
+            logger.warning(advisory)
+
+    @staticmethod
+    def _free_threaded_advisory(
+        *,
+        requested: bool,
+        explicitly_set: bool,
+        abiflags: str,
+        scie_pants_version: str | None,
+    ) -> str | None:
+        """Warn when `pants_free_threaded` was set but the launcher did not honor it.
+
+        The option is consumed by the `scie-pants` launcher, so a launcher that predates it (or a
+        standalone scie) silently ignores it. We detect that mismatch from the ABI Pants is
+        actually running on.
+        """
+        if not explicitly_set:
+            return None
+        running_free_threaded = "t" in abiflags
+        if requested == running_free_threaded:
+            return None
+        want = "free-threaded" if requested else "GIL-enabled"
+        got = "free-threaded" if running_free_threaded else "GIL-enabled"
+        if scie_pants_version is None:
+            return softwrap(
+                f"""
+                `[GLOBAL] pants_free_threaded` is set to {str(requested).lower()}, but Pants is
+                running on a {got} CPython and the setting was not applied. This option is
+                consumed by the `scie-pants` launcher and has no effect on a standalone scie or a
+                `PANTS_SOURCE` run; download the {want} distribution instead.
+                """
+            )
+        return softwrap(
+            f"""
+            `[GLOBAL] pants_free_threaded` is set to {str(requested).lower()}, but Pants is
+            running on a {got} CPython. Your `scie-pants` launcher ({scie_pants_version}) did not
+            apply the setting: it either predates `pants_free_threaded` or found no {want}
+            distribution for Pants {VERSION}. Update `scie-pants` to select the {want}
+            distribution.
+            """
+        )
 
     @staticmethod
     def maybe_enable_stack_trampoline(opts: OptionValueContainer) -> None:

--- a/src/python/pants/option/global_options_test.py
+++ b/src/python/pants/option/global_options_test.py
@@ -12,7 +12,12 @@ import pytest
 
 from pants.base.build_environment import get_buildroot
 from pants.engine.internals.native_engine import PyRemotingOptions
-from pants.option.bootstrap_options import DynamicRemoteOptions, ExecutionOptions, RemoteProvider
+from pants.option.bootstrap_options import (
+    BootstrapOptions,
+    DynamicRemoteOptions,
+    ExecutionOptions,
+    RemoteProvider,
+)
 from pants.option.errors import OptionsError
 from pants.option.global_options import GlobalOptions
 from pants.option.options_bootstrapper import OptionsBootstrapper
@@ -271,3 +276,36 @@ def test_remote_provider_matches_rust_enum(
         client_key_path=None,
         append_only_caches_base_path=None,
     )
+
+
+@pytest.mark.parametrize(
+    "requested, explicitly_set, abiflags, scie_pants_version, expected",
+    [
+        (True, False, "", "0.14.0", None),
+        (True, False, "t", None, None),
+        (True, True, "t", "0.14.0", None),
+        (False, True, "", "0.14.0", None),
+        (True, True, "", "0.14.0", "did not"),
+        (False, True, "t", "0.14.0", "did not"),
+        (True, True, "", None, "standalone scie"),
+        (False, True, "t", None, "standalone scie"),
+    ],
+)
+def test_free_threaded_advisory(
+    requested: bool,
+    explicitly_set: bool,
+    abiflags: str,
+    scie_pants_version: str | None,
+    expected: str | None,
+) -> None:
+    advisory = BootstrapOptions._free_threaded_advisory(
+        requested=requested,
+        explicitly_set=explicitly_set,
+        abiflags=abiflags,
+        scie_pants_version=scie_pants_version,
+    )
+    if expected is None:
+        assert advisory is None
+    else:
+        assert advisory is not None
+        assert expected in advisory

--- a/src/python/pants_release/BUILD
+++ b/src/python/pants_release/BUILD
@@ -3,4 +3,14 @@
 
 python_sources()
 
-python_tests(name="test")
+python_tests(
+    name="test",
+    overrides={
+        "generate_github_workflows_test.py": {
+            "dependencies": [
+                "//pants.toml:files",
+                "src/python/pants/backend/python/util_rules/pex_cli.py",
+            ],
+        },
+    },
+)

--- a/src/python/pants_release/BUILD
+++ b/src/python/pants_release/BUILD
@@ -7,10 +7,7 @@ python_tests(
     name="test",
     overrides={
         "generate_github_workflows_test.py": {
-            "dependencies": [
-                "//pants.toml:files",
-                "src/python/pants/backend/python/util_rules/pex_cli.py",
-            ],
+            "dependencies": ["//pants.toml:files"],
         },
     },
 )

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -108,7 +108,7 @@ class Platform(Enum):
 # We don't specify a patch version so that we get the latest, which comes pre-installed:
 #  https://github.com/actions/setup-python#available-versions-of-python
 # NOTE: The last entry becomes the default
-_BASE_PYTHON_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+_BASE_PYTHON_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
 
 PYTHON_VERSIONS_PER_PLATFORM: dict[Platform, list[str]] = {
     Platform.LINUX_X86_64: _BASE_PYTHON_VERSIONS,

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -22,6 +22,8 @@ import toml
 import yaml
 from pants_release.common import die
 
+from pants.backend.python.util_rules.pex_cli import PEX_BINARY_HASH, PEX_VERSION
+
 
 class Pin(NamedTuple):
     ref: str
@@ -113,15 +115,6 @@ _BASE_PYTHON_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3
 
 def pants_interpreter_constraints() -> list[str]:
     return cast("list[str]", toml.load("pants.toml")["python"]["interpreter_constraints"])
-
-
-def pinned_pex() -> tuple[str, str]:
-    # visibility forbids `pants_release` depending on `pants.backend`.
-    text = Path("src/python/pants/backend/python/util_rules/pex_cli.py").read_text()
-    version = re.search(r'_PEX_VERSION = "(?P<v>v[0-9.]+)"', text)
-    sha256 = re.search(r'_PEX_BINARY_HASH = "(?P<h>[0-9a-f]{64})"', text)
-    assert version is not None and sha256 is not None, "Could not find Pex pins in pex_cli.py"
-    return version.group("v"), sha256.group("h")
 
 
 PYTHON_VERSIONS_PER_PLATFORM: dict[Platform, list[str]] = {
@@ -1011,7 +1004,6 @@ def build_wheels_job(
     ]
     ic_flags = " ".join(f"--interpreter-constraint '{ic}'" for ic in lane_ics)
     ic_env = "[" + ",".join(f"'{ic}'" for ic in lane_ics) + "]"
-    pex_version, pex_sha256 = pinned_pex()
     sha256_check = "shasum -a 256" if platform == Platform.MACOS14_ARM64 else "sha256sum"
     # For manylinux compatibility, we build Linux wheels in a container rather than directly
     # on the Ubuntu runner. As a result, we have custom steps here to check out
@@ -1101,8 +1093,8 @@ def build_wheels_job(
                     "run": dedent(
                         f"""\
                         curl -fL -o /tmp/pex.pex \\
-                        https://github.com/pex-tool/pex/releases/download/{pex_version}/pex
-                        echo "{pex_sha256}  /tmp/pex.pex" | {sha256_check} -c -
+                        https://github.com/pex-tool/pex/releases/download/{PEX_VERSION}/pex
+                        echo "{PEX_BINARY_HASH}  /tmp/pex.pex" | {sha256_check} -c -
                         PY="$(python3.14 /tmp/pex.pex {ic_flags} \\
                         -- -c 'import os, sys; print(os.path.realpath(sys.executable))')"
                         echo "PY=$PY" >> "$GITHUB_ENV"

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -1217,7 +1217,10 @@ def build_wheels_job(
                                     ),
                                 },
                             ]
-                            if platform == Platform.LINUX_X86_64
+                            # `testutil` is a pure-Python `py3-none-any` wheel, so both ABI lanes
+                            # produce an identical artifact. Upload it from a single lane to avoid
+                            # a duplicate release-asset name collision.
+                            if platform == Platform.LINUX_X86_64 and free_threaded
                             else []
                         ),
                     ]

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -110,6 +110,20 @@ class Platform(Enum):
 # NOTE: The last entry becomes the default
 _BASE_PYTHON_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
 
+
+def pants_interpreter_constraints() -> list[str]:
+    return cast("list[str]", toml.load("pants.toml")["python"]["interpreter_constraints"])
+
+
+def pinned_pex() -> tuple[str, str]:
+    # visibility forbids `pants_release` depending on `pants.backend`.
+    text = Path("src/python/pants/backend/python/util_rules/pex_cli.py").read_text()
+    version = re.search(r'_PEX_VERSION = "(?P<v>v[0-9.]+)"', text)
+    sha256 = re.search(r'_PEX_BINARY_HASH = "(?P<h>[0-9a-f]{64})"', text)
+    assert version is not None and sha256 is not None, "Could not find Pex pins in pex_cli.py"
+    return version.group("v"), sha256.group("h")
+
+
 PYTHON_VERSIONS_PER_PLATFORM: dict[Platform, list[str]] = {
     Platform.LINUX_X86_64: _BASE_PYTHON_VERSIONS,
     # Python 3.7 isn't installable by setup-python on ARM64 Ubuntu 24.04.
@@ -986,8 +1000,19 @@ def build_wheels_job(
     platform: Platform,
     for_deploy_ref: str | None,
     needs: list[str] | None,
+    free_threaded: bool = True,
 ) -> Jobs:
     helper = Helper(platform)
+    abi = "cp314t" if free_threaded else "cp314"
+    abi_extra = "free-threaded" if free_threaded else "gil"
+    lane_ics = [
+        f"CPython[{abi_extra}]{ic.removeprefix('CPython')}"
+        for ic in pants_interpreter_constraints()
+    ]
+    ic_flags = " ".join(f"--interpreter-constraint '{ic}'" for ic in lane_ics)
+    ic_env = "[" + ",".join(f"'{ic}'" for ic in lane_ics) + "]"
+    pex_version, pex_sha256 = pinned_pex()
+    sha256_check = "shasum -a 256" if platform == Platform.MACOS14_ARM64 else "sha256sum"
     # For manylinux compatibility, we build Linux wheels in a container rather than directly
     # on the Ubuntu runner. As a result, we have custom steps here to check out
     # the code, install rustup and expose Pythons.
@@ -1019,6 +1044,7 @@ def build_wheels_job(
                     echo "/opt/python/cp312-cp312/bin" >> $GITHUB_PATH
                     echo "/opt/python/cp313-cp313/bin" >> $GITHUB_PATH
                     echo "/opt/python/cp314-cp314/bin" >> $GITHUB_PATH
+                    echo "/opt/python/cp314-cp314t/bin" >> $GITHUB_PATH
                     """
                 ),
             },
@@ -1039,9 +1065,9 @@ def build_wheels_job(
         IS_PANTS_OWNER if for_deploy_ref else f"({IS_PANTS_OWNER}) && ({DONT_SKIP_WHEELS})"
     )
     return {
-        helper.job_name("build_wheels"): {
+        helper.job_name("build_wheels" if free_threaded else "build_wheels_cp314"): {
             "if": if_condition,
-            "name": f"Build wheels ({str(platform.value)})",
+            "name": f"Build wheels ({str(platform.value)}, {abi})",
             "runs-on": helper.runs_on(),
             "permissions": {
                 "id-token": "write",
@@ -1070,13 +1096,28 @@ def build_wheels_job(
                     else install_go()
                 ),
                 {
+                    # `which python3.14` can't tell the two ABIs apart; Pex can.
+                    "name": "Select the distribution interpreter",
+                    "run": dedent(
+                        f"""\
+                        curl -fL -o /tmp/pex.pex \\
+                        https://github.com/pex-tool/pex/releases/download/{pex_version}/pex
+                        echo "{pex_sha256}  /tmp/pex.pex" | {sha256_check} -c -
+                        PY="$(python3.14 /tmp/pex.pex {ic_flags} \\
+                        -- -c 'import os, sys; print(os.path.realpath(sys.executable))')"
+                        echo "PY=$PY" >> "$GITHUB_ENV"
+                        echo "PANTS_PYTHON_INTERPRETER_CONSTRAINTS={ic_env}" >> "$GITHUB_ENV"
+                        """
+                    ),
+                },
+                {
                     "name": "Build wheels",
                     "run": "./pants run src/python/pants_release/release.py -- build-wheels",
                     "env": helper.platform_env(),
                 },
                 {
                     "name": "Build Pants PEX",
-                    "run": "./pants package src/python/pants:pants-pex",
+                    "run": f"./pants package src/python/pants:pants-pex@scie_pbs_free_threaded={abi}",
                     "env": helper.platform_env(),
                 },
                 helper.upload_log_artifacts(name="wheels-and-pex"),
@@ -1195,6 +1236,9 @@ def build_wheels_jobs(*, for_deploy_ref: str | None = None, needs: list[str] | N
         **build_wheels_job(Platform.LINUX_X86_64, for_deploy_ref, needs),
         **build_wheels_job(Platform.LINUX_ARM64, for_deploy_ref, needs),
         **build_wheels_job(Platform.MACOS14_ARM64, for_deploy_ref, needs),
+        **build_wheels_job(Platform.LINUX_X86_64, for_deploy_ref, needs, free_threaded=False),
+        **build_wheels_job(Platform.LINUX_ARM64, for_deploy_ref, needs, free_threaded=False),
+        **build_wheels_job(Platform.MACOS14_ARM64, for_deploy_ref, needs, free_threaded=False),
     }
 
 

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -1117,7 +1117,7 @@ def build_wheels_job(
                 },
                 {
                     "name": "Build Pants PEX",
-                    "run": f"./pants package src/python/pants:pants-pex@scie_pbs_free_threaded={abi}",
+                    "run": f"./pants package src/python/pants:pants-pex@parametrize={abi}",
                     "env": helper.platform_env(),
                 },
                 helper.upload_log_artifacts(name="wheels-and-pex"),
@@ -1134,16 +1134,17 @@ def build_wheels_job(
                         {
                             "name": "Rename the Pants Pex to its final name for upload",
                             "if": "needs.release_info.outputs.is-release == 'true'",
-                            "run": dedent(
+                            "run": f"PEX_STEM=dist/src.python.pants/pants-pex-{abi}\n"
+                            + dedent(
                                 """\
-                                PANTS_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import pants.version;print(pants.version.VERSION)")
-                                PY_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import sys;print(f'cp{sys.version_info[0]}{sys.version_info[1]}{sys.abiflags}')")
-                                PLAT=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import os;print(f'{os.uname().sysname.lower()}_{os.uname().machine.lower()}')")
+                                PANTS_VER=$(PEX_INTERPRETER=1 $PEX_STEM.pex -c "import pants.version;print(pants.version.VERSION)")
+                                PY_VER=$(PEX_INTERPRETER=1 $PEX_STEM.pex -c "import sys;print(f'cp{sys.version_info[0]}{sys.version_info[1]}{sys.abiflags}')")
+                                PLAT=$(PEX_INTERPRETER=1 $PEX_STEM.pex -c "import os;print(f'{os.uname().sysname.lower()}_{os.uname().machine.lower()}')")
                                 PEX_FILENAME=pants.$PANTS_VER-$PY_VER-$PLAT.pex
                                 PEX_SCIE_FILENAME=pants.$PANTS_VER-$PY_VER-$PLAT
 
-                                mv dist/src.python.pants/pants-pex.pex dist/src.python.pants/$PEX_FILENAME
-                                mv dist/src.python.pants/pants-pex dist/src.python.pants/$PEX_SCIE_FILENAME
+                                mv $PEX_STEM.pex dist/src.python.pants/$PEX_FILENAME
+                                mv $PEX_STEM dist/src.python.pants/$PEX_SCIE_FILENAME
                                 echo "PEX_FILENAME=$PEX_FILENAME" | tee -a "$GITHUB_ENV"
                                 echo "PEX_SCIE_FILENAME=$PEX_SCIE_FILENAME" | tee -a "$GITHUB_ENV"
                                 """

--- a/src/python/pants_release/generate_github_workflows_test.py
+++ b/src/python/pants_release/generate_github_workflows_test.py
@@ -1,0 +1,23 @@
+# Copyright 2026 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import re
+
+from pants_release.generate_github_workflows import (
+    pants_interpreter_constraints,
+    pinned_pex,
+)
+
+
+def test_pinned_pex_returns_valid_version_and_sha256() -> None:
+    version, sha256 = pinned_pex()
+    assert re.fullmatch(r"v\d+\.\d+\.\d+", version)
+    assert re.fullmatch(r"[0-9a-f]{64}", sha256)
+
+
+def test_pants_interpreter_constraints_are_valid() -> None:
+    constraints = pants_interpreter_constraints()
+    assert constraints
+    assert all(isinstance(constraint, str) and constraint for constraint in constraints)

--- a/src/python/pants_release/generate_github_workflows_test.py
+++ b/src/python/pants_release/generate_github_workflows_test.py
@@ -3,18 +3,7 @@
 
 from __future__ import annotations
 
-import re
-
-from pants_release.generate_github_workflows import (
-    pants_interpreter_constraints,
-    pinned_pex,
-)
-
-
-def test_pinned_pex_returns_valid_version_and_sha256() -> None:
-    version, sha256 = pinned_pex()
-    assert re.fullmatch(r"v\d+\.\d+\.\d+", version)
-    assert re.fullmatch(r"[0-9a-f]{64}", sha256)
+from pants_release.generate_github_workflows import pants_interpreter_constraints
 
 
 def test_pants_interpreter_constraints_are_valid() -> None:

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -62,7 +62,7 @@ use crate::{
     TypeId, Types, Value, externs, nodes,
 };
 
-#[pymodule]
+#[pymodule(gil_used = false)]
 fn native_engine(py: Python, m: &Bound<'_, PyModule>) -> PyO3Result<()> {
     intrinsics::register(py, m)?;
     externs::register(py, m)?;

--- a/src/rust/nailgun/src/server.rs
+++ b/src/rust/nailgun/src/server.rs
@@ -238,11 +238,11 @@ impl Nail for RawFdNail {
             }
         };
 
-        // Spawn the underlying function as a blocking task, and capture its exit code to append to the
-        // output stream.
+        // Spawn the underlying function as a blocking task on the request pool, and capture its
+        // exit code to append to the output stream.
         let executor = self.executor.clone();
         let nail = self.clone();
-        let exit_code_join = executor.spawn_blocking(move || {
+        let exit_code_join = executor.spawn_request_blocking(move || {
             // NB: This closure captures the stdio handles, and will drop/close them when it completes.
             (nail.runner)(RawFdExecution {
                 cmd,

--- a/src/rust/task_executor/src/lib.rs
+++ b/src/rust/task_executor/src/lib.rs
@@ -47,6 +47,8 @@ fn future_with_correct_context<F: Future>(future: F) -> impl Future<Output = F::
 pub struct Executor {
     runtime: Arc<Mutex<Option<Runtime>>>,
     handle: Handle,
+    request_pool: Arc<Mutex<Option<Runtime>>>,
+    request_pool_handle: Option<Handle>,
 }
 
 impl Executor {
@@ -63,6 +65,8 @@ impl Executor {
         Self {
             runtime: Arc::new(Mutex::new(None)),
             handle: Handle::current(),
+            request_pool: Arc::new(Mutex::new(None)),
+            request_pool_handle: None,
         }
     }
 
@@ -84,6 +88,9 @@ impl Executor {
         F: Fn() + Send + Sync + 'static,
         G: Fn() + Send + Sync + 'static,
     {
+        let on_thread_start = Arc::new(on_thread_start);
+        let on_thread_stop = Arc::new(on_thread_stop);
+
         let mut runtime_builder = Builder::new_multi_thread();
 
         runtime_builder
@@ -95,17 +102,45 @@ impl Executor {
         // tokio expires after an idle keep-alive and respawns on demand. Any per-thread state
         // created in `on_thread_start` must be torn down in `on_thread_stop`: a leak here is per
         // thread created, not per pool slot, and so grows without bound in a long-lived pantsd.
-        runtime_builder.on_thread_start(on_thread_start);
-        runtime_builder.on_thread_stop(on_thread_stop);
+        runtime_builder.on_thread_start({
+            let f = on_thread_start.clone();
+            move || f()
+        });
+        runtime_builder.on_thread_stop({
+            let f = on_thread_stop.clone();
+            move || f()
+        });
 
         let runtime = runtime_builder
             .build()
             .map_err(|e| format!("Failed to start the runtime: {e}"))?;
 
+        // A pool reserved for client requests: see `spawn_request_blocking`. The current-thread
+        // flavor spawns no workers, so this runtime is only its blocking pool.
+        let mut request_pool_builder = Builder::new_current_thread();
+        request_pool_builder
+            .max_blocking_threads(max_threads - num_worker_threads)
+            .thread_name("pants-request");
+        request_pool_builder.on_thread_start({
+            let f = on_thread_start.clone();
+            move || f()
+        });
+        request_pool_builder.on_thread_stop({
+            let f = on_thread_stop.clone();
+            move || f()
+        });
+
+        let request_pool = request_pool_builder
+            .build()
+            .map_err(|e| format!("Failed to start the request pool: {e}"))?;
+
         let handle = runtime.handle().clone();
+        let request_pool_handle = request_pool.handle().clone();
         Ok(Executor {
             runtime: Arc::new(Mutex::new(Some(runtime))),
             handle,
+            request_pool: Arc::new(Mutex::new(Some(request_pool))),
+            request_pool_handle: Some(request_pool_handle),
         })
     }
 
@@ -117,6 +152,8 @@ impl Executor {
         Self {
             runtime: Arc::new(Mutex::new(None)),
             handle: self.handle.clone(),
+            request_pool: Arc::new(Mutex::new(None)),
+            request_pool_handle: self.request_pool_handle.clone(),
         }
     }
 
@@ -197,6 +234,31 @@ impl Executor {
         })
     }
 
+    ///
+    /// Run a blocking function that hosts a client request on a pool reserved for them: on
+    /// free-threaded CPython a thread retains allocator state until it exits, so requests reuse
+    /// a few dedicated threads instead of spreading that state across the blocking pool.
+    ///
+    pub fn spawn_request_blocking<F: FnOnce() -> R + Send + 'static, R: Send + 'static>(
+        &self,
+        f: F,
+    ) -> JoinHandle<R> {
+        let stdio_destination = stdio::get_destination();
+        let workunit_store_handle = workunit_store::get_workunit_store_handle();
+        let main_handle = self.handle.clone();
+        let f = move || {
+            // This pool's runtime is driverless: resolve ambient tokio APIs to the main runtime.
+            let _main_runtime = main_handle.enter();
+            stdio::set_thread_destination(stdio_destination);
+            workunit_store::set_thread_workunit_store_handle(workunit_store_handle);
+            f()
+        };
+        match &self.request_pool_handle {
+            Some(handle) => handle.spawn_blocking(f),
+            None => self.handle.spawn_blocking(f),
+        }
+    }
+
     /// Return a reference to this executor's runtime handle.
     pub fn handle(&self) -> &Handle {
         &self.handle
@@ -214,6 +276,10 @@ impl Executor {
         };
 
         let start = Instant::now();
+        // The request pool first: an in-flight run needs the main runtime to complete.
+        if let Some(request_pool) = self.request_pool.lock().take() {
+            request_pool.shutdown_timeout(timeout + Duration::from_millis(250));
+        }
         runtime.shutdown_timeout(timeout + Duration::from_millis(250));
         if start.elapsed() > timeout {
             // Leaked tasks could lead to panics in some cases (see #16105), so warn for them.

--- a/src/rust/task_executor/src/lib.rs
+++ b/src/rust/task_executor/src/lib.rs
@@ -12,6 +12,9 @@ use parking_lot::Mutex;
 use tokio::runtime::{Builder, Handle, Runtime};
 use tokio::task::{Id, JoinError, JoinHandle, JoinSet};
 
+/// Tokio's own default. A conservative cap would stall clients rather than bound anything useful.
+const MAX_REQUEST_THREADS: usize = 512;
+
 /// Copy our (thread-local or task-local) stdio destination and current workunit parent into
 /// the task. The former ensures that when a pantsd thread kicks off a future, any stdio done
 /// by it ends up in the pantsd log as we expect. The latter ensures that when a new workunit
@@ -119,7 +122,7 @@ impl Executor {
         // flavor spawns no workers, so this runtime is only its blocking pool.
         let mut request_pool_builder = Builder::new_current_thread();
         request_pool_builder
-            .max_blocking_threads(max_threads - num_worker_threads)
+            .max_blocking_threads(MAX_REQUEST_THREADS)
             .thread_name("pants-request");
         request_pool_builder.on_thread_start({
             let f = on_thread_start.clone();
@@ -235,9 +238,10 @@ impl Executor {
     }
 
     ///
-    /// Run a blocking function that hosts a client request on a pool reserved for them: on
-    /// free-threaded CPython a thread retains allocator state until it exits, so requests reuse
-    /// a few dedicated threads instead of spreading that state across the blocking pool.
+    /// Run a blocking function that hosts a client request on a pool reserved for them.
+    ///
+    /// On free-threaded CPython a thread retains the allocator heap it warmed until it exits, so
+    /// requests keep that heap off the long-lived blocking-pool threads.
     ///
     pub fn spawn_request_blocking<F: FnOnce() -> R + Send + 'static, R: Send + 'static>(
         &self,


### PR DESCRIPTION
Switches Pants' own runtime to free-threaded CPython and makes the engine and
Pants' Python code thread-safe without the GIL.

This has been validated as running without error in my companies CI, and nets great speedups.

Most important callouts:
- Keep a persistent per-thread PyThreadState in the executor. Without
  this, every `Python::attach` cycle tears down the thread state, and on 3.14t
  that abandons the thread's mimalloc heaps. Created per tokio thread, torn down in `on_thread_stop` (blocking
  threads are recycled, so the state must not leak per thread creation).
- Makes run-scoped internals thread-safe: rule_visitor, exception_sink, logging, build_root, run_tracker.

I used https://github.com/pantsbuild/pants/pull/23437 as a launching point.

I have on speculation set this as shipping in 2.34.x, as I believe 2.33 is too far along the dev-cycles. But I also do not see any reason to delay further.

Blocks https://github.com/pantsbuild/scie-pants/pull/541

Edit:
This branch now serves as proof of green CI of the accumulation of changes, and will be rebased as its parts are accepted incrementally:
- https://github.com/pantsbuild/pants/pull/23487
- https://github.com/pantsbuild/pants/pull/23488
- https://github.com/pantsbuild/pants/pull/23489
- https://github.com/pantsbuild/pants/pull/23490
- https://github.com/pantsbuild/pants/pull/23491
- https://github.com/pantsbuild/pants/pull/23492
- https://github.com/pantsbuild/pants/pull/23497
- https://github.com/pantsbuild/pants/pull/23514

Edit2:

Now that all pre-requisites are in, this PR contains CI/CD changes and the new PANTS_FREE_THREADED option.
Current proposal for consumer UX is

| Consumer | `pants.toml#[GLOBAL].pants_free_threaded` | Resolves to | Bootstrap warning |
|---|---|---|---|
| **scie-pants - not updated** | absent / `false` | `cp314` (GIL 3.14) | - |
| **scie-pants - not updated** | `true` | `cp314` (GIL 3.14) | **"update scie-pants"**. Old launcher can't honor the field |
| **scie-pants - updated** | absent (default) | `cp314t` (free-threaded) | - |
| **scie-pants - updated** | `false` | `cp314` (GIL 3.14) | - (escape hatch) |
| **scie-pants - updated** | `true` | `cp314t` (free-threaded) | - |
| **Fat scie - `…-cp314`** | `true` | GIL 3.14 | **"no effect on a fat scie; download the binary you want"** |
| **Fat scie - `…-cp314t`** | `false` | free-threaded | **"no effect on a fat scie; download the binary you want"** |

This PR is coupled to https://github.com/pantsbuild/scie-pants/pull/541.

