### PR TITLE
Concurrent pantsd: Memoize subsystem rules once

### DIFF
--- a/src/python/pants/option/subsystem.py
+++ b/src/python/pants/option/subsystem.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import functools
 import inspect
 import re
+import threading
 from abc import ABCMeta
 from collections.abc import Callable, Iterable, Sequence
 from typing import TYPE_CHECKING, Any, ClassVar, TypeVar, cast
@@ -30,6 +31,8 @@ if TYPE_CHECKING:
     from pants.engine.rules import Rule
 
 _SubsystemT = TypeVar("_SubsystemT", bound="Subsystem")
+
+_rules_lock = threading.Lock()
 
 
 class _SubsystemMeta(ABCMeta):
@@ -171,7 +174,14 @@ class Subsystem(metaclass=_SubsystemMeta):
                     yield cls._construct_env_aware_rule()
                     yield from (cast(Rule, i) for i in add_option_fields_for(cls.EnvironmentAware))
 
-            cls._rules = tuple(inner())
+            candidate = tuple(inner())
+            # nb. Runs load backends concurrently under pantsd, so the memo must be published
+            # exactly once: a caller that later observed a second tuple would hand the rule graph
+            # two distinct rules per id. No foreign code runs under the lock, so it need not be
+            # re-entrant.
+            with _rules_lock:
+                if cls._rules is None:
+                    cls._rules = candidate
         return cast("Sequence[Rule]", cls._rules)
 
     @distinct_union_type_per_subclass

--- a/src/python/pants/option/subsystem_test.py
+++ b/src/python/pants/option/subsystem_test.py
@@ -1,6 +1,8 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import threading
+
 import pytest
 
 from pants.engine.unions import UnionMembership, UnionRule
@@ -105,3 +107,36 @@ def test_register_plugin_options() -> None:
     electrical_subsystem = Electrical(options.for_scope(Electrical.options_scope))
     assert not electrical_subsystem.options.is_on
     assert electrical_subsystem.options.contents == []
+
+
+def test_rules_memo_is_published_once_under_concurrency() -> None:
+    class Concurrent(Subsystem):
+        options_scope = "concurrent"
+        help = "Racing rules()."
+
+    entered = threading.Event()
+    resume = threading.Event()
+    original = Concurrent._construct_subsystem_rule
+    gated: list[threading.Thread] = []
+    gated_rules: list[object] = []
+
+    def gated_construct_subsystem_rule():
+        if threading.current_thread() is gated[0]:
+            entered.set()
+            assert resume.wait(timeout=60)
+        return original()
+
+    Concurrent._construct_subsystem_rule = gated_construct_subsystem_rule  # type: ignore[method-assign]
+    gated.append(threading.Thread(target=lambda: gated_rules.append(Concurrent.rules())))
+
+    try:
+        gated[0].start()
+        assert entered.wait(timeout=60)
+        # The gated thread is parked past its `_rules is None` check, so this call races it.
+        published = Concurrent.rules()
+    finally:
+        resume.set()
+        gated[0].join(timeout=60)
+
+    assert gated_rules[0] is published
+    assert Concurrent.rules() is published


### PR DESCRIPTION
Concurrent runs load backends at the same time, and the unsynchronized memo would let one `BuildConfiguration` collect multiple rules for the same id. The first publisher now wins under a lock.

This cannot occur with the pantsd concurrency lock, but I'm trying to get rid of it.

Prerequisite for https://github.com/pantsbuild/pants/issues/7654