### PR TITLE
use XXBinary more consistently

### DIFF
--- a/src/python/pants/backend/helm/subsystems/post_renderer.py
+++ b/src/python/pants/backend/helm/subsystems/post_renderer.py
@@ -26,7 +26,7 @@ from pants.backend.python.util_rules.pex import (
     setup_venv_pex_process,
 )
 from pants.core.goals.run import RunFieldSet, RunRequest, generate_run_request
-from pants.core.util_rules.system_binaries import CatBinary
+from pants.core.util_rules.system_binaries import BashBinary, CatBinary
 from pants.engine.addresses import UnparsedAddressInputs
 from pants.engine.engine_aware import EngineAwareParameter, EngineAwareReturnType
 from pants.engine.fs import CreateDigest, Digest, FileContent
@@ -183,6 +183,7 @@ async def _resolve_post_renderers(
 async def setup_post_renderer_launcher(
     request: SetupHelmPostRenderer,
     post_renderer_tool: _HelmPostRendererTool,
+    bash_binary: BashBinary,
     cat_binary: CatBinary,
 ) -> HelmPostRenderer:
     # Build post-renderer configuration file and create a digest containing it.
@@ -231,9 +232,10 @@ async def setup_post_renderer_launcher(
         f'Using post-renderer pipeline "{post_renderer_process_cli}" in {request.description_of_origin}.'
     )
 
+    # NB: Helm itself executes this script (via `--post-renderer`), so it must carry a shebang.
     postrenderer_wrapper_script = dedent(
         f"""\
-        #!/bin/bash
+        #!{bash_binary.path}
 
         # Output stdin into a file in disk
         {cat_binary.path} <&0 > {post_renderer_input_file}

--- a/src/python/pants/backend/python/providers/pyenv/custom_install/rules.py
+++ b/src/python/pants/backend/python/providers/pyenv/custom_install/rules.py
@@ -17,6 +17,7 @@ from pants.backend.python.providers.pyenv.rules import rules as pyenv_rules
 from pants.core.goals.run import RunFieldSet, RunInSandboxBehavior, RunRequest
 from pants.core.util_rules.external_tool import download_external_tool
 from pants.core.util_rules.external_tool import rules as external_tools_rules
+from pants.core.util_rules.system_binaries import BashBinary
 from pants.engine.fs import CreateDigest, FileContent
 from pants.engine.internals.native_engine import MergeDigests
 from pants.engine.internals.selectors import concurrently
@@ -66,6 +67,7 @@ async def run_pyenv_install(
     _: RunPyenvInstallFieldSet,
     platform: Platform,
     pyenv_subsystem: PyenvPythonProviderSubsystem,
+    bash: BashBinary,
 ) -> RunRequest:
     run_request, pyenv = await concurrently(
         get_pyenv_install_info(PyenvInstallInfoRequest(), **implicitly()),
@@ -79,14 +81,12 @@ async def run_pyenv_install(
                     "run_install_python_shim.sh",
                     dedent(
                         f"""\
-                        #!/usr/bin/env bash
                         set -e
                         cd "$CHROOT"
                         SPECIFIC_VERSION=$("{pyenv.exe}" latest --known $1)
                         {" ".join(run_request.args)} $SPECIFIC_VERSION
                         """
                     ).encode(),
-                    is_executable=True,
                 )
             ]
         )
@@ -94,7 +94,7 @@ async def run_pyenv_install(
     digest = await merge_digests(MergeDigests([run_request.digest, wrapper_script_digest]))
     return dataclasses.replace(
         run_request,
-        args=("{chroot}/run_install_python_shim.sh",),
+        args=(bash.path, "{chroot}/run_install_python_shim.sh"),
         digest=digest,
         extra_env=FrozenDict(
             {

--- a/src/python/pants/backend/python/providers/pyenv/rules.py
+++ b/src/python/pants/backend/python/providers/pyenv/rules.py
@@ -13,6 +13,7 @@ from pants.core.util_rules.adhoc_binaries import PythonBuildStandaloneBinary
 from pants.core.util_rules.env_vars import environment_vars_subset
 from pants.core.util_rules.external_tool import TemplatedExternalTool, download_external_tool
 from pants.core.util_rules.external_tool import rules as external_tools_rules
+from pants.core.util_rules.system_binaries import BashBinary
 from pants.engine.env_vars import EXTRA_ENV_VARS_USAGE_HELP, EnvironmentVarsRequest
 from pants.engine.fs import CreateDigest, FileContent
 from pants.engine.internals.native_engine import MergeDigests
@@ -115,6 +116,7 @@ async def get_pyenv_install_info(
     pyenv_env_aware: PyenvPythonProviderSubsystem.EnvironmentAware,
     platform: Platform,
     bootstrap_python: PythonBuildStandaloneBinary,
+    bash: BashBinary,
 ) -> RunRequest:
     env_vars, pyenv = await concurrently(
         environment_vars_subset(
@@ -134,7 +136,6 @@ async def get_pyenv_install_info(
                     "install_python_shim.sh",
                     dedent(
                         f"""\
-                        #!/usr/bin/env bash
                         set -e
                         export PYENV_ROOT=$(readlink {PYENV_NAMED_CACHE})/{installation_fingerprint}
                         DEST="$PYENV_ROOT"/versions/$1
@@ -145,7 +146,6 @@ async def get_pyenv_install_info(
                         echo "$DEST"/bin/python
                         """
                     ).encode(),
-                    is_executable=True,
                 ),
                 FileContent(
                     "install_python_shim.py",
@@ -186,7 +186,6 @@ async def get_pyenv_install_info(
                             main()
                         """
                     ).encode(),
-                    is_executable=True,
                 ),
             ]
         )
@@ -195,7 +194,7 @@ async def get_pyenv_install_info(
     digest = await merge_digests(MergeDigests([install_script_digest, pyenv.digest]))
     return RunRequest(
         digest=digest,
-        args=["./install_python_shim.sh"],
+        args=[bash.path, "./install_python_shim.sh"],
         extra_env={
             "PATH": env_vars.get("PATH", ""),
             "TMPDIR": "{chroot}/tmpdir",

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -53,6 +53,7 @@ from pants.core.util_rules.system_binaries import (
     MkdirBinary,
     MktempBinary,
     MvBinary,
+    ShBinary,
 )
 from pants.engine.collection import Collection
 from pants.engine.fs import CreateDigest, FileContent, MergeDigests, RemovePrefix
@@ -171,6 +172,7 @@ async def mypy_typecheck_partition(
     cp: CpBinary,
     mv: MvBinary,
     ln: LnBinary,
+    sh: ShBinary,
     global_options: GlobalOptions,
 ) -> CheckResult:
     # MyPy requires 3.5+ to run, but uses the typed-ast library to work with 2.7, 3.4, 3.5, 3.6,
@@ -274,14 +276,12 @@ async def mypy_typecheck_partition(
 
     if mypy.cache_mode == MyPyCacheMode.none:
         script_content = dedent(f"""\
-            #!/bin/sh
             {mypy_command}
         """)
     else:
         sandbox_cache_dir = f"{run_cache_dir}/{py_version}"
 
         script_content = dedent(f"""\
-            #!/bin/sh
             # We want to leverage the MyPy cache for fast incremental runs of MyPy.
             # Pants exposes "append_only_caches" we can leverage, but with the caveat
             # that it requires either only appending files, or multiprocess-safe access.
@@ -359,7 +359,6 @@ async def mypy_typecheck_partition(
                 FileContent(
                     "__mypy_runner.sh",
                     script_content.encode(),
-                    is_executable=True,
                 )
             ]
         )
@@ -414,7 +413,7 @@ async def mypy_typecheck_partition(
         ),
         **implicitly(),
     )
-    process = dataclasses.replace(process, argv=("./__mypy_runner.sh",))
+    process = dataclasses.replace(process, argv=(sh.path, "./__mypy_runner.sh"))
     result = await execute_process(process, **implicitly())
     report = await remove_prefix(RemovePrefix(result.output_digest, REPORT_DIR))
     return CheckResult.from_fallible_process_result(

--- a/src/python/pants/backend/typescript/goals/check.py
+++ b/src/python/pants/backend/typescript/goals/check.py
@@ -28,7 +28,13 @@ from pants.base.build_root import BuildRoot
 from pants.build_graph.address import Address
 from pants.core.goals.check import CheckRequest, CheckResult, CheckResults, CheckSubsystem
 from pants.core.target_types import FileSourceField
-from pants.core.util_rules.system_binaries import CpBinary, FindBinary, MkdirBinary, TouchBinary
+from pants.core.util_rules.system_binaries import (
+    CpBinary,
+    FindBinary,
+    MkdirBinary,
+    TouchBinary,
+    find_sh,
+)
 from pants.engine.fs import (
     EMPTY_DIGEST,
     CreateDigest,
@@ -215,8 +221,7 @@ async def create_tsc_wrapper_script(
     package_dirs_str = " ".join(f'"{d}"' for d in package_dirs)
     output_dirs_str = " ".join(f'"{d}"' for d in package_output_dirs)
 
-    script_content = f"""#!/bin/sh
-# TypeScript incremental compilation cache wrapper
+    script_content = f"""# TypeScript incremental compilation cache wrapper
 
 # All source files in sandbox have mtime as at sandbox creation (e.g. when the process started).
 # Without any special handling, tsc will do a fast immediate rebuild (without checking tsbuildinfo metadata).
@@ -274,7 +279,6 @@ done
                 FileContent(
                     f"{project.root_dir}/{tsc_wrapper_filename}",
                     script_content.encode(),
-                    is_executable=True,
                 )
             ]
         ),
@@ -408,9 +412,10 @@ async def _prepare_tsc_build_process(
 
     process = await prepare_tool_process(tool_request_with_resolve, **implicitly())
 
+    sh = await find_sh(**implicitly())
     process_with_wrapper = replace(
         process,
-        argv=(f"./{tsc_wrapper_filename}",) + process.argv,
+        argv=(sh.path, f"./{tsc_wrapper_filename}") + process.argv,
         working_directory=project.root_dir,
         output_directories=package_output_dirs,
     )


### PR DESCRIPTION
As pointed out by https://github.com/pantsbuild/pants/pull/23479 there are several places where we use the XXBinary classes, but then go and hard code one of the paths anyway.  This follows up on the feedback from the prior PR and prefers the XXBinary classes.

This should also improve support on systems (ex: NixOS, GoboLinux) that have atypical layouts.

Notice: I used an LLM to search, looking for callsites where we were inconsistent and could fix in a mechanical way.