### PR TITLE
Resolve symlinks & shims in `build-support/common.sh`

### DIFF
--- a/build-support/common.sh
+++ b/build-support/common.sh
@@ -61,6 +61,8 @@ function determine_python() {
   if [[ "$("${interpreter_path}" --version 2>&1 > /dev/null)" == "pyenv: python${version}"* ]]; then
     echo "pants: The Python ${version} interpreter at ${interpreter_path} is an inactive pyenv interpreter" 1>&2 && return 1
   fi
+  # If the interpreter is a symlink/shim, resolve it to the real path.
+  interpreter_path="$("${interpreter_path}" -c 'import sys; print(sys.executable)')"
   echo "${interpreter_path}"
   return 0
 }


### PR DESCRIPTION
pyenv-virtualenvs active status is not necessarily persistent state in sub cmds, which has been very annoying to work around when building the engine.

This change makes it so pyo3 recieves the interpreter path, not the shim.