### PR TITLE
upgrade indicatif from 0.18.4 to 0.18.6

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -757,9 +757,9 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -1895,7 +1895,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.9",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -2126,9 +2126,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.18.4"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
 dependencies = [
  "console",
  "portable-atomic",

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -160,7 +160,7 @@ hyper-rustls = "0.27"
 hyper-util = "0.1"
 ignore = "0.4.25"
 indexmap = { version = "2.13.0", features = ["std", "serde"] }
-indicatif = "0.18.4"
+indicatif = "0.18.6"
 indoc = "2.0.7"
 internment = "0.6"
 itertools = "0.14"


### PR DESCRIPTION
Changelogs:
 * https://github.com/console-rs/indicatif/releases/tag/0.18.5
 * https://github.com/console-rs/indicatif/releases/tag/0.18.6

I'm most interested in the 0.18.5 fixes in my quest against flicker.