### PR TITLE
admit concurrently() items through a semaphore window

### DIFF
--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -83,6 +83,7 @@ pub struct Core {
     pub watcher: Option<Arc<InvalidationWatcher>>,
     pub build_root: PathBuf,
     pub local_parallelism: usize,
+    pub remote_parallelism: Option<usize>,
     pub graceful_shutdown_timeout: Duration,
     pub sessions: Sessions,
     pub named_caches: NamedCaches,
@@ -756,6 +757,9 @@ impl Core {
             build_root,
             watcher,
             local_parallelism: exec_strategy_opts.local_parallelism,
+            remote_parallelism: remoting_opts
+                .execution_enable
+                .then_some(exec_strategy_opts.remote_parallelism),
             graceful_shutdown_timeout: exec_strategy_opts.graceful_shutdown_timeout,
             sessions,
             named_caches,

--- a/src/rust/engine/src/nodes/task.rs
+++ b/src/rust/engine/src/nodes/task.rs
@@ -156,6 +156,9 @@ impl Task {
         // of its entire in-flight subgraph in memory until it completes.
         // The semaphore must be scoped to this call: a shared pool would deadlock when the
         // items of nested `concurrently(..)` groups held permits while waiting for their children to acquire.
+        // TODO: The window and its multipliers are ad hoc, and per-call scoping admits up to
+        // window^depth items when nested. A dependency-aware semaphore with permit inheritance
+        // would give a global bound without deadlock: https://github.com/pantsbuild/pants/issues/23503
         let window = std::cmp::max(
             64,
             std::cmp::max(

--- a/src/rust/engine/src/nodes/task.rs
+++ b/src/rust/engine/src/nodes/task.rs
@@ -152,9 +152,29 @@ impl Task {
         entry: Intern<rule_graph::Entry<Rule>>,
         items: Vec<externs::AllItem>,
     ) -> NodeResult<Vec<Value>> {
-        let futures = items
-            .into_iter()
-            .map(|item| Self::gen_all_item(context, params.clone(), entry, item));
+        // NB: Use a semaphore rather than all at once: every eagerly requested item pins the futures
+        // of its entire in-flight subgraph in memory until it completes.
+        // The semaphore must be scoped to this call: a shared pool would deadlock when the
+        // items of nested `concurrently(..)` groups held permits while waiting for their children to acquire.
+        let window = std::cmp::max(
+            64,
+            std::cmp::max(
+                context.core.local_parallelism * 4,
+                context.core.remote_parallelism.unwrap_or(0) * 2,
+            ),
+        );
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(window));
+        let futures = items.into_iter().map(|item| {
+            let semaphore = semaphore.clone();
+            let params = params.clone();
+            async move {
+                let _permit = semaphore
+                    .acquire()
+                    .await
+                    .expect("The semaphore is never closed.");
+                Self::gen_all_item(context, params, entry, item).await
+            }
+        });
         future::try_join_all(futures).await
     }
 


### PR DESCRIPTION
A rule may request tens of thousands of items which pins significant chunk of memory. Meanwhile, the engine can only process so many nodes at once. The result is unnecessary allocator churn (so slower) and high peak memory.

For my machine based off of main I record going from 3.7GB to 2.0GB peak RAM usage with this change. Execution time improves a bit, mainly where `concurrently` nests.