### PR TITLE
Upgrade rust dep internment to 0.8

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -16,17 +16,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
-name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.15",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -43,6 +32,12 @@ checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
@@ -928,7 +923,6 @@ source = "git+https://github.com/stuhood/deepsize.git?rev=5c8bee5443fcafe4aaa927
 dependencies = [
  "deepsize_derive",
  "indexmap 1.9.3",
- "internment",
  "log",
  "smallvec",
 ]
@@ -1672,9 +1666,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "hashbrown"
@@ -1682,6 +1673,8 @@ version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -1895,7 +1888,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.9",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -2177,12 +2170,12 @@ dependencies = [
 
 [[package]]
 name = "internment"
-version = "0.6.0"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73bd1419c48e9f496d5830cc2f7fff35cab112193f289fd7266ab0679bb97237"
+checksum = "636d4b0f6a39fd684effe2a73f5310df16a3fa7954c26d36833e98f44d1977a2"
 dependencies = [
- "hashbrown 0.12.3",
- "parking_lot 0.12.5",
+ "deepsize",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -162,7 +162,7 @@ ignore = "0.4.25"
 indexmap = { version = "2.13.0", features = ["std", "serde"] }
 indicatif = "0.18.4"
 indoc = "2.0.7"
-internment = "0.6"
+internment = { version = "0.8", features = ["deepsize"] }
 itertools = "0.14"
 libc = "0.2.182"
 lmdb-rkv = { git = "https://github.com/pantsbuild/lmdb-rs.git", rev = "6ae7a552aa2c932c3ddf652a68cdde2fed547cbc" }
@@ -244,6 +244,11 @@ tree-sitter = "0.26.8"
 tree-sitter-dockerfile = { git = "https://github.com/pantsbuild/tree-sitter-dockerfile.git", rev = "508588913c93a30e7ef09a4ac3ecdee955b7b950" }
 tree-sitter-python = "0.25.0"
 tree-sitter-typescript = "0.23.2"
+
+# internment's `deepsize` feature provides the `DeepSizeOf for Intern<T>` impl, which must
+# be implemented against the same deepsize crate as the rest of the workspace (the fork above).
+[patch.crates-io]
+deepsize = { git = "https://github.com/stuhood/deepsize.git", rev = "5c8bee5443fcafe4aaa9274490d354412d0955c1" }
 
 # Default lints adopted by most crates in this workspace.
 

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -24,7 +24,7 @@ async-trait = { workspace = true }
 protos = { path = "../protos" }
 bytes = { workspace = true }
 cache = { path = "../cache" }
-deepsize = { workspace = true, features = ["internment", "smallvec", "indexmap"] }
+deepsize = { workspace = true, features = ["smallvec", "indexmap"] }
 dep_inference = { path = "../dep_inference" }
 derivative = { workspace = true }
 docker = { path = "../process_execution/docker" }

--- a/src/rust/fs/src/directory.rs
+++ b/src/rust/fs/src/directory.rs
@@ -156,13 +156,13 @@ impl Name {
         if cfg!(debug_assertions) {
             assert!(Path::new(name).components().count() < 2)
         }
-        Name(Intern::from(name))
+        Name(Intern::from_ref(name))
     }
 
     fn from_remexec_name(name: &str) -> Result<Self, String> {
         let mut components = Path::new(name).components().fuse();
         match (components.next(), components.next()) {
-            (Some(std::path::Component::Normal(_)), None) => Ok(Name(Intern::from(name))),
+            (Some(std::path::Component::Normal(_)), None) => Ok(Name(Intern::from_ref(name))),
             _ => Err(format!("Remote output path component is invalid: {name:?}")),
         }
     }
@@ -630,7 +630,7 @@ impl DigestTrie {
             // TODO: It's likely that a DigestTrie should hold its own Digest, to avoid re-computing it
             // here.
             let root = Entry::Directory(Directory::from_digest_tree(
-                Name(Intern::from("")),
+                Name(Intern::from_ref("")),
                 self.clone(),
             ));
             f(&PathBuf::new(), &root);
@@ -1235,7 +1235,7 @@ fn first_path_component_to_name(path: &Path) -> Result<Name, String> {
         .as_os_str()
         .to_str()
         .ok_or_else(|| format!("{first_path_component:?} is not representable in UTF8"))?;
-    Ok(Name(Intern::from(name)))
+    Ok(Name(Intern::from_ref(name)))
 }
 
 /// Return any entries which did not have the same Digest as the given Entry.

--- a/src/rust/rule_graph/Cargo.toml
+++ b/src/rust/rule_graph/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Pants Build <pantsbuild@gmail.com>"]
 publish = false
 
 [dependencies]
-deepsize = { workspace = true, features = ["internment", "smallvec"] }
+deepsize = { workspace = true, features = ["smallvec"] }
 fnv = { workspace = true }
 indexmap = { workspace = true }
 internment = { workspace = true }


### PR DESCRIPTION
- Intern::from was renamed to from_ref
- DeepSizeOf impl now comes from internment's own deepsize feature
- The intern pool now uses std::sync::Mutex instead of parking_lot.