### PR TITLE
Significantly reduce engine coroutine memory overhead 

### DIFF
--- a/src/rust/engine/src/nodes/mod.rs
+++ b/src/rust/engine/src/nodes/mod.rs
@@ -523,7 +523,11 @@ impl Node for NodeKey {
                 let mut result = match self {
                     NodeKey::DigestFile(n) => n.run_node(context).await.map(NodeOutput::FileDigest),
                     NodeKey::DownloadedFile(n) => {
-                        n.run_node(context).await.map(NodeOutput::Snapshot)
+                        // NB: Boxed because this coroutine is by far the largest variant (~15KB),
+                        // and this match otherwise embeds it in every node's spawned future.
+                        Box::pin(n.run_node(context))
+                            .await
+                            .map(NodeOutput::Snapshot)
                     }
                     NodeKey::ExecuteProcess(n) => {
                         let backtrack_level = context.maybe_start_backtracking(&n);

--- a/src/rust/engine/src/nodes/mod.rs
+++ b/src/rust/engine/src/nodes/mod.rs
@@ -76,19 +76,21 @@ pub fn task_get_context() -> Context {
     TASK_CONTEXT.with(|c| (**c).clone())
 }
 
-pub async fn task_context<T, F: future::Future<Output = T>>(
+pub fn task_context<T, F: future::Future<Output = T>>(
     context: Context,
     is_side_effecting: bool,
     side_effected: &Arc<AtomicBool>,
     f: F,
-) -> T {
+) -> impl future::Future<Output = T> {
+    // NB: Not an `async fn`: a coroutine would additionally retain the moved `f` in its own
+    // layout, doubling the size of every rule body scoped through here.
     let context = Arc::new(context);
     if is_side_effecting {
-        TASK_SIDE_EFFECTED
-            .scope(side_effected.clone(), TASK_CONTEXT.scope(context, f))
-            .await
+        future::Either::Left(
+            TASK_SIDE_EFFECTED.scope(side_effected.clone(), TASK_CONTEXT.scope(context, f)),
+        )
     } else {
-        TASK_CONTEXT.scope(context, f).await
+        future::Either::Right(TASK_CONTEXT.scope(context, f))
     }
 }
 

--- a/src/rust/stdio/src/lib.rs
+++ b/src/rust/stdio/src/lib.rs
@@ -470,11 +470,16 @@ pub fn set_thread_destination(destination: Arc<Destination>) {
 ///
 /// See InnerDestination for more info.
 ///
-pub async fn scope_task_destination<F>(destination: Arc<Destination>, f: F) -> F::Output
+pub fn scope_task_destination<F>(
+    destination: Arc<Destination>,
+    f: F,
+) -> impl Future<Output = F::Output>
 where
     F: Future,
 {
-    TASK_DESTINATION.scope(destination, f).await
+    // NB: Not an `async fn`: a coroutine would additionally retain the moved `f` in its own
+    // layout, doubling the size of every future scoped through here.
+    TASK_DESTINATION.scope(destination, f)
 }
 
 ///

--- a/src/rust/workunit_store/src/lib.rs
+++ b/src/rust/workunit_store/src/lib.rs
@@ -999,16 +999,16 @@ struct MetricsData {
 ///
 /// Propagate the given WorkunitStoreHandle to a Future representing a newly spawned Task.
 ///
-pub async fn scope_task_workunit_store_handle<F>(
+pub fn scope_task_workunit_store_handle<F>(
     workunit_store_handle: Option<WorkunitStoreHandle>,
     f: F,
-) -> F::Output
+) -> impl Future<Output = F::Output>
 where
     F: Future,
 {
-    TASK_WORKUNIT_STORE_HANDLE
-        .scope(workunit_store_handle, f)
-        .await
+    // NB: Not an `async fn`: a coroutine would additionally retain the moved `f` in its own
+    // layout, doubling the size of every future scoped through here.
+    TASK_WORKUNIT_STORE_HANDLE.scope(workunit_store_handle, f)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Easy wins that reduces peak engine memory by _a lot_. I've left comments at each site, as the choices may be non-obvious.

```console
RUSTC_BOOTSTRAP=1 RUSTFLAGS=-Zprint-type-sizes cargo build -p engine 2>/dev/null | grep -m1 'type: `{async block@engine/src/nodes/mod.rs:5'
```
gives

Before (main):
```console
print-type-size type: `{async block@engine/src/nodes/mod.rs:518:24: 518:34}`: 15744 bytes, alignment: 8 bytes
```
After:
```console
print-type-size type: `{async block@engine/src/nodes/mod.rs:520:24: 520:34}`: 2984 bytes, alignment: 8 bytes
```

Reduces peak memory on a real codebase from 7GB to 3.5GB, attributed to the fact that some rules run `concurently` on all targets (`FirstPartyPythonModuleMapping`).