### PR TITLE
2.33 performance notes (Cherry-pick of #23545)

### DIFF
--- a/docs/notes/2.33.x.md
+++ b/docs/notes/2.33.x.md
@@ -14,6 +14,7 @@ Thank you to [Klaviyo](https://www.klaviyo.com/) and [Depot](https://www.depot.d
 
 - `pants.backend.observability.opentelemetry` backend for reporting workunit tracing to OpenTelemetry.
 - The Golang backend now uses substantially less memory for common workloads.
+- Several core parts of Pants have had their overhead reduced or been ported to Rust.  On operations where execution time is dominated by Pants itself like `dependencies ::` or `lint --only=visibility ::` cold-start speedups on the order of 1.5x have been reported.
 
 ### Deprecations
 


### PR DESCRIPTION
See #23502 for `hyperfine` runs.  We don't have a benchmark suite to give a fancy geo mean or anything, but I think this is a defensible claim that doesn't set unreasonable expectations.

closes #23502
