### PR TITLE
Write index config to both uv.toml and pyproject.toml

### DIFF
--- a/src/python/pants/backend/python/goals/lockfile_test.py
+++ b/src/python/pants/backend/python/goals/lockfile_test.py
@@ -669,7 +669,7 @@ def test_uv_lockfile_generation(
                     ]
                 ),
                 find_links=FrozenOrderedSet([]),
-                interpreter_constraints=InterpreterConstraints(["CPython>=3.9,<3.15"]),
+                interpreter_constraints=InterpreterConstraints(["CPython==3.14"]),
                 resolve_name="test",
                 lockfile_dest="test.lock",
                 diff=False,
@@ -717,7 +717,7 @@ def test_uv_lockfile_generation(
     metadata = json.loads(by_path["test.lock.metadata"].content.decode())
     assert metadata["version"] == 8
     assert metadata["lockfile_format"] == LockfileFormat.UV
-    assert metadata["valid_for_interpreter_constraints"] == ["CPython<3.15,>=3.9"]
+    assert metadata["valid_for_interpreter_constraints"] == ["CPython==3.14"]
     assert metadata["generated_with_requirements"] == [
         "ansicolors==1.1.8",
         "cowsay@ git+https://github.com/VaasuDevanS/cowsay-python@dcf7236f0b5ece9ed56e91271486e560526049cf",
@@ -733,7 +733,7 @@ def test_uv_lockfile_generation_with_sources(rule_runner: PythonRuleRunner) -> N
     rule_runner.set_options(
         [
             "--python-resolves={'test': 'test.lock'}",
-            "--python-repos-indexes=['alt=https://pypi.org/simple/']",
+            "--python-repos-indexes=['alt=https://pypi.org/simple/', 'https://test.pypi.org/simple']",
             "--python-resolves-to-sources={'test': ['alt=ansicolors>=1.0']}",
         ],
         env_inherit=PYTHON_BOOTSTRAP_ENV,
@@ -743,9 +743,14 @@ def test_uv_lockfile_generation_with_sources(rule_runner: PythonRuleRunner) -> N
         GenerateLockfileResult,
         [
             GenerateUvLockfile(
-                requirements=FrozenOrderedSet(["ansicolors==1.1.8"]),
+                requirements=FrozenOrderedSet(
+                    [
+                        "ansicolors==1.1.8",
+                        "pantsbuild-testpypi-only==0.0.1",  # Exists only on test.pypi.org, not on pypi.org
+                    ]
+                ),
                 find_links=FrozenOrderedSet([]),
-                interpreter_constraints=InterpreterConstraints(["CPython>=3.9,<3.15"]),
+                interpreter_constraints=InterpreterConstraints(["CPython==3.14"]),
                 resolve_name="test",
                 lockfile_dest="test.lock",
                 diff=False,

--- a/src/python/pants/backend/python/util_rules/pex_requirements.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements.py
@@ -410,6 +410,34 @@ class ResolvePexConstraintsFile:
     constraints: FrozenOrderedSet[PipRequirement]
 
 
+def generate_uv_index_config(indexes: Iterable[str] | None, table_name: str) -> Iterable[str]:
+    if not indexes:
+        return ["no-index = true"]
+
+    parsed_indexes = []
+    for index in indexes:
+        part1, _, part2 = index.partition("=")
+        (name, url) = (part1, part2) if part2 else ("", part1)
+        parsed_indexes.append((name, url))
+
+    lines = []
+    if parsed_indexes:
+        # To turn off uv's fallback to PyPI we must set some other index to be the default.
+        # In uv the default index has the lowest priority, regardless of its position in the
+        # list of indexes, so we set the last index to be that default, to match user intent.
+        table_header = f"[[{table_name}]]"
+        for i, (name, url) in enumerate(parsed_indexes):
+            is_default = i == len(parsed_indexes) - 1
+            lines.append(table_header)
+            if name:
+                lines.append(f'name = "{name}"')
+            lines.append(f'url = "{url}"')
+            if is_default:
+                lines.append("default = true")
+    lines.append("")
+    return lines
+
+
 @dataclass(frozen=True)
 class ResolveConfig:
     """Configuration from `[python]` that impacts how the resolve is created."""
@@ -519,6 +547,12 @@ class ResolveConfig:
         if self.uploaded_prior_to:
             config_lines.append(f'exclude-newer = "{self.uploaded_prior_to}"')
             config_lines.append("")
+
+        # We run with `--no-config` to turn off ambient config discovery. Therefore uv won't use
+        # index config from pyproject.toml for lockfile generation, and we must write it to uv.toml.
+        # However we also write it to pyproject.toml so that uv can validate the source names
+        # in `sources`.
+        config_lines.extend(generate_uv_index_config(self.indexes, "index"))
 
         return "\n".join(config_lines) + "\n" if config_lines else ""
 

--- a/src/python/pants/backend/python/util_rules/uv.py
+++ b/src/python/pants/backend/python/util_rules/uv.py
@@ -28,6 +28,7 @@ from pants.backend.python.util_rules.lockfile_metadata import (
 from pants.backend.python.util_rules.pex_environment import PythonExecutable
 from pants.backend.python.util_rules.pex_requirements import (
     LoadedLockfile,
+    generate_uv_index_config,
 )
 from pants.base.build_root import BuildRoot
 from pants.core.util_rules import system_binaries
@@ -145,39 +146,24 @@ def generate_pyproject_toml(
         """
     ).format(resolve=resolve, requires_python=requires_python, deps_lines=deps_lines)
 
-    if indexes is not None:
-        parsed_indexes = []
-        for index in indexes:
-            part1, _, part2 = index.partition("=")
-            (name, url) = (part1, part2) if part2 else ("", part1)
-            parsed_indexes.append((name, url))
-        if parsed_indexes:
-            # To turn off uv's fallback to PyPI we must set some other index to be the default.
-            # In uv the default index has the lowest priority, regardless of its position in the
-            # list of indexes, so we set the last index to be that default, to match user intent.
-            for i, (name, url) in enumerate(parsed_indexes):
-                is_default = i == len(parsed_indexes) - 1
-                content += "[[tool.uv.index]]\n"
-                if name:
-                    content += f'name = "{name}"\n'
-                content += f'url = "{url}"\n'
-                if is_default:
-                    content += "default = true\n"
-                content += "\n"
-        else:
-            content += "no-index = true\n\n"
+    # The indexes must be in pyproject.toml so uv can validate the index names in sources.
+    # (Technically we only need those referenced in sources and not all of them, but it's fine
+    # if the others are mentioned too).
+    extra_lines = list(generate_uv_index_config(indexes, "tool.uv.index"))
+    extra_lines.append("")
 
     sources = tuple(sources)
     if sources:
-        source_lines = ["[tool.uv.sources]"]
+        extra_lines.append("[tool.uv.sources]")
         for source in sources:
             index_name, _, scope = source.partition("=")
             req = Requirement(scope)
             # Markers may contain double-quotes, so we use single quotes in the TOML.
             marker = f", marker = '{req.marker}'" if req.marker else ""
-            source_lines.append(f'{req.name} = {{ index = "{index_name}"{marker} }}')
-        source_lines.append("")
-        content += "\n".join(source_lines) + "\n"
+            extra_lines.append(f'{req.name} = {{ index = "{index_name}"{marker} }}')
+        extra_lines.append("")
+
+    content += "\n".join(extra_lines)
 
     return content
 


### PR DESCRIPTION
- It's needed in pyproject.toml to validate any `source` references
- It's needed in uv.toml for actual lockfile generation, since we run
  with `--no-config` to prevent picking up ambient config files, which
  also prevents reading `tool.uv` config from pyproject.toml.

Fixes #23455 