### PR TITLE
Concurrent pantsd: stdio per run log

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -4708,6 +4708,7 @@ dependencies = [
  "libc",
  "log",
  "parking_lot 0.12.5",
+ "tempfile",
  "tokio",
 ]
 

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -2008,12 +2008,13 @@ fn stdio_thread_set_destination(stdio_destination: &Bound<'_, PyStdioDestination
     stdio_destination.borrow().0.set_for_current_thread();
 }
 
-// TODO: Needs to be thread-local / associated with the Console.
 #[pyfunction]
 #[pyo3(signature = (log_path))]
 fn set_per_run_log_path(py: Python, log_path: Option<PathBuf>) {
     py.detach(|| {
-        PANTS_LOGGER.set_per_run_logs(log_path);
+        if let Err(e) = stdio::get_destination().set_per_run_log_path(log_path) {
+            warn!("{e}");
+        }
     })
 }
 

--- a/src/rust/logging/src/logger.rs
+++ b/src/rust/logging/src/logger.rs
@@ -22,7 +22,6 @@ const TIME_FORMAT_STR: &str = "%H:%M:%S";
 pub static PANTS_LOGGER: LazyLock<PantsLogger> = LazyLock::new(PantsLogger::new);
 
 struct Inner {
-    per_run_logs: Mutex<Option<File>>,
     log_file: Mutex<Option<File>>,
     global_level: LevelFilter,
     show_rust_3rdparty_logs: bool,
@@ -37,7 +36,6 @@ pub struct PantsLogger(ArcSwap<Inner>);
 impl PantsLogger {
     pub fn new() -> PantsLogger {
         PantsLogger(ArcSwap::from(Arc::new(Inner {
-            per_run_logs: Mutex::new(None),
             log_file: Mutex::new(None),
             global_level: LevelFilter::Off,
             show_rust_3rdparty_logs: true,
@@ -86,7 +84,6 @@ impl PantsLogger {
             })?;
 
         PANTS_LOGGER.0.store(Arc::new(Inner {
-            per_run_logs: Mutex::default(),
             log_file: Mutex::new(Some(log_file)),
             global_level,
             show_rust_3rdparty_logs,
@@ -106,23 +103,6 @@ impl PantsLogger {
         // environment variables to decide.
         colored::control::set_override(true);
         Ok(())
-    }
-
-    pub fn set_per_run_logs(&self, per_run_log_path: Option<PathBuf>) {
-        match per_run_log_path {
-            None => {
-                *self.0.load().per_run_logs.lock() = None;
-            }
-            Some(path) => {
-                let file = OpenOptions::new()
-                    .create(true)
-                    .append(true)
-                    .open(path)
-                    .map_err(|err| format!("Error opening per-run logfile: {err}"))
-                    .unwrap();
-                *self.0.load().per_run_logs.lock() = Some(file);
-            }
-        };
     }
 
     /// log_from_python is only used in the Python FFI, which in turn is only called within the
@@ -223,13 +203,7 @@ impl Log for PantsLogger {
         };
         let log_bytes = log_string.as_bytes();
 
-        {
-            let mut maybe_per_run_file = inner.per_run_logs.lock();
-            if let Some(ref mut file) = *maybe_per_run_file {
-                // deliberately ignore errors writing to per-run log file
-                let _ = file.write_all(log_bytes);
-            }
-        }
+        destination.write_per_run_log(log_bytes);
 
         // Attempt to write to stdio, and write to the pantsd log if we fail (either because we don't
         // have a valid stdio instance, or because of an error).

--- a/src/rust/stdio/Cargo.toml
+++ b/src/rust/stdio/Cargo.toml
@@ -11,5 +11,8 @@ log = { workspace = true }
 parking_lot = { workspace = true }
 tokio = { workspace = true, features = ["rt"] }
 
+[dev-dependencies]
+tempfile = { workspace = true }
+
 [lints]
 workspace = true

--- a/src/rust/stdio/src/lib.rs
+++ b/src/rust/stdio/src/lib.rs
@@ -3,12 +3,15 @@
 
 mod term;
 
+#[cfg(test)]
+mod tests;
+
 pub use term::{TermReadDestination, TermWriteDestination, TryCloneAsFile};
 
 use libc::c_int;
 use std::cell::RefCell;
 use std::fmt;
-use std::fs::File;
+use std::fs::{File, OpenOptions};
 use std::future::Future;
 use std::io::{Read, Write};
 use std::mem::ManuallyDrop;
@@ -18,6 +21,7 @@ use std::os::unix::io::FromRawFd;
 use std::os::windows::io::FromRawHandle;
 #[cfg(windows)]
 use std::os::windows::raw::HANDLE;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use parking_lot::Mutex;
@@ -157,14 +161,25 @@ impl fmt::Debug for InnerDestination {
 }
 
 #[derive(Debug)]
-pub struct Destination(Mutex<InnerDestination>);
+pub struct Destination {
+    inner: Mutex<InnerDestination>,
+    per_run_log: Mutex<Option<File>>,
+}
 
 impl Destination {
+    fn new(inner: InnerDestination) -> Destination {
+        Destination {
+            inner: Mutex::new(inner),
+            per_run_log: Mutex::new(None),
+        }
+    }
+
     ///
     /// Clears the Destination, setting it back to Logging.
     ///
     pub fn console_clear(&self) {
-        *self.0.lock() = InnerDestination::Logging;
+        *self.inner.lock() = InnerDestination::Logging;
+        *self.per_run_log.lock() = None;
     }
 
     ///
@@ -184,7 +199,7 @@ impl Destination {
         ),
         String,
     > {
-        let mut destination = self.0.lock();
+        let mut destination = self.inner.lock();
         let stderr_use_color = match *destination {
             InnerDestination::Console(Console {
                 stderr_use_color, ..
@@ -214,7 +229,7 @@ impl Destination {
     /// Clears Exclusive access and restores the Console.
     ///
     fn exclusive_clear(&self, console: Console) {
-        let mut destination = self.0.lock();
+        let mut destination = self.inner.lock();
         if matches!(*destination, InnerDestination::Exclusive { .. }) {
             *destination = InnerDestination::Console(console);
         } else {
@@ -227,7 +242,7 @@ impl Destination {
     /// Set whether to use color for stderr.
     ///
     pub fn stderr_set_use_color(&self, use_color: bool) {
-        let mut destination = self.0.lock();
+        let mut destination = self.inner.lock();
         if let InnerDestination::Console(ref mut console) = *destination {
             console.stderr_set_use_color(use_color);
         }
@@ -237,7 +252,7 @@ impl Destination {
     /// True if color should be used with stderr.
     ///
     pub fn stderr_use_color(&self) -> bool {
-        let destination = self.0.lock();
+        let destination = self.inner.lock();
         match *destination {
             InnerDestination::Console(ref console) => console.stderr_use_color,
             InnerDestination::Exclusive {
@@ -248,10 +263,41 @@ impl Destination {
     }
 
     ///
+    /// Set (or clear) a file to which a copy of all log output rendered for this Destination
+    /// should be appended.
+    ///
+    pub fn set_per_run_log_path(&self, path: Option<PathBuf>) -> Result<(), String> {
+        let file = match path {
+            Some(path) => Some(
+                OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(&path)
+                    .map_err(|e| {
+                        format!("Error opening per-run logfile at {}: {e}", path.display())
+                    })?,
+            ),
+            None => None,
+        };
+        *self.per_run_log.lock() = file;
+        Ok(())
+    }
+
+    ///
+    /// Write a copy of the given log content to the per-run log file, if one is set.
+    ///
+    pub fn write_per_run_log(&self, content: &[u8]) {
+        // Deliberately ignore errors writing to the per-run log file.
+        if let Some(ref mut file) = *self.per_run_log.lock() {
+            let _ = file.write_all(content);
+        }
+    }
+
+    ///
     /// Read from stdin if it is available on the current Destination.
     ///
     pub fn read_stdin(&self, buf: &mut [u8]) -> std::io::Result<usize> {
-        let mut destination = self.0.lock();
+        let mut destination = self.inner.lock();
         match *destination {
             InnerDestination::Console(ref mut console) => console.read_stdin(buf),
             InnerDestination::Exclusive { .. } => Err(std::io::Error::new(
@@ -270,7 +316,7 @@ impl Destination {
     /// available.
     ///
     pub fn write_stdout(&self, content: &[u8]) {
-        let mut destination = self.0.lock();
+        let mut destination = self.inner.lock();
         let error_res = match *destination {
             InnerDestination::Console(ref mut console) => {
                 // Write to the underlying Console.
@@ -307,7 +353,7 @@ impl Destination {
     /// written stdio might result in infinite recursion.
     ///
     pub fn write_stderr_raw(&self, content: &[u8]) -> Result<(), String> {
-        let mut destination = self.0.lock();
+        let mut destination = self.inner.lock();
         match *destination {
             InnerDestination::Console(ref mut console) => {
                 console.write_stderr(content).map_err(|e| e.to_string())
@@ -327,7 +373,7 @@ impl Destination {
     /// available.
     ///
     pub fn write_stderr(&self, content: &[u8]) {
-        let mut destination = self.0.lock();
+        let mut destination = self.inner.lock();
         let error_res = match *destination {
             InnerDestination::Console(ref mut console) => {
                 // Write to the underlying Console.
@@ -373,7 +419,7 @@ impl Destination {
     /// time the caller interacts with it.
     ///
     pub fn stdin_as_c_fd(&self) -> Result<CFd, String> {
-        match &*self.0.lock() {
+        match &*self.inner.lock() {
       InnerDestination::Console(console) => Ok(console.stdin_as_c_fd()),
       InnerDestination::Logging => {
         Err("No associated file descriptor for the Logging destination".to_owned())
@@ -390,7 +436,7 @@ impl Destination {
     /// time the caller interacts with it.
     ///
     pub fn stdout_as_c_fd(&self) -> Result<CFd, String> {
-        match &*self.0.lock() {
+        match &*self.inner.lock() {
       InnerDestination::Console(console) => Ok(console.stdout_as_c_fd()),
       InnerDestination::Logging => {
         Err("No associated file descriptor for the Logging destination".to_owned())
@@ -407,7 +453,7 @@ impl Destination {
     /// time the caller interacts with it.
     ///
     pub fn stderr_as_c_fd(&self) -> Result<CFd, String> {
-        match &*self.0.lock() {
+        match &*self.inner.lock() {
       InnerDestination::Console(console) => Ok(console.stderr_as_c_fd()),
       InnerDestination::Logging => {
         Err("No associated file descriptor for the Logging destination".to_owned())
@@ -424,7 +470,7 @@ impl Destination {
     /// lock is held while it runs.
     ///
     pub fn with_stderr_file<T>(&self, f: impl FnOnce(&File) -> T) -> Result<T, String> {
-        match &*self.0.lock() {
+        match &*self.inner.lock() {
       InnerDestination::Console(console) => Ok(f(console.stderr_file())),
       InnerDestination::Logging => {
         Err("No associated file descriptor for the Logging destination".to_owned())
@@ -440,7 +486,7 @@ thread_local! {
   ///
   /// See set_thread_destination.
   ///
-  static THREAD_DESTINATION: RefCell<Arc<Destination>> = RefCell::new(Arc::new(Destination(Mutex::new(InnerDestination::Logging))))
+  static THREAD_DESTINATION: RefCell<Arc<Destination>> = RefCell::new(Arc::new(Destination::new(InnerDestination::Logging)))
 }
 
 // Note: The behavior of this task_local! invocation is affected by the `tokio_no_const_thread_local`
@@ -455,8 +501,8 @@ task_local! {
 /// using `set_thread_destination`.
 ///
 pub fn new_console_destination(stdin_fd: CFd, stdout_fd: CFd, stderr_fd: CFd) -> Arc<Destination> {
-    Arc::new(Destination(Mutex::new(InnerDestination::Console(
-        Console::new(stdin_fd, stdout_fd, stderr_fd),
+    Arc::new(Destination::new(InnerDestination::Console(Console::new(
+        stdin_fd, stdout_fd, stderr_fd,
     ))))
 }
 

--- a/src/rust/stdio/src/tests.rs
+++ b/src/rust/stdio/src/tests.rs
@@ -1,0 +1,68 @@
+// Copyright 2026 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use crate::{Destination, InnerDestination, get_destination, set_thread_destination};
+
+#[test]
+fn per_run_log_is_destination_scoped() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let path_one = tempdir.path().join("one.log");
+    let path_two = tempdir.path().join("two.log");
+
+    let write_via_thread = |path: PathBuf, content: &'static [u8]| {
+        std::thread::spawn(move || {
+            set_thread_destination(Arc::new(Destination::new(InnerDestination::Logging)));
+            get_destination().set_per_run_log_path(Some(path)).unwrap();
+            get_destination().write_per_run_log(content);
+        })
+        .join()
+        .unwrap()
+    };
+
+    write_via_thread(path_one.clone(), b"one");
+    write_via_thread(path_two.clone(), b"two");
+
+    assert_eq!(std::fs::read(&path_one).unwrap(), b"one");
+    assert_eq!(std::fs::read(&path_two).unwrap(), b"two");
+}
+
+#[test]
+fn per_run_log_ignores_writes_when_unset() {
+    let destination = Destination::new(InnerDestination::Logging);
+    destination.write_per_run_log(b"dropped");
+}
+
+#[test]
+fn per_run_log_cleared_by_none() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let path = tempdir.path().join("run.log");
+
+    let destination = Destination::new(InnerDestination::Logging);
+    destination
+        .set_per_run_log_path(Some(path.clone()))
+        .unwrap();
+    destination.write_per_run_log(b"kept");
+    destination.set_per_run_log_path(None).unwrap();
+    destination.write_per_run_log(b"dropped");
+
+    assert_eq!(std::fs::read(&path).unwrap(), b"kept");
+}
+
+#[test]
+fn console_clear_clears_per_run_log() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let path = tempdir.path().join("run.log");
+
+    let destination = Destination::new(InnerDestination::Logging);
+    destination
+        .set_per_run_log_path(Some(path.clone()))
+        .unwrap();
+    destination.write_per_run_log(b"kept");
+    destination.console_clear();
+    destination.write_per_run_log(b"dropped");
+
+    assert_eq!(std::fs::read(&path).unwrap(), b"kept");
+}


### PR DESCRIPTION
`PANTS_LOGGER` held the per-run log file in one process-global slot, so `set_per_run_log_path` applied to every thread. There was a `TODO` for this.

Move it onto the thread-local `stdio::Destination`, next to the Console it belongs to.

This is a noop for users. Preparatory work for #7654.