### PR TITLE
Fix "Long running tasks" logging when dynamic_ui is disabled

### DIFF
--- a/docs/notes/2.34.x.md
+++ b/docs/notes/2.34.x.md
@@ -26,6 +26,8 @@ Published Pants binaries are now compiled with a new `dist` Cargo profile that e
 
 Pants option config files are now parsed as TOML 1.1 rather than TOML 1.0. This covers `pants.toml` and any other file named by `[GLOBAL].pants_config_files`, the rcfiles named by `[GLOBAL].pantsrc_files` (`/etc/pantsrc`, `~/.pants.rc` and `.pants.rc` by default), and `.toml` files referenced by `@fromfile` option values. Inline tables may now span multiple lines and end with a trailing comma, strings may use the `\e` and `\xHH` escapes, and times may omit their seconds. TOML 1.1 only adds syntax to TOML 1.0, so existing files continue to parse unchanged. TOML files read by backends, such as `pyproject.toml`, are unaffected.
 
+Fixed "Long running tasks:" straggler logging not printing when `dynamic_ui = false`. A memory-leak optimization in [#23485](https://github.com/pantsbuild/pants/pull/23485) disabled the heavy-hitters workunit channel when the dynamic UI was off, but that channel is also used by the non-dynamic-UI `Logging` display to report long-running tasks. This caused CI builds (where `dynamic_ui` defaults to `false`) to lose their heartbeat output and potentially time out.
+
 ### Goals
 
 ### Backends

--- a/src/rust/engine/src/session.rs
+++ b/src/rust/engine/src/session.rs
@@ -159,9 +159,10 @@ impl Session {
         }
         // Only queue workunit messages for consumers which will actually poll for them: the
         // streaming channel is enabled later iff a streaming workunit consumer registers (see
-        // `enable_streaming_workunits`), and the heavy hitters consumer only exists for the
-        // dynamic UI.
-        let workunit_store = WorkunitStore::new(!dynamic_ui, max_workunit_level, false, dynamic_ui);
+        // `enable_streaming_workunits`). The heavy hitters channel is always enabled because it
+        // feeds both the dynamic UI (via `heavy_hitters`) and the non-dynamic-UI straggler
+        // logging (via `straggling_workunits`).
+        let workunit_store = WorkunitStore::new(!dynamic_ui, max_workunit_level, false, true);
         let display = tokio::sync::Mutex::new(SessionDisplay::new(
             &workunit_store,
             core.local_parallelism,


### PR DESCRIPTION
This addresses https://github.com/pantsbuild/pants/issues/23603

## Problem

In Pants v2.32, when `dynamic_ui = false` is configured (the default on CI where no TTY is present), Pants would periodically print `Long running tasks:` lines to the console. This output serves as a heartbeat that prevents CI systems from timing out long-running builds.

In v2.33, this console output no longer appears, causing CI timeout failures.

## Root Cause

Commit 52d5fa0449 (#23485, "Skip queueing workunit messages for consumers that never poll to avoid unbound memory growth") introduced a regression.

The `WorkunitStore` constructor gained a `ui_consumers` flag that controls whether messages are sent to the `heavy_hitters_data` channel:

```rust
// session.rs line 164
let workunit_store = WorkunitStore::new(!dynamic_ui, max_workunit_level, false, dynamic_ui);
//                                                                              ^^^^^^^^^^
//                                                                              ui_consumers
```

When `dynamic_ui = false`, `ui_consumers = false`, so `self.ui_sender = None` in the `WorkunitStore`. This means workunit `StoreMsg` messages (Started/Completed/Canceled) are **never sent** to the `heavy_hitters_data` receiver channel.

When the `SessionDisplay::Logging` variant calls `straggling_workunits()` to print "Long running tasks:", `HeavyHittersData::refresh_store()` finds nothing because no messages were ever delivered to its receiver — the sender was `None`.

### The incorrect assumption

The comment in the original commit says: *"the heavy hitters consumer only exists for the dynamic UI"*. This is incorrect:

- `SessionDisplay::ConsoleUI` (dynamic UI **on**) → uses `heavy_hitters()` to render the dynamic task display
- `SessionDisplay::Logging` (dynamic UI **off**) → uses `straggling_workunits()` to log long-running tasks

Both read from the same `heavy_hitters_data` channel. Both need messages delivered to function.

## Fix

Always enable the heavy hitters channel (`ui_consumers = true`), since it is needed by both `ConsoleUI` (via `heavy_hitters()`) and `Logging` (via `straggling_workunits()`).

```diff
-let workunit_store = WorkunitStore::new(!dynamic_ui, max_workunit_level, false, dynamic_ui);
+let workunit_store = WorkunitStore::new(!dynamic_ui, max_workunit_level, false, true);
```

This is a one-line change in `src/rust/engine/src/session.rs`.

### Impact on the original optimization

The original PR aimed to avoid unbounded memory growth from messages queued for consumers that never poll. This fix means the heavy hitters channel will always have messages sent to it, but this is safe because:
- When `dynamic_ui = true`: `ConsoleUI::render()` polls `heavy_hitters()` regularly
- When `dynamic_ui = false`: `SessionDisplay::Logging` polls `straggling_workunits()` regularly

In both cases, the channel **is** actively polled, so messages do not accumulate.