### PR TITLE
upgrade to rust v1.97.1

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,7 +45,7 @@ jobs:
     - name: Install Rust toolchain
       run: |
         # Set the default toolchain. Installs the toolchain if it is not already installed.
-        rustup default 1.97.0
+        rustup default 1.97.1
         cargo version
     - name: Expose Pythons
       run: |
@@ -173,7 +173,7 @@ jobs:
     - name: Install Rust toolchain
       run: |
         # Set the default toolchain. Installs the toolchain if it is not already installed.
-        rustup default 1.97.0
+        rustup default 1.97.1
         cargo version
     - name: Expose Pythons
       run: |
@@ -337,7 +337,7 @@ jobs:
       with:
         key: macOS14-ARM64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
         path: |
-          ~/.rustup/toolchains/1.97.0-*
+          ~/.rustup/toolchains/1.97.1-*
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo
@@ -472,7 +472,7 @@ jobs:
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
         path: |
-          ~/.rustup/toolchains/1.97.0-*
+          ~/.rustup/toolchains/1.97.1-*
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -61,7 +61,7 @@ jobs:
       with:
         key: Linux-ARM64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
         path: |
-          ~/.rustup/toolchains/1.97.0-*
+          ~/.rustup/toolchains/1.97.1-*
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo
@@ -172,7 +172,7 @@ jobs:
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
         path: |
-          ~/.rustup/toolchains/1.97.0-*
+          ~/.rustup/toolchains/1.97.1-*
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo
@@ -290,7 +290,7 @@ jobs:
       with:
         key: macOS14-ARM64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
         path: |
-          ~/.rustup/toolchains/1.97.0-*
+          ~/.rustup/toolchains/1.97.1-*
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo
@@ -392,7 +392,7 @@ jobs:
     - name: Install Rust toolchain
       run: |
         # Set the default toolchain. Installs the toolchain if it is not already installed.
-        rustup default 1.97.0
+        rustup default 1.97.1
         cargo version
     - name: Expose Pythons
       run: |
@@ -472,7 +472,7 @@ jobs:
     - name: Install Rust toolchain
       run: |
         # Set the default toolchain. Installs the toolchain if it is not already installed.
-        rustup default 1.97.0
+        rustup default 1.97.1
         cargo version
     - name: Expose Pythons
       run: |
@@ -573,7 +573,7 @@ jobs:
       with:
         key: macOS14-ARM64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
         path: |
-          ~/.rustup/toolchains/1.97.0-*
+          ~/.rustup/toolchains/1.97.1-*
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo

--- a/src/rust/rust-toolchain
+++ b/src/rust/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.97.0"
+channel = "1.97.1"
 profile = "minimal"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Upgrade to Rust v1.97.1 which "fixes a [miscompilation in an LLVM optimization](https://github.com/rust-lang/rust/issues/159035)."