### PR TITLE
Perf: lazy initialize bootstrap scheduler

### DIFF
--- a/src/python/pants/backend/BUILD
+++ b/src/python/pants/backend/BUILD
@@ -58,12 +58,14 @@ __dependents_rules__(
             "[/python/util_rules/pex_requirements.py]",
         ),
         "src/python/pants/init/plugin_resolver.py",
+        "src/python/pants/init/plugin_resolver_rules.py",
         DEFAULT_DEPENDENTS_RULES,
     ),
     (
         "[/python/util_rules/pex.py]",
         "src/python/pants/core/goals/update_build_files.py",
         "src/python/pants/init/plugin_resolver.py",
+        "src/python/pants/init/plugin_resolver_rules.py",
         DEFAULT_DEPENDENTS_RULES,
     ),
     (

--- a/src/python/pants/init/options_initializer.py
+++ b/src/python/pants/init/options_initializer.py
@@ -23,7 +23,6 @@ from pants.init.extension_loader import (
     load_build_configuration_from_source,
 )
 from pants.init.plugin_resolver import PluginResolver
-from pants.init.plugin_resolver import rules as plugin_resolver_rules
 from pants.option.bootstrap_options import DynamicRemoteOptions
 from pants.option.errors import UnknownFlagsError
 from pants.option.options import Options
@@ -106,6 +105,11 @@ def _collect_backends_requirements(backends: list[str]) -> list[str]:
 def create_bootstrap_scheduler(
     options_bootstrapper: OptionsBootstrapper, executor: PyExecutor
 ) -> BootstrapScheduler:
+    # Imported here rather than at module scope: this pulls in the Python/PEX rule modules, which
+    # are only needed to pex-resolve distribution plugins. Keeping the import lazy leaves them off
+    # the startup critical path when there is nothing to resolve.
+    from pants.init.plugin_resolver_rules import rules as plugin_resolver_rules
+
     bc_builder = BuildConfiguration.Builder()
     # To load plugins, we only need access to the Python/PEX rules.
     load_build_configuration_from_source(bc_builder, ["pants.backend.python"])

--- a/src/python/pants/init/options_initializer.py
+++ b/src/python/pants/init/options_initializer.py
@@ -142,8 +142,11 @@ class OptionsInitializer:
         options_bootstrapper: OptionsBootstrapper,
         executor: PyExecutor,
     ) -> None:
-        self._bootstrap_scheduler = create_bootstrap_scheduler(options_bootstrapper, executor)
-        self._plugin_resolver = PluginResolver(self._bootstrap_scheduler)
+        # Build the bootstrap scheduler lazily: it is only needed to pex-resolve distribution
+        # plugins, so `PluginResolver` skips it entirely when there is nothing to resolve.
+        self._plugin_resolver = PluginResolver(
+            lambda: create_bootstrap_scheduler(options_bootstrapper, executor)
+        )
 
     def build_config(
         self,

--- a/src/python/pants/init/plugin_resolver.py
+++ b/src/python/pants/init/plugin_resolver.py
@@ -9,27 +9,21 @@ import site
 import sys
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from packaging.requirements import Requirement
 
-from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
-from pants.backend.python.util_rules.pex import PexRequest, VenvPexProcess, create_venv_pex
-from pants.backend.python.util_rules.pex_environment import PythonExecutable
-from pants.backend.python.util_rules.pex_requirements import PexRequirements
 from pants.core.environments.rules import determine_bootstrap_environment
 from pants.engine.collection import DeduplicatedCollection
 from pants.engine.env_vars import CompleteEnvironmentVars
-from pants.engine.environment import EnvironmentName
 from pants.engine.internals.selectors import Params
 from pants.engine.internals.session import SessionValues
-from pants.engine.process import ProcessCacheScope, execute_process_or_raise
-from pants.engine.rules import QueryRule, collect_rules, implicitly, rule
 from pants.init.bootstrap_scheduler import BootstrapScheduler
 from pants.init.import_util import find_matching_distributions
-from pants.option.global_options import GlobalOptions
 from pants.option.options_bootstrapper import OptionsBootstrapper
-from pants.util.logging import LogLevel
+
+if TYPE_CHECKING:
+    from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 
 logger = logging.getLogger(__name__)
 
@@ -48,69 +42,6 @@ class PluginsRequest:
 
 class ResolvedPluginDistributions(DeduplicatedCollection[str]):
     sort_input = True
-
-
-@rule
-async def resolve_plugins(
-    request: PluginsRequest,
-    global_options: GlobalOptions,
-) -> ResolvedPluginDistributions:
-    """This rule resolves plugins using a VenvPex, and exposes the absolute paths of their dists.
-
-    NB: This relies on the fact that PEX constructs venvs in a stable location (within the
-    `named_caches` directory), but consequently needs to disable the process cache: see the
-    ProcessCacheScope reference in the body.
-    """
-    req_strings = sorted(global_options.plugins + request.requirements)
-
-    requirements = PexRequirements(
-        req_strings_or_addrs=req_strings,
-        constraints_strings=(str(constraint) for constraint in request.constraints),
-        description_of_origin="configured Pants plugins",
-    )
-    if not requirements:
-        return ResolvedPluginDistributions()
-
-    python: PythonExecutable | None = None
-    if not request.interpreter_constraints:
-        python = PythonExecutable.fingerprinted(
-            sys.executable, ".".join(map(str, sys.version_info[:3])).encode("utf8")
-        )
-
-    plugins_pex = await create_venv_pex(
-        **implicitly(
-            PexRequest(
-                output_filename="pants_plugins.pex",
-                internal_only=True,
-                python=python,
-                requirements=requirements,
-                interpreter_constraints=request.interpreter_constraints or InterpreterConstraints(),
-                additional_args=("--preserve-pip-download-log", "pex-pip-download.log"),
-                description=f"Resolving plugins: {', '.join(req_strings)}",
-            )
-        )
-    )
-
-    # NB: We run this Process per-restart because it (intentionally) leaks named cache
-    # paths in a way that invalidates the Process-cache. See the method doc.
-    cache_scope = (
-        ProcessCacheScope.PER_SESSION
-        if global_options.plugins_force_resolve
-        else ProcessCacheScope.PER_RESTART_SUCCESSFUL
-    )
-
-    plugins_process_result = await execute_process_or_raise(
-        **implicitly(
-            VenvPexProcess(
-                plugins_pex,
-                argv=("-c", "import os, site; print(os.linesep.join(site.getsitepackages()))"),
-                description="Extracting plugin locations",
-                level=LogLevel.DEBUG,
-                cache_scope=cache_scope,
-            )
-        )
-    )
-    return ResolvedPluginDistributions(plugins_process_result.stdout.decode().strip().split("\n"))
 
 
 class PluginResolver:
@@ -198,10 +129,3 @@ class PluginResolver:
             ResolvedPluginDistributions,
             session.product_request(ResolvedPluginDistributions, params)[0],
         )
-
-
-def rules():
-    return [
-        QueryRule(ResolvedPluginDistributions, [PluginsRequest, EnvironmentName]),
-        *collect_rules(),
-    ]

--- a/src/python/pants/init/plugin_resolver.py
+++ b/src/python/pants/init/plugin_resolver.py
@@ -7,7 +7,7 @@ import importlib.metadata
 import logging
 import site
 import sys
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from typing import cast
 
@@ -122,13 +122,23 @@ class PluginResolver:
 
     def __init__(
         self,
-        scheduler: BootstrapScheduler,
+        scheduler: Callable[[], BootstrapScheduler],
         interpreter_constraints: InterpreterConstraints | None = None,
         inherit_existing_constraints: bool = True,
     ) -> None:
-        self._scheduler = scheduler
+        # The scheduler is built lazily: it is only needed to pex-resolve distribution plugins,
+        # which most repos do not configure. Deferring it keeps the second rule-graph build and
+        # its backend load off the critical path when there is nothing to resolve.
+        self._scheduler_factory = scheduler
+        self._scheduler_instance: BootstrapScheduler | None = None
         self._interpreter_constraints = interpreter_constraints
         self._inherit_existing_constraints = inherit_existing_constraints
+
+    @property
+    def _scheduler(self) -> BootstrapScheduler:
+        if self._scheduler_instance is None:
+            self._scheduler_instance = self._scheduler_factory()
+        return self._scheduler_instance
 
     def resolve(
         self,
@@ -137,6 +147,13 @@ class PluginResolver:
         requirements: Iterable[str] = (),
     ) -> list[str]:
         """Resolves any configured plugins and adds them to the sys.path as a side effect."""
+        requirements = tuple(requirements)
+        # `resolve_plugins` resolves `[GLOBAL].plugins` plus these backend requirements. With
+        # neither, it would resolve nothing, so short-circuit before building the bootstrap
+        # scheduler (which exists only to run this resolution).
+        configured_plugins = options_bootstrapper.bootstrap_options.for_global_scope().plugins
+        if not configured_plugins and not requirements:
+            return []
 
         def to_requirement(d):
             return f"{d.name}=={d.version}"

--- a/src/python/pants/init/plugin_resolver_rules.py
+++ b/src/python/pants/init/plugin_resolver_rules.py
@@ -1,0 +1,87 @@
+# Copyright 2026 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import sys
+
+from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
+from pants.backend.python.util_rules.pex import PexRequest, VenvPexProcess, create_venv_pex
+from pants.backend.python.util_rules.pex_environment import PythonExecutable
+from pants.backend.python.util_rules.pex_requirements import PexRequirements
+from pants.engine.environment import EnvironmentName
+from pants.engine.process import ProcessCacheScope, execute_process_or_raise
+from pants.engine.rules import QueryRule, collect_rules, implicitly, rule
+from pants.init.plugin_resolver import PluginsRequest, ResolvedPluginDistributions
+from pants.option.global_options import GlobalOptions
+from pants.util.logging import LogLevel
+
+
+@rule
+async def resolve_plugins(
+    request: PluginsRequest,
+    global_options: GlobalOptions,
+) -> ResolvedPluginDistributions:
+    """This rule resolves plugins using a VenvPex, and exposes the absolute paths of their dists.
+
+    NB: This relies on the fact that PEX constructs venvs in a stable location (within the
+    `named_caches` directory), but consequently needs to disable the process cache: see the
+    ProcessCacheScope reference in the body.
+    """
+    req_strings = sorted(global_options.plugins + request.requirements)
+
+    requirements = PexRequirements(
+        req_strings_or_addrs=req_strings,
+        constraints_strings=(str(constraint) for constraint in request.constraints),
+        description_of_origin="configured Pants plugins",
+    )
+    if not requirements:
+        return ResolvedPluginDistributions()
+
+    python: PythonExecutable | None = None
+    if not request.interpreter_constraints:
+        python = PythonExecutable.fingerprinted(
+            sys.executable, ".".join(map(str, sys.version_info[:3])).encode("utf8")
+        )
+
+    plugins_pex = await create_venv_pex(
+        **implicitly(
+            PexRequest(
+                output_filename="pants_plugins.pex",
+                internal_only=True,
+                python=python,
+                requirements=requirements,
+                interpreter_constraints=request.interpreter_constraints or InterpreterConstraints(),
+                additional_args=("--preserve-pip-download-log", "pex-pip-download.log"),
+                description=f"Resolving plugins: {', '.join(req_strings)}",
+            )
+        )
+    )
+
+    # NB: We run this Process per-restart because it (intentionally) leaks named cache
+    # paths in a way that invalidates the Process-cache. See the method doc.
+    cache_scope = (
+        ProcessCacheScope.PER_SESSION
+        if global_options.plugins_force_resolve
+        else ProcessCacheScope.PER_RESTART_SUCCESSFUL
+    )
+
+    plugins_process_result = await execute_process_or_raise(
+        **implicitly(
+            VenvPexProcess(
+                plugins_pex,
+                argv=("-c", "import os, site; print(os.linesep.join(site.getsitepackages()))"),
+                description="Extracting plugin locations",
+                level=LogLevel.DEBUG,
+                cache_scope=cache_scope,
+            )
+        )
+    )
+    return ResolvedPluginDistributions(plugins_process_result.stdout.decode().strip().split("\n"))
+
+
+def rules():
+    return [
+        QueryRule(ResolvedPluginDistributions, [PluginsRequest, EnvironmentName]),
+        *collect_rules(),
+    ]

--- a/src/python/pants/init/plugin_resolver_test.py
+++ b/src/python/pants/init/plugin_resolver_test.py
@@ -284,7 +284,7 @@ def plugin_resolution(
             sys.path.insert(0, str(site_packages_path))
 
         plugin_resolver = PluginResolver(
-            bootstrap_scheduler,
+            lambda: bootstrap_scheduler,
             interpreter_constraints,
             inherit_existing_constraints=inherit_existing_constraints,
         )


### PR DESCRIPTION
Shaves of about 0.1s startup time. The second commit is only meaningful when plugins are imported in parallel / python backend is not used.

I intend to introduce paralllel backend imports after https://github.com/pantsbuild/pants/pull/23477.