### PR TITLE
refactor BuildBarn REAPI integration test and add another regression test

### DIFF
--- a/src/python/pants/engine/internals/buildbarn_integration_tests/buildbarn_remote_cache_integration_test.py
+++ b/src/python/pants/engine/internals/buildbarn_integration_tests/buildbarn_remote_cache_integration_test.py
@@ -7,15 +7,18 @@ import os
 import shutil
 import subprocess
 import time
+from collections.abc import Callable
 
 import pytest
 
-from pants.engine.fs import Digest, DigestContents
+from pants.engine.fs import CreateDigest, Digest, DigestContents, Directory
 from pants.engine.internals.buildbarn_integration_tests.stack import LocalBuildbarnStack
 from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import QueryRule
 from pants.testutil.rule_runner import RuleRunner
 from pants.util.logging import LogLevel
+
+ProcessFactory = Callable[[RuleRunner], Process]
 
 
 def _docker_available() -> bool:
@@ -49,7 +52,7 @@ def _remote_cache_args(address: str, instance_name: str) -> list[str]:
 
 
 def _run_process(
-    process: Process, *, address: str, instance_name: str
+    process_factory: ProcessFactory, *, address: str, instance_name: str
 ) -> tuple[dict[str, bytes], Digest, dict[str, int]]:
     rule_runner = RuleRunner(
         rules=[
@@ -64,6 +67,7 @@ def _run_process(
         ],
     )
 
+    process = process_factory(rule_runner)
     result = rule_runner.request(ProcessResult, [process])
     contents = rule_runner.request(DigestContents, [result.output_digest])
 
@@ -76,20 +80,42 @@ def _run_process(
     )
 
 
+def _fixed_process(process: Process) -> ProcessFactory:
+    return lambda _: process
+
+
+def _working_directory_process(rule_runner: RuleRunner) -> Process:
+    input_digest = rule_runner.request(Digest, [CreateDigest([Directory("workdir")])])
+    return Process(
+        [
+            "/bin/sh",
+            "-c",
+            "/bin/echo workdir-root > root.txt && /bin/mkdir -p sub && /bin/echo workdir-child > sub/child.txt",
+        ],
+        description="Create working directory outputs",
+        input_digest=input_digest,
+        working_directory="workdir",
+        output_directories=[""],
+        level=LogLevel.INFO,
+    )
+
+
 def test_buildbarn_remote_cache_roundtrips_outputs(subtests) -> None:
     cases = (
         (
             "file and directory outputs",
-            Process(
-                [
-                    "/bin/sh",
-                    "-c",
-                    "/bin/echo file-output > file.txt && /bin/mkdir -p out && /bin/echo nested-output > out/nested.txt",
-                ],
-                description="Create file and directory outputs",
-                output_files=["file.txt"],
-                output_directories=["out"],
-                level=LogLevel.INFO,
+            _fixed_process(
+                Process(
+                    [
+                        "/bin/sh",
+                        "-c",
+                        "/bin/echo file-output > file.txt && /bin/mkdir -p out && /bin/echo nested-output > out/nested.txt",
+                    ],
+                    description="Create file and directory outputs",
+                    output_files=["file.txt"],
+                    output_directories=["out"],
+                    level=LogLevel.INFO,
+                )
             ),
             {
                 "file.txt": b"file-output\n",
@@ -98,15 +124,17 @@ def test_buildbarn_remote_cache_roundtrips_outputs(subtests) -> None:
         ),
         (
             'root output directory (".")',
-            Process(
-                [
-                    "/bin/sh",
-                    "-c",
-                    "/bin/echo root > root.txt && /bin/mkdir -p sub && /bin/echo child > sub/child.txt",
-                ],
-                description="Create root output directory contents",
-                output_directories=["."],
-                level=LogLevel.INFO,
+            _fixed_process(
+                Process(
+                    [
+                        "/bin/sh",
+                        "-c",
+                        "/bin/echo root > root.txt && /bin/mkdir -p sub && /bin/echo child > sub/child.txt",
+                    ],
+                    description="Create root output directory contents",
+                    output_directories=["."],
+                    level=LogLevel.INFO,
+                )
             ),
             {
                 "root.txt": b"root\n",
@@ -115,28 +143,38 @@ def test_buildbarn_remote_cache_roundtrips_outputs(subtests) -> None:
         ),
         (
             'root output directory ("")',
-            Process(
-                [
-                    "/bin/sh",
-                    "-c",
-                    "/bin/echo empty-root > root.txt && /bin/mkdir -p sub && /bin/echo empty-child > sub/child.txt",
-                ],
-                description="Create empty root output directory contents",
-                output_directories=[""],
-                level=LogLevel.INFO,
+            _fixed_process(
+                Process(
+                    [
+                        "/bin/sh",
+                        "-c",
+                        "/bin/echo empty-root > root.txt && /bin/mkdir -p sub && /bin/echo empty-child > sub/child.txt",
+                    ],
+                    description="Create empty root output directory contents",
+                    output_directories=[""],
+                    level=LogLevel.INFO,
+                )
             ),
             {
                 "root.txt": b"empty-root\n",
                 "sub/child.txt": b"empty-child\n",
             },
         ),
+        (
+            'working directory output directory ("")',
+            _working_directory_process,
+            {
+                "root.txt": b"workdir-root\n",
+                "sub/child.txt": b"workdir-child\n",
+            },
+        ),
     )
 
     with LocalBuildbarnStack() as buildbarn:
-        for name, process, expected_contents in cases:
+        for name, process_factory, expected_contents in cases:
             with subtests.test(name):
                 contents1, digest1, metrics1 = _run_process(
-                    process,
+                    process_factory,
                     address=buildbarn.address,
                     instance_name=buildbarn.instance_name,
                 )
@@ -146,7 +184,7 @@ def test_buildbarn_remote_cache_roundtrips_outputs(subtests) -> None:
                 assert "backtrack_attempts" not in metrics1
 
                 contents2, digest2, metrics2 = _run_process(
-                    process,
+                    process_factory,
                     address=buildbarn.address,
                     instance_name=buildbarn.instance_name,
                 )

--- a/src/python/pants/engine/internals/buildbarn_integration_tests/buildbarn_remote_cache_integration_test.py
+++ b/src/python/pants/engine/internals/buildbarn_integration_tests/buildbarn_remote_cache_integration_test.py
@@ -153,3 +153,42 @@ def test_buildbarn_remote_cache_roundtrips_root_output_directory() -> None:
         assert metrics2["remote_cache_requests"] == 1
         assert metrics2["remote_cache_requests_cached"] == 1
         assert "backtrack_attempts" not in metrics2
+
+
+def test_buildbarn_remote_cache_roundtrips_empty_root_output_directory() -> None:
+    expected_contents = {
+        "root.txt": b"empty-root\n",
+        "sub/child.txt": b"empty-child\n",
+    }
+    process = Process(
+        [
+            "/bin/sh",
+            "-c",
+            "/bin/echo empty-root > root.txt && /bin/mkdir -p sub && /bin/echo empty-child > sub/child.txt",
+        ],
+        description="Create empty root output directory contents",
+        output_directories=[""],
+        level=LogLevel.INFO,
+    )
+
+    with LocalBuildbarnStack() as buildbarn:
+        contents1, digest1, metrics1 = _run_process(
+            process,
+            address=buildbarn.address,
+            instance_name=buildbarn.instance_name,
+        )
+        assert contents1 == expected_contents
+        assert metrics1["remote_cache_requests"] == 1
+        assert metrics1["remote_cache_requests_uncached"] == 1
+        assert "backtrack_attempts" not in metrics1
+
+        contents2, digest2, metrics2 = _run_process(
+            process,
+            address=buildbarn.address,
+            instance_name=buildbarn.instance_name,
+        )
+        assert contents2 == expected_contents
+        assert digest1 == digest2
+        assert metrics2["remote_cache_requests"] == 1
+        assert metrics2["remote_cache_requests_cached"] == 1
+        assert "backtrack_attempts" not in metrics2

--- a/src/python/pants/engine/internals/buildbarn_integration_tests/buildbarn_remote_cache_integration_test.py
+++ b/src/python/pants/engine/internals/buildbarn_integration_tests/buildbarn_remote_cache_integration_test.py
@@ -76,119 +76,82 @@ def _run_process(
     )
 
 
-def test_buildbarn_remote_cache_roundtrips_file_and_directory_outputs() -> None:
-    expected_contents = {
-        "file.txt": b"file-output\n",
-        "out/nested.txt": b"nested-output\n",
-    }
-    process = Process(
-        [
-            "/bin/sh",
-            "-c",
-            "/bin/echo file-output > file.txt && /bin/mkdir -p out && /bin/echo nested-output > out/nested.txt",
-        ],
-        description="Create file and directory outputs",
-        output_files=["file.txt"],
-        output_directories=["out"],
-        level=LogLevel.INFO,
+def test_buildbarn_remote_cache_roundtrips_outputs(subtests) -> None:
+    cases = (
+        (
+            "file and directory outputs",
+            Process(
+                [
+                    "/bin/sh",
+                    "-c",
+                    "/bin/echo file-output > file.txt && /bin/mkdir -p out && /bin/echo nested-output > out/nested.txt",
+                ],
+                description="Create file and directory outputs",
+                output_files=["file.txt"],
+                output_directories=["out"],
+                level=LogLevel.INFO,
+            ),
+            {
+                "file.txt": b"file-output\n",
+                "out/nested.txt": b"nested-output\n",
+            },
+        ),
+        (
+            'root output directory (".")',
+            Process(
+                [
+                    "/bin/sh",
+                    "-c",
+                    "/bin/echo root > root.txt && /bin/mkdir -p sub && /bin/echo child > sub/child.txt",
+                ],
+                description="Create root output directory contents",
+                output_directories=["."],
+                level=LogLevel.INFO,
+            ),
+            {
+                "root.txt": b"root\n",
+                "sub/child.txt": b"child\n",
+            },
+        ),
+        (
+            'root output directory ("")',
+            Process(
+                [
+                    "/bin/sh",
+                    "-c",
+                    "/bin/echo empty-root > root.txt && /bin/mkdir -p sub && /bin/echo empty-child > sub/child.txt",
+                ],
+                description="Create empty root output directory contents",
+                output_directories=[""],
+                level=LogLevel.INFO,
+            ),
+            {
+                "root.txt": b"empty-root\n",
+                "sub/child.txt": b"empty-child\n",
+            },
+        ),
     )
 
     with LocalBuildbarnStack() as buildbarn:
-        contents1, digest1, metrics1 = _run_process(
-            process,
-            address=buildbarn.address,
-            instance_name=buildbarn.instance_name,
-        )
-        assert contents1 == expected_contents
-        assert metrics1["remote_cache_requests"] == 1
-        assert metrics1["remote_cache_requests_uncached"] == 1
-        assert "backtrack_attempts" not in metrics1
+        for name, process, expected_contents in cases:
+            with subtests.test(name):
+                contents1, digest1, metrics1 = _run_process(
+                    process,
+                    address=buildbarn.address,
+                    instance_name=buildbarn.instance_name,
+                )
+                assert contents1 == expected_contents
+                assert metrics1["remote_cache_requests"] == 1
+                assert metrics1["remote_cache_requests_uncached"] == 1
+                assert "backtrack_attempts" not in metrics1
 
-        contents2, digest2, metrics2 = _run_process(
-            process,
-            address=buildbarn.address,
-            instance_name=buildbarn.instance_name,
-        )
-        assert contents2 == expected_contents
-        assert digest1 == digest2
-        assert metrics2["remote_cache_requests"] == 1
-        assert metrics2["remote_cache_requests_cached"] == 1
-        assert "backtrack_attempts" not in metrics2
-
-
-def test_buildbarn_remote_cache_roundtrips_root_output_directory() -> None:
-    expected_contents = {
-        "root.txt": b"root\n",
-        "sub/child.txt": b"child\n",
-    }
-    process = Process(
-        [
-            "/bin/sh",
-            "-c",
-            "/bin/echo root > root.txt && /bin/mkdir -p sub && /bin/echo child > sub/child.txt",
-        ],
-        description="Create root output directory contents",
-        output_directories=["."],
-        level=LogLevel.INFO,
-    )
-
-    with LocalBuildbarnStack() as buildbarn:
-        contents1, digest1, metrics1 = _run_process(
-            process,
-            address=buildbarn.address,
-            instance_name=buildbarn.instance_name,
-        )
-        assert contents1 == expected_contents
-        assert metrics1["remote_cache_requests"] == 1
-        assert metrics1["remote_cache_requests_uncached"] == 1
-        assert "backtrack_attempts" not in metrics1
-
-        contents2, digest2, metrics2 = _run_process(
-            process,
-            address=buildbarn.address,
-            instance_name=buildbarn.instance_name,
-        )
-        assert contents2 == expected_contents
-        assert digest1 == digest2
-        assert metrics2["remote_cache_requests"] == 1
-        assert metrics2["remote_cache_requests_cached"] == 1
-        assert "backtrack_attempts" not in metrics2
-
-
-def test_buildbarn_remote_cache_roundtrips_empty_root_output_directory() -> None:
-    expected_contents = {
-        "root.txt": b"empty-root\n",
-        "sub/child.txt": b"empty-child\n",
-    }
-    process = Process(
-        [
-            "/bin/sh",
-            "-c",
-            "/bin/echo empty-root > root.txt && /bin/mkdir -p sub && /bin/echo empty-child > sub/child.txt",
-        ],
-        description="Create empty root output directory contents",
-        output_directories=[""],
-        level=LogLevel.INFO,
-    )
-
-    with LocalBuildbarnStack() as buildbarn:
-        contents1, digest1, metrics1 = _run_process(
-            process,
-            address=buildbarn.address,
-            instance_name=buildbarn.instance_name,
-        )
-        assert contents1 == expected_contents
-        assert metrics1["remote_cache_requests"] == 1
-        assert metrics1["remote_cache_requests_uncached"] == 1
-        assert "backtrack_attempts" not in metrics1
-
-        contents2, digest2, metrics2 = _run_process(
-            process,
-            address=buildbarn.address,
-            instance_name=buildbarn.instance_name,
-        )
-        assert contents2 == expected_contents
-        assert digest1 == digest2
-        assert metrics2["remote_cache_requests"] == 1
-        assert metrics2["remote_cache_requests_cached"] == 1
-        assert "backtrack_attempts" not in metrics2
+                contents2, digest2, metrics2 = _run_process(
+                    process,
+                    address=buildbarn.address,
+                    instance_name=buildbarn.instance_name,
+                )
+                assert contents2 == expected_contents
+                assert digest1 == digest2
+                assert metrics2["remote_cache_requests"] == 1
+                assert metrics2["remote_cache_requests_cached"] == 1
+                assert "backtrack_attempts" not in metrics2

--- a/src/python/pants/engine/internals/buildbarn_integration_tests/buildbarn_remote_cache_integration_test.py
+++ b/src/python/pants/engine/internals/buildbarn_integration_tests/buildbarn_remote_cache_integration_test.py
@@ -18,8 +18,6 @@ from pants.engine.rules import QueryRule
 from pants.testutil.rule_runner import RuleRunner
 from pants.util.logging import LogLevel
 
-ProcessFactory = Callable[[RuleRunner], Process]
-
 
 def _docker_available() -> bool:
     docker = shutil.which("docker")
@@ -52,7 +50,10 @@ def _remote_cache_args(address: str, instance_name: str) -> list[str]:
 
 
 def _run_process(
-    process_factory: ProcessFactory, *, address: str, instance_name: str
+    process_input: Process | Callable[[RuleRunner], Process],
+    *,
+    address: str,
+    instance_name: str,
 ) -> tuple[dict[str, bytes], Digest, dict[str, int]]:
     rule_runner = RuleRunner(
         rules=[
@@ -67,7 +68,7 @@ def _run_process(
         ],
     )
 
-    process = process_factory(rule_runner)
+    process = process_input if isinstance(process_input, Process) else process_input(rule_runner)
     result = rule_runner.request(ProcessResult, [process])
     contents = rule_runner.request(DigestContents, [result.output_digest])
 
@@ -78,10 +79,6 @@ def _run_process(
         result.output_digest,
         rule_runner.scheduler.get_metrics(),
     )
-
-
-def _fixed_process(process: Process) -> ProcessFactory:
-    return lambda _: process
 
 
 def _working_directory_process(rule_runner: RuleRunner) -> Process:
@@ -104,18 +101,16 @@ def test_buildbarn_remote_cache_roundtrips_outputs(subtests) -> None:
     cases = (
         (
             "file and directory outputs",
-            _fixed_process(
-                Process(
-                    [
-                        "/bin/sh",
-                        "-c",
-                        "/bin/echo file-output > file.txt && /bin/mkdir -p out && /bin/echo nested-output > out/nested.txt",
-                    ],
-                    description="Create file and directory outputs",
-                    output_files=["file.txt"],
-                    output_directories=["out"],
-                    level=LogLevel.INFO,
-                )
+            Process(
+                [
+                    "/bin/sh",
+                    "-c",
+                    "/bin/echo file-output > file.txt && /bin/mkdir -p out && /bin/echo nested-output > out/nested.txt",
+                ],
+                description="Create file and directory outputs",
+                output_files=["file.txt"],
+                output_directories=["out"],
+                level=LogLevel.INFO,
             ),
             {
                 "file.txt": b"file-output\n",
@@ -124,17 +119,15 @@ def test_buildbarn_remote_cache_roundtrips_outputs(subtests) -> None:
         ),
         (
             'root output directory (".")',
-            _fixed_process(
-                Process(
-                    [
-                        "/bin/sh",
-                        "-c",
-                        "/bin/echo root > root.txt && /bin/mkdir -p sub && /bin/echo child > sub/child.txt",
-                    ],
-                    description="Create root output directory contents",
-                    output_directories=["."],
-                    level=LogLevel.INFO,
-                )
+            Process(
+                [
+                    "/bin/sh",
+                    "-c",
+                    "/bin/echo root > root.txt && /bin/mkdir -p sub && /bin/echo child > sub/child.txt",
+                ],
+                description="Create root output directory contents",
+                output_directories=["."],
+                level=LogLevel.INFO,
             ),
             {
                 "root.txt": b"root\n",
@@ -143,17 +136,15 @@ def test_buildbarn_remote_cache_roundtrips_outputs(subtests) -> None:
         ),
         (
             'root output directory ("")',
-            _fixed_process(
-                Process(
-                    [
-                        "/bin/sh",
-                        "-c",
-                        "/bin/echo empty-root > root.txt && /bin/mkdir -p sub && /bin/echo empty-child > sub/child.txt",
-                    ],
-                    description="Create empty root output directory contents",
-                    output_directories=[""],
-                    level=LogLevel.INFO,
-                )
+            Process(
+                [
+                    "/bin/sh",
+                    "-c",
+                    "/bin/echo empty-root > root.txt && /bin/mkdir -p sub && /bin/echo empty-child > sub/child.txt",
+                ],
+                description="Create empty root output directory contents",
+                output_directories=[""],
+                level=LogLevel.INFO,
             ),
             {
                 "root.txt": b"empty-root\n",
@@ -171,10 +162,10 @@ def test_buildbarn_remote_cache_roundtrips_outputs(subtests) -> None:
     )
 
     with LocalBuildbarnStack() as buildbarn:
-        for name, process_factory, expected_contents in cases:
+        for name, process_input, expected_contents in cases:
             with subtests.test(name):
                 contents1, digest1, metrics1 = _run_process(
-                    process_factory,
+                    process_input,
                     address=buildbarn.address,
                     instance_name=buildbarn.instance_name,
                 )
@@ -184,7 +175,7 @@ def test_buildbarn_remote_cache_roundtrips_outputs(subtests) -> None:
                 assert "backtrack_attempts" not in metrics1
 
                 contents2, digest2, metrics2 = _run_process(
-                    process_factory,
+                    process_input,
                     address=buildbarn.address,
                     instance_name=buildbarn.instance_name,
                 )

--- a/src/python/pants/engine/internals/buildbarn_integration_tests/buildbarn_remote_execution_integration_test.py
+++ b/src/python/pants/engine/internals/buildbarn_integration_tests/buildbarn_remote_execution_integration_test.py
@@ -162,48 +162,45 @@ def local_buildbarn_remote_execution() -> Iterator[RemoteExecutionBuildbarn]:
         stack.teardown()
 
 
-def test_buildbarn_remote_execution_runs_process() -> None:
-    process = Process(
-        [
-            "/bin/sh",
-            "-c",
-            "/bin/true",
-        ],
-        description="Buildbarn remote execution control case",
-        level=LogLevel.INFO,
-    )
-
+def test_buildbarn_remote_execution(subtests) -> None:
     with local_buildbarn_remote_execution() as buildbarn:
-        run = _run_remote_process(process, buildbarn=buildbarn)
+        with subtests.test("control process"):
+            process = Process(
+                [
+                    "/bin/sh",
+                    "-c",
+                    "/bin/true",
+                ],
+                description="Buildbarn remote execution control case",
+                level=LogLevel.INFO,
+            )
+            run = _run_remote_process(process, buildbarn=buildbarn)
 
-    assert run.contents == {}
-    assert run.metrics.get("remote_execution_requests", 0) == 1
-    assert len(run.remote_action_digest.fingerprint) == 64
-    assert len(run.remote_command_digest.fingerprint) == 64
-    assert run.process_workunit["metadata"]["exit_code"] == 0
+            assert run.contents == {}
+            assert run.metrics.get("remote_execution_requests", 0) == 1
+            assert len(run.remote_action_digest.fingerprint) == 64
+            assert len(run.remote_command_digest.fingerprint) == 64
+            assert run.process_workunit["metadata"]["exit_code"] == 0
 
+        with subtests.test('root output directory (".")'):
+            expected_contents = {
+                "root.txt": b"root\n",
+                "sub/child.txt": b"child\n",
+            }
+            process = Process(
+                [
+                    "/bin/sh",
+                    "-c",
+                    "/bin/echo root > root.txt && /bin/mkdir -p sub && /bin/echo child > sub/child.txt",
+                ],
+                description="Buildbarn remote execution root output case",
+                output_directories=["."],
+                level=LogLevel.INFO,
+            )
+            run = _run_remote_process(process, buildbarn=buildbarn)
 
-def test_buildbarn_remote_execution_root_output_directory() -> None:
-    expected_contents = {
-        "root.txt": b"root\n",
-        "sub/child.txt": b"child\n",
-    }
-    process = Process(
-        [
-            "/bin/sh",
-            "-c",
-            "/bin/echo root > root.txt && /bin/mkdir -p sub && /bin/echo child > sub/child.txt",
-        ],
-        description="Buildbarn remote execution root output case",
-        output_directories=["."],
-        level=LogLevel.INFO,
-    )
-
-    with local_buildbarn_remote_execution() as buildbarn:
-        run = _run_remote_process(process, buildbarn=buildbarn)
-
-    assert run.contents == expected_contents
-    assert run.metrics.get("remote_execution_requests", 0) == 1
-    assert len(run.remote_action_digest.fingerprint) == 64
-    assert len(run.remote_command_digest.fingerprint) == 64
-    assert run.process_workunit["metadata"]["exit_code"] == 0
+            assert run.contents == expected_contents
+            assert run.metrics.get("remote_execution_requests", 0) == 1
+            assert len(run.remote_action_digest.fingerprint) == 64
+            assert len(run.remote_command_digest.fingerprint) == 64
+            assert run.process_workunit["metadata"]["exit_code"] == 0

--- a/src/python/pants/engine/internals/buildbarn_integration_tests/buildbarn_remote_execution_integration_test.py
+++ b/src/python/pants/engine/internals/buildbarn_integration_tests/buildbarn_remote_execution_integration_test.py
@@ -7,14 +7,14 @@ import itertools
 import os
 import shutil
 import subprocess
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
 
 import pytest
 
 from pants.base.specs import Specs
-from pants.engine.fs import Digest, DigestContents, FileDigest
+from pants.engine.fs import CreateDigest, Digest, DigestContents, Directory, FileDigest
 from pants.engine.internals.buildbarn_integration_tests.stack import (
     LocalBuildbarnStack,
     RemoteExecutionBuildbarn,
@@ -27,6 +27,8 @@ from pants.goal.run_tracker import RunTracker
 from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.rule_runner import RuleRunner
 from pants.util.logging import LogLevel
+
+ProcessFactory = Callable[[RuleRunner], Process]
 
 
 @dataclass(frozen=True)
@@ -81,7 +83,7 @@ def _new_run_tracker() -> RunTracker:
 
 
 def _run_remote_process(
-    process: Process,
+    process_factory: ProcessFactory,
     *,
     buildbarn: RemoteExecutionBuildbarn,
 ) -> RemoteExecutionRun:
@@ -98,6 +100,7 @@ def _run_remote_process(
             *_remote_execution_args(buildbarn),
         ],
     )
+    process = process_factory(rule_runner)
     tracker = WorkunitTracker()
     with rule_runner.pushd():
         handler = StreamingWorkunitHandler(
@@ -135,6 +138,53 @@ def _run_remote_process(
     )
 
 
+def _fixed_process(process: Process) -> ProcessFactory:
+    return lambda _: process
+
+
+def _working_directory_process(rule_runner: RuleRunner) -> Process:
+    input_digest = rule_runner.request(Digest, [CreateDigest([Directory("workdir")])])
+    return Process(
+        [
+            "/bin/sh",
+            "-c",
+            "/bin/echo workdir-root > root.txt && /bin/mkdir -p sub && /bin/echo workdir-child > sub/child.txt",
+        ],
+        description="Buildbarn remote execution working directory output case",
+        input_digest=input_digest,
+        working_directory="workdir",
+        output_directories=[""],
+        level=LogLevel.INFO,
+    )
+
+
+def _assert_output_cache_roundtrip(
+    process_factory: ProcessFactory,
+    expected_contents: dict[str, bytes],
+    *,
+    buildbarn: RemoteExecutionBuildbarn,
+) -> None:
+    run1 = _run_remote_process(process_factory, buildbarn=buildbarn)
+
+    assert run1.contents == expected_contents
+    assert run1.metrics.get("remote_execution_requests", 0) == 1
+    assert "backtrack_attempts" not in run1.metrics
+    assert len(run1.remote_action_digest.fingerprint) == 64
+    assert len(run1.remote_command_digest.fingerprint) == 64
+    assert run1.process_workunit["metadata"]["exit_code"] == 0
+
+    run2 = _run_remote_process(process_factory, buildbarn=buildbarn)
+
+    assert run2.contents == expected_contents
+    assert run2.output_digest == run1.output_digest
+    assert run2.metrics.get("remote_execution_requests", 0) == 0
+    assert run2.metrics.get("remote_cache_requests_cached", 0) == 1
+    assert "backtrack_attempts" not in run2.metrics
+    assert run2.remote_action_digest == run1.remote_action_digest
+    assert run2.remote_command_digest == run1.remote_command_digest
+    assert run2.process_workunit["metadata"]["exit_code"] == 0
+
+
 def _worker_preflight(buildbarn: RemoteExecutionBuildbarn) -> None:
     preflight_process = Process(
         [
@@ -145,7 +195,7 @@ def _worker_preflight(buildbarn: RemoteExecutionBuildbarn) -> None:
         description="Buildbarn worker preflight",
         level=LogLevel.INFO,
     )
-    run = _run_remote_process(preflight_process, buildbarn=buildbarn)
+    run = _run_remote_process(_fixed_process(preflight_process), buildbarn=buildbarn)
     assert run.contents == {}
     assert run.metrics.get("remote_execution_requests", 0) == 1
     assert run.process_workunit["metadata"]["exit_code"] == 0
@@ -174,7 +224,7 @@ def test_buildbarn_remote_execution(subtests) -> None:
                 description="Buildbarn remote execution control case",
                 level=LogLevel.INFO,
             )
-            run = _run_remote_process(process, buildbarn=buildbarn)
+            run = _run_remote_process(_fixed_process(process), buildbarn=buildbarn)
 
             assert run.contents == {}
             assert run.metrics.get("remote_execution_requests", 0) == 1
@@ -197,22 +247,16 @@ def test_buildbarn_remote_execution(subtests) -> None:
                 output_directories=["."],
                 level=LogLevel.INFO,
             )
-            run1 = _run_remote_process(process, buildbarn=buildbarn)
+            _assert_output_cache_roundtrip(
+                _fixed_process(process), expected_contents, buildbarn=buildbarn
+            )
 
-            assert run1.contents == expected_contents
-            assert run1.metrics.get("remote_execution_requests", 0) == 1
-            assert "backtrack_attempts" not in run1.metrics
-            assert len(run1.remote_action_digest.fingerprint) == 64
-            assert len(run1.remote_command_digest.fingerprint) == 64
-            assert run1.process_workunit["metadata"]["exit_code"] == 0
-
-            run2 = _run_remote_process(process, buildbarn=buildbarn)
-
-            assert run2.contents == expected_contents
-            assert run2.output_digest == run1.output_digest
-            assert run2.metrics.get("remote_execution_requests", 0) == 0
-            assert run2.metrics.get("remote_cache_requests_cached", 0) == 1
-            assert "backtrack_attempts" not in run2.metrics
-            assert run2.remote_action_digest == run1.remote_action_digest
-            assert run2.remote_command_digest == run1.remote_command_digest
-            assert run2.process_workunit["metadata"]["exit_code"] == 0
+        with subtests.test('working directory output directory ("")'):
+            _assert_output_cache_roundtrip(
+                _working_directory_process,
+                {
+                    "root.txt": b"workdir-root\n",
+                    "sub/child.txt": b"workdir-child\n",
+                },
+                buildbarn=buildbarn,
+            )

--- a/src/python/pants/engine/internals/buildbarn_integration_tests/buildbarn_remote_execution_integration_test.py
+++ b/src/python/pants/engine/internals/buildbarn_integration_tests/buildbarn_remote_execution_integration_test.py
@@ -163,8 +163,6 @@ def _assert_output_cache_roundtrip(
     assert run1.contents == expected_contents
     assert run1.metrics.get("remote_execution_requests", 0) == 1
     assert "backtrack_attempts" not in run1.metrics
-    assert len(run1.remote_action_digest.fingerprint) == 64
-    assert len(run1.remote_command_digest.fingerprint) == 64
     assert run1.process_workunit["metadata"]["exit_code"] == 0
 
     run2 = _run_remote_process(process_input, buildbarn=buildbarn)
@@ -222,8 +220,6 @@ def test_buildbarn_remote_execution(subtests) -> None:
 
             assert run.contents == {}
             assert run.metrics.get("remote_execution_requests", 0) == 1
-            assert len(run.remote_action_digest.fingerprint) == 64
-            assert len(run.remote_command_digest.fingerprint) == 64
             assert run.process_workunit["metadata"]["exit_code"] == 0
 
         with subtests.test('root output directory (".")'):

--- a/src/python/pants/engine/internals/buildbarn_integration_tests/buildbarn_remote_execution_integration_test.py
+++ b/src/python/pants/engine/internals/buildbarn_integration_tests/buildbarn_remote_execution_integration_test.py
@@ -28,8 +28,6 @@ from pants.testutil.option_util import create_options_bootstrapper
 from pants.testutil.rule_runner import RuleRunner
 from pants.util.logging import LogLevel
 
-ProcessFactory = Callable[[RuleRunner], Process]
-
 
 @dataclass(frozen=True)
 class RemoteExecutionRun:
@@ -83,7 +81,7 @@ def _new_run_tracker() -> RunTracker:
 
 
 def _run_remote_process(
-    process_factory: ProcessFactory,
+    process_input: Process | Callable[[RuleRunner], Process],
     *,
     buildbarn: RemoteExecutionBuildbarn,
 ) -> RemoteExecutionRun:
@@ -100,7 +98,7 @@ def _run_remote_process(
             *_remote_execution_args(buildbarn),
         ],
     )
-    process = process_factory(rule_runner)
+    process = process_input if isinstance(process_input, Process) else process_input(rule_runner)
     tracker = WorkunitTracker()
     with rule_runner.pushd():
         handler = StreamingWorkunitHandler(
@@ -138,10 +136,6 @@ def _run_remote_process(
     )
 
 
-def _fixed_process(process: Process) -> ProcessFactory:
-    return lambda _: process
-
-
 def _working_directory_process(rule_runner: RuleRunner) -> Process:
     input_digest = rule_runner.request(Digest, [CreateDigest([Directory("workdir")])])
     return Process(
@@ -159,12 +153,12 @@ def _working_directory_process(rule_runner: RuleRunner) -> Process:
 
 
 def _assert_output_cache_roundtrip(
-    process_factory: ProcessFactory,
+    process_input: Process | Callable[[RuleRunner], Process],
     expected_contents: dict[str, bytes],
     *,
     buildbarn: RemoteExecutionBuildbarn,
 ) -> None:
-    run1 = _run_remote_process(process_factory, buildbarn=buildbarn)
+    run1 = _run_remote_process(process_input, buildbarn=buildbarn)
 
     assert run1.contents == expected_contents
     assert run1.metrics.get("remote_execution_requests", 0) == 1
@@ -173,7 +167,7 @@ def _assert_output_cache_roundtrip(
     assert len(run1.remote_command_digest.fingerprint) == 64
     assert run1.process_workunit["metadata"]["exit_code"] == 0
 
-    run2 = _run_remote_process(process_factory, buildbarn=buildbarn)
+    run2 = _run_remote_process(process_input, buildbarn=buildbarn)
 
     assert run2.contents == expected_contents
     assert run2.output_digest == run1.output_digest
@@ -195,7 +189,7 @@ def _worker_preflight(buildbarn: RemoteExecutionBuildbarn) -> None:
         description="Buildbarn worker preflight",
         level=LogLevel.INFO,
     )
-    run = _run_remote_process(_fixed_process(preflight_process), buildbarn=buildbarn)
+    run = _run_remote_process(preflight_process, buildbarn=buildbarn)
     assert run.contents == {}
     assert run.metrics.get("remote_execution_requests", 0) == 1
     assert run.process_workunit["metadata"]["exit_code"] == 0
@@ -224,7 +218,7 @@ def test_buildbarn_remote_execution(subtests) -> None:
                 description="Buildbarn remote execution control case",
                 level=LogLevel.INFO,
             )
-            run = _run_remote_process(_fixed_process(process), buildbarn=buildbarn)
+            run = _run_remote_process(process, buildbarn=buildbarn)
 
             assert run.contents == {}
             assert run.metrics.get("remote_execution_requests", 0) == 1
@@ -247,9 +241,7 @@ def test_buildbarn_remote_execution(subtests) -> None:
                 output_directories=["."],
                 level=LogLevel.INFO,
             )
-            _assert_output_cache_roundtrip(
-                _fixed_process(process), expected_contents, buildbarn=buildbarn
-            )
+            _assert_output_cache_roundtrip(process, expected_contents, buildbarn=buildbarn)
 
         with subtests.test('working directory output directory ("")'):
             _assert_output_cache_roundtrip(

--- a/src/python/pants/engine/internals/buildbarn_integration_tests/buildbarn_remote_execution_integration_test.py
+++ b/src/python/pants/engine/internals/buildbarn_integration_tests/buildbarn_remote_execution_integration_test.py
@@ -197,10 +197,22 @@ def test_buildbarn_remote_execution(subtests) -> None:
                 output_directories=["."],
                 level=LogLevel.INFO,
             )
-            run = _run_remote_process(process, buildbarn=buildbarn)
+            run1 = _run_remote_process(process, buildbarn=buildbarn)
 
-            assert run.contents == expected_contents
-            assert run.metrics.get("remote_execution_requests", 0) == 1
-            assert len(run.remote_action_digest.fingerprint) == 64
-            assert len(run.remote_command_digest.fingerprint) == 64
-            assert run.process_workunit["metadata"]["exit_code"] == 0
+            assert run1.contents == expected_contents
+            assert run1.metrics.get("remote_execution_requests", 0) == 1
+            assert "backtrack_attempts" not in run1.metrics
+            assert len(run1.remote_action_digest.fingerprint) == 64
+            assert len(run1.remote_command_digest.fingerprint) == 64
+            assert run1.process_workunit["metadata"]["exit_code"] == 0
+
+            run2 = _run_remote_process(process, buildbarn=buildbarn)
+
+            assert run2.contents == expected_contents
+            assert run2.output_digest == run1.output_digest
+            assert run2.metrics.get("remote_execution_requests", 0) == 0
+            assert run2.metrics.get("remote_cache_requests_cached", 0) == 1
+            assert "backtrack_attempts" not in run2.metrics
+            assert run2.remote_action_digest == run1.remote_action_digest
+            assert run2.remote_command_digest == run1.remote_command_digest
+            assert run2.process_workunit["metadata"]["exit_code"] == 0


### PR DESCRIPTION
- Refactor the BuildBarn integration tests to only spin up BuildBarn server stack once for cache tests and once for remote execution tests.
- Add  regression test for `output_directories=[""]`` case when working directory is a subdirectory.