### PR TITLE
Upgrade pex to v2.97.0

### DIFF
--- a/docs/notes/2.33.x.md
+++ b/docs/notes/2.33.x.md
@@ -75,7 +75,6 @@ The default version of [Pex](https://github.com/pex-tool/pex) used by the Python
  - Support for [Pip 26.1](https://pip.pypa.io/en/stable/news/#v26-1).
  - In [some cases](https://github.com/pex-tool/pex/pull/3159) lockfile creation is significantly faster.
  - Fixed `pex3 lock sync` failing to handle multiple input requirements for the same project name.
- - Fixed `--scie-only` for foreign platforms.
  - The `scie_pbs_stripped` field of `pex_binary` targets can now be combined with `scie_pbs_free_threaded`.
 
  Note that `v2.97.0` is now also the *minimum* required version of Pex. If you're pinning to an earlier version you must upgrade. Pex is very scrupulous about backwards compatibility, so this should not be a problem in general. If the pin was specifically to avoid a bug in Pex, that bug should be [reported](https://github.com/pex-tool/pex/issues/new), after first confirming that there isn't an existing [open issue](https://github.com/pex-tool/pex/issues) for it.

--- a/docs/notes/2.33.x.md
+++ b/docs/notes/2.33.x.md
@@ -70,13 +70,15 @@ Fixed a bug where the Python Build Standalone provider used a host interpreter p
 
 Fixed dependency validation for Python targets to honor resolve-derived interpreter constraints when `[python].default_to_resolve_interpreter_constraints` is enabled.
 
-The default version of [Pex](https://github.com/pex-tool/pex) used by the Python backend has been upgraded to [`v2.96.1`](https://github.com/pex-tool/pex/releases/tag/v2.96.1). Of particular note for Pants users:
+The default version of [Pex](https://github.com/pex-tool/pex) used by the Python backend has been upgraded to [`v2.97.0`](https://github.com/pex-tool/pex/releases/tag/v2.97.0). Of particular note for Pants users:
 
  - Support for [Pip 26.1](https://pip.pypa.io/en/stable/news/#v26-1).
  - In [some cases](https://github.com/pex-tool/pex/pull/3159) lockfile creation is significantly faster.
  - Fixed `pex3 lock sync` failing to handle multiple input requirements for the same project name.
+ - Fixed `--scie-only` for foreign platforms.
+ - The `scie_pbs_stripped` field of `pex_binary` targets can now be combined with `scie_pbs_free_threaded`.
 
- Note that `v2.95.1` is now also the *minimum* required version of Pex. If you're pinning to an earlier version you must upgrade. Pex is very scrupulous about backwards compatibility, so this should not be a problem in general. If the pin was specifically to avoid a bug in Pex, that bug should be [reported](https://github.com/pex-tool/pex/issues/new), after first confirming that there isn't an existing [open issue](https://github.com/pex-tool/pex/issues) for it.
+ Note that `v2.97.0` is now also the *minimum* required version of Pex. If you're pinning to an earlier version you must upgrade. Pex is very scrupulous about backwards compatibility, so this should not be a problem in general. If the pin was specifically to avoid a bug in Pex, that bug should be [reported](https://github.com/pex-tool/pex/issues/new), after first confirming that there isn't an existing [open issue](https://github.com/pex-tool/pex/issues) for it.
 
 The `pex_binary` target now has a `validate_entry_point` which plumbs through the [`--validate-entry-point`](https://github.com/pex-tool/pex/releases/tag/v1.4.5) flag to Pex.  This validates the entry point by importing it in a separate process at build time.
 

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -41,9 +41,9 @@ from pants.util.strutil import softwrap
 logger = logging.getLogger(__name__)
 
 
-_PEX_VERSION = "v2.96.1"
-_PEX_BINARY_HASH = "fcb10c5c0f560bb6c5e072f88dcee5123690d5b2aef4e76d75caed733101378b"
-_PEX_BINARY_SIZE = 5040040
+_PEX_VERSION = "v2.97.0"
+_PEX_BINARY_HASH = "cedb222723b5dd68d96997168943c0c932a904e360515c0edd9f85e4bb674cc9"
+_PEX_BINARY_SIZE = 5040201
 
 
 class PexCli(TemplatedExternalTool):
@@ -53,7 +53,7 @@ class PexCli(TemplatedExternalTool):
 
     default_version = _PEX_VERSION
     default_url_template = "https://github.com/pex-tool/pex/releases/download/{version}/pex"
-    version_constraints = ">=2.95.1,<3.0"
+    version_constraints = ">=2.97.0,<3.0"
 
     # extra args to be passed to the pex tool; note that they
     # are going to apply to all invocations of the pex tool.


### PR DESCRIPTION
Changelogs:
- https://github.com/pex-tool/pex/releases/tag/v2.97.0
- https://github.com/pex-tool/pex/releases/tag/v2.96.2