### PR TITLE
Free-threaded: Export free threaded site packages

### DIFF
--- a/docs/notes/2.33.x.md
+++ b/docs/notes/2.33.x.md
@@ -70,6 +70,8 @@ Fixed a bug where the Python Build Standalone provider used a host interpreter p
 
 Fixed dependency validation for Python targets to honor resolve-derived interpreter constraints when `[python].default_to_resolve_interpreter_constraints` is enabled.
 
+Fixed `pants export` to use the free-threaded `site-packages` directory name (e.g. `lib/python3.14t/site-packages`) when exporting a resolve for a free-threaded interpreter.
+
 The default version of [Pex](https://github.com/pex-tool/pex) used by the Python backend has been upgraded to [`v2.97.0`](https://github.com/pex-tool/pex/releases/tag/v2.97.0). Of particular note for Pants users:
 
  - Support for [Pip 26.1](https://pip.pypa.io/en/stable/news/#v26-1).

--- a/src/python/pants/backend/python/goals/export.py
+++ b/src/python/pants/backend/python/goals/export.py
@@ -162,6 +162,20 @@ async def _get_full_python_version(python: PythonExecutable) -> str:
     return res.stdout.strip().decode()
 
 
+async def _get_abi_thread_suffix(python: PythonExecutable) -> str:
+    # The suffix (e.g. "t" for a free-threaded build, else "") that venvs append to their
+    # `lib/pythonX.Y{suffix}/site-packages` directory name.
+    argv = [
+        python.path,
+        "-c",
+        "import sysconfig; print(sysconfig.get_config_var('abi_thread') or '')",
+    ]
+    res = await execute_process_or_raise(
+        **implicitly(Process(argv, description="Get interpreter ABI thread suffix"))
+    )
+    return res.stdout.strip().decode()
+
+
 @dataclass(frozen=True)
 class VenvExportRequest:
     py_version: str
@@ -280,8 +294,12 @@ async def do_export(
             wheels_snapshot = await digest_to_snapshot(req.editable_local_dists_digest)
             # We need the paths to the installed .dist-info directories to finish installation.
             py_major_minor_version = ".".join(req.py_version.split(".", 2)[:2])
+            abi_thread_suffix = await _get_abi_thread_suffix(requirements_pex.python)
             lib_dir = os.path.join(
-                output_path, "lib", f"python{py_major_minor_version}", "site-packages"
+                output_path,
+                "lib",
+                f"python{py_major_minor_version}{abi_thread_suffix}",
+                "site-packages",
             )
             dist_info_dirs = [
                 # This builds: dist/.../resolve/3.8.9/lib/python3.8/site-packages/pkg_name-1.2.3.dist-info

--- a/src/python/pants/backend/python/goals/export_integration_test.py
+++ b/src/python/pants/backend/python/goals/export_integration_test.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import platform
 import shutil
+import sysconfig
 from collections.abc import Mapping
 from pathlib import Path
 from textwrap import dedent
@@ -97,7 +98,10 @@ def test_export(py_resolve_format: PythonResolveExportFormat, py_hermetic_script
         if py_resolve_format == PythonResolveExportFormat.symlinked_immutable_virtualenv:
             assert export_dir.is_symlink(), f"expected export dir '{export_dir}' is not a symlink"
 
-        lib_dir = export_dir / "lib" / f"python{py_minor_version}" / "site-packages"
+        abi_thread_suffix = sysconfig.get_config_var("abi_thread") or ""
+        lib_dir = (
+            export_dir / "lib" / f"python{py_minor_version}{abi_thread_suffix}" / "site-packages"
+        )
         assert lib_dir.is_dir(), f"expected export lib dir '{lib_dir}' does not exist"
         expected_ansicolors_dir = lib_dir / f"ansicolors-{ansicolors_version}.dist-info"
         assert expected_ansicolors_dir.is_dir(), (


### PR DESCRIPTION
This is not a pre-requisite for running pants free-threaded, it is a latent bug in the export goal that surfaces when CI runs targeting python 3.14t.