### PR TITLE
Correctly rename uv existing lockfiles for use with --sync

### DIFF
--- a/docs/notes/2.34.x.md
+++ b/docs/notes/2.34.x.md
@@ -25,14 +25,16 @@ Fixed a bug where `SingleSourceField` could not be hydrated for generated target
 #### Docker
 
 The option `[docker].build_extra_options` or/and the `build_extra_options` field of `docker_image` targets can now be used to pass extra options to docker build or podman build. Make sure that the options are understood by the tool.
-The build_extra_options field allows you to pass any valid build flags directly to docker or podman. 
-Options that are set in the docker image target such as `pull` or `build_no_cache` in pants.toml are surpressed by the extra options when they conflict. 
+The build_extra_options field allows you to pass any valid build flags directly to docker or podman.
+Options that are set in the docker image target such as `pull` or `build_no_cache` in pants.toml are surpressed by the extra options when they conflict.
 
 #### Helm
 
 #### JVM
 
 #### Python
+
+Fixed a bug that caused `generate-lockfiles --sync` not to have its intended effect when using `uv` lockfiles.
 
 #### Shell
 

--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -8,6 +8,7 @@ import os.path
 from collections import defaultdict
 from dataclasses import dataclass
 from operator import itemgetter
+from typing import cast
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.subsystems.setup import PythonSetup, Resolver
@@ -19,7 +20,11 @@ from pants.backend.python.target_types import (
 )
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.lockfile_diff import _generate_lockfile_diff
-from pants.backend.python.util_rules.lockfile_metadata import LockfileFormat, PythonLockfileMetadata
+from pants.backend.python.util_rules.lockfile_metadata import (
+    LockfileFormat,
+    PythonLockfileMetadata,
+    PythonLockfileMetadataV8,
+)
 from pants.backend.python.util_rules.pex import (
     CompletePlatforms,
     digest_complete_platform_addresses,
@@ -28,10 +33,14 @@ from pants.backend.python.util_rules.pex import (
 from pants.backend.python.util_rules.pex_cli import PexCliProcess, maybe_log_pex_stderr
 from pants.backend.python.util_rules.pex_environment import PexSubsystem
 from pants.backend.python.util_rules.pex_requirements import (
+    LoadedLockfileRequest,
     PexRequirements,
+    Resolve,
     ResolveConfig,
     ResolveConfigRequest,
     determine_resolve_config,
+    get_lockfile_for_resolve,
+    load_lockfile,
     strip_comments_from_pex_json_lockfile,
 )
 from pants.backend.python.util_rules.uv import UvEnvironment, generate_pyproject_toml
@@ -53,6 +62,7 @@ from pants.engine.fs import (
     CreateDigest,
     Digest,
     FileContent,
+    FileEntry,
     GlobExpansionConjunction,
     MergeDigests,
     PathGlobs,
@@ -63,6 +73,7 @@ from pants.engine.internals.target_adaptor import TargetAdaptor
 from pants.engine.intrinsics import (
     create_digest,
     get_digest_contents,
+    get_digest_entries,
     merge_digests,
     path_globs_to_digest,
 )
@@ -360,23 +371,26 @@ async def generate_uv_lockfile(
         sources=resolve_config.sources,
     )
 
+    # uv always writes the lockfile to `uv.lock` in the project directory. We capture that
+    # and rename it to req.lockfile_dest in the final digest.
+    uv_lock = "uv.lock"
+
+    existing_uv_lock_digest = EMPTY_DIGEST
     if generate_lockfiles_subsystem.sync:
         # `uv lock` does a minimal update by default if an existing lockfile is present.
         # So we just need to make sure it is. There are no special flags to specify.
-        existing_lockfile_digest = await path_globs_to_digest(
-            PathGlobs(
-                globs=(req.lockfile_dest,),
-                # We ignore errors, since the lockfile may not exist.
-                glob_match_error_behavior=GlobMatchErrorBehavior.ignore,
-                conjunction=GlobExpansionConjunction.any_match,
-            )
-        )
-    else:
-        existing_lockfile_digest = EMPTY_DIGEST
+        lockfile = await get_lockfile_for_resolve(Resolve(req.resolve_name, False), **implicitly())
+        loaded_lockfile = await load_lockfile(LoadedLockfileRequest(lockfile), **implicitly())
+        if isinstance(loaded_lockfile.metadata, PythonLockfileMetadataV8):
+            if cast(PythonLockfileMetadataV8, loaded_lockfile).lockfile_format == LockfileFormat.UV:
+                # Rename the configured lockfile destination to uv.lock.
+                repo_lock_entry = cast(
+                    FileEntry, next(iter(await get_digest_entries(loaded_lockfile.lockfile_digest)))
+                )
+                existing_uv_lock_digest = await create_digest(
+                    CreateDigest([FileEntry(uv_lock, repo_lock_entry.file_digest)])
+                )
 
-    # uv always writes the lockfile to `uv.lock` in the project directory. We capture that
-    # and rename it to req.lockfile_dest in the final digest.
-    uv_lock_output = "uv.lock"
     uv_config = resolve_config.uv_config(extra_find_links=req.find_links)
 
     uv_config_digest = await create_digest(
@@ -389,7 +403,7 @@ async def generate_uv_lockfile(
     )
 
     input_digest = await merge_digests(
-        MergeDigests([downloaded_uv.digest, uv_config_digest, existing_lockfile_digest])
+        MergeDigests([downloaded_uv.digest, uv_config_digest, existing_uv_lock_digest])
     )
 
     result = await execute_process_or_raise(
@@ -401,7 +415,7 @@ async def generate_uv_lockfile(
                 ),
                 env=uv_env.env,
                 input_digest=input_digest,
-                output_files=(uv_lock_output,),
+                output_files=(uv_lock,),
                 append_only_caches=downloaded_uv.append_only_caches(),
                 description=f"Generate uv lockfile for {req.resolve_name}",
                 # We disable persistent caching so that when you generate a lockfile, you always
@@ -412,9 +426,9 @@ async def generate_uv_lockfile(
     )
 
     # Rename uv.lock to the configured lockfile destination.
-    uv_lock_contents = await get_digest_contents(result.output_digest)
-    uv_lock_digest = await create_digest(
-        CreateDigest([FileContent(req.lockfile_dest, next(iter(uv_lock_contents)).content)])
+    uv_lock_entry = cast(FileEntry, next(iter(await get_digest_entries(result.output_digest))))
+    repo_lock_digest = await create_digest(
+        CreateDigest([FileEntry(req.lockfile_dest, uv_lock_entry.file_digest)])
     )
 
     regenerate_command = (
@@ -454,7 +468,7 @@ async def generate_uv_lockfile(
             ]
         )
     )
-    final_lockfile_digest = await merge_digests(MergeDigests([metadata_digest, uv_lock_digest]))
+    final_lockfile_digest = await merge_digests(MergeDigests([metadata_digest, repo_lock_digest]))
 
     if req.diff:
         diff = await _generate_lockfile_diff(

--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -382,14 +382,24 @@ async def generate_uv_lockfile(
         # So we just need to make sure it is. There are no special flags to specify.
         lockfile = await get_lockfile_for_resolve(Resolve(req.resolve_name, False), **implicitly())
         loaded_lockfile = await load_lockfile(LoadedLockfileRequest(lockfile), **implicitly())
-        if isinstance(loaded_lockfile.metadata, PythonLockfileMetadataV8):
-            if cast(PythonLockfileMetadataV8, loaded_lockfile).lockfile_format == LockfileFormat.UV:
-                # Rename the configured lockfile destination to uv.lock.
-                repo_lock_entry = cast(
-                    FileEntry, next(iter(await get_digest_entries(loaded_lockfile.lockfile_digest)))
-                )
+        if (
+            isinstance(metadata_v8 := loaded_lockfile.metadata, PythonLockfileMetadataV8)
+            and metadata_v8.lockfile_format == LockfileFormat.UV
+        ):
+            # Rename the configured lockfile destination to uv.lock.
+            if isinstance(
+                repo_lock_entry := next(
+                    iter(await get_digest_entries(loaded_lockfile.lockfile_digest))
+                ),
+                FileEntry,
+            ):
                 existing_uv_lock_digest = await create_digest(
                     CreateDigest([FileEntry(uv_lock, repo_lock_entry.file_digest)])
+                )
+            else:
+                # Should never happen, assuming the lockfile is a regular file.
+                raise ValueError(
+                    f"Expected lockfile entry to be a FileEntry but was a {type(repo_lock_entry)}"
                 )
 
     uv_config = resolve_config.uv_config(extra_find_links=req.find_links)

--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -67,7 +67,7 @@ from pants.engine.fs import (
     MergeDigests,
     PathGlobs,
 )
-from pants.engine.internals.native_engine import EMPTY_DIGEST
+from pants.engine.internals.native_engine import EMPTY_DIGEST, EngineError
 from pants.engine.internals.synthetic_targets import SyntheticAddressMaps, SyntheticTargetsRequest
 from pants.engine.internals.target_adaptor import TargetAdaptor
 from pants.engine.intrinsics import (
@@ -381,26 +381,31 @@ async def generate_uv_lockfile(
         # `uv lock` does a minimal update by default if an existing lockfile is present.
         # So we just need to make sure it is. There are no special flags to specify.
         lockfile = await get_lockfile_for_resolve(Resolve(req.resolve_name, False), **implicitly())
-        loaded_lockfile = await load_lockfile(LoadedLockfileRequest(lockfile), **implicitly())
-        if (
-            isinstance(metadata_v8 := loaded_lockfile.metadata, PythonLockfileMetadataV8)
-            and metadata_v8.lockfile_format == LockfileFormat.UV
-        ):
-            # Rename the configured lockfile destination to uv.lock.
-            if isinstance(
-                repo_lock_entry := next(
-                    iter(await get_digest_entries(loaded_lockfile.lockfile_digest))
-                ),
-                FileEntry,
+        try:
+            loaded_lockfile = await load_lockfile(LoadedLockfileRequest(lockfile), **implicitly())
+            if (
+                isinstance(metadata_v8 := loaded_lockfile.metadata, PythonLockfileMetadataV8)
+                and metadata_v8.lockfile_format == LockfileFormat.UV
             ):
-                existing_uv_lock_digest = await create_digest(
-                    CreateDigest([FileEntry(uv_lock, repo_lock_entry.file_digest)])
-                )
-            else:
-                # Should never happen, assuming the lockfile is a regular file.
-                raise ValueError(
-                    f"Expected lockfile entry to be a FileEntry but was a {type(repo_lock_entry)}"
-                )
+                # Rename the configured lockfile destination to uv.lock.
+                if isinstance(
+                    repo_lock_entry := next(
+                        iter(await get_digest_entries(loaded_lockfile.lockfile_digest))
+                    ),
+                    FileEntry,
+                ):
+                    existing_uv_lock_digest = await create_digest(
+                        CreateDigest([FileEntry(uv_lock, repo_lock_entry.file_digest)])
+                    )
+                else:
+                    # Should never happen, assuming the lockfile is a regular file.
+                    raise ValueError(
+                        f"Expected lockfile entry to be a FileEntry but was a {type(repo_lock_entry)}"
+                    )
+        except EngineError:
+            # May fail if the file doesn't exist, which is expected the first time a new lockfile
+            # is generated.
+            pass
 
     uv_config = resolve_config.uv_config(extra_find_links=req.find_links)
 

--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -220,6 +220,7 @@ async def generate_pex_lockfile(
             PexCliProcess(
                 subcommand=("lock", "sync" if generate_lockfiles_subsystem.sync else "create"),
                 extra_args=(
+                    "-v",
                     f"{output_flag}={req.lockfile_dest}",
                     f"--style={req.lock_style}",
                     "--pip-version",
@@ -259,7 +260,7 @@ async def generate_pex_lockfile(
                 ),
                 output_files=(req.lockfile_dest,),
                 description=f"Generate pex lockfile for {req.resolve_name}",
-                # Instead of caching lockfile generation with LMDB, we instead use the invalidation
+                # Instead of caching lockfile generation with LMDB, we use the invalidation
                 # scheme from `lockfile_metadata.py` to check for stale/invalid lockfiles. This is
                 # necessary so that our invalidation is resilient to deleting LMDB or running on a
                 # new machine.

--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -67,7 +67,7 @@ from pants.engine.fs import (
     MergeDigests,
     PathGlobs,
 )
-from pants.engine.internals.native_engine import EMPTY_DIGEST, EngineError
+from pants.engine.internals.native_engine import EMPTY_DIGEST, IntrinsicError
 from pants.engine.internals.synthetic_targets import SyntheticAddressMaps, SyntheticTargetsRequest
 from pants.engine.internals.target_adaptor import TargetAdaptor
 from pants.engine.intrinsics import (
@@ -220,7 +220,6 @@ async def generate_pex_lockfile(
             PexCliProcess(
                 subcommand=("lock", "sync" if generate_lockfiles_subsystem.sync else "create"),
                 extra_args=(
-                    "-v",
                     f"{output_flag}={req.lockfile_dest}",
                     f"--style={req.lock_style}",
                     "--pip-version",
@@ -402,7 +401,7 @@ async def generate_uv_lockfile(
                     raise ValueError(
                         f"Expected lockfile entry to be a FileEntry but was a {type(repo_lock_entry)}"
                     )
-        except EngineError:
+        except IntrinsicError:
             # May fail if the file doesn't exist, which is expected the first time a new lockfile
             # is generated.
             pass

--- a/src/python/pants/backend/python/goals/lockfile_test.py
+++ b/src/python/pants/backend/python/goals/lockfile_test.py
@@ -766,3 +766,75 @@ def test_uv_lockfile_generation_with_sources(rule_runner: PythonRuleRunner) -> N
     packages = {pkg["name"]: pkg for pkg in lock_data.get("package", []) if "version" in pkg}
     assert "ansicolors" in packages
     assert packages["ansicolors"]["version"] == "1.1.8"
+
+
+def test_uv_lockfile_sync(rule_runner: PythonRuleRunner) -> None:
+    """`generate-lockfiles --sync` must rename the existing uv lockfile to `uv.lock` so that uv
+    performs a minimal update against it, rather than a full regeneration.
+
+    Regression test for https://github.com/pantsbuild/pants/pull/23514.
+    """
+    requirements = FrozenOrderedSet(["ansicolors==1.1.8"])
+    interpreter_constraints = InterpreterConstraints(["CPython==3.14"])
+
+    def generate() -> DigestContents:
+        result = rule_runner.request(
+            GenerateLockfileResult,
+            [
+                GenerateUvLockfile(
+                    requirements=requirements,
+                    find_links=FrozenOrderedSet([]),
+                    interpreter_constraints=interpreter_constraints,
+                    resolve_name="test",
+                    lockfile_dest="test.lock",
+                    diff=False,
+                )
+            ],
+        )
+        return rule_runner.request(DigestContents, [result.digest])
+
+    # First, generate the lockfile from scratch and materialize it (plus its sidecar metadata)
+    # into the build root so that `--sync` has an existing lockfile to pick up.
+    rule_runner.set_options(
+        ["--python-resolves={'test': 'test.lock'}"],
+        env_inherit=PYTHON_BOOTSTRAP_ENV,
+    )
+    initial_result = rule_runner.request(
+        GenerateLockfileResult,
+        [
+            GenerateUvLockfile(
+                requirements=requirements,
+                find_links=FrozenOrderedSet([]),
+                interpreter_constraints=interpreter_constraints,
+                resolve_name="test",
+                lockfile_dest="test.lock",
+                diff=False,
+            )
+        ],
+    )
+    rule_runner.write_digest(initial_result.digest)
+
+    # Now re-generate with `--sync`. This exercises the code path that reads the existing
+    # `test.lock`, confirms it is a uv-format lockfile, and renames it to `uv.lock` for uv to
+    # perform a minimal update against.
+    rule_runner.set_options(
+        [
+            "--python-resolves={'test': 'test.lock'}",
+            "--generate-lockfiles-sync",
+        ],
+        env_inherit=PYTHON_BOOTSTRAP_ENV,
+    )
+    sync_digest_contents = generate()
+
+    by_path = {fc.path: fc for fc in sync_digest_contents}
+    assert "test.lock" in by_path
+    assert "test.lock.metadata" in by_path
+
+    lock_data = tomllib.loads(by_path["test.lock"].content.decode())
+    packages = {pkg["name"]: pkg for pkg in lock_data.get("package", []) if "version" in pkg}
+    assert "ansicolors" in packages
+    assert packages["ansicolors"]["version"] == "1.1.8"
+
+    metadata = json.loads(by_path["test.lock.metadata"].content.decode())
+    assert metadata["lockfile_format"] == LockfileFormat.UV
+    assert metadata["generated_with_requirements"] == ["ansicolors==1.1.8"]

--- a/src/python/pants/backend/python/goals/lockfile_test.py
+++ b/src/python/pants/backend/python/goals/lockfile_test.py
@@ -24,6 +24,7 @@ from pants.backend.python.util_rules.interpreter_constraints import InterpreterC
 from pants.backend.python.util_rules.lockfile_metadata import LockfileFormat
 from pants.core.goals.generate_lockfiles import GenerateLockfileResult, UserGenerateLockfiles
 from pants.engine.fs import DigestContents
+from pants.engine.internals.native_engine import Digest
 from pants.engine.internals.scheduler import ExecutionError
 from pants.testutil.python_rule_runner import PythonRuleRunner
 from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule
@@ -768,73 +769,133 @@ def test_uv_lockfile_generation_with_sources(rule_runner: PythonRuleRunner) -> N
     assert packages["ansicolors"]["version"] == "1.1.8"
 
 
-def test_uv_lockfile_sync(rule_runner: PythonRuleRunner) -> None:
-    """`generate-lockfiles --sync` must rename the existing uv lockfile to `uv.lock` so that uv
-    performs a minimal update against it, rather than a full regeneration.
+def test_pex_lockfile_sync(rule_runner: PythonRuleRunner) -> None:
+    # Pex's "sync" semantics are slightly different from uv's. Pex will update packages whose
+    # requirement strings have changed. So to test the pex case we constrain the initial `cowsay`
+    # version to 6.0 via a constraints file.
+    orig_requirements = FrozenOrderedSet(["ansicolors==1.1.7", "cowsay>=6.0,<=6.1"])
+    updated_requirements = FrozenOrderedSet(["ansicolors==1.1.8", "cowsay>=6.0,<=6.1"])
 
-    Regression test for https://github.com/pantsbuild/pants/pull/23514.
-    """
-    requirements = FrozenOrderedSet(["ansicolors==1.1.8"])
-    interpreter_constraints = InterpreterConstraints(["CPython==3.14"])
+    def generate(reqs: FrozenOrderedSet[str], sync: bool, with_constraints: bool = False) -> Digest:
+        # Generates a lockfile and returns its output digest.
+        sync_opt = "--generate-lockfiles-sync" if sync else "--no-generate-lockfiles-sync"
+        args = [
+            "--python-resolves={'test': 'test.lock'}",
+            "--python-separate-lockfile-metadata-file",
+            sync_opt,
+        ]
+        if with_constraints:
+            args.append("--python-resolves-to-constraints-file={'test': 'constraints.txt'}")
+        rule_runner.write_files({"constraints.txt": "cowsay==6.0"})
+        rule_runner.set_options(args, env_inherit=PYTHON_BOOTSTRAP_ENV)
+        req = GeneratePexLockfile(
+            requirements=reqs,
+            find_links=FrozenOrderedSet([]),
+            interpreter_constraints=InterpreterConstraints(["CPython==3.14.*"]),
+            lock_style="universal",
+            complete_platforms=tuple(),
+            resolve_name="test",
+            lockfile_dest="test.lock",
+            diff=False,
+        )
 
-    def generate() -> DigestContents:
         result = rule_runner.request(
             GenerateLockfileResult,
-            [
-                GenerateUvLockfile(
-                    requirements=requirements,
-                    find_links=FrozenOrderedSet([]),
-                    interpreter_constraints=interpreter_constraints,
-                    resolve_name="test",
-                    lockfile_dest="test.lock",
-                    diff=False,
-                )
-            ],
+            [req],
         )
-        return rule_runner.request(DigestContents, [result.digest])
+        return result.digest
 
-    # First, generate the lockfile from scratch and materialize it (plus its sidecar metadata)
-    # into the build root so that `--sync` has an existing lockfile to pick up.
-    rule_runner.set_options(
-        ["--python-resolves={'test': 'test.lock'}"],
-        env_inherit=PYTHON_BOOTSTRAP_ENV,
-    )
-    initial_result = rule_runner.request(
-        GenerateLockfileResult,
-        [
-            GenerateUvLockfile(
-                requirements=requirements,
-                find_links=FrozenOrderedSet([]),
-                interpreter_constraints=interpreter_constraints,
-                resolve_name="test",
-                lockfile_dest="test.lock",
-                diff=False,
-            )
-        ],
-    )
-    rule_runner.write_digest(initial_result.digest)
+    def get_versions(digest: Digest) -> dict[str, str]:
+        # Returns a map of package names to versions from a lockfile in a digest.
+        digest_contents = rule_runner.request(DigestContents, [digest])
+        path_to_file_content = {fc.path: fc for fc in digest_contents}
+        assert "test.lock" in path_to_file_content
+        assert "test.lock.metadata" in path_to_file_content
+        lock_data = json.loads(path_to_file_content["test.lock"].content.decode())
+        package_to_version = {
+            pkg["project_name"]: pkg["version"]
+            for pkg in lock_data["locked_resolves"][0]["locked_requirements"]
+        }
+        return package_to_version
 
-    # Now re-generate with `--sync`. This exercises the code path that reads the existing
-    # `test.lock`, confirms it is a uv-format lockfile, and renames it to `uv.lock` for uv to
-    # perform a minimal update against.
-    rule_runner.set_options(
-        [
+    def generate_and_get_versions(reqs: FrozenOrderedSet[str], sync: bool) -> dict[str, str]:
+        # Generates a lockfile and returns a map of package names to versions.
+        return get_versions(generate(reqs, sync))
+
+    # Generate the initial lockfile and write its digest.
+    digest = generate(orig_requirements, False, with_constraints=True)
+    rule_runner.write_digest(digest)
+    versions = get_versions(digest)
+    assert {"ansicolors": "1.1.7", "cowsay": "6.0"} == versions
+
+    # Regenerate without --sync (note that we don't write the digest, so this updated lockfile
+    # does not affect the following call to generate_and_get_versions).
+    versions = generate_and_get_versions(updated_requirements, sync=False)
+    assert {"ansicolors": "1.1.8", "cowsay": "6.1"} == versions
+
+    # Regenerate with --sync.
+    versions = generate_and_get_versions(updated_requirements, sync=True)
+    assert {"ansicolors": "1.1.8", "cowsay": "6.0"} == versions
+
+
+def test_uv_lockfile_sync(rule_runner: PythonRuleRunner) -> None:
+    # uv's "sync" semantics are slightly different from pex's. uv will not update packages even
+    # if their requirement strings have changed, as long as the old version still is still valid.
+    # So we can constrain `cowsay` directly in the requirement string.
+    orig_requirements = FrozenOrderedSet(["ansicolors==1.1.7", "cowsay==6.0"])
+    updated_requirements = FrozenOrderedSet(["ansicolors==1.1.8", "cowsay>=6.0,<=6.1"])
+
+    def generate(reqs: FrozenOrderedSet[str], sync: bool, with_constraints: bool = False) -> Digest:
+        # Generates a lockfile and returns its output digest.
+        sync_opt = "--generate-lockfiles-sync" if sync else "--no-generate-lockfiles-sync"
+        args = [
             "--python-resolves={'test': 'test.lock'}",
-            "--generate-lockfiles-sync",
-        ],
-        env_inherit=PYTHON_BOOTSTRAP_ENV,
-    )
-    sync_digest_contents = generate()
+            "--python-separate-lockfile-metadata-file",
+            sync_opt,
+        ]
+        rule_runner.write_files({"constraints.txt": "cowsay==6.0"})
+        rule_runner.set_options(args, env_inherit=PYTHON_BOOTSTRAP_ENV)
+        req = GenerateUvLockfile(
+            requirements=reqs,
+            find_links=FrozenOrderedSet([]),
+            interpreter_constraints=InterpreterConstraints(["CPython==3.14"]),
+            resolve_name="test",
+            lockfile_dest="test.lock",
+            diff=False,
+        )
 
-    by_path = {fc.path: fc for fc in sync_digest_contents}
-    assert "test.lock" in by_path
-    assert "test.lock.metadata" in by_path
+        result = rule_runner.request(
+            GenerateLockfileResult,
+            [req],
+        )
+        return result.digest
 
-    lock_data = tomllib.loads(by_path["test.lock"].content.decode())
-    packages = {pkg["name"]: pkg for pkg in lock_data.get("package", []) if "version" in pkg}
-    assert "ansicolors" in packages
-    assert packages["ansicolors"]["version"] == "1.1.8"
+    def get_versions(digest: Digest) -> dict[str, str]:
+        # Returns a map of package names to versions from a lockfile in a digest.
+        digest_contents = rule_runner.request(DigestContents, [digest])
+        path_to_file_content = {fc.path: fc for fc in digest_contents}
+        assert "test.lock" in path_to_file_content
+        assert "test.lock.metadata" in path_to_file_content
+        lock_data = tomllib.loads(path_to_file_content["test.lock"].content.decode())
+        package_to_version = {pkg["name"]: pkg["version"] for pkg in lock_data.get("package", [])}
+        del package_to_version["pants-lockfile-for-test"]
+        return package_to_version
 
-    metadata = json.loads(by_path["test.lock.metadata"].content.decode())
-    assert metadata["lockfile_format"] == LockfileFormat.UV
-    assert metadata["generated_with_requirements"] == ["ansicolors==1.1.8"]
+    def generate_and_get_versions(reqs: FrozenOrderedSet[str], sync: bool) -> dict[str, str]:
+        # Generates a lockfile and returns a map of package names to versions.
+        return get_versions(generate(reqs, sync))
+
+    # Generate the initial lockfile and write its digest.
+    digest = generate(orig_requirements, False, with_constraints=True)
+    rule_runner.write_digest(digest)
+    versions = get_versions(digest)
+    assert {"ansicolors": "1.1.7", "cowsay": "6.0"} == versions
+
+    # Regenerate without --sync (note that we don't write the digest, so this updated lockfile
+    # does not affect the following call to generate_and_get_versions).
+    versions = generate_and_get_versions(updated_requirements, sync=False)
+    assert {"ansicolors": "1.1.8", "cowsay": "6.1"} == versions
+
+    # Regenerate with --sync.
+    versions = generate_and_get_versions(updated_requirements, sync=True)
+    assert {"ansicolors": "1.1.8", "cowsay": "6.0"} == versions

--- a/src/python/pants/backend/python/goals/lockfile_test.py
+++ b/src/python/pants/backend/python/goals/lockfile_test.py
@@ -845,7 +845,7 @@ def test_uv_lockfile_sync(rule_runner: PythonRuleRunner) -> None:
     orig_requirements = FrozenOrderedSet(["ansicolors==1.1.7", "cowsay==6.0"])
     updated_requirements = FrozenOrderedSet(["ansicolors==1.1.8", "cowsay>=6.0,<=6.1"])
 
-    def generate(reqs: FrozenOrderedSet[str], sync: bool, with_constraints: bool = False) -> Digest:
+    def generate(reqs: FrozenOrderedSet[str], sync: bool) -> Digest:
         # Generates a lockfile and returns its output digest.
         sync_opt = "--generate-lockfiles-sync" if sync else "--no-generate-lockfiles-sync"
         args = [
@@ -885,8 +885,9 @@ def test_uv_lockfile_sync(rule_runner: PythonRuleRunner) -> None:
         # Generates a lockfile and returns a map of package names to versions.
         return get_versions(generate(reqs, sync))
 
-    # Generate the initial lockfile and write its digest.
-    digest = generate(orig_requirements, False, with_constraints=True)
+    # Generate the initial lockfile and write its digest (we also test that `sync` works when
+    # there is no lockfile).
+    digest = generate(orig_requirements, True)
     rule_runner.write_digest(digest)
     versions = get_versions(digest)
     assert {"ansicolors": "1.1.7", "cowsay": "6.0"} == versions


### PR DESCRIPTION
`uv` does a minimal update of existing lockfiles by default.
So implementing `generate-lockfiles --sync` in that case
is just a matter of making the existing lockfile available
in the sandbox.

Unfortunately in doing so we neglected to rename it
to the literal name `uv.lock` expected by `uv`, so 
the `--sync` functionality didn't generally work in this case.

This change renames the existing lockfile (if it is in fact
a uv lockfile). 

This mirrors the existing rename of `uv.lock` to the target
name in the repo.

This change also makes both renames use FileEntry
instead of FileContent, so we don't have to materialize
the lockfile contents into memory.