### PR TITLE
update the default Pex version to 2.98.4

### DIFF
--- a/docs/notes/2.34.x.md
+++ b/docs/notes/2.34.x.md
@@ -48,9 +48,11 @@ Fixed a bug that caused `generate-lockfiles --sync` not to have its intended eff
 
 Interpreter constraints can now select a specific CPython ABI, to distinguish the free-threaded (no-GIL) build from the standard build. Qualify the interpreter type using either a PEP 508 extra, `CPython[free-threaded]` or `CPython[gil]`, or the equivalent `CPython+t` / `CPython-t` spellings. Both spellings are adopted from Pex. For example, `interpreter_constraints=["CPython[free-threaded]==3.14.*"]` matches only free-threaded 3.14 interpreters, while `CPython==3.14.*` continues to match either ABI.
 
-The default version of [Pex](https://github.com/pex-tool/pex) used by the Python backend has been upgraded to [`v2.97.3`](https://github.com/pex-tool/pex/releases/tag/v2.97.3). Of particular note for Pants users:
+The default version of [Pex](https://github.com/pex-tool/pex) used by the Python backend has been upgraded to [`v2.98.4`](https://github.com/pex-tool/pex/releases/tag/v2.98.4). Of particular note for Pants users:
 
  - [Fix concurrent use of artifact downloads](https://github.com/pex-tool/pex/pull/3207).
+ - [Fix marker processing in `--style universal` locks to respect `and` binding more
+tightly than `or` in the spec](https://github.com/pex-tool/pex/releases/tag/v2.98.1)
 
 #### Shell
 

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -41,9 +41,9 @@ from pants.util.strutil import softwrap
 logger = logging.getLogger(__name__)
 
 
-_PEX_VERSION = "v2.97.3"
-_PEX_BINARY_HASH = "61bc0afdb879b791c30211a809fddc542e36f6b4533240c85fb56753f6d65c05"
-_PEX_BINARY_SIZE = 5038874
+_PEX_VERSION = "v2.98.4"
+_PEX_BINARY_HASH = "78d4bae9f6f4d7e63465e79aff2bd9b199a18340f1d6624cb5af236aa90218b6"
+_PEX_BINARY_SIZE = 5129912
 
 
 class PexCli(TemplatedExternalTool):


### PR DESCRIPTION
Release Notes:
 * https://github.com/pex-tool/pex/releases/tag/v2.98.0
 * https://github.com/pex-tool/pex/releases/tag/v2.98.1
 * https://github.com/pex-tool/pex/releases/tag/v2.98.2
 * https://github.com/pex-tool/pex/releases/tag/v2.98.3
 * https://github.com/pex-tool/pex/releases/tag/v2.98.4