### PR TITLE
Fix changed since whitespace 23307

### DIFF
--- a/bug_repro/BUILD
+++ b/bug_repro/BUILD
@@ -1,3 +1,0 @@
-target(name="target1")
-
-target(name="target2")

--- a/bug_repro/BUILD
+++ b/bug_repro/BUILD
@@ -1,0 +1,3 @@
+target(name="target1")
+
+target(name="target2")

--- a/docs/notes/2.34.x.md
+++ b/docs/notes/2.34.x.md
@@ -16,6 +16,8 @@ Thank you to [Klaviyo](https://www.klaviyo.com/) for their Platinum tier support
 
 ### General
 
+Fixed an issue where `pants --changed-since` would unnecessarily invalidate all targets in a `BUILD` file when only whitespace or comment lines were modified.
+
 ### Goals
 
 ### Backends

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -1238,6 +1238,7 @@ def find_source_blocks_owners(
 async def find_owners(
     owners_request: OwnersRequest,
     local_environment_name: ChosenLocalEnvironmentName,
+    target_origin_sources_blocks_options: TargetOriginSourcesBlocksOptions,
 ) -> Owners:
     block_owners: tuple[Owners, ...] = (
         await concurrently(
@@ -1329,11 +1330,14 @@ async def find_owners(
             ):
                 continue
 
-
             # If we have block-level change information (`sources_blocks`) for this BUILD file,
             # we skip adding all its targets indiscriminately. The precise targets affected
             # by the line changes are already captured by the `block_owners` calculation.
-            if not matching_files and bfa.rel_path in owners_request.sources_blocks:
+            if (
+                not matching_files
+                and target_origin_sources_blocks_options.enable
+                and bfa.rel_path in owners_request.sources_blocks
+            ):
                 continue
 
             unmatched_sources -= matching_files

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -1329,6 +1329,13 @@ async def find_owners(
             ):
                 continue
 
+
+            # If we have block-level change information (`sources_blocks`) for this BUILD file,
+            # we skip adding all its targets indiscriminately. The precise targets affected
+            # by the line changes are already captured by the `block_owners` calculation.
+            if not matching_files and bfa.rel_path in owners_request.sources_blocks:
+                continue
+
             unmatched_sources -= matching_files
             result.add(candidate_tgt.address)
 

--- a/src/python/pants/vcs/changed_integration_test.py
+++ b/src/python/pants/vcs/changed_integration_test.py
@@ -217,20 +217,23 @@ def test_delete_atom_target(repo: str) -> None:
 
 
 def test_change_build_file(repo: str) -> None:
-    """Every target in a BUILD file is changed when it's edited.
+    """Testing BUILD file invalidation with and without block-level tracking.
 
-    This is because we don't know what the target was like before-hand, so we're overly
-    conservative.
+    By default, we are overly conservative and assume any BUILD file change affects all targets.
+    With --enable-target-origin-sources-blocks=True, we use AST block tracking to precisely map changes.
     """
     append_to_file("BUILD", "# foo")
+
+    # Default behavior: Overly conservative (Flag is False)
     # Note that the target generator `//:lib` does not show up.
     assert_list_stdout(
         repo, ["//app.sh:lib", "//dep.sh:lib", "//transitive.sh:lib", "//:standalone"]
     )
-
-    # This is because the BUILD file gets expanded with all its targets, then their sources are
-    # used. This might not be desirable behavior.
     assert_count_loc(repo, expected_num_files=4)
+
+    # Smart Behavior: Block-level tracking (Flag is True)
+    # Since we only added a comment, no targets are invalidated.
+    assert_list_stdout(repo, [], extra_args=["--enable-target-origin-sources-blocks=True"])
 
 
 def test_different_build_file_changed(repo: str) -> None:


### PR DESCRIPTION
Resolves #23307

### Problem
Currently, `pants --changed-since` unnecessarily invalidates all targets within a `BUILD` file when only whitespace or unrelated comment lines are modified. The system falls back to a blanket invalidation because it assumes the entire file's structural integrity changed.

### Solution
When `--changed-since` interacts with the SCM, it already populates `sources_blocks` with the precise modified lines. However, the fallback condition in `find_owners` was still applying a blanket invalidation to all targets in the modified `BUILD` file, ignoring this block-level precision.

This PR adds a guard to skip this blanket invalidation if `sources_blocks` are available for the file, allowing `block_owners` to correctly filter only the affected targets natively.