### PR TITLE
gitignore scala/metals IDE artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ __pycache__/
 .emacs.desktop*
 .idea
 /.vscode/
+.bsp/
+.metals/
+.scala-build/
 .cache
 .pants.d
 # TODO: We can probably delete these 3. They have not been used in a long time, if ever.


### PR DESCRIPTION
With Metals enabled in for example VSCode on the Pants repo, some IDE artifacts are not covered by .gitignore, same class as the `.idea` ignore.