### PR TITLE
upgrade rust to v1.97.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,7 +44,7 @@ jobs:
     - name: Install Rust toolchain
       run: |
         # Set the default toolchain. Installs the toolchain if it is not already installed.
-        rustup default 1.96.0
+        rustup default 1.97.0
         cargo version
     - name: Expose Pythons
       run: |
@@ -171,7 +171,7 @@ jobs:
     - name: Install Rust toolchain
       run: |
         # Set the default toolchain. Installs the toolchain if it is not already installed.
-        rustup default 1.96.0
+        rustup default 1.97.0
         cargo version
     - name: Expose Pythons
       run: |
@@ -334,7 +334,7 @@ jobs:
       with:
         key: macOS14-ARM64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
         path: |
-          ~/.rustup/toolchains/1.96.0-*
+          ~/.rustup/toolchains/1.97.0-*
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo
@@ -469,7 +469,7 @@ jobs:
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
         path: |
-          ~/.rustup/toolchains/1.96.0-*
+          ~/.rustup/toolchains/1.97.0-*
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -61,7 +61,7 @@ jobs:
       with:
         key: Linux-ARM64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
         path: |
-          ~/.rustup/toolchains/1.96.0-*
+          ~/.rustup/toolchains/1.97.0-*
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo
@@ -170,7 +170,7 @@ jobs:
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
         path: |
-          ~/.rustup/toolchains/1.96.0-*
+          ~/.rustup/toolchains/1.97.0-*
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo
@@ -286,7 +286,7 @@ jobs:
       with:
         key: macOS14-ARM64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
         path: |
-          ~/.rustup/toolchains/1.96.0-*
+          ~/.rustup/toolchains/1.97.0-*
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo
@@ -386,7 +386,7 @@ jobs:
     - name: Install Rust toolchain
       run: |
         # Set the default toolchain. Installs the toolchain if it is not already installed.
-        rustup default 1.96.0
+        rustup default 1.97.0
         cargo version
     - name: Expose Pythons
       run: |
@@ -466,7 +466,7 @@ jobs:
     - name: Install Rust toolchain
       run: |
         # Set the default toolchain. Installs the toolchain if it is not already installed.
-        rustup default 1.96.0
+        rustup default 1.97.0
         cargo version
     - name: Expose Pythons
       run: |
@@ -567,7 +567,7 @@ jobs:
       with:
         key: macOS14-ARM64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
         path: |
-          ~/.rustup/toolchains/1.96.0-*
+          ~/.rustup/toolchains/1.97.0-*
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -666,7 +666,7 @@ impl Core {
 
         let sandboxer = if exec_strategy_opts.use_sandboxer {
             let sandboxer_bin = get_sandboxer_binary()?;
-            debug!("Running against sandboxer at {:?}", &sandboxer_bin);
+            debug!("Running against sandboxer at {:?}", sandboxer_bin);
             Some(
                 Sandboxer::new(
                     sandboxer_bin,

--- a/src/rust/engine/src/downloads.rs
+++ b/src/rust/engine/src/downloads.rs
@@ -245,7 +245,7 @@ pub async fn download(
 
             return Retry::spawn(retry_strategy, || {
                 attempt_number += 1;
-                log::debug!("Downloading {} (attempt #{})", &url, &attempt_number);
+                log::debug!("Downloading {} (attempt #{})", url, attempt_number);
                 attempt_download(
                     http_client,
                     &url,
@@ -254,7 +254,7 @@ pub async fn download(
                     expected_digest,
                 )
                 .map_err(|err| {
-                    log::debug!("Error while downloading {}: {}", &url, err);
+                    log::debug!("Error while downloading {}: {}", url, err);
                     match err {
                         StreamingError::Retryable(msg) => RetryError::transient(msg),
                         StreamingError::Permanent(msg) => RetryError::permanent(msg),

--- a/src/rust/engine/src/externs/engine_aware.rs
+++ b/src/rust/engine/src/externs/engine_aware.rs
@@ -28,10 +28,9 @@ impl EngineAwareReturnType {
             // If the metadata already existed, or if its level changed, we need to update it.
             let (mut metadata, level) = if let Some((metadata, old_level)) = old {
                 (metadata, new_level.unwrap_or(old_level))
-            } else if let Some(level) = new_level {
-                (WorkunitMetadata::default(), level)
             } else {
-                return None;
+                let level = new_level?;
+                (WorkunitMetadata::default(), level)
             };
 
             metadata.message = Self::message(task_result);

--- a/src/rust/engine/src/externs/fs.rs
+++ b/src/rust/engine/src/externs/fs.rs
@@ -679,11 +679,11 @@ impl PyFilespec {
 
     fn __repr__(&self) -> String {
         if self.excludes.is_empty() {
-            format!("Filespec(includes={:?})", &*self.includes)
+            format!("Filespec(includes={:?})", *self.includes)
         } else {
             format!(
                 "Filespec(includes={:?}, excludes={:?})",
-                &*self.includes, &*self.excludes
+                *self.includes, *self.excludes
             )
         }
     }

--- a/src/rust/engine/src/intrinsics/docker.rs
+++ b/src/rust/engine/src/intrinsics/docker.rs
@@ -53,12 +53,12 @@ fn docker_resolve_image(docker_request: Value) -> PyGeneratorResponseNativeCall 
         let image_metadata = docker.inspect_image(&image_name).await.map_err(|err| {
             format!(
                 "Failed to resolve image ID for image `{}`: {:?}",
-                &image_name, err
+                image_name, err
             )
         })?;
         let image_id = image_metadata
             .id
-            .ok_or_else(|| format!("Image does not exist: `{}`", &image_name))?;
+            .ok_or_else(|| format!("Image does not exist: `{}`", image_name))?;
 
         Ok::<_, Failure>(Python::attach(|py| {
             externs::unsafe_call(

--- a/src/rust/engine/src/nodes/downloaded_file.rs
+++ b/src/rust/engine/src/nodes/downloaded_file.rs
@@ -55,7 +55,7 @@ impl DownloadedFile {
         let path = RelativePath::new(&file_name).map_err(|e| {
             format!(
                 "The file name derived from {} was {} which is not relative: {:?}",
-                &url, &file_name, e
+                url, file_name, e
             )
         })?;
 

--- a/src/rust/grpc_util/src/tls.rs
+++ b/src/rust/grpc_util/src/tls.rs
@@ -137,7 +137,7 @@ impl TryFrom<Config> for ClientConfig {
             the correct PEM file. Error(s):\n\n",
                                 );
                                 for error in &native_root_certs_result.errors {
-                                    write!(&mut msg, "{}\n\n", &error)
+                                    write!(&mut msg, "{}\n\n", error)
                                         .expect("write into mutable string");
                                 }
                                 return Err(msg);

--- a/src/rust/options/src/config.rs
+++ b/src/rust/options/src/config.rs
@@ -368,7 +368,7 @@ fn add_to_sha256(value: &Value, hasher: &mut Sha256) {
         Value::String(s) => hasher.update(s.as_bytes()),
         Value::Integer(i) => hasher.update(&i.to_le_bytes()),
         Value::Float(f) => hasher.update(&f.to_le_bytes()),
-        Value::Boolean(b) => hasher.update(&(if *b { [b'1'] } else { [b'0'] })),
+        Value::Boolean(b) => hasher.update(&(if *b { *b"1" } else { *b"0" })),
         // We don't support datetime types in config, so we won't incur this to_string() cost
         // in practice.
         Value::Datetime(dt) => hasher.update(dt.to_string().as_bytes()),

--- a/src/rust/pants_ng/options/src/pants_invocation.rs
+++ b/src/rust/pants_ng/options/src/pants_invocation.rs
@@ -268,7 +268,7 @@ impl PantsInvocation {
                     .push(flag.value.clone());
             }
             if let Some(subcommand) = &command.subcommand {
-                let subcommand_scope = format!("{}.{}", &command.name, &subcommand.name);
+                let subcommand_scope = format!("{}.{}", command.name, subcommand.name);
                 let flags_for_scope = flags.entry(Scope::named(&subcommand_scope)).or_default();
                 for flag in &subcommand.flags {
                     flags_for_scope

--- a/src/rust/pantsd/src/lib.rs
+++ b/src/rust/pantsd/src/lib.rs
@@ -101,7 +101,7 @@ impl Metadata {
                     .map_err(|e| {
                         format!(
                             "Failed to parse pantsd port from {socket_metadata_path}: {err}",
-                            socket_metadata_path = &socket_metadata_path.display(),
+                            socket_metadata_path = socket_metadata_path.display(),
                             err = e
                         )
                     })
@@ -119,7 +119,7 @@ impl Metadata {
                 format!(
                     "Failed to read {name} from {metadata_path}: {err}",
                     name = name,
-                    metadata_path = &metadata_path.display(),
+                    metadata_path = metadata_path.display(),
                     err = e
                 )
             })

--- a/src/rust/process_execution/docker/src/docker.rs
+++ b/src/rust/process_execution/docker/src/docker.rs
@@ -110,10 +110,10 @@ impl DockerOnceCell {
             let major = (*major).parse::<usize>().map_err(|err| format!("Failed to decode Docker API major version `{major}`: {err}"))?;
             let minor = (*minor).parse::<usize>().map_err(|err| format!("Failed to decode Docker API minor version `{minor}`: {err}"))?;
             if major < 1 || (major == 1 && minor < 41) {
-              return Err(format!("Pants requires Docker to support API version 1.41 or higher. Local Docker only supports: {:?}", &version.api_version));
+              return Err(format!("Pants requires Docker to support API version 1.41 or higher. Local Docker only supports: {:?}", version.api_version));
             }
           }
-          _ => return Err(format!("Unparseable API version `{}` returned by Docker.", &api_version)),
+          _ => return Err(format!("Unparseable API version `{}` returned by Docker.", api_version)),
         }
         Ok(docker)
       })
@@ -539,7 +539,7 @@ impl process_execution::CommandRunner for CommandRunner<'_> {
                             .into_string()
                             .map_err(|s| format!("Unable to convert sandbox path to string due to non UTF-8 characters: {s:?}"))?;
                         apply_chroot(&sandbox_path_in_container, &mut mreq);
-                        log::trace!("sandbox_path_in_container = {:?}", &sandbox_path_in_container);
+                        log::trace!("sandbox_path_in_container = {:?}", sandbox_path_in_container);
                         mreq.working_directory
                             .as_ref()
                             .map(|relpath| Path::new(&sandbox_path_in_container).join(relpath))
@@ -774,7 +774,7 @@ impl Command {
                 err,
             })?;
 
-        log::trace!("created execution {}", &exec.id);
+        log::trace!("created execution {}", exec.id);
 
         let exec_result =
             docker
@@ -790,7 +790,7 @@ impl Command {
             panic!("Unexpected value returned from start_exec: {exec_result:?}");
         };
 
-        log::trace!("started execution {}", &exec.id);
+        log::trace!("started execution {}", exec.id);
 
         let exec_id = exec.id.to_owned();
         let docker = docker.to_owned();
@@ -800,16 +800,16 @@ impl Command {
           while let Some(output_msg) = output_stream.next().await {
             match output_msg {
                 Ok(LogOutput::StdOut { message }) => {
-                    log::trace!("execution {} wrote {} bytes to stdout", &exec_id, message.len());
+                    log::trace!("execution {} wrote {} bytes to stdout", exec_id, message.len());
                     yield ChildOutput::Stdout(message);
                 }
                 Ok(LogOutput::StdErr { message }) => {
-                    log::trace!("execution {} wrote {} bytes to stderr", &exec_id, message.len());
+                    log::trace!("execution {} wrote {} bytes to stderr", exec_id, message.len());
                     yield ChildOutput::Stderr(message);
                 }
                 Ok(_) => (),
                 Err(err) => {
-                    log::trace!("error while capturing output of execution {}: {:?}", &exec_id, err);
+                    log::trace!("error while capturing output of execution {}: {:?}", exec_id, err);
                 }
             }
           }
@@ -817,11 +817,11 @@ impl Command {
           let exec_metadata = docker
             .inspect_exec(&exec_id)
             .await
-            .map_err(|err| format!("Failed to inspect Docker execution `{}`: {:?}", &exec_id, err))?;
+            .map_err(|err| format!("Failed to inspect Docker execution `{}`: {:?}", exec_id, err))?;
 
           let status_code = exec_metadata
             .exit_code
-            .ok_or_else(|| format!("Inspected execution `{}` for exit status but status was missing.", &exec_id))?;
+            .ok_or_else(|| format!("Inspected execution `{}` for exit status but status was missing.", exec_id))?;
 
           log::trace!("execution {} exited with status code {}", &exec_id, status_code);
 
@@ -976,13 +976,13 @@ impl<'a> ContainerCache<'a> {
             .map_err(|err| {
                 format!(
                     "Failed to start Docker container `{}` for image `{image_name}`: {err:?}",
-                    &container.id
+                    container.id
                 )
             })?;
 
         log::debug!(
             "started container `{}` for image `{image_name}`",
-            &container.id,
+            container.id,
         );
 
         Ok(container.id)

--- a/src/rust/process_execution/pe_nailgun/src/lib.rs
+++ b/src/rust/process_execution/pe_nailgun/src/lib.rs
@@ -187,7 +187,7 @@ impl process_execution::CommandRunner for CommandRunner {
                     &nailgun_name,
                     nailgun_args,
                 );
-                trace!("Running request under nailgun:\n {:#?}", &client_req);
+                trace!("Running request under nailgun:\n {:#?}", client_req);
 
                 // Get an instance of a nailgun server for this fingerprint, and then run in its directory.
                 let mut nailgun_process = self

--- a/src/rust/process_execution/pe_nailgun/src/nailgun_pool.rs
+++ b/src/rust/process_execution/pe_nailgun/src/nailgun_pool.rs
@@ -303,7 +303,7 @@ fn spawn_and_read_port(
         .map_err(|e| {
             format!(
                 "Failed to create child handle for nailgun with cmd: {} options {:#?}: {}",
-                &cmd, &process, e
+                cmd, process, e
             )
         })?;
 

--- a/src/rust/process_execution/pe_nailgun/src/parsed_jvm_command_lines.rs
+++ b/src/rust/process_execution/pe_nailgun/src/parsed_jvm_command_lines.rs
@@ -44,7 +44,7 @@ impl ParsedJVMCommandLines {
         if args_to_consume.clone().peekable().peek().is_some() {
             return Err(format!(
                 "Malformed command line: There are still arguments to consume: {:?}",
-                &args_to_consume
+                args_to_consume
             ));
         }
 

--- a/src/rust/process_execution/remote/src/remote.rs
+++ b/src/rust/process_execution/remote/src/remote.rs
@@ -257,7 +257,7 @@ impl CommandRunner {
             Some(Ok(operation)) => {
                 trace!(
                     "wait_on_operation_stream (build_id={}): got operation: {:?}",
-                    &context.build_id, &operation
+                    context.build_id, operation
                 );
 
                 // Extract the operation name.
@@ -316,7 +316,7 @@ impl CommandRunner {
 
         trace!(
             "wait_on_operation_stream (build_id={}): monitoring stream",
-            &context.build_id
+            context.build_id
         );
 
         // If the server returns an `ExecutionStage` other than `Unknown`, then we assume that it
@@ -583,7 +583,7 @@ impl CommandRunner {
                     Some(OperationResult::Error(rpc_status)) => {
                         // Infrastructure error. Retry it.
                         let msg = format_error(&rpc_status);
-                        debug!("got operation error for runid {:?}: {}", &run_id, &msg);
+                        debug!("got operation error for runid {:?}: {}", run_id, msg);
                         return Err(ExecutionError::Retryable(msg));
                     }
                     None => {
@@ -741,7 +741,7 @@ impl CommandRunner {
                     // Execute method.
                     debug!(
                         "no current operation: submitting execute request: build_id={}; execute_request={:?}",
-                        context.build_id, &execute_request
+                        context.build_id, execute_request
                     );
                     workunit.increment_counter(Metric::RemoteExecutionRPCExecute, 1);
                     let mut client = self.execution_client.as_ref().clone();
@@ -907,7 +907,7 @@ impl process_execution::CommandRunner for CommandRunner {
     ) -> Result<FallibleProcessResultWithPlatform, ProcessError> {
         // Retrieve capabilities for this server.
         let capabilities = self.get_capabilities().await?;
-        trace!("RE capabilities: {:?}", &capabilities);
+        trace!("RE capabilities: {:?}", capabilities);
 
         // Construct the REv2 ExecuteRequest and related data for this execution request.
         let EntireExecuteRequest {
@@ -930,7 +930,7 @@ impl process_execution::CommandRunner for CommandRunner {
         debug!("Remote execution: {}", request.description);
         debug!(
             "built REv2 request (build_id={}): action={:?}; command={:?}; execute_request={:?}",
-            &build_id, action, command, execute_request
+            build_id, action, command, execute_request
         );
 
         // Record the time that we started to process this request, then compute the ultimate
@@ -980,7 +980,7 @@ impl process_execution::CommandRunner for CommandRunner {
                         // The Err in this match arm originates from the timeout future.
                         debug!(
                             "remote execution for build_id={} timed out after {:?}",
-                            &build_id, deadline_duration
+                            build_id, deadline_duration
                         );
                         workunit.update_metadata(|initial| {
                             let initial = initial.map(|(m, _)| m).unwrap_or_default();

--- a/src/rust/process_execution/sandboxer/src/lib.rs
+++ b/src/rust/process_execution/sandboxer/src/lib.rs
@@ -78,7 +78,7 @@ fn ensure_socket_file_removed(socket_path: &Path) -> Result<(), String> {
             ret = Ok(());
         }
     } else {
-        debug!("Removed existing socket file {}", &socket_path.display());
+        debug!("Removed existing socket file {}", socket_path.display());
     }
     ret.map_err(|e| e.to_string())
 }
@@ -146,7 +146,7 @@ impl SandboxerService {
                 // Note: just a regular thread::sleep() since this is not an async context.
                 thread::sleep(SandboxerService::POLLING_INTERVAL);
                 if !fs::exists(&socket_path).unwrap_or(false) {
-                    warn!("Socket file {} deleted. Exiting.", &socket_path.display());
+                    warn!("Socket file {} deleted. Exiting.", socket_path.display());
                     let _ = graceful_shutdown_tx.send(());
                     break;
                 }
@@ -207,7 +207,7 @@ impl SandboxerGrpcImpl {
         request: Request<MaterializeDirectoryRequest>,
     ) -> Result<Response<MaterializeDirectoryResponse>, String> {
         let r = request.into_inner();
-        debug!("Received materialize_directory() request: {:#?}", &r);
+        debug!("Received materialize_directory() request: {:#?}", r);
         let destination_root: PathBuf = r.destination_root.into();
         let digest: Digest = r.digest.ok_or("No digest provided")?.try_into()?;
         let dir_digest = DirectoryDigest::from_persisted_digest(digest);
@@ -459,7 +459,7 @@ impl Sandboxer {
 
         debug!(
             "Spawning sandboxer with cmd: {} {}",
-            &self.sandboxer_bin.to_string_lossy(),
+            self.sandboxer_bin.to_string_lossy(),
             cmd.as_std()
                 .get_args()
                 .map(|a| a.to_string_lossy())

--- a/src/rust/process_execution/src/lib.rs
+++ b/src/rust/process_execution/src/lib.rs
@@ -1157,13 +1157,13 @@ fn maybe_make_wrapper_script(
                     && !parent.as_os_str().is_empty()
                 {
                     let parent_quoted = quote_path(parent)?;
-                    writeln!(&mut fragment, "/bin/mkdir -p {}", &parent_quoted)
+                    writeln!(&mut fragment, "/bin/mkdir -p {}", parent_quoted)
                         .map_err(|err| format!("write! failed: {err}"))?;
                 }
                 writeln!(
                     &mut fragment,
                     "/bin/ln -s {} {}",
-                    &cache_path,
+                    cache_path,
                     quote_path(path.as_path())?
                 )
                 .map_err(|err| format!("write! failed: {err}"))?;

--- a/src/rust/process_execution/src/local.rs
+++ b/src/rust/process_execution/src/local.rs
@@ -720,7 +720,7 @@ pub async fn prepare_workdir(
         if let Some(sandboxer) = sandboxer {
             debug!(
                 "Materializing via sandboxer to {:?}: {:#?}",
-                &workdir_path, &complete_input_digest
+                workdir_path, complete_input_digest
             );
             // Ensure that the tree is persisted in the store, so that the sandboxer
             // can materialize it from there.  Since record_digest_trie() takes ownership of its
@@ -749,7 +749,7 @@ pub async fn prepare_workdir(
         } else {
             debug!(
                 "Materializing directly to {:?}: {:#?}",
-                &workdir_path, &complete_input_digest
+                workdir_path, complete_input_digest
             );
             store
                 .materialize_directory(

--- a/src/rust/protos/src/conversions.rs
+++ b/src/rust/protos/src/conversions.rs
@@ -25,7 +25,7 @@ impl TryFrom<&crate::pb::build::bazel::remote::execution::v2::Digest> for hashin
         d: &crate::pb::build::bazel::remote::execution::v2::Digest,
     ) -> Result<Self, Self::Error> {
         hashing::Fingerprint::from_hex_string(&d.hash)
-            .map_err(|err| format!("Bad fingerprint in Digest {:?}: {:?}", &d.hash, err))
+            .map_err(|err| format!("Bad fingerprint in Digest {:?}: {:?}", d.hash, err))
             .map(|fingerprint| hashing::Digest::new(fingerprint, d.size_bytes as usize))
     }
 }
@@ -37,7 +37,7 @@ impl TryFrom<crate::pb::build::bazel::remote::execution::v2::Digest> for hashing
         d: crate::pb::build::bazel::remote::execution::v2::Digest,
     ) -> Result<Self, Self::Error> {
         hashing::Fingerprint::from_hex_string(&d.hash)
-            .map_err(|err| format!("Bad fingerprint in Digest {:?}: {:?}", &d.hash, err))
+            .map_err(|err| format!("Bad fingerprint in Digest {:?}: {:?}", d.hash, err))
             .map(|fingerprint| hashing::Digest::new(fingerprint, d.size_bytes as usize))
     }
 }

--- a/src/rust/remote_provider/remote_provider_reapi/src/byte_store.rs
+++ b/src/rust/remote_provider/remote_provider_reapi/src/byte_store.rs
@@ -148,7 +148,7 @@ impl Provider {
         let instance_name = self.instance_name.clone().unwrap_or_default();
         let resource_name = format!(
             "{}{}uploads/{}/blobs/{}/{}",
-            &instance_name,
+            instance_name,
             if instance_name.is_empty() { "" } else { "/" },
             uuid::Uuid::new_v4(),
             digest.hash,
@@ -372,7 +372,7 @@ impl ByteStoreProvider for Provider {
         let instance_name = self.instance_name.clone().unwrap_or_default();
         let resource_name = format!(
             "{}{}blobs/{}/{}",
-            &instance_name,
+            instance_name,
             if instance_name.is_empty() { "" } else { "/" },
             digest.hash,
             digest.size_bytes

--- a/src/rust/rust-toolchain
+++ b/src/rust/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.96.0"
+channel = "1.97.0"
 profile = "minimal"
 components = ["clippy", "rustfmt"]

--- a/src/rust/testutil/mock/src/cas_service.rs
+++ b/src/rust/testutil/mock/src/cas_service.rs
@@ -408,7 +408,7 @@ impl ContentAddressableStorage for StubCASResponder {
                 Err(err) => {
                     return Status::invalid_argument(format!(
                         "Bad fingerprint: {}: {}",
-                        &digest.hash, err
+                        digest.hash, err
                     ));
                 }
             };
@@ -471,7 +471,7 @@ impl ContentAddressableStorage for StubCASResponder {
                         None,
                         Status::invalid_argument(format!(
                             "Bad fingerprint: {}: {}",
-                            &digest.hash, err
+                            digest.hash, err
                         )),
                     );
                 }


### PR DESCRIPTION
Upgrade Rust to [v1.97.0](https://blog.rust-lang.org/2026/07/09/Rust-1.97.0/).

Note: Rust builds now expose linker messages as warnings instead of not passing them through:

```
warning: linker stderr: ld: symbols in __TEXT,text_env (/REDACTED/pants/src/rust/target/release/deps/liblmdb_sys-544fa3d5744d7408.rlib[5](b40eeb0d3a911fbe-mdb.o)) have unwind information, but it's not a code section (missing 'regular,pure_instructions' section flag)
  |
  = note: `#[warn(linker_messages)]` on by default
  = note: the `linker_messages` lint ignores `-D warnings`

warning: `sandboxer` (bin "sandboxer_client") generated 1 warning
warning: `sandboxer` (bin "sandboxer") generated 1 warning (1 duplicate)
```