### PR TITLE
Free-threaded: Pex-style ABI interpreter constraints via extras

### DIFF
--- a/docs/docs/python/overview/interpreter-compatibility.mdx
+++ b/docs/docs/python/overview/interpreter-compatibility.mdx
@@ -35,6 +35,23 @@ As a shortcut, you can leave off `CPython` and just put the version specifier. F
 If you use Python code on Apple's M1/M2 hardware you may need to set your interpreter constraints to Python 3.9+, as many tools, such as Black, will not install correctly on earlier Python versions on this platform.
 :::
 
+## Selecting the free-threaded (no-GIL) CPython ABI
+
+The free-threaded (no-GIL) and standard CPython builds share a version but are distinct ABIs, so `CPython>=3.13` matches either. Qualify the interpreter type with an extra to pin one: `CPython[free-threaded]>=3.13` or `CPython[gil]>=3.13` (the `CPython+t` / `CPython-t` spellings also work). Pants selects the matching interpreter from the [search path](#changing-the-interpreter-search-path), so one of that ABI must be discoverable.
+
+`parametrize` it to build both wheels of a `python_distribution` at once:
+
+```python title="BUILD"
+python_distribution(
+    name="dist",
+    interpreter_constraints=parametrize(
+        gil=["CPython[gil]>=3.13"],
+        ft=["CPython[free-threaded]>=3.13"],
+    ),
+    # ...
+)
+```
+
 ## Using multiple Python versions in the same project
 
 Pants also allows you to specify the interpreter compatibility for particular targets. This allows you to use multiple Python versions in the same repository, such as allowing you to incrementally migrate from Python 2 to Python 3.

--- a/docs/docs/python/overview/interpreter-compatibility.mdx
+++ b/docs/docs/python/overview/interpreter-compatibility.mdx
@@ -37,7 +37,7 @@ If you use Python code on Apple's M1/M2 hardware you may need to set your interp
 
 ## Selecting the free-threaded (no-GIL) CPython ABI
 
-The free-threaded (no-GIL) and standard CPython builds share a version but are distinct ABIs, so `CPython>=3.13` matches either. Qualify the interpreter type with an extra to pin one: `CPython[free-threaded]>=3.13` or `CPython[gil]>=3.13` (the `CPython+t` / `CPython-t` spellings also work). Pants selects the matching interpreter from the [search path](#changing-the-interpreter-search-path), so one of that ABI must be discoverable.
+The free-threaded (no-GIL) and standard CPython builds share a version but are distinct ABIs, so `CPython>=3.13` matches either. Qualify the interpreter type to pin one, using either an extra, `CPython[free-threaded]>=3.13` or `CPython[gil]>=3.13`, or the equivalent `CPython+t` / `CPython-t` spellings. Both spellings are adopted from [Pex](https://docs.pex-tool.org) and may evolve alongside future Python packaging standards. Pants selects the matching interpreter from the [search path](#changing-the-interpreter-search-path), so one of that ABI must be discoverable.
 
 `parametrize` it to build both wheels of a `python_distribution` at once:
 

--- a/docs/notes/2.34.x.md
+++ b/docs/notes/2.34.x.md
@@ -26,7 +26,7 @@ Thank you to [Klaviyo](https://www.klaviyo.com/) for their Platinum tier support
 
 #### Python
 
-Interpreter constraints can now select a specific CPython ABI, to distinguish the free-threaded (no-GIL) build from the standard build. Qualify the interpreter type with a PEP 508 extra: `CPython[free-threaded]` or `CPython[gil]` (the equivalent Pex spellings `CPython+t` / `CPython-t` are also accepted). For example, `interpreter_constraints=["CPython[free-threaded]==3.14.*"]` matches only free-threaded 3.14 interpreters, while `CPython==3.14.*` continues to match either ABI.
+Interpreter constraints can now select a specific CPython ABI, to distinguish the free-threaded (no-GIL) build from the standard build. Qualify the interpreter type using either a PEP 508 extra, `CPython[free-threaded]` or `CPython[gil]`, or the equivalent `CPython+t` / `CPython-t` spellings. Both spellings are adopted from Pex. For example, `interpreter_constraints=["CPython[free-threaded]==3.14.*"]` matches only free-threaded 3.14 interpreters, while `CPython==3.14.*` continues to match either ABI.
 
 #### Shell
 

--- a/docs/notes/2.34.x.md
+++ b/docs/notes/2.34.x.md
@@ -26,6 +26,8 @@ Thank you to [Klaviyo](https://www.klaviyo.com/) for their Platinum tier support
 
 #### Python
 
+Interpreter constraints can now select a specific CPython ABI, to distinguish the free-threaded (no-GIL) build from the standard build. Qualify the interpreter type with a PEP 508 extra: `CPython[free-threaded]` or `CPython[gil]` (the equivalent Pex spellings `CPython+t` / `CPython-t` are also accepted). For example, `interpreter_constraints=["CPython[free-threaded]==3.14.*"]` matches only free-threaded 3.14 interpreters, while `CPython==3.14.*` continues to match either ABI.
+
 #### Shell
 
 #### Javascript

--- a/src/python/pants/backend/python/util_rules/interpreter_constraints.py
+++ b/src/python/pants/backend/python/util_rules/interpreter_constraints.py
@@ -61,22 +61,71 @@ def interpreter_constraints_contains(
     return InterpreterConstraints(a).contains(InterpreterConstraints(b), interpreter_universe)
 
 
+# Pex admits PEP 508 extra on the interpreter type -- `CPython[free-threaded]` /
+# `CPython[gil]`. A constraint without one matches either ABI.
+FREE_THREADED_ABI = "free-threaded"
+GIL_ABI = "gil"
+_ABI_EXTRAS = frozenset({FREE_THREADED_ABI, GIL_ABI})
+
+
+def _abi_qualifier(requirement: Requirement) -> str | None:
+    if FREE_THREADED_ABI in requirement.extras:
+        return FREE_THREADED_ABI
+    if GIL_ABI in requirement.extras:
+        return GIL_ABI
+    return None
+
+
+def _abi_extra_str(requirement: Requirement) -> str:
+    abi = _abi_qualifier(requirement)
+    return f"[{abi}]" if abi else ""
+
+
+# E.g. `CPython+t==3.14.*`. That form is not valid PEP 508, so we rewrite it to
+# the equivalent PEP 508 extra. Pex accepts both spellings; see
+# https://github.com/pex-tool/pex/pull/3067 and https://github.com/pex-tool/pex/pull/3068.
+_ABI_VALUE_SUFFIX_RE = re.compile(r"^(?P<name>[A-Za-z][A-Za-z0-9._]*)?(?P<abi>[+-]t)(?P<rest>.*)$")
+
+
+def _rewrite_pex_abi_value_form(constraint: str) -> str:
+    match = _ABI_VALUE_SUFFIX_RE.match(constraint)
+    if not match:
+        return constraint
+    abi = FREE_THREADED_ABI if match.group("abi") == "+t" else GIL_ABI
+    return f"{match.group('name') or ''}[{abi}]{match.group('rest')}"
+
+
 @memoized
 def parse_constraint(constraint: str) -> Requirement:
     """Parse an interpreter constraint, e.g., CPython>=2.7,<3.
 
-    We allow shorthand such as `>=3.7`, which gets expanded to `CPython>=3.7`. See Pex's
-    interpreter.py's `parse_requirement()`.
+    We allow shorthand such as `>=3.7`, which gets expanded to `CPython>=3.7`. The free-threaded
+     CPython ABIs may be selected with a PEP 508 extra: `CPython[free-threaded]` /
+    `CPython[gil]`. We also support the pex equivalent `CPython+t` / `CPython-t` abiflag spelling.
     """
+    normalized = _rewrite_pex_abi_value_form(constraint)
     try:
-        parsed_requirement = Requirement(constraint)
+        parsed_requirement = Requirement(normalized)
     except InvalidRequirement as err:
         try:
-            parsed_requirement = Requirement(f"CPython{constraint}")
+            parsed_requirement = Requirement(f"CPython{normalized}")
         except InvalidRequirement:
             raise InvalidRequirement(
                 f"Failed to parse Python interpreter constraint `{constraint}`: {err}"
             )
+
+    unknown_extras = parsed_requirement.extras - _ABI_EXTRAS
+    if unknown_extras:
+        raise InvalidRequirement(
+            f"Failed to parse Python interpreter constraint `{constraint}`: unknown qualifier(s) "
+            f"{sorted(unknown_extras)}. The only supported qualifiers are `[{FREE_THREADED_ABI}]` "
+            f"and `[{GIL_ABI}]`."
+        )
+    if _ABI_EXTRAS <= parsed_requirement.extras:
+        raise InvalidRequirement(
+            f"Failed to parse Python interpreter constraint `{constraint}`: cannot require both "
+            f"`[{FREE_THREADED_ABI}]` and `[{GIL_ABI}]`."
+        )
 
     return parsed_requirement
 
@@ -85,9 +134,18 @@ def parse_constraint(constraint: str) -> Requirement:
 class InterpreterConstraints(FrozenOrderedSet[Requirement], EngineAwareParameter):
     @classmethod
     def for_fixed_python_version(
-        cls, python_version_str: str, interpreter_type: str = "CPython"
+        cls,
+        python_version_str: str,
+        interpreter_type: str = "CPython",
+        *,
+        free_threaded: bool | None = None,
     ) -> InterpreterConstraints:
-        return cls([f"{interpreter_type}=={python_version_str}"])
+        qualifier = ""
+        if free_threaded is True:
+            qualifier = f"[{FREE_THREADED_ABI}]"
+        elif free_threaded is False:
+            qualifier = f"[{GIL_ABI}]"
+        return cls([f"{interpreter_type}{qualifier}=={python_version_str}"])
 
     def __new__(cls, constraints: Iterable[str | Requirement] = ()) -> InterpreterConstraints:
         # #12578 `parse_constraint` will sort the requirement's component constraints into a stable form.
@@ -153,11 +211,19 @@ class InterpreterConstraints(FrozenOrderedSet[Requirement], EngineAwareParameter
             assert len(parsed_requirements) > 0, "At least one `Requirement` must be supplied."
             expected_name = parsed_requirements[0].name
             current_requirement_specifier = parsed_requirements[0].specifier
+            abi = _abi_qualifier(parsed_requirements[0])
             for requirement in parsed_requirements[1:]:
                 if requirement.name != expected_name:
                     return impossible
+                req_abi = _abi_qualifier(requirement)
+                if req_abi is not None:
+                    if abi is not None and abi != req_abi:
+                        # e.g. `CPython[free-threaded]` AND `CPython[gil]`.
+                        return impossible
+                    abi = req_abi
                 current_requirement_specifier &= requirement.specifier
-            return Requirement(f"{expected_name}{current_requirement_specifier}")
+            qualifier = f"[{abi}]" if abi else ""
+            return Requirement(f"{expected_name}{qualifier}{current_requirement_specifier}")
 
         ored_constraints = (
             and_constraints(constraints_product)
@@ -290,7 +356,7 @@ class InterpreterConstraints(FrozenOrderedSet[Requirement], EngineAwareParameter
                 for req in self:
                     if req.specifier.contains(f"{major}.{minor}.{p}"):
                         # We've found the minimum major.minor that is compatible.
-                        req_strs = [f"{req.name}=={major}.{minor}.*"]
+                        req_strs = [f"{req.name}{_abi_extra_str(req)}=={major}.{minor}.*"]
                         # Now find any patches within that major.minor that we must exclude.
                         invalid_patches = sorted(
                             set(range(0, _PATCH_VERSION_UPPER_BOUND + 1))
@@ -421,6 +487,20 @@ class InterpreterConstraints(FrozenOrderedSet[Requirement], EngineAwareParameter
 
         return valid_patches
 
+    def requires_free_threaded_abi(self) -> bool | None:
+        """
+        Returns None if the ABI is unspecified or mixed across the
+        OR'd alternatives.
+        """
+        if not self:
+            return None
+        abis = {_abi_qualifier(req) for req in self}
+        if abis == {FREE_THREADED_ABI}:
+            return True
+        if abis == {GIL_ABI}:
+            return False
+        return None
+
     def contains(self, other: InterpreterConstraints, interpreter_universe: Iterable[str]) -> bool:
         """Returns True if the `InterpreterConstraints` specified in `other` is a subset of these
         `InterpreterConstraints`.
@@ -429,6 +509,10 @@ class InterpreterConstraints(FrozenOrderedSet[Requirement], EngineAwareParameter
         """
         if self == other:
             return True
+        # If we pin a specific ABI, `other` is only contained if it pins the same ABI.
+        self_abi = self.requires_free_threaded_abi()
+        if self_abi is not None and other.requires_free_threaded_abi() != self_abi:
+            return False
         this = self.enumerate_python_versions(interpreter_universe)
         that = other.enumerate_python_versions(interpreter_universe)
         return this.issuperset(that)
@@ -493,7 +577,7 @@ def _major_minor_version_when_single_and_entire(ics: InterpreterConstraints) -> 
 
     req = next(iter(ics))
 
-    just_cpython = req.name == "CPython" and not req.extras and not req.marker
+    just_cpython = req.name == "CPython" and req.extras <= _ABI_EXTRAS and not req.marker
     if not just_cpython:
         raise _NonSimpleMajorMinor()
 

--- a/src/python/pants/backend/python/util_rules/interpreter_constraints.py
+++ b/src/python/pants/backend/python/util_rules/interpreter_constraints.py
@@ -141,10 +141,8 @@ class InterpreterConstraints(FrozenOrderedSet[Requirement], EngineAwareParameter
         free_threaded: bool | None = None,
     ) -> InterpreterConstraints:
         qualifier = ""
-        if free_threaded is True:
-            qualifier = f"[{FREE_THREADED_ABI}]"
-        elif free_threaded is False:
-            qualifier = f"[{GIL_ABI}]"
+        if free_threaded is not None:
+            qualifier = f"[{FREE_THREADED_ABI}]" if free_threaded else f"[{GIL_ABI}]"
         return cls([f"{interpreter_type}{qualifier}=={python_version_str}"])
 
     def __new__(cls, constraints: Iterable[str | Requirement] = ()) -> InterpreterConstraints:

--- a/src/python/pants/backend/python/util_rules/interpreter_constraints_test.py
+++ b/src/python/pants/backend/python/util_rules/interpreter_constraints_test.py
@@ -151,6 +151,21 @@ def test_merge_interpreter_constraints() -> None:
         expected=["PyPy>=43.0,<44.0", "Jython>=1.2,<1.3"],
     )
 
+    # The free-threaded / GIL ABI qualifier is preserved, and an unqualified constraint (which
+    # matches either ABI) narrows to whichever ABI it is ANDed with.
+    assert_merged(
+        inp=[["CPython[free-threaded]==3.14.*"], ["CPython==3.14.*"]],
+        expected=["CPython[free-threaded]==3.14.*"],
+    )
+    assert_merged(
+        inp=[["CPython[gil]>=3.14"], ["CPython==3.14.*"]],
+        expected=["CPython[gil]>=3.14,==3.14.*"],
+    )
+    assert_merged(
+        inp=[["CPython[free-threaded]==3.14.*"], ["CPython[free-threaded]>=3.13"]],
+        expected=["CPython[free-threaded]==3.14.*,>=3.13"],
+    )
+
     # Ensure we error when there is no solution.
     def assert_impossible(constraints, expected_msg):
         with pytest.raises(ValueError) as excinfo:
@@ -163,6 +178,11 @@ def test_merge_interpreter_constraints() -> None:
         )
 
     assert_impossible([["CPython==3.7.*"], ["PyPy==43.0"]], "(CPython==3.7.*) AND (PyPy==43.0)")
+    # The two CPython ABIs are mutually exclusive.
+    assert_impossible(
+        [["CPython[free-threaded]==3.14.*"], ["CPython[gil]==3.14.*"]],
+        "(CPython[free-threaded]==3.14.*) AND (CPython[gil]==3.14.*)",
+    )
     assert_impossible(
         [["CPython==3.7.*", "Jython>=1.2"], ["PyPy==43.0", "Stackless<3.7"]],
         "(CPython==3.7.* OR Jython>=1.2) AND (PyPy==43.0 OR Stackless<3.7)",
@@ -238,6 +258,7 @@ def test_interpreter_constraints_minimum_python_version(
         (["CPython==3.7.*", "PyPy==3.6.*"], "PyPy==3.6.*"),
         (["CPython"], "CPython==2.7.*"),
         (["CPython==3.7.*,<3.6"], None),
+        (["CPython[free-threaded]>=3.9"], "CPython[free-threaded]==3.9.*"),
         ([], None),
     ],
 )
@@ -454,6 +475,12 @@ def test_enumerate_python_versions_invalid_universe(version: str) -> None:
             [">=3.5"],
             True,
         ),  # target matches a weirdly specified non-disjoint IC list
+        # An ABI-agnostic candidate contains an ABI-qualified target...
+        (["==3.9.*"], ["CPython[free-threaded]==3.9.*"], True),
+        # ...but a qualified candidate does not contain an agnostic or opposite-ABI target.
+        (["CPython[free-threaded]==3.9.*"], ["==3.9.*"], False),
+        (["CPython[free-threaded]==3.9.*"], ["CPython[gil]==3.9.*"], False),
+        (["CPython[free-threaded]>=3.9"], ["CPython[free-threaded]==3.9.*"], True),
     ),
 )
 def test_contains(candidate, target, matches) -> None:
@@ -498,6 +525,8 @@ def test_partition_into_major_minor_versions(constraints: list[str], expected: l
         (["CPython==2.7.*"], (2, 7)),
         (["==3.0.*"], (3, 0)),
         (["==3.45.*"], (3, 45)),
+        (["CPython[free-threaded]==3.14.*"], (3, 14)),
+        (["CPython[gil]==3.14.*"], (3, 14)),
         ([">=3.45,<3.46"], (3, 45)),
         (["CPython>=3.45,<3.46"], (3, 45)),
         (["<3.46,>=3.45"], (3, 45)),
@@ -552,6 +581,13 @@ def test_major_minor_version_when_single_and_entire(
         ("CPython==3.9.*", "CPython==3.9.*"),
         ("==3.9.*", "CPython==3.9.*"),
         ("PyPy==3.9.*", "PyPy==3.9.*"),
+        ("CPython[free-threaded]==3.14.*", "CPython[free-threaded]==3.14.*"),
+        ("CPython[gil]==3.14.*", "CPython[gil]==3.14.*"),
+        ("[free-threaded]==3.14.*", "CPython[free-threaded]==3.14.*"),
+        # Pex's `+t` / `-t` value spelling is accepted and normalized to the `[extra]` form.
+        ("CPython+t==3.14.*", "CPython[free-threaded]==3.14.*"),
+        ("CPython-t==3.14.*", "CPython[gil]==3.14.*"),
+        ("+t==3.14.*", "CPython[free-threaded]==3.14.*"),
     ],
 )
 def test_parse_python_interpreter_constraint_when_valid(input_ic: str, expected: str) -> None:
@@ -559,10 +595,50 @@ def test_parse_python_interpreter_constraint_when_valid(input_ic: str, expected:
 
 
 @pytest.mark.parametrize(
+    ("constraints", "expected"),
+    [
+        ([], None),
+        (["CPython==3.14.*"], None),
+        (["CPython[free-threaded]==3.14.*"], True),
+        (["CPython[gil]==3.14.*"], False),
+        (["CPython[free-threaded]==3.14.*", "CPython[free-threaded]==3.15.*"], True),
+        # Mixed ABIs across the OR'd alternatives are not a single requirement.
+        (["CPython[free-threaded]==3.14.*", "CPython[gil]==3.14.*"], None),
+        (["CPython[free-threaded]==3.14.*", "CPython==3.15.*"], None),
+    ],
+)
+def test_requires_free_threaded_abi(constraints: list[str], expected: bool | None) -> None:
+    assert InterpreterConstraints(constraints).requires_free_threaded_abi() is expected
+
+
+def test_for_fixed_python_version_free_threaded() -> None:
+    assert InterpreterConstraints.for_fixed_python_version("3.14.1") == InterpreterConstraints(
+        ["CPython==3.14.1"]
+    )
+    assert InterpreterConstraints.for_fixed_python_version(
+        "3.14.1", free_threaded=True
+    ) == InterpreterConstraints(["CPython[free-threaded]==3.14.1"])
+    assert InterpreterConstraints.for_fixed_python_version(
+        "3.14.1", free_threaded=False
+    ) == InterpreterConstraints(["CPython[gil]==3.14.1"])
+
+
+def test_free_threaded_qualifier_reaches_pex_arg_list() -> None:
+    # Pex selects the ABI from this qualifier; it must survive to the CLI verbatim.
+    ics = InterpreterConstraints(["CPython[free-threaded]==3.14.*"])
+    assert ics.generate_pex_arg_list() == [
+        "--interpreter-constraint",
+        "CPython[free-threaded]==3.14.*",
+    ]
+
+
+@pytest.mark.parametrize(
     ("input_ic", "expected_error"),
     [
         ("some-invalid-constraint-3.9.*", "Failed to parse Python interpreter constraint"),
         ("3.9.*", "Failed to parse Python interpreter constraint"),
+        ("CPython[nogil]==3.14.*", "unknown qualifier"),
+        ("CPython[free-threaded,gil]==3.14.*", "cannot require both"),
     ],
 )
 def test_parse_python_interpreter_constraint_when_invalid(


### PR DESCRIPTION
https://github.com/pex-tool/pex/pull/3067 gave us the tools for explicit interpreter selection via constraints, lets use them.