### PR TITLE
Infer python dist ics from pyproject

### DIFF
--- a/docs/docs/python/overview/building-distributions.mdx
+++ b/docs/docs/python/overview/building-distributions.mdx
@@ -63,6 +63,10 @@ Running `pants package example/dists:mydist` will cause Pants to inspect the `[b
 
 If you want to build just a wheel or just an sdist, you can set `sdist=False` or `wheel=False` on the `python_distribution` target.
 
+:::note Interpreter constraints are inferred from `pyproject.toml`
+If you don't set the `interpreter_constraints` field on a `python_distribution`, Pants infers it from the `[project].requires-python` value in a `pyproject.toml` in the same directory, if present. An explicit `interpreter_constraints` field always takes precedence, and if there is no `pyproject.toml` (or no `requires-python`) Pants falls back to the `[python].interpreter_constraints` option.
+:::
+
 ### Setuptools
 
 If relying on legacy Setuptools behavior, you don't have a `pyproject.toml` resource, so your target is simply:

--- a/docs/notes/2.33.x.md
+++ b/docs/notes/2.33.x.md
@@ -90,15 +90,15 @@ Fixed `pants export` to use the free-threaded `site-packages` directory name (e.
 
 The default version of [Pex](https://github.com/pex-tool/pex) used by the Python backend has been upgraded to [`v2.97.1`](https://github.com/pex-tool/pex/releases/tag/v2.97.1). Of particular note for Pants users:
 
-- Support for [Pip 26.1](https://pip.pypa.io/en/stable/news/#v26-1).
-- In [some cases](https://github.com/pex-tool/pex/pull/3159) lockfile creation is significantly faster.
-- Fixed `pex3 lock sync` failing to handle multiple input requirements for the same project name.
-- The `scie_pbs_stripped` field of `pex_binary` targets can now be combined with `scie_pbs_free_threaded`.
-- `lock sync` now works with "split universal" locks.
+ - Support for [Pip 26.1](https://pip.pypa.io/en/stable/news/#v26-1).
+ - In [some cases](https://github.com/pex-tool/pex/pull/3159) lockfile creation is significantly faster.
+ - Fixed `pex3 lock sync` failing to handle multiple input requirements for the same project name.
+ - The `scie_pbs_stripped` field of `pex_binary` targets can now be combined with `scie_pbs_free_threaded`.
+ - `lock sync` now works with "split universal" locks.
 
-Note that `v2.97.1` is now also the _minimum_ required version of Pex. If you're pinning to an earlier version you must upgrade. Pex is very scrupulous about backwards compatibility, so this should not be a problem in general. If the pin was specifically to avoid a bug in Pex, that bug should be [reported](https://github.com/pex-tool/pex/issues/new), after first confirming that there isn't an existing [open issue](https://github.com/pex-tool/pex/issues) for it.
+ Note that `v2.97.1` is now also the *minimum* required version of Pex. If you're pinning to an earlier version you must upgrade. Pex is very scrupulous about backwards compatibility, so this should not be a problem in general. If the pin was specifically to avoid a bug in Pex, that bug should be [reported](https://github.com/pex-tool/pex/issues/new), after first confirming that there isn't an existing [open issue](https://github.com/pex-tool/pex/issues) for it.
 
-The `pex_binary` target now has a `validate_entry_point` which plumbs through the [`--validate-entry-point`](https://github.com/pex-tool/pex/releases/tag/v1.4.5) flag to Pex. This validates the entry point by importing it in a separate process at build time.
+The `pex_binary` target now has a `validate_entry_point` which plumbs through the [`--validate-entry-point`](https://github.com/pex-tool/pex/releases/tag/v1.4.5) flag to Pex.  This validates the entry point by importing it in a separate process at build time.
 
 Fixed a bug in Ruff backend where ancestor `__init__.py` files were not included in `fix` partitions which changed how Ruff's importing sorting logic operated. Thie caused `pants fix` to see no need for import sorting even though `pants lint` flagged the need.
 
@@ -108,17 +108,14 @@ Fixed a bug where `--sync`-ing a Pex lockfile with legacy metadata headers faile
 
 Added a default module mapping for `apache-airflow-mypy`, which provides the `airflow_mypy` module.
 
-The default interpreter constraints for bundled tools have been standardized on `>=3.10,<3.15`. This drops support for Python 3.9 which reached end-of-life on [2025-10-31](https://www.python.org/downloads/release/python-3925/) and support was removed from Pip in [26.1](https://pip.pypa.io/en/stable/news/#v26-1). If you are specifically relying on a Python 3.9 interpreter to run a tool, or if you require a different version of a tool than the new default, then you will need to generate a custom lockfile for that tool with the appropriate interpreter constraints. As part of this several default bundled versions have been updated. Notably this includes:
+The default interpreter constraints for bundled tools have been standardized on `>=3.10,<3.15`.  This drops support for Python 3.9 which reached end-of-life on [2025-10-31](https://www.python.org/downloads/release/python-3925/) and support was removed from Pip in [26.1](https://pip.pypa.io/en/stable/news/#v26-1).  If you are specifically relying on a Python 3.9 interpreter to run a tool, or if you require a different version of a tool than the new default, then you will need to generate a custom lockfile for that tool with the appropriate interpreter constraints.  As part of this several default bundled versions have been updated.  Notably this includes:
+ * `mypy`: `1.19.1 -> 1.20.2`
+ * `mypy-protobuf`: `3.6.0 -> 3.7.0`
+ * `coverage`:  `7.10.7 -> 7.14.3`
+ * `protobuf`: `6.33.1 -> 7.35.1`
+ * The version of packaging (`26.2`) and setuptools (`82.x`) was also updated across the bundled lockfiles.
 
-- `mypy`: `1.19.1 -> 1.20.2`
-- `mypy-protobuf`: `3.6.0 -> 3.7.0`
-- `coverage`: `7.10.7 -> 7.14.3`
-- `protobuf`: `6.33.1 -> 7.35.1`
-- The version of packaging (`26.2`) and setuptools (`82.x`) was also updated across the bundled lockfiles.
-
-The lockfiles Pants bundles for tools (such as `mypy` or `pytest`) as well as Pants' own internal Python lockfiles now use a two day [dependency cooldown](https://sethmlarson.dev/pip-relative-dependency-cooldowns). The cooldowon itself is not a direct change for users, but said lockfiles were all regenerated to match. No top-level subsystem tools were updated, but several tool dependencies were (see above).
-
-The lockfiles Pants bundles for tools (such as `mypy` or `pytest`) as well as Pants' own internal Python lockfiles now use a two day [dependency cooldown](https://sethmlarson.dev/pip-relative-dependency-cooldowns). The cooldowon itself is not a direct change for users, but said lockfiles were all regenerated to match. No top-level subsystem tools were updated, but several tool dependencies were (see above).
+The lockfiles Pants bundles for tools (such as `mypy` or `pytest`) as well as Pants' own internal Python lockfiles now use a two day [dependency cooldown](https://sethmlarson.dev/pip-relative-dependency-cooldowns).  The cooldowon itself is not a direct change for users, but said lockfiles were all regenerated to match. No top-level subsystem tools were updated, but several tool dependencies were (see above).
 
 The default version of the sqlfluff in the bundled tool lockfile has been upgraded from `2.3.5` to [`4.2.2`](https://docs.sqlfluff.com/en/stable/reference/releasenotes.html).
 

--- a/docs/notes/2.33.x.md
+++ b/docs/notes/2.33.x.md
@@ -90,15 +90,15 @@ Fixed `pants export` to use the free-threaded `site-packages` directory name (e.
 
 The default version of [Pex](https://github.com/pex-tool/pex) used by the Python backend has been upgraded to [`v2.97.1`](https://github.com/pex-tool/pex/releases/tag/v2.97.1). Of particular note for Pants users:
 
- - Support for [Pip 26.1](https://pip.pypa.io/en/stable/news/#v26-1).
- - In [some cases](https://github.com/pex-tool/pex/pull/3159) lockfile creation is significantly faster.
- - Fixed `pex3 lock sync` failing to handle multiple input requirements for the same project name.
- - The `scie_pbs_stripped` field of `pex_binary` targets can now be combined with `scie_pbs_free_threaded`.
- - `lock sync` now works with "split universal" locks.
+- Support for [Pip 26.1](https://pip.pypa.io/en/stable/news/#v26-1).
+- In [some cases](https://github.com/pex-tool/pex/pull/3159) lockfile creation is significantly faster.
+- Fixed `pex3 lock sync` failing to handle multiple input requirements for the same project name.
+- The `scie_pbs_stripped` field of `pex_binary` targets can now be combined with `scie_pbs_free_threaded`.
+- `lock sync` now works with "split universal" locks.
 
- Note that `v2.97.1` is now also the *minimum* required version of Pex. If you're pinning to an earlier version you must upgrade. Pex is very scrupulous about backwards compatibility, so this should not be a problem in general. If the pin was specifically to avoid a bug in Pex, that bug should be [reported](https://github.com/pex-tool/pex/issues/new), after first confirming that there isn't an existing [open issue](https://github.com/pex-tool/pex/issues) for it.
+Note that `v2.97.1` is now also the _minimum_ required version of Pex. If you're pinning to an earlier version you must upgrade. Pex is very scrupulous about backwards compatibility, so this should not be a problem in general. If the pin was specifically to avoid a bug in Pex, that bug should be [reported](https://github.com/pex-tool/pex/issues/new), after first confirming that there isn't an existing [open issue](https://github.com/pex-tool/pex/issues) for it.
 
-The `pex_binary` target now has a `validate_entry_point` which plumbs through the [`--validate-entry-point`](https://github.com/pex-tool/pex/releases/tag/v1.4.5) flag to Pex.  This validates the entry point by importing it in a separate process at build time.
+The `pex_binary` target now has a `validate_entry_point` which plumbs through the [`--validate-entry-point`](https://github.com/pex-tool/pex/releases/tag/v1.4.5) flag to Pex. This validates the entry point by importing it in a separate process at build time.
 
 Fixed a bug in Ruff backend where ancestor `__init__.py` files were not included in `fix` partitions which changed how Ruff's importing sorting logic operated. Thie caused `pants fix` to see no need for import sorting even though `pants lint` flagged the need.
 
@@ -108,14 +108,17 @@ Fixed a bug where `--sync`-ing a Pex lockfile with legacy metadata headers faile
 
 Added a default module mapping for `apache-airflow-mypy`, which provides the `airflow_mypy` module.
 
-The default interpreter constraints for bundled tools have been standardized on `>=3.10,<3.15`.  This drops support for Python 3.9 which reached end-of-life on [2025-10-31](https://www.python.org/downloads/release/python-3925/) and support was removed from Pip in [26.1](https://pip.pypa.io/en/stable/news/#v26-1).  If you are specifically relying on a Python 3.9 interpreter to run a tool, or if you require a different version of a tool than the new default, then you will need to generate a custom lockfile for that tool with the appropriate interpreter constraints.  As part of this several default bundled versions have been updated.  Notably this includes:
- * `mypy`: `1.19.1 -> 1.20.2`
- * `mypy-protobuf`: `3.6.0 -> 3.7.0`
- * `coverage`:  `7.10.7 -> 7.14.3`
- * `protobuf`: `6.33.1 -> 7.35.1`
- * The version of packaging (`26.2`) and setuptools (`82.x`) was also updated across the bundled lockfiles.
+The default interpreter constraints for bundled tools have been standardized on `>=3.10,<3.15`. This drops support for Python 3.9 which reached end-of-life on [2025-10-31](https://www.python.org/downloads/release/python-3925/) and support was removed from Pip in [26.1](https://pip.pypa.io/en/stable/news/#v26-1). If you are specifically relying on a Python 3.9 interpreter to run a tool, or if you require a different version of a tool than the new default, then you will need to generate a custom lockfile for that tool with the appropriate interpreter constraints. As part of this several default bundled versions have been updated. Notably this includes:
 
-The lockfiles Pants bundles for tools (such as `mypy` or `pytest`) as well as Pants' own internal Python lockfiles now use a two day [dependency cooldown](https://sethmlarson.dev/pip-relative-dependency-cooldowns).  The cooldowon itself is not a direct change for users, but said lockfiles were all regenerated to match. No top-level subsystem tools were updated, but several tool dependencies were (see above).
+- `mypy`: `1.19.1 -> 1.20.2`
+- `mypy-protobuf`: `3.6.0 -> 3.7.0`
+- `coverage`: `7.10.7 -> 7.14.3`
+- `protobuf`: `6.33.1 -> 7.35.1`
+- The version of packaging (`26.2`) and setuptools (`82.x`) was also updated across the bundled lockfiles.
+
+The lockfiles Pants bundles for tools (such as `mypy` or `pytest`) as well as Pants' own internal Python lockfiles now use a two day [dependency cooldown](https://sethmlarson.dev/pip-relative-dependency-cooldowns). The cooldowon itself is not a direct change for users, but said lockfiles were all regenerated to match. No top-level subsystem tools were updated, but several tool dependencies were (see above).
+
+The lockfiles Pants bundles for tools (such as `mypy` or `pytest`) as well as Pants' own internal Python lockfiles now use a two day [dependency cooldown](https://sethmlarson.dev/pip-relative-dependency-cooldowns). The cooldowon itself is not a direct change for users, but said lockfiles were all regenerated to match. No top-level subsystem tools were updated, but several tool dependencies were (see above).
 
 The default version of the sqlfluff in the bundled tool lockfile has been upgraded from `2.3.5` to [`4.2.2`](https://docs.sqlfluff.com/en/stable/reference/releasenotes.html).
 

--- a/docs/notes/2.34.x.md
+++ b/docs/notes/2.34.x.md
@@ -43,6 +43,8 @@ Fixed a bug that caused `generate-lockfiles --sync` not to have its intended eff
 
 Interpreter constraints can now select a specific CPython ABI, to distinguish the free-threaded (no-GIL) build from the standard build. Qualify the interpreter type using either a PEP 508 extra, `CPython[free-threaded]` or `CPython[gil]`, or the equivalent `CPython+t` / `CPython-t` spellings. Both spellings are adopted from Pex. For example, `interpreter_constraints=["CPython[free-threaded]==3.14.*"]` matches only free-threaded 3.14 interpreters, while `CPython==3.14.*` continues to match either ABI.
 
+A `python_distribution` target now infers its `interpreter_constraints` from the `[project].requires-python` value in a `pyproject.toml` in the same directory, when the field is not set explicitly. An explicit `interpreter_constraints` field still takes precedence, and targets without a sibling `pyproject.toml` (or `requires-python`) continue to fall back to `[python].interpreter_constraints` ([#23417](https://github.com/pantsbuild/pants/issues/23417)).
+
 The default version of [Pex](https://github.com/pex-tool/pex) used by the Python backend has been upgraded to [`v2.97.3`](https://github.com/pex-tool/pex/releases/tag/v2.97.3). Of particular note for Pants users:
 
  - [Fix concurrent use of artifact downloads](https://github.com/pex-tool/pex/pull/3207).

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -442,7 +442,8 @@ class PexExecutableField(Field):
 class PexArgsField(StringSequenceField):
     alias: ClassVar[str] = "args"
     help = help_text(
-        lambda: f"""
+        lambda: (
+            f"""
         Freeze these command-line args into the PEX. Allows you to run generic entry points
         on specific arguments without creating a shim file.
 
@@ -451,6 +452,7 @@ class PexArgsField(StringSequenceField):
         `{PexExtraBuildArgsField.alias}` passes arguments to the process that does the
         packaging.
         """
+        )
     )
 
 
@@ -458,7 +460,8 @@ class PexExtraBuildArgsField(StringSequenceField):
     alias: ClassVar[str] = "extra_build_args"
     default = ()
     help = help_text(
-        lambda: f"""
+        lambda: (
+            f"""
         Extra arguments to pass to the `pex` invocation used to build this PEX. These are
         passed after all other arguments. This can be used to pass extra options that
         Pants doesn't have built-in support for.
@@ -467,6 +470,7 @@ class PexExtraBuildArgsField(StringSequenceField):
         arguments used by the packaged PEX when executed, `{PexExtraBuildArgsField.alias}`
         passes arguments to the process that does the packaging.
         """
+        )
     )
 
 
@@ -1257,7 +1261,8 @@ class PythonTestsDependenciesField(PythonDependenciesField):
 class PythonTestsEntryPointDependenciesField(DictStringToStringSequenceField):
     alias = "entry_point_dependencies"
     help = help_text(
-        lambda: f"""
+        lambda: (
+            f"""
         Dependencies on entry point metadata of `{PythonDistribution.alias}` targets.
 
         This is a dict where each key is a `{PythonDistribution.alias}` address
@@ -1294,6 +1299,7 @@ class PythonTestsEntryPointDependenciesField(DictStringToStringSequenceField):
         standard library (available on older Python interpreters via the
         `importlib-metadata` distribution).
         """
+        )
     )
 
 
@@ -1999,11 +2005,29 @@ class LongDescriptionPathField(StringField):
     )
 
 
+class PythonDistributionInterpreterConstraintsField(InterpreterConstraintsField):
+    help = help_text(
+        f"""
+        The Python interpreters this distribution is compatible with.
+
+        Each element should be written in pip-style format, e.g. `CPython==2.7.*` or
+        `CPython>=3.6,<4`.
+
+        If this field is not set, Pants will infer the constraints from the `[project].requires-python`
+        value in a `pyproject.toml` file in the same directory as this target, if there is one.
+        Failing that, it defaults to the option `[python].interpreter_constraints`.
+
+        See {doc_url("docs/python/overview/interpreter-compatibility")} for how these interpreter
+        constraints are merged with the constraints of dependencies.
+        """
+    )
+
+
 class PythonDistribution(Target):
     alias: ClassVar[str] = "python_distribution"
     core_fields = (
         *COMMON_TARGET_FIELDS,
-        InterpreterConstraintsField,
+        PythonDistributionInterpreterConstraintsField,
         PythonDistributionDependenciesField,
         PythonDistributionEntryPointsField,
         PythonProvidesField,

--- a/src/python/pants/backend/python/target_types_rules.py
+++ b/src/python/pants/backend/python/target_types_rules.py
@@ -16,6 +16,10 @@ from dataclasses import dataclass
 from itertools import chain
 from typing import DefaultDict, cast
 
+import toml
+from packaging.requirements import InvalidRequirement
+from toml import TomlDecodeError
+
 from pants.backend.python.dependency_inference.module_mapper import (
     PythonModuleOwners,
     PythonModuleOwnersRequest,
@@ -47,21 +51,24 @@ from pants.backend.python.target_types import (
     ResolvePexEntryPointRequest,
     ResolvePythonDistributionEntryPointsRequest,
 )
-from pants.backend.python.util_rules.interpreter_constraints import interpreter_constraints_contains
+from pants.backend.python.util_rules.interpreter_constraints import (
+    InterpreterConstraints,
+    interpreter_constraints_contains,
+)
 from pants.core.target_types import ResolveLikeFieldToValueRequest, ResolveLikeFieldToValueResult
 from pants.core.util_rules.unowned_dependency_behavior import (
     UnownedDependencyError,
     UnownedDependencyUsage,
 )
 from pants.engine.addresses import Address, Addresses, UnparsedAddressInputs
-from pants.engine.fs import GlobMatchErrorBehavior, PathGlobs
+from pants.engine.fs import DigestContents, GlobMatchErrorBehavior, PathGlobs
 from pants.engine.internals.graph import (
     determine_explicitly_provided_dependencies,
     resolve_target,
     resolve_targets,
     resolve_unparsed_address_inputs,
 )
-from pants.engine.intrinsics import path_globs_to_paths
+from pants.engine.intrinsics import get_digest_contents, path_globs_to_paths
 from pants.engine.rules import collect_rules, concurrently, implicitly, rule
 from pants.engine.target import (
     DependenciesRequest,
@@ -74,6 +81,7 @@ from pants.engine.target import (
     InferDependenciesRequest,
     InferredDependencies,
     InvalidFieldException,
+    Target,
     TargetFilesGeneratorSettings,
     TargetFilesGeneratorSettingsRequest,
     ValidatedDependencies,
@@ -625,6 +633,92 @@ class DependencyValidationFieldSet(FieldSet):
     interpreter_constraints: InterpreterConstraintsField
 
 
+@dataclass(frozen=True)
+class PythonDistributionEffectiveInterpreterConstraintsRequest:
+    target: Target
+
+
+@dataclass(frozen=True)
+class PythonDistributionEffectiveInterpreterConstraints:
+    value: InterpreterConstraints
+
+
+def _pyproject_requires_python(contents: DigestContents, address: Address) -> str | None:
+    """Extract `[project].requires-python` from a target's sibling `pyproject.toml`, if any.
+
+    Returns `None` if there is no `pyproject.toml`, or it has no `[project].requires-python`.
+    """
+    if not contents:
+        return None
+    file_content = next(iter(contents))
+    try:
+        pyproject = toml.loads(file_content.content.decode())
+    except (TomlDecodeError, UnicodeDecodeError) as e:
+        raise InvalidFieldException(
+            softwrap(
+                f"""
+                Failed to parse {file_content.path}, used to infer `interpreter_constraints` for the
+                `python_distribution` target {address}: {e}
+                """
+            )
+        )
+    project = pyproject.get("project")
+    if not isinstance(project, dict):
+        return None
+    requires_python = project.get("requires-python")
+    if requires_python is None:
+        return None
+    if not isinstance(requires_python, str):
+        raise InvalidFieldException(
+            softwrap(
+                f"""
+                The `[project].requires-python` field in {file_content.path}, used to infer
+                `interpreter_constraints` for the `python_distribution` target {address}, must be
+                a string, but was {requires_python!r}.
+                """
+            )
+        )
+    return requires_python
+
+
+@rule
+async def resolve_python_distribution_effective_interpreter_constraints(
+    request: PythonDistributionEffectiveInterpreterConstraintsRequest,
+    python_setup: PythonSetup,
+) -> PythonDistributionEffectiveInterpreterConstraints:
+    target = request.target
+    interpreter_constraints = target[InterpreterConstraintsField]
+    resolve = target[PythonResolveField] if target.has_field(PythonResolveField) else None
+    if interpreter_constraints.value is None:
+        pyproject_path = os.path.join(target.address.spec_path, "pyproject.toml")
+        digest_contents = await get_digest_contents(
+            **implicitly(
+                PathGlobs([pyproject_path], glob_match_error_behavior=GlobMatchErrorBehavior.ignore)
+            )
+        )
+        requires_python = _pyproject_requires_python(digest_contents, target.address)
+        if requires_python is not None:
+            try:
+                inferred = InterpreterConstraints([requires_python])
+            except InvalidRequirement as e:
+                raise InvalidFieldException(
+                    softwrap(
+                        f"""
+                        Failed to infer `interpreter_constraints` for the `python_distribution`
+                        target {target.address} from `[project].requires-python` in
+                        {pyproject_path}: {e}
+                        """
+                    )
+                )
+            return PythonDistributionEffectiveInterpreterConstraints(inferred)
+
+    return PythonDistributionEffectiveInterpreterConstraints(
+        InterpreterConstraints(
+            interpreter_constraints.value_or_configured_default(python_setup, resolve)
+        )
+    )
+
+
 class PythonValidateDependenciesRequest(ValidateDependenciesRequest):
     field_set_type = DependencyValidationFieldSet
 
@@ -653,13 +747,22 @@ async def validate_python_dependencies(
         ),
     )
 
-    # Validate that the ICs for dependencies are all compatible with our own.
-    target_ics = request.field_set.interpreter_constraints.value_or_configured_default(
-        python_setup,
-        root_target.target[PythonResolveField]
-        if root_target.target.has_field(PythonResolveField)
-        else None,
-    )
+    # Validate that the ICs for dependencies are all compatible with our own. For a
+    # `python_distribution` the constraints may be inferred from a sibling `pyproject.toml`, so
+    # consult the effective constraints rather than the field value alone.
+    if root_target.target.has_field(PythonProvidesField):
+        effective_ics = await resolve_python_distribution_effective_interpreter_constraints(
+            PythonDistributionEffectiveInterpreterConstraintsRequest(root_target.target),
+            **implicitly(),
+        )
+        target_ics = tuple(str(ic) for ic in effective_ics.value)
+    else:
+        target_ics = request.field_set.interpreter_constraints.value_or_configured_default(
+            python_setup,
+            root_target.target[PythonResolveField]
+            if root_target.target.has_field(PythonResolveField)
+            else None,
+        )
     non_subset_items = []
     for dep in dependencies:
         if not dep.target.has_field(InterpreterConstraintsField):

--- a/src/python/pants/backend/python/target_types_rules.py
+++ b/src/python/pants/backend/python/target_types_rules.py
@@ -42,6 +42,7 @@ from pants.backend.python.target_types import (
     PythonDistributionDependenciesField,
     PythonDistributionEntryPoint,
     PythonDistributionEntryPointsField,
+    PythonDistributionInterpreterConstraintsField,
     PythonFilesGeneratorSettingsRequest,
     PythonProvidesField,
     PythonResolveField,
@@ -61,7 +62,7 @@ from pants.core.util_rules.unowned_dependency_behavior import (
     UnownedDependencyUsage,
 )
 from pants.engine.addresses import Address, Addresses, UnparsedAddressInputs
-from pants.engine.fs import DigestContents, GlobMatchErrorBehavior, PathGlobs
+from pants.engine.fs import GlobMatchErrorBehavior, PathGlobs
 from pants.engine.internals.graph import (
     determine_explicitly_provided_dependencies,
     resolve_target,
@@ -81,7 +82,6 @@ from pants.engine.target import (
     InferDependenciesRequest,
     InferredDependencies,
     InvalidFieldException,
-    Target,
     TargetFilesGeneratorSettings,
     TargetFilesGeneratorSettingsRequest,
     ValidatedDependencies,
@@ -633,35 +633,19 @@ class DependencyValidationFieldSet(FieldSet):
     interpreter_constraints: InterpreterConstraintsField
 
 
-@dataclass(frozen=True)
-class PythonDistributionEffectiveInterpreterConstraintsRequest:
-    target: Target
+class InvalidPyprojectRequiresPythonError(Exception):
+    """The `[project].requires-python` value in a `pyproject.toml` could not be used to infer
+    interpreter constraints."""
 
 
-@dataclass(frozen=True)
-class PythonDistributionEffectiveInterpreterConstraints:
-    value: InterpreterConstraints
+def _pyproject_requires_python(file_content: bytes) -> str | None:
+    """Extract `[project].requires-python` from the contents of a `pyproject.toml`.
 
-
-def _pyproject_requires_python(contents: DigestContents, address: Address) -> str | None:
-    """Extract `[project].requires-python` from a target's sibling `pyproject.toml`, if any.
-
-    Returns `None` if there is no `pyproject.toml`, or it has no `[project].requires-python`.
+    Returns `None` if the file has no `[project].requires-python`. Raises `TomlDecodeError` or
+    `UnicodeDecodeError` if the contents cannot be parsed as TOML, and `ValueError` if
+    `[project].requires-python` is present but not a string.
     """
-    if not contents:
-        return None
-    file_content = next(iter(contents))
-    try:
-        pyproject = toml.loads(file_content.content.decode())
-    except (TomlDecodeError, UnicodeDecodeError) as e:
-        raise InvalidFieldException(
-            softwrap(
-                f"""
-                Failed to parse {file_content.path}, used to infer `interpreter_constraints` for the
-                `python_distribution` target {address}: {e}
-                """
-            )
-        )
+    pyproject = toml.loads(file_content.decode())
     project = pyproject.get("project")
     if not isinstance(project, dict):
         return None
@@ -669,54 +653,52 @@ def _pyproject_requires_python(contents: DigestContents, address: Address) -> st
     if requires_python is None:
         return None
     if not isinstance(requires_python, str):
-        raise InvalidFieldException(
-            softwrap(
-                f"""
-                The `[project].requires-python` field in {file_content.path}, used to infer
-                `interpreter_constraints` for the `python_distribution` target {address}, must be
-                a string, but was {requires_python!r}.
-                """
-            )
+        raise ValueError(
+            f"The `[project].requires-python` field must be a string, but was {requires_python!r}."
         )
     return requires_python
 
 
 @rule
-async def resolve_python_distribution_effective_interpreter_constraints(
-    request: PythonDistributionEffectiveInterpreterConstraintsRequest,
+async def resolve_python_distribution_interpreter_constraints(
+    field: PythonDistributionInterpreterConstraintsField,
     python_setup: PythonSetup,
-) -> PythonDistributionEffectiveInterpreterConstraints:
-    target = request.target
-    interpreter_constraints = target[InterpreterConstraintsField]
-    resolve = target[PythonResolveField] if target.has_field(PythonResolveField) else None
-    if interpreter_constraints.value is None:
-        pyproject_path = os.path.join(target.address.spec_path, "pyproject.toml")
+) -> InterpreterConstraints:
+    if field.value is None:
+        pyproject_path = os.path.join(field.address.spec_path, "pyproject.toml")
         digest_contents = await get_digest_contents(
             **implicitly(
                 PathGlobs([pyproject_path], glob_match_error_behavior=GlobMatchErrorBehavior.ignore)
             )
         )
-        requires_python = _pyproject_requires_python(digest_contents, target.address)
-        if requires_python is not None:
+        if digest_contents:
+            file_content = next(iter(digest_contents))
             try:
-                inferred = InterpreterConstraints([requires_python])
-            except InvalidRequirement as e:
-                raise InvalidFieldException(
+                requires_python = _pyproject_requires_python(file_content.content)
+            except (TomlDecodeError, UnicodeDecodeError, ValueError) as e:
+                raise InvalidPyprojectRequiresPythonError(
                     softwrap(
                         f"""
                         Failed to infer `interpreter_constraints` for the `python_distribution`
-                        target {target.address} from `[project].requires-python` in
-                        {pyproject_path}: {e}
+                        target {field.address} from {file_content.path}: {e}
                         """
                     )
                 )
-            return PythonDistributionEffectiveInterpreterConstraints(inferred)
+            if requires_python is not None:
+                try:
+                    return InterpreterConstraints([requires_python])
+                except InvalidRequirement as e:
+                    raise InvalidPyprojectRequiresPythonError(
+                        softwrap(
+                            f"""
+                            Failed to infer `interpreter_constraints` for the `python_distribution`
+                            target {field.address} from `[project].requires-python` in
+                            {file_content.path}: {e}
+                            """
+                        )
+                    )
 
-    return PythonDistributionEffectiveInterpreterConstraints(
-        InterpreterConstraints(
-            interpreter_constraints.value_or_configured_default(python_setup, resolve)
-        )
-    )
+    return InterpreterConstraints(field.value_or_configured_default(python_setup, resolve=None))
 
 
 class PythonValidateDependenciesRequest(ValidateDependenciesRequest):
@@ -751,11 +733,11 @@ async def validate_python_dependencies(
     # `python_distribution` the constraints may be inferred from a sibling `pyproject.toml`, so
     # consult the effective constraints rather than the field value alone.
     if root_target.target.has_field(PythonProvidesField):
-        effective_ics = await resolve_python_distribution_effective_interpreter_constraints(
-            PythonDistributionEffectiveInterpreterConstraintsRequest(root_target.target),
+        effective_ics = await resolve_python_distribution_interpreter_constraints(
+            root_target.target[PythonDistributionInterpreterConstraintsField],
             **implicitly(),
         )
-        target_ics = tuple(str(ic) for ic in effective_ics.value)
+        target_ics = tuple(str(ic) for ic in effective_ics)
     else:
         target_ics = request.field_set.interpreter_constraints.value_or_configured_default(
             python_setup,

--- a/src/python/pants/backend/python/target_types_test.py
+++ b/src/python/pants/backend/python/target_types_test.py
@@ -8,6 +8,7 @@ from collections.abc import Iterable
 from textwrap import dedent
 
 import pytest
+from toml import TomlDecodeError
 
 from pants.backend.python import target_types_rules
 from pants.backend.python.dependency_inference.rules import import_rules
@@ -22,6 +23,7 @@ from pants.backend.python.target_types import (
     PexExecutableField,
     PexScriptField,
     PythonDistribution,
+    PythonDistributionInterpreterConstraintsField,
     PythonRequirementsField,
     PythonRequirementTarget,
     PythonSourcesGeneratorTarget,
@@ -35,11 +37,11 @@ from pants.backend.python.target_types_rules import (
     DependencyValidationFieldSet,
     InferPexBinaryEntryPointDependency,
     InferPythonDistributionDependencies,
+    InvalidPyprojectRequiresPythonError,
     PexBinaryEntryPointDependencyInferenceFieldSet,
     PythonDistributionDependenciesInferenceFieldSet,
-    PythonDistributionEffectiveInterpreterConstraints,
-    PythonDistributionEffectiveInterpreterConstraintsRequest,
     PythonValidateDependenciesRequest,
+    _pyproject_requires_python,
     resolve_pex_entry_point,
 )
 from pants.backend.python.util_rules import python_sources
@@ -166,8 +168,8 @@ def _python_dependency_validation_rule_runner(*, options: Iterable[str] = ()) ->
             *target_types_rules.rules(),
             QueryRule(ValidatedDependencies, [PythonValidateDependenciesRequest]),
             QueryRule(
-                PythonDistributionEffectiveInterpreterConstraints,
-                [PythonDistributionEffectiveInterpreterConstraintsRequest],
+                InterpreterConstraints,
+                [PythonDistributionInterpreterConstraintsField],
             ),
         ],
         target_types=[PythonDistribution, PythonSourceTarget],
@@ -492,7 +494,7 @@ def test_validate_python_distribution_dependencies_invalid_pyproject_requires_py
 
     with pytest.raises(ExecutionError) as exc:
         _validate_python_dependencies(rule_runner)
-    assert isinstance(exc.value.wrapped_exceptions[0], InvalidFieldException)
+    assert isinstance(exc.value.wrapped_exceptions[0], InvalidPyprojectRequiresPythonError)
     assert "`[project].requires-python` field" in str(exc.value)
 
 
@@ -521,8 +523,8 @@ def test_validate_python_distribution_dependencies_malformed_pyproject() -> None
 
     with pytest.raises(ExecutionError) as exc:
         _validate_python_dependencies(rule_runner)
-    assert isinstance(exc.value.wrapped_exceptions[0], InvalidFieldException)
-    assert "Failed to parse" in str(exc.value)
+    assert isinstance(exc.value.wrapped_exceptions[0], InvalidPyprojectRequiresPythonError)
+    assert "Failed to infer" in str(exc.value)
 
 
 def test_validate_python_distribution_dependencies_pyproject_without_requires_python() -> None:
@@ -550,12 +552,34 @@ def test_validate_python_distribution_dependencies_pyproject_without_requires_py
     assert _validate_python_dependencies(rule_runner) == ValidatedDependencies()
 
 
+def test_pyproject_requires_python_extracts_value() -> None:
+    assert _pyproject_requires_python(b'[project]\nrequires-python = ">=3.10"') == ">=3.10"
+
+
+def test_pyproject_requires_python_without_project_table() -> None:
+    assert _pyproject_requires_python(b"[build-system]\nrequires = ['setuptools']") is None
+
+
+def test_pyproject_requires_python_without_requires_python() -> None:
+    assert _pyproject_requires_python(b'[project]\nname = "demo"') is None
+
+
+def test_pyproject_requires_python_non_string_raises() -> None:
+    with pytest.raises(ValueError):
+        _pyproject_requires_python(b"[project]\nrequires-python = 42")
+
+
+def test_pyproject_requires_python_malformed_toml_raises() -> None:
+    with pytest.raises(TomlDecodeError):
+        _pyproject_requires_python(b"[project\nrequires-python = ")
+
+
 def _effective_interpreter_constraints(rule_runner: RuleRunner) -> InterpreterConstraints:
     tgt = rule_runner.get_target(Address("project", target_name="app"))
     return rule_runner.request(
-        PythonDistributionEffectiveInterpreterConstraints,
-        [PythonDistributionEffectiveInterpreterConstraintsRequest(tgt)],
-    ).value
+        InterpreterConstraints,
+        [tgt[PythonDistributionInterpreterConstraintsField]],
+    )
 
 
 def test_python_distribution_effective_interpreter_constraints_inferred() -> None:

--- a/src/python/pants/backend/python/target_types_test.py
+++ b/src/python/pants/backend/python/target_types_test.py
@@ -37,10 +37,13 @@ from pants.backend.python.target_types_rules import (
     InferPythonDistributionDependencies,
     PexBinaryEntryPointDependencyInferenceFieldSet,
     PythonDistributionDependenciesInferenceFieldSet,
+    PythonDistributionEffectiveInterpreterConstraints,
+    PythonDistributionEffectiveInterpreterConstraintsRequest,
     PythonValidateDependenciesRequest,
     resolve_pex_entry_point,
 )
 from pants.backend.python.util_rules import python_sources
+from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.core.goals.generate_lockfiles import UnrecognizedResolveNamesError
 from pants.core.util_rules.unowned_dependency_behavior import UnownedDependencyError
 from pants.engine.addresses import Address, Addresses
@@ -162,6 +165,10 @@ def _python_dependency_validation_rule_runner(*, options: Iterable[str] = ()) ->
         rules=[
             *target_types_rules.rules(),
             QueryRule(ValidatedDependencies, [PythonValidateDependenciesRequest]),
+            QueryRule(
+                PythonDistributionEffectiveInterpreterConstraints,
+                [PythonDistributionEffectiveInterpreterConstraintsRequest],
+            ),
         ],
         target_types=[PythonDistribution, PythonSourceTarget],
         objects={"python_artifact": PythonArtifact},
@@ -371,6 +378,240 @@ def test_validate_python_dependencies_without_python_resolve_field() -> None:
     )
 
     assert _validate_python_dependencies(rule_runner) == ValidatedDependencies()
+
+
+def test_validate_python_distribution_dependencies_infers_interpreter_constraints_from_pyproject() -> (
+    None
+):
+    rule_runner = _python_dependency_validation_rule_runner()
+    rule_runner.write_files(
+        {
+            "project/pyproject.toml": '[project]\nrequires-python = ">=3.10"',
+            "project/dep.py": "",
+            "project/BUILD": dedent(
+                """\
+                python_distribution(
+                    name="app",
+                    dependencies=[":dep"],
+                    provides=python_artifact(name="demo"),
+                )
+                python_source(
+                    name="dep",
+                    source="dep.py",
+                    interpreter_constraints=[">=3.8,<4"],
+                )
+                """
+            ),
+        }
+    )
+
+    assert _validate_python_dependencies(rule_runner) == ValidatedDependencies()
+
+
+def test_validate_python_distribution_dependencies_prefers_explicit_interpreter_constraints() -> (
+    None
+):
+    rule_runner = _python_dependency_validation_rule_runner()
+    rule_runner.write_files(
+        {
+            "project/pyproject.toml": '[project]\nrequires-python = ">=3.11"',
+            "project/dep.py": "",
+            "project/BUILD": dedent(
+                """\
+                python_distribution(
+                    name="app",
+                    dependencies=[":dep"],
+                    interpreter_constraints=["==3.10.*"],
+                    provides=python_artifact(name="demo"),
+                )
+                python_source(
+                    name="dep",
+                    source="dep.py",
+                    interpreter_constraints=["==3.10.*"],
+                )
+                """
+            ),
+        }
+    )
+
+    assert _validate_python_dependencies(rule_runner) == ValidatedDependencies()
+
+
+def test_validate_python_distribution_dependencies_incompatible_inferred_interpreter_constraints() -> (
+    None
+):
+    rule_runner = _python_dependency_validation_rule_runner()
+    rule_runner.write_files(
+        {
+            "project/pyproject.toml": '[project]\nrequires-python = ">=3.11"',
+            "project/dep.py": "",
+            "project/BUILD": dedent(
+                """\
+                python_distribution(
+                    name="app",
+                    dependencies=[":dep"],
+                    provides=python_artifact(name="demo"),
+                )
+                python_source(
+                    name="dep",
+                    source="dep.py",
+                    interpreter_constraints=["==3.10.*"],
+                )
+                """
+            ),
+        }
+    )
+
+    with pytest.raises(ExecutionError) as exc:
+        _validate_python_dependencies(rule_runner)
+    assert isinstance(exc.value.wrapped_exceptions[0], InvalidFieldException)
+
+
+def test_validate_python_distribution_dependencies_invalid_pyproject_requires_python() -> None:
+    rule_runner = _python_dependency_validation_rule_runner()
+    rule_runner.write_files(
+        {
+            "project/pyproject.toml": "[project]\nrequires-python = 42",
+            "project/dep.py": "",
+            "project/BUILD": dedent(
+                """\
+                python_distribution(
+                    name="app",
+                    dependencies=[":dep"],
+                    provides=python_artifact(name="demo"),
+                )
+                python_source(
+                    name="dep",
+                    source="dep.py",
+                    interpreter_constraints=[">=3.8,<4"],
+                )
+                """
+            ),
+        }
+    )
+
+    with pytest.raises(ExecutionError) as exc:
+        _validate_python_dependencies(rule_runner)
+    assert isinstance(exc.value.wrapped_exceptions[0], InvalidFieldException)
+    assert "`[project].requires-python` field" in str(exc.value)
+
+
+def test_validate_python_distribution_dependencies_malformed_pyproject() -> None:
+    rule_runner = _python_dependency_validation_rule_runner()
+    rule_runner.write_files(
+        {
+            "project/pyproject.toml": "[project\nrequires-python = ",
+            "project/dep.py": "",
+            "project/BUILD": dedent(
+                """\
+                python_distribution(
+                    name="app",
+                    dependencies=[":dep"],
+                    provides=python_artifact(name="demo"),
+                )
+                python_source(
+                    name="dep",
+                    source="dep.py",
+                    interpreter_constraints=[">=3.8,<4"],
+                )
+                """
+            ),
+        }
+    )
+
+    with pytest.raises(ExecutionError) as exc:
+        _validate_python_dependencies(rule_runner)
+    assert isinstance(exc.value.wrapped_exceptions[0], InvalidFieldException)
+    assert "Failed to parse" in str(exc.value)
+
+
+def test_validate_python_distribution_dependencies_pyproject_without_requires_python() -> None:
+    rule_runner = _python_dependency_validation_rule_runner()
+    rule_runner.write_files(
+        {
+            "project/pyproject.toml": "[build-system]\nrequires = ['setuptools']",
+            "project/dep.py": "",
+            "project/BUILD": dedent(
+                """\
+                python_distribution(
+                    name="app",
+                    dependencies=[":dep"],
+                    provides=python_artifact(name="demo"),
+                )
+                python_source(
+                    name="dep",
+                    source="dep.py",
+                )
+                """
+            ),
+        }
+    )
+
+    assert _validate_python_dependencies(rule_runner) == ValidatedDependencies()
+
+
+def _effective_interpreter_constraints(rule_runner: RuleRunner) -> InterpreterConstraints:
+    tgt = rule_runner.get_target(Address("project", target_name="app"))
+    return rule_runner.request(
+        PythonDistributionEffectiveInterpreterConstraints,
+        [PythonDistributionEffectiveInterpreterConstraintsRequest(tgt)],
+    ).value
+
+
+def test_python_distribution_effective_interpreter_constraints_inferred() -> None:
+    rule_runner = _python_dependency_validation_rule_runner()
+    rule_runner.write_files(
+        {
+            "project/pyproject.toml": '[project]\nrequires-python = ">=3.10"',
+            "project/BUILD": dedent(
+                """\
+                python_distribution(
+                    name="app",
+                    provides=python_artifact(name="demo"),
+                )
+                """
+            ),
+        }
+    )
+    assert _effective_interpreter_constraints(rule_runner) == InterpreterConstraints([">=3.10"])
+
+
+def test_python_distribution_effective_interpreter_constraints_explicit_wins() -> None:
+    rule_runner = _python_dependency_validation_rule_runner()
+    rule_runner.write_files(
+        {
+            "project/pyproject.toml": '[project]\nrequires-python = ">=3.10"',
+            "project/BUILD": dedent(
+                """\
+                python_distribution(
+                    name="app",
+                    interpreter_constraints=["==3.11.*"],
+                    provides=python_artifact(name="demo"),
+                )
+                """
+            ),
+        }
+    )
+    assert _effective_interpreter_constraints(rule_runner) == InterpreterConstraints(["==3.11.*"])
+
+
+def test_python_distribution_effective_interpreter_constraints_falls_back_to_default() -> None:
+    rule_runner = _python_dependency_validation_rule_runner(
+        options=["--python-interpreter-constraints=['==3.9.*']"]
+    )
+    rule_runner.write_files(
+        {
+            "project/BUILD": dedent(
+                """\
+                python_distribution(
+                    name="app",
+                    provides=python_artifact(name="demo"),
+                )
+                """
+            ),
+        }
+    )
+    assert _effective_interpreter_constraints(rule_runner) == InterpreterConstraints(["==3.9.*"])
 
 
 @pytest.mark.parametrize(

--- a/src/python/pants/backend/python/util_rules/package_dists.py
+++ b/src/python/pants/backend/python/util_rules/package_dists.py
@@ -36,7 +36,9 @@ from pants.backend.python.target_types import (
     WheelField,
 )
 from pants.backend.python.target_types_rules import (
+    PythonDistributionEffectiveInterpreterConstraintsRequest,
     SetupPyError,
+    resolve_python_distribution_effective_interpreter_constraints,
     resolve_python_distribution_entry_points,
 )
 from pants.backend.python.util_rules.dists import (
@@ -417,9 +419,19 @@ async def create_dist_build_request(
     else:
         extra_build_time_env = EnvironmentVars()
 
-    interpreter_constraints = InterpreterConstraints.create_from_targets(
-        transitive_targets.closure, python_setup
-    ) or InterpreterConstraints(python_setup.interpreter_constraints)
+    dependency_interpreter_constraints = InterpreterConstraints.create_from_targets(
+        (tgt for tgt in transitive_targets.closure if tgt.address != dist_tgt.address), python_setup
+    )
+    dist_interpreter_constraints = (
+        await resolve_python_distribution_effective_interpreter_constraints(
+            PythonDistributionEffectiveInterpreterConstraintsRequest(dist_tgt),
+            **implicitly(),
+        )
+    )
+    interpreter_constraints_to_merge = [dist_interpreter_constraints.value]
+    if dependency_interpreter_constraints:
+        interpreter_constraints_to_merge.append(dependency_interpreter_constraints)
+    interpreter_constraints = InterpreterConstraints.merge(interpreter_constraints_to_merge)
     chroot = await generate_chroot(
         DistBuildChrootRequest(
             exported_target,

--- a/src/python/pants/backend/python/util_rules/package_dists.py
+++ b/src/python/pants/backend/python/util_rules/package_dists.py
@@ -23,6 +23,7 @@ from pants.backend.python.target_types import (
     GenerateSetupField,
     LongDescriptionPathField,
     PythonDistributionEntryPointsField,
+    PythonDistributionInterpreterConstraintsField,
     PythonDistributionOutputPathField,
     PythonGeneratingSourcesBase,
     PythonProvidesField,
@@ -36,10 +37,9 @@ from pants.backend.python.target_types import (
     WheelField,
 )
 from pants.backend.python.target_types_rules import (
-    PythonDistributionEffectiveInterpreterConstraintsRequest,
     SetupPyError,
-    resolve_python_distribution_effective_interpreter_constraints,
     resolve_python_distribution_entry_points,
+    resolve_python_distribution_interpreter_constraints,
 )
 from pants.backend.python.util_rules.dists import (
     BuildSystemRequest,
@@ -422,13 +422,11 @@ async def create_dist_build_request(
     dependency_interpreter_constraints = InterpreterConstraints.create_from_targets(
         (tgt for tgt in transitive_targets.closure if tgt.address != dist_tgt.address), python_setup
     )
-    dist_interpreter_constraints = (
-        await resolve_python_distribution_effective_interpreter_constraints(
-            PythonDistributionEffectiveInterpreterConstraintsRequest(dist_tgt),
-            **implicitly(),
-        )
+    dist_interpreter_constraints = await resolve_python_distribution_interpreter_constraints(
+        dist_tgt[PythonDistributionInterpreterConstraintsField],
+        **implicitly(),
     )
-    interpreter_constraints_to_merge = [dist_interpreter_constraints.value]
+    interpreter_constraints_to_merge = [dist_interpreter_constraints]
     if dependency_interpreter_constraints:
         interpreter_constraints_to_merge.append(dependency_interpreter_constraints)
     interpreter_constraints = InterpreterConstraints.merge(interpreter_constraints_to_merge)


### PR DESCRIPTION
A `python_distribution` target now infers its `interpreter_constraints` from the `[project].requires-python` value in a `pyproject.toml` in the same directory, when the field is not set explicitly. An explicit `interpreter_constraints` field still takes precedence, and targets without a sibling `pyproject.toml` (or `requires-python`) continue to fall back to `[python].interpreter_constraints` ([#23417](https://github.com/pantsbuild/pants/issues/23417)).


Happy to take feedback and add / remove changes that maintainers suggest.