### PR TITLE
perf(golang): materialize package subset for third party compile

### DIFF
--- a/docs/notes/2.34.x.md
+++ b/docs/notes/2.34.x.md
@@ -40,6 +40,8 @@ Options that are set in the docker image target such as `pull` or `build_no_cach
 
 #### Go
 
+Optimized third-party Go package compilation by materializing only the package's own sources into the compile sandbox instead of the whole module, reducing materialization overhead in cold builds.
+
 ### Plugin API changes
 
 ## Full Changelog

--- a/src/python/pants/backend/go/util_rules/build_pkg_target.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target.py
@@ -59,7 +59,7 @@ from pants.backend.go.util_rules.stdlib_archives import (
 from pants.backend.go.util_rules.third_party_pkg import (
     ThirdPartyPkgAnalysisRequest,
     extract_package_info,
-    third_party_pkg_sources_digest,
+    resolve_third_party_pkg_sources_digest,
 )
 from pants.build_graph.address import Address
 from pants.engine.engine_aware import EngineAwareParameter
@@ -484,7 +484,7 @@ async def setup_build_go_package_target_request(
         imports = set(_third_party_pkg_info.imports)
         dir_path = _third_party_pkg_info.dir_path
         pkg_name = _third_party_pkg_info.name
-        digest = await third_party_pkg_sources_digest(_third_party_pkg_info)
+        digest = await resolve_third_party_pkg_sources_digest(_third_party_pkg_info)
         minimum_go_version = _third_party_pkg_info.minimum_go_version
         go_file_names = _third_party_pkg_info.go_files
         s_files = _third_party_pkg_info.s_files

--- a/src/python/pants/backend/go/util_rules/build_pkg_target.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target.py
@@ -59,6 +59,7 @@ from pants.backend.go.util_rules.stdlib_archives import (
 from pants.backend.go.util_rules.third_party_pkg import (
     ThirdPartyPkgAnalysisRequest,
     extract_package_info,
+    third_party_pkg_sources_digest,
 )
 from pants.build_graph.address import Address
 from pants.engine.engine_aware import EngineAwareParameter
@@ -483,7 +484,7 @@ async def setup_build_go_package_target_request(
         imports = set(_third_party_pkg_info.imports)
         dir_path = _third_party_pkg_info.dir_path
         pkg_name = _third_party_pkg_info.name
-        digest = _third_party_pkg_info.digest
+        digest = await third_party_pkg_sources_digest(_third_party_pkg_info)
         minimum_go_version = _third_party_pkg_info.minimum_go_version
         go_file_names = _third_party_pkg_info.go_files
         s_files = _third_party_pkg_info.s_files

--- a/src/python/pants/backend/go/util_rules/build_pkg_target_test.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target_test.py
@@ -17,6 +17,7 @@ from pants.backend.go.dependency_inference import (
     GoModuleImportPathsMappingsHook,
 )
 from pants.backend.go.target_types import GoModTarget, GoOwningGoModAddressField, GoPackageTarget
+from pants.backend.go.testutil import gen_module_gomodproxy
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -362,6 +363,94 @@ def test_build_third_party_pkg_target(rule_runner: RuleRunner) -> None:
         ],
         expected_transitive_dependency_import_paths=[],
     )
+
+
+def test_third_party_pkg_digest_is_sliced_to_package_sources(rule_runner: RuleRunner) -> None:
+    import_path = "pantsbuild.org/go-slice-for-test"
+    version = "v0.0.1"
+    files = gen_module_gomodproxy(
+        version,
+        import_path,
+        (
+            ("pure/pure.go", "package pure\n\nfunc Two() int { return 2 }\n"),
+            # Glob metacharacters in file names must not affect the slicing globs.
+            ("pure/helpers[gen].go", "package pure\n"),
+            ("other/other.go", "package other\n"),
+            (
+                "embedder/embedder.go",
+                dedent(
+                    """\
+                    package embedder
+
+                    import _ "embed"
+
+                    //go:embed data/msg.txt
+                    var Msg string
+                    """
+                ),
+            ),
+            ("embedder/data/msg.txt", "hello\n"),
+            ("native/native.go", "package native\n\nfunc Two() int { return 2 }\n"),
+            ("native/native.h", "#define TWO 2\n"),
+        ),
+    )
+    files.update(
+        {
+            "BUILD": "go_mod(name='mod')",
+            "go.mod": dedent(
+                f"""\
+                module example.com/slicetest
+                go 1.17
+
+                require {import_path} {version}
+                """
+            ),
+        }
+    )
+    rule_runner.write_files(files)
+    rule_runner.set_options(
+        [
+            f"--golang-subprocess-env-vars=GOPROXY=file://{rule_runner.build_root}/go-mod-proxy",
+            "--golang-subprocess-env-vars=GOSUMDB=off",
+        ],
+        env_inherit={"PATH"},
+    )
+
+    prefix = f"gopath/pkg/mod/{import_path}@{version}"
+
+    def get_build_request(pkg_import_path: str) -> BuildGoPackageRequest:
+        return rule_runner.request(
+            BuildGoPackageRequest,
+            [
+                BuildGoPackageTargetRequest(
+                    Address("", target_name="mod", generated_name=pkg_import_path),
+                    build_opts=GoBuildOptions(),
+                )
+            ],
+        )
+
+    def digest_files(request: BuildGoPackageRequest) -> set[str]:
+        return set(rule_runner.request(Snapshot, [request.digest]).files)
+
+    pure_request = get_build_request(f"{import_path}/pure")
+    assert digest_files(pure_request) == {
+        f"{prefix}/pure/pure.go",
+        f"{prefix}/pure/helpers[gen].go",
+    }
+
+    embedder_request = get_build_request(f"{import_path}/embedder")
+    assert digest_files(embedder_request) == {
+        f"{prefix}/embedder/embedder.go",
+        f"{prefix}/embedder/data/msg.txt",
+    }
+
+    # Native-code packages keep the whole module.
+    native_files = digest_files(get_build_request(f"{import_path}/native"))
+    assert f"{prefix}/other/other.go" in native_files
+
+    # The sliced packages still compile.
+    assert_built(rule_runner, pure_request, expected_import_paths=[f"{import_path}/pure"])
+    assert_built(rule_runner, embedder_request, expected_import_paths=[f"{import_path}/embedder"])
 
 
 def test_build_target_with_dependencies(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/backend/go/util_rules/third_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/third_party_pkg.py
@@ -95,24 +95,28 @@ class ThirdPartyPkgAnalysis:
 
     error: GoThirdPartyPkgError | None = None
 
+    @property
+    def contains_native_sources(self) -> bool:
+        return bool(
+            self.cgo_files
+            or self.c_files
+            or self.cxx_files
+            or self.m_files
+            or self.f_files
+            or self.s_files
+            or self.h_files
+            or self.syso_files
+        )
 
-async def third_party_pkg_sources_digest(pkg_info: ThirdPartyPkgAnalysis) -> Digest:
+
+async def resolve_third_party_pkg_sources_digest(pkg_info: ThirdPartyPkgAnalysis) -> Digest:
     """Slice the whole-module analysis digest down to the files this package's compilation
     consumes.
 
     Native-code packages keep the whole module: their include closure is not knowable from
     `go list` metadata.
     """
-    if (
-        pkg_info.cgo_files
-        or pkg_info.c_files
-        or pkg_info.cxx_files
-        or pkg_info.m_files
-        or pkg_info.f_files
-        or pkg_info.s_files
-        or pkg_info.h_files
-        or pkg_info.syso_files
-    ):
+    if pkg_info.contains_native_sources:
         return pkg_info.digest
 
     glob = f"{pkg_info.dir_path}/**" if pkg_info.embed_config else f"{pkg_info.dir_path}/*"

--- a/src/python/pants/backend/go/util_rules/third_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/third_party_pkg.py
@@ -34,6 +34,7 @@ from pants.engine.fs import (
 )
 from pants.engine.intrinsics import (
     create_digest,
+    digest_subset_to_digest,
     digest_to_snapshot,
     execute_process,
     get_digest_contents,
@@ -93,6 +94,29 @@ class ThirdPartyPkgAnalysis:
     xtest_embed_config: EmbedConfig | None = None
 
     error: GoThirdPartyPkgError | None = None
+
+
+async def third_party_pkg_sources_digest(pkg_info: ThirdPartyPkgAnalysis) -> Digest:
+    """Slice the whole-module analysis digest down to the files this package's compilation
+    consumes.
+
+    Native-code packages keep the whole module: their include closure is not knowable from
+    `go list` metadata.
+    """
+    if (
+        pkg_info.cgo_files
+        or pkg_info.c_files
+        or pkg_info.cxx_files
+        or pkg_info.m_files
+        or pkg_info.f_files
+        or pkg_info.s_files
+        or pkg_info.h_files
+        or pkg_info.syso_files
+    ):
+        return pkg_info.digest
+
+    glob = f"{pkg_info.dir_path}/**" if pkg_info.embed_config else f"{pkg_info.dir_path}/*"
+    return await digest_subset_to_digest(DigestSubset(pkg_info.digest, PathGlobs([glob])))
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
When compiling third party Go packages, Pants materializes the entire module digest into the sandbox. This can be expensive, especially for large modules. And it quickly gets more expensive as you compile multiple packages from that large module.

This change reduces that overhead significantly by slicing the digests down to the package that is being compiled. There's 3 tiers to ensure unaffected builds:
- When there's native code, we must keep the entire module since its include closure can reference files not reported by the analysis.
- When it includes `//go:embed`, they can escape downwards in the subtree, but not to the parent, so we must slice the dir recursively.
- In all other cases we can take a shallow slice of the package.

### Verification

Packaged 13 first party binaries with a mix of third party dependencies including native libraries, with byte identical output.

### Benchmark

Measured with a cold `pants check` on ~160 first party packages importing from a mix of ~650 third party modules, across ~3300 process executions.

| metric | before | after | change
| :-- | --: | --: | --: |
| wall time | 465.8s | 242.9s | 1.92x faster |
| CPU sys | 3498.8s | 1491.1s | 2.35x less |
| CPU user | 461.5s | 407.3s | -12% |
| RSS max | 2.73 GB | 2.76 GB | ~flat |

The same check measured with a cache pre-seeded with module download and analysis, covering only the compile phase.

| metric | before | after | change
| :-- | --: | --: | --: |
| wall time | 300.3s | 75.1s | 4.00x faster |
| CPU sys | 2232.7s | 241.2s | 9.26x less |
| CPU user | 385.1s | 333.9s | -13% |
| RSS max | 2.23 GB | 1.73 GB | -22% |

Sandbox materialization (system CPU) is the main driver for wall time improvement.

Warm and cached runs measured unaffected.

Notice: Claude Code assisted with generating tests and verification/benchmark tooling