### PR TITLE
enable "thin LTO" in new `dist` profile

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,7 @@ jobs:
       image: quay.io/pypa/manylinux_2_28_aarch64:latest
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+      MODE: dist
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
     if: github.repository_owner == 'pantsbuild'
@@ -136,6 +137,7 @@ jobs:
       - /:/mnt/host-root
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+      MODE: dist
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
     if: github.repository_owner == 'pantsbuild'
@@ -284,6 +286,7 @@ jobs:
   build_wheels_macos14_arm64:
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: false
+      MODE: dist
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
     if: github.repository_owner == 'pantsbuild'

--- a/build-support/bin/rust/bootstrap_code.sh
+++ b/build-support/bin/rust/bootstrap_code.sh
@@ -11,7 +11,7 @@ source "${REPO_ROOT}/build-support/common.sh"
 # Defines:
 # + NATIVE_ROOT: The Rust code directory, ie: src/rust.
 # + MODE: Whether to run in debug or release mode.
-# + MODE_FLAG: The string to pass to Cargo to determine if we're in debug or release mode.
+# + MODE_FLAG: An array of arguments to pass to Cargo to select the profile to build with.
 # Exposes:
 # + calculate_current_hash: Generate a stable hash to determine if we need to rebuild the engine.
 # shellcheck source=build-support/bin/rust/calculate_engine_hash.sh
@@ -45,7 +45,7 @@ function _build_native_code() {
   # NB: See Cargo.toml with regard to the `extension-module` features.
   "${REPO_ROOT}/cargo" build \
     --features=extension-module \
-    ${MODE_FLAG} \
+    "${MODE_FLAG[@]}" \
     -p engine \
     -p client \
     -p sandboxer \

--- a/build-support/bin/rust/calculate_engine_hash.sh
+++ b/build-support/bin/rust/calculate_engine_hash.sh
@@ -12,11 +12,13 @@ source "${REPO_ROOT}/build-support/common.sh"
 
 readonly NATIVE_ROOT="${REPO_ROOT}/src/rust"
 
-# N.B. Set $MODE to "debug" for faster builds.
+# N.B. Set $MODE to "debug" for faster builds, or "dist" for the profile used
+# to build published artifacts.
 readonly MODE="${MODE:-release}"
 case "$MODE" in
-  debug) MODE_FLAG="" ;;
-  *) MODE_FLAG="--release" ;;
+  debug) MODE_FLAG=() ;;
+  dist) MODE_FLAG=(--profile dist) ;;
+  *) MODE_FLAG=(--release) ;;
 esac
 
 function calculate_current_hash() {
@@ -30,7 +32,7 @@ function calculate_current_hash() {
   (
     cd "${REPO_ROOT}" || exit 1
     (
-      echo "${MODE_FLAG}"
+      echo "${MODE_FLAG[*]}"
       uname -mps
       # the engine only depends on the implementation and major.minor version, not the patch
       "${PY}" -c 'import sys; print(sys.implementation.name, sys.version_info.major, sys.version_info.minor, sys.abiflags)'

--- a/docs/docs/contributions/development/developing-rust.mdx
+++ b/docs/docs/contributions/development/developing-rust.mdx
@@ -55,6 +55,8 @@ As described in [Setting up Pants](./setting-up-pants.mdx), we default to compil
 When working on Rust, you typically should set the environment variable `MODE=debug` for substantially faster compiles.
 :::
 
+There is also `MODE=dist`, the profile used to build published artifacts. It enables additional optimizations, like link-time optimization, that are usually too slow to be worthwhile for local development.
+
 ### Run tests
 
 To run tests for all crates, run:

--- a/docs/docs/contributions/development/setting-up-pants.mdx
+++ b/docs/docs/contributions/development/setting-up-pants.mdx
@@ -50,9 +50,11 @@ Rust compilation is really slow. Fortunately, this step gets cached, so you will
 :::
 
 :::note Want a faster compile?
-We default to compiling with Rust's `release` mode, instead of its `debug` mode, because this makes Pants substantially faster. However, this results in the compile taking 5-10x longer.
+We default to compiling with Rust's `release` mode, instead of its `debug` mode, because this makes Pants substantially faster. However, this results in the compile taking 5-10x longer. This is generally a good balance in the common case of working on the Pants Python code instead of the Pants Rust engine.
 
 If you are okay with Pants running much slower when iterating, set the environment variable `MODE=debug` and rerun `pants` to compile in debug mode.
+
+(Published Pants releases are built with `MODE=dist`, which enables further optimizations, such as link-time optimization, that take additional time.)
 :::
 
 :::caution Rust compilation can use lots of storage

--- a/docs/notes/2.34.x.md
+++ b/docs/notes/2.34.x.md
@@ -22,6 +22,7 @@ Fixed an issue where `pants --changed-since` would unnecessarily invalidate all 
 
 The `indicatif-spinner` `dynamic_ui_renderer` (default), now renders on a dedicated thread.  This should reduce jitter and display a smoother spinner under heavy load.
 
+Published Pants binaries are now compiled with a new `dist` Cargo profile that enables ["thin" Link Time Optimization](https://nnethercote.github.io/perf-book/build-configuration.html#link-time-optimization). This results in a slightly smaller binary and a few percentage points of improved performance on certain workloads. From-source (contributor) builds continue to use the `release` profile, which now uses the default `codegen-units` and so compiles noticeably faster.
 
 ### Goals
 

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -1058,11 +1058,12 @@ def build_wheels_job(
             "env": {
                 "ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION": bool(container),
                 **DISABLE_REMOTE_CACHE_ENV,
-                # If we're not deploying these wheels, build in debug mode, which allows for
-                # incremental compilation across wheels. If this becomes too slow in CI, most likely
-                # the answer will be to adjust the `opt-level` for the relevant Cargo profile rather
-                # than to not use debug mode.
-                **({} if for_deploy_ref else {"MODE": "debug"}),
+                # Wheels that are deployed are built with the `dist` Cargo profile (the most
+                # optimized, and most expensive to compile). If we're not deploying these wheels,
+                # build in debug mode, which allows for incremental compilation across wheels. If
+                # this becomes too slow in CI, most likely the answer will be to adjust the
+                # `opt-level` for the relevant Cargo profile rather than to not use debug mode.
+                **({"MODE": "dist"} if for_deploy_ref else {"MODE": "debug"}),
             },
             "steps": [
                 *initial_steps,

--- a/src/python/pants_release/release.py
+++ b/src/python/pants_release/release.py
@@ -659,8 +659,11 @@ def build_fs_util() -> None:
     # include it in our releases because it can be a useful standalone tool.
     banner("Building fs_util")
     command = ["./cargo", "build", "-p", "fs_util"]
-    release_mode = os.environ.get("MODE", "") != "debug"
-    if release_mode:
+    mode = os.environ.get("MODE", "release")
+    if mode == "dist":
+        command.extend(["--profile", "dist"])
+    elif mode != "debug":
+        mode = "release"
         command.append("--release")
     subprocess.run(command, check=True, env={**os.environ, "RUST_BACKTRACE": "1"})
     current_os = (
@@ -673,7 +676,7 @@ def build_fs_util() -> None:
     )
     dest_dir.mkdir(parents=True, exist_ok=True)
     shutil.copy(
-        f"src/rust/target/{'release' if release_mode else 'debug'}/fs_util",
+        f"src/rust/target/{mode}/fs_util",
         dest_dir,
     )
     green(f"Built fs_util at {dest_dir / 'fs_util'}.")

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -2,6 +2,12 @@
 # Enable only "line tables", which give line information in backtraces, but do not record information
 # about local variables.
 debug = 1
+
+# The profile used to build published artifacts (wheels, fs_util), via MODE=dist.
+# More expensive to compile than `release`, in exchange for a smaller and faster binary.
+[profile.dist]
+inherits = "release"
+lto = "thin"
 # Optimise for the speed of our binary, rather than the speed of compilation.
 codegen-units = 1
 


### PR DESCRIPTION
This is a followup and replacement for
https://github.com/pantsbuild/pants/pull/23179 following the review feedback there.  Instead of adding more optimizations to the `release` profile it creates a new `dist` profile.  The bikeshed naming logic for the profile breakdown:
 * `release`: This is the built in cargo name so we are stuck with it. We use it by default and it does "some" optimization which is a good balance for the (I think) most common case of someone working on Python rules code.
 * `dist`: Intended to have maximum optimization for release artifacts.  It is same name used by `ruff` and `uv`.  I moved the `codegen-units` here as requested before.
 * `debug`: Whatever cargo defaults to.

In various tests with hyperfine for the prior PR I saw like `1.05 ± 0.06`, or `1.02 ± 0.09`. So not going to write a blog post about it, but we don't seem to hit any pathological corner cases and I'll take a few percentage points for free.

Rough Summary Table:

| Cold Build                  | Wall Time | `libengine.so` |
|-----------------------------|-----------|----------------|
| Old release (cgu=1, no LTO) | 2m33s     | 189.9 MiB      |
| New release (cgu=16)        | 1m53s     | 247.1 MiB      |
| dist (thin LTO, cgu=1)      | 3m57s     | 173.8 MiB      |

References:
 * https://nnethercote.github.io/perf-book/build-configuration.html#link-time-optimization
 * https://doc.rust-lang.org/cargo/reference/profiles.html#lto
 
NOTICE: Futzing with bash done my an LLM.

closes #23179