### PR TITLE
fix(rust): add fallback to Podman sockets for docker_environments

### DIFF
--- a/docs/notes/2.34.x.md
+++ b/docs/notes/2.34.x.md
@@ -18,6 +18,8 @@ Thank you to [Klaviyo](https://www.klaviyo.com/) for their Platinum tier support
 
 Fixed a bug where `SingleSourceField` could not be hydrated for generated targets because files were validated before code generation ran.
 
+The Rust engine now automatically falls back to common Podman socket paths (rootless and rootful) for `docker_environments` if the default Docker socket is unavailable.
+
 ### Goals
 
 ### Backends

--- a/src/rust/process_execution/docker/src/docker.rs
+++ b/src/rust/process_execution/docker/src/docker.rs
@@ -95,8 +95,29 @@ impl DockerOnceCell {
         self
       .cell
       .get_or_try_init(async move {
-        let docker = Docker::connect_with_local_defaults()
-          .map_err(|err| format!("Failed to connect to local Docker: {err}"))?;
+        let docker = Docker::connect_with_local_defaults().or_else(|original_err| {
+            if let Ok(xdg) = std::env::var("XDG_RUNTIME_DIR") {
+                let podman_sock = format!("{}/podman/podman.sock", xdg);
+                if std::path::Path::new(&podman_sock).exists() {
+                    let podman_uri = format!("unix://{}", podman_sock);
+                    return Docker::connect_with_socket(
+                        &podman_uri,
+                        120,
+                        bollard::API_DEFAULT_VERSION
+                    );
+                }
+            }
+
+            if std::path::Path::new("/run/podman/podman.sock").exists() {
+                return Docker::connect_with_socket(
+                    "unix:///run/podman/podman.sock",
+                    120,
+                    bollard::API_DEFAULT_VERSION
+                );
+            }
+
+            Err(original_err)
+        }).map_err(|err| format!("Failed to connect to local Docker/Podman: {err}"))?;
 
         let version = docker.version().await
           .map_err(|err| format!("Failed to obtain version from local Docker: {err}"))?;


### PR DESCRIPTION
Fixes #22936.

## Problem
Currently, users utilizing Podman for `docker_environments` face connection errors because the Rust engine (using the Bollard client) strictly defaults to the standard Docker socket (`/var/run/docker.sock`). When this socket is not found, the execution fails, forcing users to manually set the `DOCKER_HOST` environment variable to point to their Podman socket.

## Solution
This PR introduces a fallback mechanism when initializing the Docker client in `docker.rs`:
- It first attempts to connect using standard local defaults.
- If that fails, it proactively checks for the existence of common Podman socket paths:
  Rootless Podman: `$XDG_RUNTIME_DIR/podman/podman.sock`
  Rootful Podman: `/run/podman/podman.sock`
- If either socket exists, it establishes the connection using `Docker::connect_with_socket`.
- If all attempts fail, it correctly bubbles up the original Docker connection error.

This eliminates the need for manual workarounds and provides out-of-the-box support for Podman users.