### PR TITLE
Free-threaded: Engine groundwork for performant free-threading

### DIFF
--- a/docs/notes/2.33.x.md
+++ b/docs/notes/2.33.x.md
@@ -20,6 +20,8 @@ Thank you to [Klaviyo](https://www.klaviyo.com/) for their Platinum tier support
 
 The thread used by the [`workunit-logger`](https://www.pantsbuild.org/2.33/reference/subsystems/workunit-logger) is now named.
 
+The engine's executor threads now keep a persistent Python thread state for the lifetime of each thread instead of creating and destroying one around every engine-to-Python call. Among other things, this keeps `PANTS_DEBUG` debug tracing attached to engine threads. Engine key interning also assigns ids with a single atomic dict operation. Both changes are groundwork for running Pants on free-threaded CPython.
+
 Fixed a crash with `IntrinsicError: Not a directory` when a `system_binary` target (or any binary lookup) encountered a non-directory entry on `PATH`, such as a symlink to a file or a path whose components include a file.
 
 Fixed a bug where certain limited terminals that report a width of 0 (like Emacs eshell) were not handled correctly.

--- a/src/rust/engine/src/externs/scheduler.rs
+++ b/src/rust/engine/src/externs/scheduler.rs
@@ -33,6 +33,9 @@ thread_local! {
 /// every attach. `PyEval_SaveThread` then detaches, leaving the thread parked without a state
 /// attached (which would otherwise block free-threaded stop-the-world pauses).
 fn thread_state_create() {
+    if unsafe { ffi::Py_IsInitialized() } == 0 {
+        return;
+    }
     // SAFETY: This hook runs first on a fresh runtime thread, which is not attached and has no
     // gilstate yet: `PyGILState_Ensure` creates this thread's state and attaches, and
     // `PyEval_SaveThread` detaches and returns that state. Both stay valid until the matching

--- a/src/rust/engine/src/externs/scheduler.rs
+++ b/src/rust/engine/src/externs/scheduler.rs
@@ -33,6 +33,10 @@ thread_local! {
 /// every attach. `PyEval_SaveThread` then detaches, leaving the thread parked without a state
 /// attached (which would otherwise block free-threaded stop-the-world pauses).
 fn thread_state_create() {
+    // SAFETY: This hook runs first on a fresh runtime thread, which is not attached and has no
+    // gilstate yet: `PyGILState_Ensure` creates this thread's state and attaches, and
+    // `PyEval_SaveThread` detaches and returns that state. Both stay valid until the matching
+    // `PyGILState_Release` in `thread_state_destroy` drops the last gilstate reference.
     unsafe {
         let gilstate = ffi::PyGILState_Ensure();
         let tstate = ffi::PyEval_SaveThread();
@@ -51,6 +55,12 @@ fn thread_state_create() {
 /// reference has CPython clear and delete the state.
 fn thread_state_destroy() {
     if let Some((tstate, gilstate)) = THREAD_STATE.take() {
+        // SAFETY: `tstate` and `gilstate` come from the paired `PyGILState_Ensure`/
+        // `PyEval_SaveThread` in `thread_state_create` on this same thread, and the thread is
+        // detached here (hooks run outside any `Python::attach` scope). `PyEval_RestoreThread`
+        // re-attaches the still-valid state, and releasing the last gilstate reference has
+        // CPython clear and delete it. If the interpreter has already been finalized,
+        // re-attaching would abort the process, so the state is leaked instead.
         unsafe {
             if ffi::Py_IsInitialized() != 0 {
                 ffi::PyEval_RestoreThread(tstate);

--- a/src/rust/engine/src/externs/scheduler.rs
+++ b/src/rust/engine/src/externs/scheduler.rs
@@ -93,10 +93,24 @@ impl PyExecutor {
 
 impl Drop for PyExecutor {
     fn drop(&mut self) {
-        if !self.0.is_shutdown() {
-            // This can lead to hangs, since `Drop` will run on an arbitrary thread under arbitrary
-            // locks. See #18211.
-            log::warn!("Executor was not shut down explicitly.");
+        if self.0.is_shutdown() {
+            return;
+        }
+        log::warn!("Executor was not shut down explicitly.");
+        // Dropping the Runtime joins its threads, and each thread attaches to Python in
+        // `thread_state_destroy` before exiting. `Drop` runs attached (via garbage collection),
+        // so shut down with this thread detached or the joins deadlock on the GIL.
+        //
+        // Shutting down from within a runtime would panic, and attaching from a detached thread
+        // acquires the GIL, which can deadlock under arbitrary Python-side locks (see #18211):
+        // leak it in both cases.
+        //
+        // When already attached, `Python::attach` acquires nothing and `py.detach` only releases.
+        //
+        // SAFETY: `PyGILState_Check` may be called from any thread at any time.
+        if tokio::runtime::Handle::try_current().is_err() && unsafe { ffi::PyGILState_Check() } == 1
+        {
+            Python::attach(|py| py.detach(|| self.0.shutdown(Duration::from_secs(3))));
         }
     }
 }

--- a/src/rust/engine/src/externs/scheduler.rs
+++ b/src/rust/engine/src/externs/scheduler.rs
@@ -1,6 +1,7 @@
 // Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+use std::cell::Cell;
 use std::time::Duration;
 
 use pyo3::exceptions::PyException;
@@ -12,11 +13,51 @@ pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     Ok(())
 }
 
-// NB: This exists because we need the PyInterpreterState to pass to PyThreadState_New,
-// however PyInterpreterState_Get wasn't added until Py 3.9. They vary in implementation, but because
-// we don't have any sub-interpreters they should both return the same object.
-unsafe extern "C" {
-    pub fn PyInterpreterState_Main() -> *mut ffi::PyInterpreterState;
+thread_local! {
+    /// This thread's detached `PyThreadState` and the `PyGILState_STATE` returned by the
+    /// `PyGILState_Ensure` call that created it.
+    static THREAD_STATE: Cell<Option<(*mut ffi::PyThreadState, ffi::PyGILState_STATE)>> =
+        const { Cell::new(None) };
+}
+
+/// Create a thread state for this thread up front and keep it until `thread_state_destroy`.
+///
+/// Each `Python::attach` on a thread with no thread state creates one via `PyGILState_Ensure`
+/// and destroys it again on release. That resets the debug trace function between calls (see
+/// https://github.com/PyO3/pyo3/issues/2495), and on free-threaded builds the teardown is
+/// expensive: `PyThreadState_Clear` abandons the thread's mimalloc heaps, which every other
+/// thread then pays to reclaim on allocation.
+///
+/// NB: The state must be created with `PyGILState_Ensure`: the gilstate machinery does not know
+/// about states created with `PyThreadState_New`, and would still create and destroy its own on
+/// every attach. `PyEval_SaveThread` then detaches, leaving the thread parked without a state
+/// attached (which would otherwise block free-threaded stop-the-world pauses).
+fn thread_state_create() {
+    unsafe {
+        let gilstate = ffi::PyGILState_Ensure();
+        let tstate = ffi::PyEval_SaveThread();
+        THREAD_STATE.set(Some((tstate, gilstate)));
+    }
+    if std::env::var("PANTS_DEBUG").is_ok() {
+        Python::attach(|py| {
+            let _ = py.eval(c"__import__('debugpy').debug_this_thread()", None, None);
+        });
+    }
+}
+
+/// Release the thread state created by `thread_state_create`. Tokio recycles blocking-pool
+/// threads after an idle timeout, so thread states must die with their threads or they
+/// accumulate for the life of the process. Re-attaching and then releasing the last gilstate
+/// reference has CPython clear and delete the state.
+fn thread_state_destroy() {
+    if let Some((tstate, gilstate)) = THREAD_STATE.take() {
+        unsafe {
+            if ffi::Py_IsInitialized() != 0 {
+                ffi::PyEval_RestoreThread(tstate);
+                ffi::PyGILState_Release(gilstate);
+            }
+        }
+    }
 }
 
 #[pyclass]
@@ -27,20 +68,12 @@ pub struct PyExecutor(pub task_executor::Executor);
 impl PyExecutor {
     #[new]
     fn __new__(core_threads: usize, max_threads: usize) -> PyResult<Self> {
-        task_executor::Executor::new_owned(core_threads, max_threads, || {
-            // NB: We need a PyThreadState object which lives throughout the lifetime of this thread
-            // as the debug trace object is attached to it. Otherwise the PyThreadState is
-            // constructed/destroyed with each `with_gil` call (inside PyGILState_Ensure/PyGILState_Release).
-            //
-            // Constructing (and leaking) a ThreadState object allocates and associates it with the current
-            // thread, and the Python runtime won't wipe the trace function between calls.
-            // See https://github.com/PyO3/pyo3/issues/2495
-            let _ =
-                unsafe { ffi::PyThreadState_New(Python::attach(|_| PyInterpreterState_Main())) };
-            Python::attach(|py| {
-                let _ = py.eval(c"__import__('debugpy').debug_this_thread()", None, None);
-            });
-        })
+        task_executor::Executor::new_owned(
+            core_threads,
+            max_threads,
+            thread_state_create,
+            thread_state_destroy,
+        )
         .map(PyExecutor)
         .map_err(PyException::new_err)
     }

--- a/src/rust/engine/src/externs/scheduler.rs
+++ b/src/rust/engine/src/externs/scheduler.rs
@@ -4,13 +4,42 @@
 use std::cell::Cell;
 use std::time::Duration;
 
+use parking_lot::RwLock;
 use pyo3::exceptions::PyException;
 use pyo3::ffi;
 use pyo3::prelude::*;
 
 pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyExecutor>()?;
+    // LIFO: registering at import time makes this run last among `atexit` callbacks.
+    m.py()
+        .import("atexit")?
+        .call_method1("register", (wrap_pyfunction!(python_exiting, m)?,))?;
     Ok(())
+}
+
+/// Whether engine threads may still attach to the interpreter. `python_exiting` flips this from
+/// `atexit`, which `Py_FinalizeEx` runs before marking the runtime finalizing and after all
+/// later-registered callbacks (such as executor shutdowns). The thread hooks attach under the
+/// read lock, so they can never race finalization and hang or touch a freed state.
+static PYTHON_ALIVE: RwLock<bool> = RwLock::new(true);
+
+#[pyfunction]
+fn python_exiting(py: Python) {
+    py.detach(|| {
+        *PYTHON_ALIVE.write() = false;
+    });
+}
+
+/// Runs `f`, which may attach to the interpreter, under the `PYTHON_ALIVE` gate. Skips `f`
+/// once Python is shutting down, or when the interpreter is not initialized.
+fn with_python_alive(f: impl FnOnce()) {
+    let alive = PYTHON_ALIVE.read();
+    // SAFETY: `Py_IsInitialized` only reads a runtime flag and may be called from any thread at
+    // any time, even before initialization or after finalization.
+    if *alive && unsafe { ffi::Py_IsInitialized() != 0 } {
+        f()
+    }
 }
 
 thread_local! {
@@ -33,23 +62,22 @@ thread_local! {
 /// every attach. `PyEval_SaveThread` then detaches, leaving the thread parked without a state
 /// attached (which would otherwise block free-threaded stop-the-world pauses).
 fn thread_state_create() {
-    if unsafe { ffi::Py_IsInitialized() } == 0 {
-        return;
-    }
-    // SAFETY: This hook runs first on a fresh runtime thread, which is not attached and has no
-    // gilstate yet: `PyGILState_Ensure` creates this thread's state and attaches, and
-    // `PyEval_SaveThread` detaches and returns that state. Both stay valid until the matching
-    // `PyGILState_Release` in `thread_state_destroy` drops the last gilstate reference.
-    unsafe {
-        let gilstate = ffi::PyGILState_Ensure();
-        let tstate = ffi::PyEval_SaveThread();
-        THREAD_STATE.set(Some((tstate, gilstate)));
-    }
-    if std::env::var("PANTS_DEBUG").is_ok() {
-        Python::attach(|py| {
-            let _ = py.eval(c"__import__('debugpy').debug_this_thread()", None, None);
-        });
-    }
+    with_python_alive(|| {
+        // SAFETY: A fresh runtime thread is not attached and has no gilstate yet:
+        // `PyGILState_Ensure` creates this thread's state and attaches, `PyEval_SaveThread`
+        // detaches and returns it, and both stay valid until the matching `PyGILState_Release`
+        // in `thread_state_destroy`.
+        unsafe {
+            let gilstate = ffi::PyGILState_Ensure();
+            let tstate = ffi::PyEval_SaveThread();
+            THREAD_STATE.set(Some((tstate, gilstate)));
+        }
+        if std::env::var("PANTS_DEBUG").is_ok() {
+            Python::attach(|py| {
+                let _ = py.eval(c"__import__('debugpy').debug_this_thread()", None, None);
+            });
+        }
+    });
 }
 
 /// Release the thread state created by `thread_state_create`. Tokio recycles blocking-pool
@@ -57,20 +85,20 @@ fn thread_state_create() {
 /// accumulate for the life of the process. Re-attaching and then releasing the last gilstate
 /// reference has CPython clear and delete the state.
 fn thread_state_destroy() {
-    if let Some((tstate, gilstate)) = THREAD_STATE.take() {
-        // SAFETY: `tstate` and `gilstate` come from the paired `PyGILState_Ensure`/
-        // `PyEval_SaveThread` in `thread_state_create` on this same thread, and the thread is
-        // detached here (hooks run outside any `Python::attach` scope). `PyEval_RestoreThread`
-        // re-attaches the still-valid state, and releasing the last gilstate reference has
-        // CPython clear and delete it. If the interpreter has already been finalized,
-        // re-attaching would abort the process, so the state is leaked instead.
+    let Some((tstate, gilstate)) = THREAD_STATE.take() else {
+        return;
+    };
+    // Leak the state if Python is shutting down.
+    with_python_alive(|| {
+        // SAFETY: `tstate` and `gilstate` come from the paired calls in `thread_state_create` on
+        // this same thread, which is detached here; the `PYTHON_ALIVE` read lock keeps the
+        // interpreter alive across the attach. Releasing the last gilstate reference has CPython
+        // clear and delete the state.
         unsafe {
-            if ffi::Py_IsInitialized() != 0 {
-                ffi::PyEval_RestoreThread(tstate);
-                ffi::PyGILState_Release(gilstate);
-            }
+            ffi::PyEval_RestoreThread(tstate);
+            ffi::PyGILState_Release(gilstate);
         }
-    }
+    });
 }
 
 #[pyclass]

--- a/src/rust/engine/src/interning.rs
+++ b/src/rust/engine/src/interning.rs
@@ -54,13 +54,13 @@ impl Interns {
         let (id, type_id): (u64, TypeId) = {
             let v = v.bind(py);
             let keys = self.keys.bind(py);
-            let id: u64 = if let Some(key) = keys.get_item(v)? {
-                key.extract()?
-            } else {
-                let id = self.id_generator.fetch_add(1, atomic::Ordering::Relaxed);
-                keys.set_item(v, id)?;
-                id
-            };
+            // `setdefault` is a single dict operation, so the check-and-assign is atomic on
+            // free-threaded builds (a separate get-then-set lets two threads mint distinct ids
+            // for equal values, breaking Key's id-based equality). A lost race only wastes an id.
+            let candidate = self.id_generator.fetch_add(1, atomic::Ordering::Relaxed);
+            let id: u64 = keys
+                .call_method1(pyo3::intern!(py, "setdefault"), (v, candidate))?
+                .extract()?;
             (id, TypeId::new(&v.get_type()))
         };
 

--- a/src/rust/fs/store/benches/store.rs
+++ b/src/rust/fs/store/benches/store.rs
@@ -22,7 +22,7 @@ use tempfile::TempDir;
 use store::{OneOffStoreFileByDigest, Snapshot, SnapshotOps, Store, SubsetParams};
 
 fn executor() -> Executor {
-    Executor::new_owned(num_cpus::get(), num_cpus::get() * 4, || ()).unwrap()
+    Executor::new_owned(num_cpus::get(), num_cpus::get() * 4, || (), || ()).unwrap()
 }
 
 pub fn criterion_benchmark_materialize(c: &mut Criterion) {

--- a/src/rust/task_executor/src/lib.rs
+++ b/src/rust/task_executor/src/lib.rs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 use std::collections::HashMap;
-use std::env;
 use std::future::Future;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -75,13 +74,15 @@ impl Executor {
     /// need thread configurability, but also want to know reliably when the Runtime will shutdown
     /// (which, because it is static, will only be at the entire process' exit).
     ///
-    pub fn new_owned<F>(
+    pub fn new_owned<F, G>(
         num_worker_threads: usize,
         max_threads: usize,
         on_thread_start: F,
+        on_thread_stop: G,
     ) -> Result<Executor, String>
     where
         F: Fn() + Send + Sync + 'static,
+        G: Fn() + Send + Sync + 'static,
     {
         let mut runtime_builder = Builder::new_multi_thread();
 
@@ -90,9 +91,12 @@ impl Executor {
             .max_blocking_threads(max_threads - num_worker_threads)
             .enable_all();
 
-        if env::var("PANTS_DEBUG").is_ok() {
-            runtime_builder.on_thread_start(on_thread_start);
-        };
+        // NB: These run on every runtime-managed thread, including blocking-pool threads, which
+        // tokio expires after an idle keep-alive and respawns on demand. Any per-thread state
+        // created in `on_thread_start` must be torn down in `on_thread_stop`: a leak here is per
+        // thread created, not per pool slot, and so grows without bound in a long-lived pantsd.
+        runtime_builder.on_thread_start(on_thread_start);
+        runtime_builder.on_thread_stop(on_thread_stop);
 
         let runtime = runtime_builder
             .build()


### PR DESCRIPTION
Keep a persistent per-thread PyThreadState in the executor. Without this, every Python::attach cycle tears down the thread state, and on 3.14t that abandons the thread's mimalloc heaps. Created per tokio thread, torn down in on_thread_stop (blocking threads are recycled, so the state must not leak per thread creation).

setdefault thread-safety is documented here: https://docs.python.org/3/library/threadsafety.html#thread-safety-for-dict-objects.