### PR TITLE
provide an explicit shebang for the mypy shell script

### DIFF
--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -274,12 +274,14 @@ async def mypy_typecheck_partition(
 
     if mypy.cache_mode == MyPyCacheMode.none:
         script_content = dedent(f"""\
+            #!/bin/sh
             {mypy_command}
         """)
     else:
         sandbox_cache_dir = f"{run_cache_dir}/{py_version}"
 
         script_content = dedent(f"""\
+            #!/bin/sh
             # We want to leverage the MyPy cache for fast incremental runs of MyPy.
             # Pants exposes "append_only_caches" we can leverage, but with the caveat
             # that it requires either only appending files, or multiprocess-safe access.


### PR DESCRIPTION
So, I had looked at this a few times and been curious how it worked. The answer exposed by https://github.com/pantsbuild/pants/pull/23466 is that it only *accidentally* worked.  To quote from https://man7.org/linux/man-pages/man3/exec.3.html:

       If the header of a file isn't recognized (the attempted execve(2)
       failed with the error ENOEXEC), these functions will execute the
       shell (/bin/sh) with the path of the file as its first argument.
       (If this attempt fails, no further searching is done.)

So on certain glibc code paths there is a `/bib/sh` fallback, but if you just ask the Kernel to exec some "random" looking bytes it ain't gonna work.