### PR TITLE
Free-threaded: Abiflags aware build artifacts

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -90,7 +90,7 @@ jobs:
       name: Rename the Pants Pex to its final name for upload
       run: |
         PANTS_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import pants.version;print(pants.version.VERSION)")
-        PY_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import sys;print(f'cp{sys.version_info[0]}{sys.version_info[1]}')")
+        PY_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import sys;print(f'cp{sys.version_info[0]}{sys.version_info[1]}{sys.abiflags}')")
         PLAT=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import os;print(f'{os.uname().sysname.lower()}_{os.uname().machine.lower()}')")
         PEX_FILENAME=pants.$PANTS_VER-$PY_VER-$PLAT.pex
         PEX_SCIE_FILENAME=pants.$PANTS_VER-$PY_VER-$PLAT
@@ -227,7 +227,7 @@ jobs:
       name: Rename the Pants Pex to its final name for upload
       run: |
         PANTS_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import pants.version;print(pants.version.VERSION)")
-        PY_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import sys;print(f'cp{sys.version_info[0]}{sys.version_info[1]}')")
+        PY_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import sys;print(f'cp{sys.version_info[0]}{sys.version_info[1]}{sys.abiflags}')")
         PLAT=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import os;print(f'{os.uname().sysname.lower()}_{os.uname().machine.lower()}')")
         PEX_FILENAME=pants.$PANTS_VER-$PY_VER-$PLAT.pex
         PEX_SCIE_FILENAME=pants.$PANTS_VER-$PY_VER-$PLAT
@@ -389,7 +389,7 @@ jobs:
       name: Rename the Pants Pex to its final name for upload
       run: |
         PANTS_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import pants.version;print(pants.version.VERSION)")
-        PY_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import sys;print(f'cp{sys.version_info[0]}{sys.version_info[1]}')")
+        PY_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import sys;print(f'cp{sys.version_info[0]}{sys.version_info[1]}{sys.abiflags}')")
         PLAT=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import os;print(f'{os.uname().sysname.lower()}_{os.uname().machine.lower()}')")
         PEX_FILENAME=pants.$PANTS_VER-$PY_VER-$PLAT.pex
         PEX_SCIE_FILENAME=pants.$PANTS_VER-$PY_VER-$PLAT

--- a/build-support/bin/rust/calculate_engine_hash.sh
+++ b/build-support/bin/rust/calculate_engine_hash.sh
@@ -33,7 +33,7 @@ function calculate_current_hash() {
       echo "${MODE_FLAG}"
       uname -mps
       # the engine only depends on the implementation and major.minor version, not the patch
-      "${PY}" -c 'import sys; print(sys.implementation.name, sys.version_info.major, sys.version_info.minor)'
+      "${PY}" -c 'import sys; print(sys.implementation.name, sys.version_info.major, sys.version_info.minor, sys.abiflags)'
       git ls-files --cached --others --exclude-standard \
         "${NATIVE_ROOT}" \
         "${REPO_ROOT}/build-support/bin/rust" |

--- a/build-support/pants_venv
+++ b/build-support/pants_venv
@@ -14,13 +14,15 @@ REQUIREMENTS=(
 platform=$(uname -mps)
 
 function venv_dir() {
-  # Include the entire version string in order to differentiate e.g. PyPy from CPython.
+  # Include the implementation and version to differentiate e.g. PyPy from CPython, and the
+  # abiflags to differentiate free-threaded from GIL builds (`--version` prints "Python 3.14.3"
+  # for both, but their extension ABIs are incompatible).
   # Fingerprinting uname and python output avoids shebang length limits and any odd chars.
   # Include REPO_ROOT so that different checkouts or worktrees don't clobber each other.
   venv_fingerprint=$( (
     echo "${platform}"
     echo "${REPO_ROOT}"
-    ${PY} --version
+    ${PY} -c 'import sys; print(sys.implementation.name, ".".join(map(str, sys.version_info[:3])), sys.abiflags)'
   ) | fingerprint_data)
 
   # NB: We house these outside the working copy to avoid needing to gitignore them, but also to

--- a/src/python/pants/backend/nfpm/native_libs/elfdeps/rules_integration_test.py
+++ b/src/python/pants/backend/nfpm/native_libs/elfdeps/rules_integration_test.py
@@ -28,7 +28,7 @@ from pants.testutil.rule_runner import RuleRunner
 # The tests build a pex with wheels for the current platform.
 # These vars are used to choose the expected platform-specific test results.
 _PY_VERSION = ".".join(map(str, sys.version_info[:3]))
-_PY_TAG = "".join(map(str, sys.version_info[:2]))
+_PY_TAG = "".join(map(str, sys.version_info[:2])) + sys.abiflags
 _PY_OS = platform.system()  # Linux
 _PY_ARCH_TAG = platform.machine()  # x86_64
 _ELF_BITS_MARKER = "(64bit)" if platform.architecture() == ("64bit", "ELF") else ""

--- a/src/python/pants/backend/nfpm/native_libs/rules_integration_test.py
+++ b/src/python/pants/backend/nfpm/native_libs/rules_integration_test.py
@@ -37,7 +37,7 @@ from pants.engine.rules import QueryRule
 from pants.testutil.rule_runner import RuleRunner
 from pants.util.frozendict import FrozenDict
 
-_PY_TAG = "".join(map(str, sys.version_info[:2]))
+_PY_TAG = "".join(map(str, sys.version_info[:2])) + sys.abiflags
 _PY_OS = platform.system()  # Linux
 _PY_ARCH_TAG = platform.machine()  # x86_64
 

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -1097,7 +1097,7 @@ def build_wheels_job(
                             "run": dedent(
                                 """\
                                 PANTS_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import pants.version;print(pants.version.VERSION)")
-                                PY_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import sys;print(f'cp{sys.version_info[0]}{sys.version_info[1]}')")
+                                PY_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import sys;print(f'cp{sys.version_info[0]}{sys.version_info[1]}{sys.abiflags}')")
                                 PLAT=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import os;print(f'{os.uname().sysname.lower()}_{os.uname().machine.lower()}')")
                                 PEX_FILENAME=pants.$PANTS_VER-$PY_VER-$PLAT.pex
                                 PEX_SCIE_FILENAME=pants.$PANTS_VER-$PY_VER-$PLAT

--- a/testprojects/src/python/native/pyproject.toml
+++ b/testprojects/src/python/native/pyproject.toml
@@ -1,4 +1,5 @@
 [build-system]
-# Using the oldest `setuptools` that allows `package_dists_integration_test.py` to pass on Python 3.14
-requires = ["setuptools==66.1.0", "wheel==0.37.0", "ansicolors==1.1.8"]
+# Using the oldest `setuptools` that allows `package_dists_integration_test.py` to pass on Python 3.14.
+# wheel>=0.44 is required so that `bdist_wheel` can emit free-threaded (cp314t) ABI tags.
+requires = ["setuptools==66.1.0", "wheel==0.45.1", "ansicolors==1.1.8"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Uses `sys.abiflags` to disambiguate. Non free-threaded builds are not affected.