### PR TITLE
[codex] Validate target field subclass uniqueness

### DIFF
--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -262,6 +262,8 @@ class Target:
                 ),
             )
 
+            self._validate_single_field_subclass(SourcesField)
+            self._validate_single_field_subclass(Dependencies)
             self.validate()
         except Exception as e:
             raise InvalidTargetException(
@@ -314,6 +316,20 @@ class Target:
                 key=lambda field_type_to_val_pair: field_type_to_val_pair[0].alias,
             )
         )
+
+    def _validate_single_field_subclass(self, field_type: type[Field]) -> None:
+        matching_fields = [
+            registered_field_type
+            for registered_field_type in self.field_values
+            if issubclass(registered_field_type, field_type)
+        ]
+        if len(matching_fields) > 1:
+            aliases = ", ".join(f"`{field.alias}`" for field in matching_fields)
+            raise InvalidTargetException(
+                f"The target type `{self.alias}` must not register multiple `{field_type.__name__}` "
+                f"subclasses, but registered {aliases}. Pants can only handle one field of this "
+                "kind per target."
+            )
 
     @final
     @classmethod

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -21,6 +21,7 @@ from pants.engine.target import (
     BoolField,
     CoarsenedTarget,
     CoarsenedTargets,
+    Dependencies,
     DictStringToStringField,
     DictStringToStringSequenceField,
     ExplicitlyProvidedDependencies,
@@ -470,6 +471,48 @@ def test_async_field_mixin() -> None:
 def test_target_validate() -> None:
     with pytest.raises(InvalidTargetException):
         FortranTarget({FortranVersion.alias: "bad"}, Address("", target_name="t"))
+
+
+def test_target_validate_errors_on_multiple_sources_fields() -> None:
+    class Sources1(MultipleSourcesField):
+        alias = "sources1"
+
+    class Sources2(MultipleSourcesField):
+        alias = "sources2"
+
+    class InvalidTarget(Target):
+        alias = "invalid"
+        core_fields = (Sources1, Sources2)
+
+    with pytest.raises(
+        InvalidTargetException,
+        match=(
+            r"The target type `invalid` must not register multiple `SourcesField` subclasses, "
+            r"but registered `sources1`, `sources2`"
+        ),
+    ):
+        InvalidTarget({}, Address("", target_name="t"))
+
+
+def test_target_validate_errors_on_multiple_dependencies_fields() -> None:
+    class Deps1(Dependencies):
+        alias = "deps1"
+
+    class Deps2(Dependencies):
+        alias = "deps2"
+
+    class InvalidTarget(Target):
+        alias = "invalid"
+        core_fields = (Deps1, Deps2)
+
+    with pytest.raises(
+        InvalidTargetException,
+        match=(
+            r"The target type `invalid` must not register multiple `Dependencies` subclasses, "
+            r"but registered `deps1`, `deps2`"
+        ),
+    ):
+        InvalidTarget({}, Address("", target_name="t"))
 
 
 def test_target_residence_dir() -> None:


### PR DESCRIPTION
## Summary

- validate that a target type registers at most one `SourcesField` subclass
- apply the same validation to `Dependencies` subclasses
- add regression coverage for both cases

Fixes pantsbuild/pants#17132.

## Testing

- `./pants test src/python/pants/engine/target_test.py` (blocked locally: Pants could not find a Python 3.14 interpreter)
