### PR TITLE
Free-threaded: Drop hdrhistorgram python dependency

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -8,7 +8,6 @@ ansicolors==1.1.8
 chevron==0.14.0
 fasteners==0.20.0
 freezegun==1.5.5
-hdrhistogram==0.10.7
 ijson==3.4.0.post0
 packaging==26.0
 psutil==7.2.2

--- a/3rdparty/python/user_reqs.lock
+++ b/3rdparty/python/user_reqs.lock
@@ -824,37 +824,6 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "7bafdf18bcb142c0fe47c7b64ae3bd911b0593df4d04f1113a2ba88f05dd989d",
-              "url": "https://files.pythonhosted.org/packages/9a/8c/217f0987a175dcea53317484ca10a699a0591231045632c8a2c18da4d35b/hdrhistogram-0.10.7-cp314-cp314-musllinux_1_2_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "2241f3e1f7449eb3013a866b5a21e83c8bdc59c8ade447b7f7fe8494e367f6d8",
-              "url": "https://files.pythonhosted.org/packages/10/74/e4aebac62e490c15876f275db923a1c3f9c8c174e22d02fe63c23ad12815/hdrhistogram-0.10.7-cp314-cp314-macosx_11_0_arm64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "bed4785a5e40e6260306e8e27ee3d31299263640cd7618040df88447ed57c2bd",
-              "url": "https://files.pythonhosted.org/packages/79/ba/0f5b04dd55da744e1f8ed251f12286fb21e488f6c9671323016e4e56a106/hdrhistogram-0.10.7.tar.gz"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "2757e885a767e35be97094f07acbf9a76750c556afbb25d40111b5560786887e",
-              "url": "https://files.pythonhosted.org/packages/92/fa/f9fc7c9fed0af5fdc8316770a667a4bf94ffdda9b9c155f71a164a95a849/hdrhistogram-0.10.7-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
-            }
-          ],
-          "project_name": "hdrhistogram",
-          "requires_dists": [
-            "pbr>=1.4",
-            "setuptools>=78.1.1"
-          ],
-          "requires_python": ">=3.10",
-          "version": "0.10.7"
-        },
-        {
-          "artifacts": [
-            {
-              "algorithm": "sha256",
               "hash": "2c032fa028f46871ec7e1fc59fc15e8023eab3e6bbe6ece786a1611719a5d081",
               "url": "https://files.pythonhosted.org/packages/99/67/8d9f2c313618e161b82f3873188e7196126da1d6e29688df40eb3997c77a/httptools-0.8.0-cp314-cp314t-musllinux_1_2_x86_64.whl"
             },
@@ -1521,26 +1490,6 @@
           ],
           "requires_python": ">=3.9",
           "version": "1.1.1"
-        },
-        {
-          "artifacts": [
-            {
-              "algorithm": "sha256",
-              "hash": "ff223894eb1cd271a98076b13d3badff3bb36c424074d26334cd25aebeecea6b",
-              "url": "https://files.pythonhosted.org/packages/c0/db/61efa0d08a99f897ef98256b03e563092d36cc38dc4ebe4a85020fe40b31/pbr-7.0.3-py2.py3-none-any.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "b46004ec30a5324672683ec848aed9e8fc500b0d261d40a3229c2d2bbfcedc29",
-              "url": "https://files.pythonhosted.org/packages/5e/ab/1de9a4f730edde1bdbbc2b8d19f8fa326f036b4f18b2f72cfbea7dc53c26/pbr-7.0.3.tar.gz"
-            }
-          ],
-          "project_name": "pbr",
-          "requires_dists": [
-            "setuptools"
-          ],
-          "requires_python": ">=2.6",
-          "version": "7.0.3"
         },
         {
           "artifacts": [
@@ -3276,7 +3225,6 @@
     "fastapi==0.120.1",
     "fasteners==0.20.0",
     "freezegun==1.5.5",
-    "hdrhistogram==0.10.7",
     "ijson==3.4.0.post0",
     "mypy-typing-asserts==0.1.1",
     "mypy~=1.19.1",

--- a/3rdparty/python/user_reqs.lock.metadata
+++ b/3rdparty/python/user_reqs.lock.metadata
@@ -14,7 +14,6 @@
     "fastapi==0.120.1",
     "fasteners==0.20.0",
     "freezegun==1.5.5",
-    "hdrhistogram==0.10.7",
     "ijson==3.4.0.post0",
     "mypy-typing-asserts==0.1.1",
     "mypy~=1.19.1",

--- a/docs/notes/2.33.x.md
+++ b/docs/notes/2.33.x.md
@@ -28,7 +28,7 @@ Fixed a bug where writes of remote cache content into a local sandbox can escape
 
 Fixed broken troubleshooting documentation links.
 
-Upgraded hdrhistogram to 0.10.7, which ships pre-built wheels for python 3.14 so `clang` is no longer needed when using histogram summaries.
+Observation histogram summaries from the [stats](https://www.pantsbuild.org/2.33/reference/subsystems/stats) subsystem are now decoded natively by the engine: adding `hdrhistogram` to `[GLOBAL].plugins` is no longer required, and the dependency was removed from Pants' own requirements.
 
 Upgraded psutil to 7.2.2, which ships pre-built wheels for CPython 3.14, including free-threaded (`cp314t`) builds.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,6 @@ module = [
   "fasteners",
   "freezegun",
   "gnupg",
-  "hdrh",
-  "hdrh.histogram",
   "ijson.*",
   "nodesemver",
   "pex.*",

--- a/src/python/pants/engine/internals/native_engine.pyi
+++ b/src/python/pants/engine/internals/native_engine.pyi
@@ -1041,6 +1041,9 @@ class ProcessExecutionEnvironment:
 # ------------------------------------------------------------------------------
 
 def all_counter_names() -> list[str]: ...
+def decode_observation_histogram(
+    encoded: bytes, percentiles: Sequence[float]
+) -> dict[str, int | float]: ...
 
 # ------------------------------------------------------------------------------
 # Nailgun

--- a/src/python/pants/goal/stats_aggregator.py
+++ b/src/python/pants/goal/stats_aggregator.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import base64
 import datetime
 import json
 import logging
@@ -13,8 +12,7 @@ from enum import Enum
 from pathlib import Path
 from typing import TypedDict
 
-from hdrh.histogram import HdrHistogram
-
+from pants.engine.internals import native_engine
 from pants.engine.internals.scheduler import Workunit
 from pants.engine.rules import collect_rules, rule
 from pants.engine.streaming_workunit_handler import (
@@ -33,6 +31,10 @@ from pants.util.strutil import softwrap
 logger = logging.getLogger(__name__)
 
 HISTOGRAM_PERCENTILES = [25, 50, 75, 90, 95, 99]
+
+
+def _decode_histogram(encoded_histogram: bytes):
+    return native_engine.decode_observation_histogram(encoded_histogram, HISTOGRAM_PERCENTILES)
 
 
 class CounterObject(TypedDict):
@@ -87,7 +89,7 @@ class StatsAggregatorSubsystem(Subsystem):
             observation histograms, e.g. the number of cache hits and the time saved by
             caching.
 
-            For histogram summaries to work, you must add `hdrhistogram` to `[GLOBAL].plugins`.
+            Histogram summaries are decoded by the native engine.
             """
         ),
         advanced=True,
@@ -224,24 +226,19 @@ class StatsAggregatorCallback(WorkunitsCallback):
 
         output_lines.append("Observation histogram summaries:")
         for name, encoded_histogram in histograms.items():
-            # Note: The Python library for HDR Histogram will only decode compressed histograms
-            # that are further encoded with base64. See
-            # https://github.com/HdrHistogram/HdrHistogram_py/issues/29.
-            histogram = HdrHistogram.decode(base64.b64encode(encoded_histogram))
+            histogram = _decode_histogram(encoded_histogram)
             percentile_to_vals = "\n".join(
-                f"  p{percentile}: {value}"
-                for percentile, value in histogram.get_percentile_to_value_dict(
-                    HISTOGRAM_PERCENTILES
-                ).items()
+                f"  p{percentile}: {histogram[f'p{percentile}']}"
+                for percentile in HISTOGRAM_PERCENTILES
             )
             output_lines.append(
                 f"Summary of `{name}` observation histogram:\n"
-                f"  min: {histogram.get_min_value()}\n"
-                f"  max: {histogram.get_max_value()}\n"
-                f"  mean: {histogram.get_mean_value():.3f}\n"
-                f"  std dev: {histogram.get_stddev():.3f}\n"
-                f"  total observations: {histogram.total_count}\n"
-                f"  sum: {int(histogram.get_mean_value() * histogram.total_count)}\n"
+                f"  min: {histogram['min']}\n"
+                f"  max: {histogram['max']}\n"
+                f"  mean: {histogram['mean']:.3f}\n"
+                f"  std dev: {histogram['std_dev']:.3f}\n"
+                f"  total observations: {histogram['total_observations']}\n"
+                f"  sum: {histogram['sum']}\n"
                 f"{percentile_to_vals}"
             )
         _log_or_write_to_file_plain(self.output_file, output_lines)
@@ -302,25 +299,20 @@ class StatsAggregatorCallback(WorkunitsCallback):
 
         observation_histograms: list[ObservationHistogramObject] = []
         for name, encoded_histogram in histograms.items():
-            # Note: The Python library for HDR Histogram will only decode compressed histograms
-            # that are further encoded with base64. See
-            # https://github.com/HdrHistogram/HdrHistogram_py/issues/29.
-            histogram = HdrHistogram.decode(base64.b64encode(encoded_histogram))
+            histogram = _decode_histogram(encoded_histogram)
             percentile_to_vals = {
-                f"p{percentile}": value
-                for percentile, value in histogram.get_percentile_to_value_dict(
-                    HISTOGRAM_PERCENTILES
-                ).items()
+                f"p{percentile}": histogram[f"p{percentile}"]
+                for percentile in HISTOGRAM_PERCENTILES
             }
 
             observation_histogram: ObservationHistogramObject = {
                 "name": name,
-                "min": histogram.get_min_value(),
-                "max": histogram.get_max_value(),
-                "mean": round(histogram.get_mean_value(), 3),
-                "std_dev": round(histogram.get_stddev(), 3),
-                "total_observations": histogram.total_count,
-                "sum": int(histogram.get_mean_value() * histogram.total_count),
+                "min": histogram["min"],
+                "max": histogram["max"],
+                "mean": round(histogram["mean"], 3),
+                "std_dev": round(histogram["std_dev"], 3),
+                "total_observations": histogram["total_observations"],
+                "sum": histogram["sum"],
                 **percentile_to_vals,  # type: ignore
             }
             observation_histograms.append(observation_histogram)

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -1133,6 +1133,7 @@ dependencies = [
  "graph",
  "grpc_util",
  "hashing",
+ "hdrhistogram",
  "indexmap 2.13.0",
  "internment",
  "itertools 0.14.0",

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -35,6 +35,7 @@ futures-core = { workspace = true }
 graph = { path = "../graph" }
 grpc_util = { path = "../grpc_util" }
 hashing = { path = "../hashing" }
+hdrhistogram = { workspace = true }
 indexmap = { workspace = true }
 internment = { workspace = true }
 itertools = { workspace = true }

--- a/src/rust/engine/src/externs/workunits.rs
+++ b/src/rust/engine/src/externs/workunits.rs
@@ -2,14 +2,51 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 use pyo3::prelude::*;
+use pyo3::types::{PyBytes, PyDict, PySequence};
 use workunit_store::Metric;
 
 pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(all_counter_names, m)?)?;
+    m.add_function(wrap_pyfunction!(decode_observation_histogram, m)?)?;
     Ok(())
 }
 
 #[pyfunction]
 fn all_counter_names() -> Vec<String> {
     Metric::all_metrics()
+}
+
+#[pyfunction]
+fn decode_observation_histogram<'py>(
+    py: Python<'py>,
+    encoded: &Bound<'py, PyBytes>,
+    percentiles: &Bound<'py, PySequence>,
+) -> PyResult<Bound<'py, PyDict>> {
+    let encoded = encoded.as_bytes().to_vec();
+    let histogram = py.detach(move || {
+        let mut reader = encoded.as_slice();
+        hdrhistogram::serialization::Deserializer::new()
+            .deserialize::<u64, _>(&mut reader)
+            .map_err(|err| PyErr::new::<pyo3::exceptions::PyValueError, _>(err.to_string()))
+    })?;
+
+    let result = PyDict::new(py);
+    let mean = histogram.mean();
+    let total_observations = histogram.len();
+    result.set_item("min", histogram.min())?;
+    result.set_item("max", histogram.max())?;
+    result.set_item("mean", mean)?;
+    result.set_item("std_dev", histogram.stdev())?;
+    result.set_item("total_observations", total_observations)?;
+    result.set_item("sum", (mean * total_observations as f64) as u64)?;
+
+    for percentile in percentiles.try_iter()? {
+        let percentile: f64 = percentile?.extract()?;
+        result.set_item(
+            format!("p{}", percentile),
+            histogram.value_at_percentile(percentile),
+        )?;
+    }
+
+    Ok(result)
 }


### PR DESCRIPTION
The engine already encodes observation histograms with the Rust hdrhistogram crate; decode them there too, so the stats aggregator no longer needs the hdrhistogram Python distribution (which users had to add to `[GLOBAL].plugins` for histogram summaries).

It lacked free-threaded wheels last I checked.