### PR TITLE
Gate audit-* github workflows to pantsbuild repository owner

### DIFF
--- a/.github/workflows/audit-cargo.yml
+++ b/.github/workflows/audit-cargo.yml
@@ -13,6 +13,7 @@ permissions: {}
 jobs:
   cargo-audit:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'pantsbuild'
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/audit-zizmor.yml
+++ b/.github/workflows/audit-zizmor.yml
@@ -13,6 +13,7 @@ permissions: {}
 jobs:
   zizmor-audit:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'pantsbuild'
     permissions:
       security-events: write
     steps:


### PR DESCRIPTION
Prevent accidental run of scheduled workflows in the same fashion as in https://github.com/pantsbuild/pants/blob/602b77e6b138fcd3c8cd563d7d19a877c2634b13/.github/workflows/nudgebot.yaml#L10-L15