### PR TITLE
Fix `scalac` plugin paths in BSP options response

### DIFF
--- a/docs/notes/2.34.x.md
+++ b/docs/notes/2.34.x.md
@@ -40,6 +40,8 @@ The `COPY` rename suggestions shown when a `docker_image` build fails are now co
 
 #### JVM
 
+Fixed the `buildTarget/scalacOptions` BSP response emitting scalac plugin (`-Xplugin:`) paths relative to the build root, while the plugin jars are materialized under `.pants.d/bsp`. The paths are now absolute, matching the `classpath` entries in the same response, so BSP clients such as Metals can load the `scalac` plugins into their presentation compiler.
+
 #### Python
 
 Fixed a bug that caused `generate-lockfiles --sync` not to have its intended effect when using `uv` lockfiles.

--- a/src/python/pants/backend/scala/bsp/rules.py
+++ b/src/python/pants/backend/scala/bsp/rules.py
@@ -346,7 +346,12 @@ async def handle_bsp_scalac_options_request(
         ScalacOptionsItem(
             target=request.bsp_target_id,
             options=(
-                *local_plugins.args(local_plugins_prefix),
+                # The plugin jars are materialized under `.pants.d/bsp` in the workspace (see
+                # the `write_digest` above), so emit absolute paths for BSP clients rather than
+                # the digest-relative prefix.
+                *local_plugins.args(
+                    str(build_root.pathlib_path.joinpath(f".pants.d/bsp/{local_plugins_prefix}"))
+                ),
                 *scalac.parsed_args_for_resolve(resolve.name),
             ),
             classpath=classpath,


### PR DESCRIPTION
`handle_bsp_scalac_options_request` put `scalac` plugin jars under `.pants.d/bsp/`, but emits the `-Xplugin:` options relative to the build root:

```
-Xplugin:jvm/resolves/scala213/plugins/some-plugin.jar
```

while the jars actually are in `.pants.d/bsp/jvm/resolves/scala213/plugins`, so there is a mismatch here which causes BSP to not find the plugin which causes metals to log

```
java.nio.file.NoSuchFileException: /home/alex/code/work/backend/jvm/resolves/scala213/plugins/some-plugin.jar
	at scala.meta.internal.metals.CompilerPlugins.$anonfun$isSupportedPlugin$1(CompilerPlugins.scala:64)
```

This fixes the path to ensure that plugins can be passed to the presentation compiler. 

LLM usage note: Had an LLM write the docs summary for me