### PR TITLE
fix reapi provider to actually use remote_store_rpc_retries again

### DIFF
--- a/docs/notes/2.34.x.md
+++ b/docs/notes/2.34.x.md
@@ -28,6 +28,8 @@ Pants option config files are now parsed as TOML 1.1 rather than TOML 1.0. This 
 
 The `remote_cache_rpc_timeout_millis` & `remote_cache_rpc_concurrency` options are now correctly used again after being silently ignored since 2.19.  The documented default for `remote_cache_rpc_timeout_millis` is now `30000` to align with the actual behavior since 2.19.  If you used the defaults then nothing changes; if you explicitly set them they now take effect.
 
+Fixed a bug where `remote_store_rpc_retries` was silently ignored by the REAPI cache provider, which always used 2 retries (since 2.2). If you used the default nothing changes; if you explicitly set it, it now takes effect. Also fixed a related bug where the experimental OpenDAL provider used one more than `remote_store_rpc_retries` as the number of retries.
+
 ### Goals
 
 ### Backends

--- a/src/rust/grpc_util/src/retry.rs
+++ b/src/rust/grpc_util/src/retry.rs
@@ -21,7 +21,12 @@ pub fn status_is_retryable(status: &Status) -> bool {
 
 /// Retry a gRPC client operation using exponential back-off to delay between attempts.
 #[inline]
-pub async fn retry_call<T, E, C, F, G, Fut>(client: C, mut f: F, is_retryable: G) -> Result<T, E>
+pub async fn retry_call<T, E, C, F, G, Fut>(
+    client: C,
+    mut f: F,
+    is_retryable: G,
+    max_attempts: usize,
+) -> Result<T, E>
 where
     C: Clone,
     F: FnMut(C, u32) -> Fut,
@@ -29,14 +34,15 @@ where
     Fut: Future<Output = Result<T, E>>,
 {
     const INTERVAL_DURATION: Duration = Duration::from_millis(20);
-    const MAX_RETRIES: u32 = 3;
     const MAX_BACKOFF_DURATION: Duration = Duration::from_secs(5);
 
     let mut num_retries = 0;
     let last_error = loop {
         // Delay before the next send attempt if this is a retry.
         if num_retries > 0 {
-            let multiplier = rand::rng().random_range(0..2_u32.pow(num_retries) + 1);
+            // NB: saturating_pow because `max_attempts` is user-configurable; the sleep is capped
+            // just below anyway.
+            let multiplier = rand::rng().random_range(0..=2_u32.saturating_pow(num_retries));
             let sleep_time = INTERVAL_DURATION * multiplier;
             let sleep_time = sleep_time.min(MAX_BACKOFF_DURATION);
             tokio::time::sleep(sleep_time).await;
@@ -57,7 +63,7 @@ where
 
         num_retries += 1;
 
-        if num_retries >= MAX_RETRIES {
+        if num_retries as usize >= max_attempts {
             break last_error;
         }
     };
@@ -116,6 +122,7 @@ mod tests {
                 async move { client.next().await }
             },
             |err| err.0,
+            3,
         )
         .await;
         assert_eq!(result, Ok(3_isize));
@@ -132,6 +139,7 @@ mod tests {
             client.clone(),
             |client, _| async move { client.next().await },
             |err| err.0,
+            3,
         )
         .await;
         assert_eq!(result, Err(MockError(false, "second")));
@@ -148,9 +156,43 @@ mod tests {
             client.clone(),
             |client, _| async move { client.next().await },
             |err| err.0,
+            3,
         )
         .await;
         assert_eq!(result, Err(MockError(true, "third")));
+        assert_eq!(client.values.lock().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn retry_call_respects_max_attempts() {
+        // succeeds on the 5th attempt, more than the historical default of 3 would allow
+        let client = MockClient::new(vec![
+            Err(MockError(true, "first")),
+            Err(MockError(true, "second")),
+            Err(MockError(true, "third")),
+            Err(MockError(true, "fourth")),
+            Ok(5_isize),
+        ]);
+        let result = retry_call(
+            client.clone(),
+            |client, _| async move { client.next().await },
+            |err| err.0,
+            5,
+        )
+        .await;
+        assert_eq!(result, Ok(5_isize));
+        assert_eq!(client.values.lock().len(), 0);
+
+        // a single attempt: even a retryable error is returned immediately
+        let client = MockClient::new(vec![Err(MockError(true, "first")), Ok(2_isize)]);
+        let result = retry_call(
+            client.clone(),
+            |client, _| async move { client.next().await },
+            |err| err.0,
+            1,
+        )
+        .await;
+        assert_eq!(result, Err(MockError(true, "first")));
         assert_eq!(client.values.lock().len(), 1);
     }
 }

--- a/src/rust/remote_provider/remote_provider_opendal/src/lib.rs
+++ b/src/rust/remote_provider/remote_provider_opendal/src/lib.rs
@@ -62,7 +62,11 @@ impl Provider {
                     .with_io_timeout(options.timeout),
             )
             // TODO: RetryLayer doesn't seem to retry stores, but we should
-            .layer(RetryLayer::new().with_max_times(options.retries + 1))
+            // NB: `max_times` bounds retries _after_ the initial attempt, so passing `retries`
+            // directly yields `retries + 1` total attempts. Upstream docs are ambiguous; the
+            // semantics are pinned by backon's own tests ("executed 4 times (retry 3 times)"):
+            // https://github.com/Xuanwo/backon/blob/v1.6.0/backon/src/retry.rs#L500
+            .layer(RetryLayer::new().with_max_times(options.retries))
             .finish();
 
         let base_path = match options.instance_name {

--- a/src/rust/remote_provider/remote_provider_reapi/src/action_cache.rs
+++ b/src/rust/remote_provider/remote_provider_reapi/src/action_cache.rs
@@ -20,6 +20,7 @@ use crate::apply_headers;
 pub struct Provider {
     instance_name: Option<String>,
     action_cache_client: Arc<ActionCacheClient<LayeredService>>,
+    rpc_attempts: usize,
 }
 
 impl Provider {
@@ -31,6 +32,7 @@ impl Provider {
             headers,
             concurrency_limit,
             timeout,
+            retries,
             ..
         }: RemoteStoreOptions,
     ) -> Result<Self, String> {
@@ -51,6 +53,7 @@ impl Provider {
         Ok(Provider {
             instance_name,
             action_cache_client,
+            rpc_attempts: retries + 1,
         })
     }
 }
@@ -80,6 +83,7 @@ impl ActionCacheProvider for Provider {
                 }
             },
             status_is_retryable,
+            self.rpc_attempts,
         )
         .await
         .map_err(status_to_str)?;
@@ -105,6 +109,7 @@ impl ActionCacheProvider for Provider {
                 async move { client.get_action_result(request).await }
             },
             status_is_retryable,
+            self.rpc_attempts,
         )
         .await;
 

--- a/src/rust/remote_provider/remote_provider_reapi/src/action_cache_tests.rs
+++ b/src/rust/remote_provider/remote_provider_reapi/src/action_cache_tests.rs
@@ -3,13 +3,13 @@
 use std::{collections::BTreeMap, time::Duration};
 
 use hashing::Digest;
-use mock::StubCAS;
+use mock::{RequestType, StubCAS};
 use protos::pb::build::bazel::remote::execution::v2 as remexec;
 use remote_provider_traits::{ActionCacheProvider, RemoteProvider, RemoteStoreOptions};
 
 use super::action_cache::Provider;
 
-async fn new_provider(cas: &StubCAS) -> Provider {
+async fn new_provider_with_retries(cas: &StubCAS, retries: usize) -> Provider {
     Provider::new(RemoteStoreOptions {
         provider: RemoteProvider::Reapi,
         instance_name: None,
@@ -18,13 +18,17 @@ async fn new_provider(cas: &StubCAS) -> Provider {
         headers: BTreeMap::new(),
         concurrency_limit: 256,
         timeout: Duration::from_secs(2),
-        retries: 0,
+        retries,
         batch_api_size_limit: 0,
         chunk_size_bytes: 0,
         batch_load_enabled: false,
     })
     .await
     .unwrap()
+}
+
+async fn new_provider(cas: &StubCAS) -> Provider {
+    new_provider_with_retries(cas, 0).await
 }
 
 #[tokio::test]
@@ -77,6 +81,33 @@ async fn get_action_result_grpc_error() {
         error.contains("unavailable"),
         "Bad error message, got: {error}"
     );
+    // retries: 0 means only a single attempt is made
+    assert_eq!(
+        cas.request_counts
+            .lock()
+            .get(&RequestType::ACGetActionResult),
+        Some(&1)
+    );
+}
+
+#[tokio::test]
+async fn get_action_result_grpc_error_retries_configured_times() {
+    let cas = StubCAS::builder().ac_always_errors().build().await;
+    let provider = new_provider_with_retries(&cas, 3).await;
+
+    let action_digest = Digest::of_bytes(b"get_action_result_grpc_error_retries test");
+
+    provider
+        .get_action_result(action_digest, "")
+        .await
+        .expect_err("Want err");
+
+    assert_eq!(
+        cas.request_counts
+            .lock()
+            .get(&RequestType::ACGetActionResult),
+        Some(&4)
+    );
 }
 
 #[tokio::test]
@@ -120,5 +151,36 @@ async fn update_action_cache_grpc_error() {
     assert!(
         error.contains("unavailable"),
         "Bad error message, got: {error}"
+    );
+    // retries: 0 means only a single attempt is made
+    assert_eq!(
+        cas.request_counts
+            .lock()
+            .get(&RequestType::ACUpdateActionResult),
+        Some(&1)
+    );
+}
+
+#[tokio::test]
+async fn update_action_cache_grpc_error_retries_configured_times() {
+    let cas = StubCAS::builder().ac_always_errors().build().await;
+    let provider = new_provider_with_retries(&cas, 3).await;
+
+    let action_digest = Digest::of_bytes(b"update_action_cache_grpc_error_retries test");
+    let action_result = remexec::ActionResult {
+        exit_code: 123,
+        ..Default::default()
+    };
+
+    provider
+        .update_action_result(action_digest, action_result)
+        .await
+        .expect_err("Want err");
+
+    assert_eq!(
+        cas.request_counts
+            .lock()
+            .get(&RequestType::ACUpdateActionResult),
+        Some(&4)
     );
 }

--- a/src/rust/remote_provider/remote_provider_reapi/src/byte_store.rs
+++ b/src/rust/remote_provider/remote_provider_reapi/src/byte_store.rs
@@ -42,7 +42,7 @@ const DEFAULT_MAX_GRPC_MESSAGE_SIZE: usize = 4 * 1024 * 1024;
 pub struct Provider {
     instance_name: Option<String>,
     chunk_size_bytes: usize,
-    _rpc_attempts: usize,
+    rpc_attempts: usize,
     byte_stream_client: Arc<ByteStreamClient<LayeredService>>,
     cas_client: Arc<ContentAddressableStorageClient<LayeredService>>,
     capabilities_cell: Arc<OnceCell<ServerCapabilities>>,
@@ -110,7 +110,7 @@ impl Provider {
         Ok(Provider {
             instance_name: options.instance_name,
             chunk_size_bytes: options.chunk_size_bytes,
-            _rpc_attempts: options.retries + 1,
+            rpc_attempts: options.retries + 1,
             byte_stream_client,
             cas_client,
             capabilities_cell: Arc::new(OnceCell::new()),
@@ -334,6 +334,7 @@ impl ByteStoreProvider for Provider {
                 }
             },
             ByteStoreError::is_retryable,
+            self.rpc_attempts,
         )
         .await
         .map_err(|e| e.to_string())
@@ -359,6 +360,7 @@ impl ByteStoreProvider for Provider {
         self.store_source_stream(digest, source).await
       },
       ByteStoreError::is_retryable,
+      self.rpc_attempts,
     )
     .await
     .map_err(|e| e.to_string())
@@ -441,6 +443,7 @@ impl ByteStoreProvider for Provider {
                 })
             },
             status_is_retryable,
+            self.rpc_attempts,
         )
         .await
         .map_err(|e| e.to_string())
@@ -555,6 +558,7 @@ impl ByteStoreProvider for Provider {
                         }
                     },
                     status_is_retryable,
+                    self.rpc_attempts,
                 )
             })
             .collect::<Vec<_>>();
@@ -621,6 +625,7 @@ impl ByteStoreProvider for Provider {
                         async move { client.find_missing_blobs(request).await }
                     },
                     status_is_retryable,
+                    self.rpc_attempts,
                 )
             })
             .collect::<Vec<_>>();

--- a/src/rust/remote_provider/remote_provider_reapi/src/byte_store_tests.rs
+++ b/src/rust/remote_provider/remote_provider_reapi/src/byte_store_tests.rs
@@ -129,7 +129,31 @@ async fn load_grpc_error() {
     // retries:
     assert_eq!(
         cas.request_counts.lock().get(&RequestType::BSRead),
-        Some(&3)
+        Some(&2)
+    );
+}
+
+#[tokio::test]
+async fn load_grpc_error_retries_configured_times() {
+    let testdata = TestData::roland();
+    let cas = StubCAS::cas_always_errors().await;
+
+    let provider = Provider::new(RemoteStoreOptions {
+        retries: 4,
+        ..remote_options(cas.address(), 10 * MEGABYTES, STORE_BATCH_API_SIZE_LIMIT)
+    })
+    .await
+    .unwrap();
+    let mut destination = Vec::new();
+
+    provider
+        .load(testdata.digest(), &mut destination)
+        .await
+        .expect_err("Want error");
+
+    assert_eq!(
+        cas.request_counts.lock().get(&RequestType::BSRead),
+        Some(&5)
     );
 }
 
@@ -296,7 +320,7 @@ async fn store_file_grpc_error() {
     // retries:
     assert_eq!(
         cas.request_counts.lock().get(&RequestType::BSWrite),
-        Some(&3)
+        Some(&2)
     );
 }
 
@@ -415,7 +439,7 @@ async fn store_bytes_batch_grpc_error() {
         cas.request_counts
             .lock()
             .get(&RequestType::CASBatchUpdateBlobs),
-        Some(&3)
+        Some(&2)
     );
 }
 
@@ -444,7 +468,7 @@ async fn store_bytes_write_stream_grpc_error() {
     // retries:
     assert_eq!(
         cas.request_counts.lock().get(&RequestType::BSWrite),
-        Some(&3)
+        Some(&2)
     );
 }
 
@@ -564,7 +588,7 @@ async fn list_missing_digests_grpc_error() {
         cas.request_counts
             .lock()
             .get(&RequestType::CASFindMissingBlobs),
-        Some(&3)
+        Some(&2)
     );
 }
 

--- a/src/rust/testutil/mock/src/action_cache_service.rs
+++ b/src/rust/testutil/mock/src/action_cache_service.rs
@@ -16,6 +16,8 @@ use hashing::{Digest, Fingerprint};
 use protos::pb::build::bazel::remote::execution::v2 as remexec;
 use protos::require_digest;
 
+use crate::cas::{RequestCounter, RequestType};
+
 pub struct ActionCacheHandle {
     pub action_map: Arc<Mutex<HashMap<Fingerprint, ActionResult>>>,
     pub always_errors: Arc<AtomicBool>,
@@ -64,6 +66,7 @@ pub(crate) struct ActionCacheResponder {
     pub always_errors: Arc<AtomicBool>,
     pub read_delay: Duration,
     pub write_delay: Duration,
+    pub request_counts: Arc<RequestCounter>,
 }
 
 #[tonic::async_trait]
@@ -72,6 +75,7 @@ impl ActionCache for ActionCacheResponder {
         &self,
         request: Request<GetActionResultRequest>,
     ) -> Result<Response<ActionResult>, Status> {
+        RequestType::ACGetActionResult.record(&self.request_counts);
         sleep(self.read_delay).await;
 
         let request = request.into_inner();
@@ -106,6 +110,7 @@ impl ActionCache for ActionCacheResponder {
         &self,
         request: Request<UpdateActionResultRequest>,
     ) -> Result<Response<ActionResult>, Status> {
+        RequestType::ACUpdateActionResult.record(&self.request_counts);
         sleep(self.write_delay).await;
 
         let request = request.into_inner();

--- a/src/rust/testutil/mock/src/cas.rs
+++ b/src/rust/testutil/mock/src/cas.rs
@@ -58,6 +58,9 @@ pub enum RequestType {
     CASFindMissingBlobs,
     CASBatchUpdateBlobs,
     CASBatchReadBlobs,
+    // ActionCache
+    ACGetActionResult,
+    ACUpdateActionResult,
     // add others of interest as required
 }
 
@@ -198,6 +201,7 @@ impl StubCASBuilder {
             always_errors: ac_always_errors.clone(),
             read_delay: self.ac_read_delay,
             write_delay: self.ac_write_delay,
+            request_counts: request_counts.clone(),
         };
 
         // TODO: Refactor to just use `tokio::net::TcpListener` directly (but requries the method be async and


### PR DESCRIPTION
So I think the history here is:
 * #6931 retries honored
 * #11307 Tonic migration; deleted every read of rpc_attempts and used a hardcoded 3
 * #13807 Rust 1.57 upgrade.  Sort of caught this, but squelched with a _ prefix.
 * #19827 opendal provider added, did use the field
 * #20115 Merged byte-store and AC provider options into RemoteStoreOptions: the AC provider now also received a retries value it never read

A related bug while here was that the OpenDAL provider would retry N+1 instead of N times..

NOTE: An LLM statically identified this bug while I was trying to make an adjacent change, and generated this fix.