### PR TITLE
Implement exclusive locking around `uv sync`. (Cherry-pick of #23561)

### DIFF
--- a/docs/notes/2.33.x.md
+++ b/docs/notes/2.33.x.md
@@ -84,6 +84,8 @@ The Python Build Standalone backend ([pants.backend.python.providers.experimenta
 
 Fixed a bug that prevented using the `uv` resolver with custom indexes.
 
+Fixed a concurrency bug when working with `uv` lockfiles, e.g., when running tests.
+
 Fixed a bug where the Python Build Standalone provider used a host interpreter path when building in a `docker_environment`, causing `Failed to find interpreter` in the container.
 
 Fixed dependency validation for Python targets to honor resolve-derived interpreter constraints when `[python].default_to_resolve_interpreter_constraints` is enabled.

--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -351,6 +351,7 @@ async def generate_uv_lockfile(
     generate_lockfiles_subsystem: GenerateLockfilesSubsystem,
     downloaded_uv: DownloadedUv,
     uv_env: UvEnvironment,
+    level: LogLevel,
 ) -> GenerateLockfileResult:
     if not req.interpreter_constraints:
         raise ValueError(
@@ -427,6 +428,7 @@ async def generate_uv_lockfile(
                 argv=(
                     *downloaded_uv.args(),
                     "lock",
+                    *(["--verbose"] if level >= LogLevel.DEBUG else []),  # type: ignore[operator]
                 ),
                 env=uv_env.env,
                 input_digest=input_digest,

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -941,7 +941,6 @@ async def build_pex(
         pex_process = await composite_process_to_process(composite_process, **implicitly())
 
     result = await fallible_to_exec_result_or_raise(**implicitly(pex_process))
-
     maybe_log_pex_stderr(result.stderr, pex_subsystem.verbosity)
 
     if strip_output_chroot:

--- a/src/python/pants/backend/python/util_rules/uv.py
+++ b/src/python/pants/backend/python/util_rules/uv.py
@@ -34,7 +34,7 @@ from pants.base.build_root import BuildRoot
 from pants.core.util_rules import system_binaries
 from pants.core.util_rules.env_vars import environment_vars_subset
 from pants.core.util_rules.subprocess_environment import SubprocessEnvironmentVars
-from pants.core.util_rules.system_binaries import RealpathBinary
+from pants.core.util_rules.system_binaries import MaybeFlockBinary, RealpathBinary
 from pants.engine.composite_process import Subprocess
 from pants.engine.env_vars import EnvironmentVarsRequest
 from pants.engine.fs import (
@@ -47,9 +47,11 @@ from pants.engine.intrinsics import (
     get_digest_contents,
     merge_digests,
 )
+from pants.engine.pants_lock import pants_lock_bin
 from pants.engine.rules import collect_rules, concurrently, implicitly, rule
 from pants.util.docutil import bin_name
 from pants.util.frozendict import FrozenDict
+from pants.util.logging import LogLevel
 from pants.util.strutil import softwrap
 
 logger = logging.getLogger(__name__)
@@ -175,6 +177,8 @@ async def create_venv_repository_from_uv_lockfile(
     uv_env: UvEnvironment,
     realpath_binary: RealpathBinary,
     buildroot: BuildRoot,
+    maybe_flock_binary: MaybeFlockBinary,
+    level: LogLevel,
 ) -> VenvRepository:
     """Install all packages from a uv lockfile into a virtualenv."""
     if request.lockfile.lockfile_format != LockfileFormat.UV:
@@ -224,8 +228,9 @@ async def create_venv_repository_from_uv_lockfile(
     )
 
     # We maintain one cached venv per buildroot+interpreter+resolve. uv will efficiently
-    # incrementally update the venv as the lockfile changes, and will handle concurrency of
-    # `uv sync` with appropriate locking.
+    # incrementally update the venv as the lockfile changes. We lock around the `uv sync`
+    # invocations to ensure that they don't step on each others' toes (`uv sync` claims to
+    # be safe for concurrent invocation but it is not in practice, see above).
     buildroot_entropy = hashlib.sha256(buildroot.path.encode()).hexdigest()
     venv_path_suffix = os.path.join(buildroot_entropy, metadata.resolve, request.python.fingerprint)
 
@@ -234,6 +239,7 @@ async def create_venv_repository_from_uv_lockfile(
             *downloaded_uv.args(),
             "sync",
             "--frozen",
+            *(["--verbose"] if level >= LogLevel.DEBUG else []),  # type: ignore[operator]
             "--no-install-project",
             # TODO: extras can conflict, so we might need to be more selective.
             "--all-extras",
@@ -246,10 +252,41 @@ async def create_venv_repository_from_uv_lockfile(
     # environment this process runs in. This gives uv a stable absolute path for the venv
     # so that any entry point scripts it creates exec a valid path that doesn't reference
     # the sandbox.
+    #
+    # uv claims that you can run sync concurrently on the same venv, but this relies on a
+    # lock on the workspace (not on the target venv), and since each sandbox is its own
+    # uv workspace, these locks don't exclude each other. So instead we use flock (if available)
+    # or pants_lock (otherwise) to provide mutual exclusion on the venv.
+    # The local platform will always have pants_lock, since we bundle it with Pants.
+    # A Linux platform should normally have flock. So the cases where neither binary is available
+    # are a remote platform that isn't Linux (unlikely) or a very constrained Linux, that doesn't
+    # have flock. We error in these cases. If a user encounters this error they must ensure that
+    # flock is available on their remote executors.
+    flock = (
+        maybe_flock_binary.flock_binary.path
+        if maybe_flock_binary.flock_binary
+        else "/flock/not/found"
+    )
+    pants_lock = pants_lock_bin()
     command = dedent(
         f"""\
         cache_root="$({realpath_binary.path} {shlex.quote(VenvRepository.cache_dir)})"
-        UV_PROJECT_ENVIRONMENT="${{cache_root}}/{venv_path_suffix}" {uv_cmd}
+        project_env="${{cache_root}}/{venv_path_suffix}"
+        lock_path="${{project_env}}.lock"
+        mkdir -p "$(dirname "${{lock_path}}")"
+        (
+          if [ -x "{flock}" ]; then
+            {flock} 200 || exit 1
+          elif [ -x "{pants_lock}" ]; then
+            {pants_lock} 200 || exit 1
+          else
+            echo "ERROR: No flock or pants_lock binary found on system executing a uv process. " \
+                 "Please ensure flock is installed on this host and available on " \
+                 "[system-binaries].system_binary_paths." >&2
+            exit 1
+          fi
+          UV_PROJECT_ENVIRONMENT="${{project_env}}" {uv_cmd}
+        ) 200>"${{lock_path}}" || exit $?
         """
     )
 

--- a/src/python/pants/backend/python/util_rules/uv_test.py
+++ b/src/python/pants/backend/python/util_rules/uv_test.py
@@ -1,0 +1,155 @@
+# Copyright 2026 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import sys
+
+from pants.backend.python.goals.lockfile import GenerateUvLockfile
+from pants.backend.python.goals.lockfile import rules as lockfile_rules
+from pants.backend.python.util_rules import uv
+from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
+from pants.backend.python.util_rules.lockfile_metadata import (
+    LockfileFormat,
+    PythonLockfileMetadataV8,
+)
+from pants.backend.python.util_rules.pex import rules as pex_rules
+from pants.backend.python.util_rules.pex_environment import PythonExecutable
+from pants.backend.python.util_rules.pex_requirements import LoadedLockfile, Lockfile
+from pants.backend.python.util_rules.uv import (
+    VenvFromUvLockfileRequest,
+    VenvRepository,
+    generate_pyproject_toml,
+)
+from pants.core.environments.target_types import DockerEnvironmentTarget, LocalEnvironmentTarget
+from pants.core.goals.generate_lockfiles import GenerateLockfileResult
+from pants.core.util_rules import external_tool, subprocess_environment
+from pants.core.util_rules.env_vars import rules as env_vars_rules
+from pants.engine import composite_process
+from pants.engine.composite_process import CompositeProcess
+from pants.engine.environment import EnvironmentName
+from pants.engine.fs import Digest, DigestContents
+from pants.engine.internals.native_engine import FrozenOrderedSet
+from pants.engine.process import FallibleProcessResult, Process
+from pants.testutil.rule_runner import QueryRule, RuleRunner
+
+RESOLVE_NAME = "test-resolve"
+
+
+def _make_rule_runner(docker_image: str | None) -> RuleRunner:
+    rule_runner = RuleRunner(
+        rules=[
+            *uv.rules(),
+            *pex_rules(),
+            *lockfile_rules(),
+            *composite_process.rules(),
+            *external_tool.rules(),
+            *subprocess_environment.rules(),
+            *env_vars_rules(),
+            QueryRule(VenvRepository, [VenvFromUvLockfileRequest]),
+            QueryRule(GenerateLockfileResult, [GenerateUvLockfile]),
+            QueryRule(DigestContents, [Digest]),
+            QueryRule(Process, [CompositeProcess]),
+            QueryRule(FallibleProcessResult, [Process]),
+        ],
+        target_types=[LocalEnvironmentTarget, DockerEnvironmentTarget],
+        inherent_environment=EnvironmentName("test-env") if docker_image else EnvironmentName(None),
+    )
+    args = [f"--python-resolves={{'{RESOLVE_NAME}': 'uv.lock'}}"]
+    if docker_image:
+        rule_runner.write_files(
+            {"BUILD": f"docker_environment(name='test-env', image='{docker_image}')"}
+        )
+        rule_runner.set_options(
+            [*args, "--environments-preview-names={'test-env': '//:test-env'}"],
+            env_inherit={"PATH"},
+        )
+    else:
+        rule_runner.set_options(args, env_inherit={"PATH"})
+    return rule_runner
+
+
+def _create_venv_repository(rule_runner: RuleRunner, python_path: str) -> FallibleProcessResult:
+    metadata = PythonLockfileMetadataV8(
+        valid_for_interpreter_constraints=InterpreterConstraints(["CPython==3.14.*"]),
+        requirements=set(),
+        manylinux=None,
+        requirement_constraints=set(),
+        only_binary=set(),
+        no_binary=set(),
+        excludes=set(),
+        overrides=set(),
+        sources=set(),
+        lock_style=None,
+        complete_platforms=(),
+        uploaded_prior_to=None,
+        lockfile_format=LockfileFormat.UV,
+        resolve=RESOLVE_NAME,
+    )
+
+    pyproject = generate_pyproject_toml(
+        RESOLVE_NAME, metadata.valid_for_interpreter_constraints, ()
+    )
+    rule_runner.write_files({"pyproject.toml": pyproject, "uv.toml": ""})
+    lock_result = rule_runner.request(
+        GenerateLockfileResult,
+        [
+            GenerateUvLockfile(
+                resolve_name=RESOLVE_NAME,
+                lockfile_dest="test.lock",
+                diff=False,
+                requirements=FrozenOrderedSet(),
+                find_links=FrozenOrderedSet(),
+                interpreter_constraints=InterpreterConstraints.for_fixed_python_version("3.14.*"),
+            )
+        ],
+    )
+    uv_lock_content = rule_runner.request(DigestContents, [lock_result.digest])[0].content
+    lockfile_digest = rule_runner.make_snapshot({"test.lock": uv_lock_content.decode()}).digest
+    loaded_lockfile = LoadedLockfile(
+        lockfile_digest,
+        "test.lock",
+        metadata=metadata,
+        requirement_estimate=0,
+        lockfile_format=LockfileFormat.UV,
+        as_constraints_strings=None,
+        original_lockfile=Lockfile(
+            "test.lock", url_description_of_origin="test", resolve_name=RESOLVE_NAME
+        ),
+    )
+
+    venv_repo = rule_runner.request(
+        VenvRepository,
+        [
+            VenvFromUvLockfileRequest(
+                lockfile=loaded_lockfile,
+                python=PythonExecutable(python_path, fingerprint="00" * 32),
+            )
+        ],
+    )
+    process = rule_runner.request(
+        Process,
+        [
+            CompositeProcess(
+                [venv_repo.creation_subprocess],
+                description="Create venv from uv lockfile",
+            )
+        ],
+    )
+    return rule_runner.request(FallibleProcessResult, [process])
+
+
+def test_local_environment() -> None:
+    # Locally, flock is used if present (typically Linux), and pants_lock otherwise
+    # (typically macOS, which has no flock binary).
+    rule_runner = _make_rule_runner(docker_image=None)
+    result = _create_venv_repository(rule_runner, sys.executable)
+    assert result.exit_code == 0, result.stderr.decode()
+
+
+def test_docker_environment_with_flock() -> None:
+    # In a docker environment the pants_lock binary is not available in the container, so success
+    # proves that the container's flock binary was used.
+    rule_runner = _make_rule_runner(docker_image="python:3.14-slim")
+    result = _create_venv_repository(rule_runner, "/usr/local/bin/python3")
+    assert result.exit_code == 0, result.stderr.decode()


### PR DESCRIPTION
Works around a deficiency in `uv`'s claimed
synchronization.

Uses `flock` where available, or `pants_lock`
otherwise.
