### PR TITLE
Restore "Long running tasks" logging when the dynamic UI is disabled

### DIFF
--- a/docs/notes/2.33.x.md
+++ b/docs/notes/2.33.x.md
@@ -32,6 +32,8 @@ Fixed a bug where certain limited terminals that report a width of 0 (like Emacs
 
 Fixed a bug where writes of remote cache content into a local sandbox could escape the requested output root.
 
+Fixed a bug where the periodic `Long running tasks:` log lines were not printed when `dynamic_ui` was disabled (the default in CI), which could cause CI systems to time out for lack of output.
+
 Remote execution and remote caching now use the REAPI `output_paths` field, improving compatibility with providers such as BuildBarn and fixing processes that capture the sandbox root as an output directory (for example, `output_directories=["."]`). This changes remote action digests for affected processes, so users may see one-time remote cache misses after upgrading.
 
 Fixed broken troubleshooting documentation links.

--- a/src/rust/engine/src/session.rs
+++ b/src/rust/engine/src/session.rs
@@ -157,11 +157,9 @@ impl Session {
         if dynamic_ui {
             max_workunit_level = std::cmp::max(max_workunit_level, log::Level::Debug);
         }
-        // Only queue workunit messages for consumers which will actually poll for them: the
-        // streaming channel is enabled later iff a streaming workunit consumer registers (see
-        // `enable_streaming_workunits`), and the heavy hitters consumer only exists for the
-        // dynamic UI.
-        let workunit_store = WorkunitStore::new(!dynamic_ui, max_workunit_level, false, dynamic_ui);
+        // The streaming channel is enabled later iff a streaming workunit consumer registers (see
+        // `enable_streaming_workunits`).
+        let workunit_store = WorkunitStore::new(!dynamic_ui, max_workunit_level, false);
         let display = tokio::sync::Mutex::new(SessionDisplay::new(
             &workunit_store,
             core.local_parallelism,
@@ -342,6 +340,9 @@ impl Session {
     }
 
     pub fn maybe_display_render(&self) {
+        // Neither display mode consumes the heavy hitters queue on every tick, so drain it here
+        // (outside of the display lock) to keep it from growing between renders.
+        self.state.workunit_store.refresh_heavy_hitters();
         let mut display = if let Ok(display) = self.handle.display.try_lock() {
             display
         } else {

--- a/src/rust/fs/fs_util/src/main.rs
+++ b/src/rust/fs/fs_util/src/main.rs
@@ -63,7 +63,7 @@ struct SummaryWithDigest {
 #[tokio::main]
 async fn main() {
     env_logger::init();
-    let workunit_store = WorkunitStore::new(false, log::Level::Debug, true, true);
+    let workunit_store = WorkunitStore::new(false, log::Level::Debug, true);
     workunit_store.init_thread_state(None);
 
     match execute(

--- a/src/rust/grpc_util/src/metrics.rs
+++ b/src/rust/grpc_util/src/metrics.rs
@@ -137,7 +137,7 @@ mod tests {
 
     #[tokio::test]
     async fn collects_network_metrics() {
-        let ws = WorkunitStore::new(true, Level::Debug, true, true);
+        let ws = WorkunitStore::new(true, Level::Debug, true);
         ws.init_thread_state(None);
 
         let metric_for_path: Arc<HashMap<String, ObservationMetric>> = {

--- a/src/rust/process_execution/remote/src/remote_tests.rs
+++ b/src/rust/process_execution/remote/src/remote_tests.rs
@@ -1455,7 +1455,7 @@ async fn sends_headers() {
     .await
     .unwrap();
     let context = Context {
-        workunit_store: WorkunitStore::new(false, log::Level::Debug, true, true),
+        workunit_store: WorkunitStore::new(false, log::Level::Debug, true),
         build_id: String::from("marmosets"),
         run_id: RunId(0),
         ..Context::default()

--- a/src/rust/process_execution/src/lib.rs
+++ b/src/rust/process_execution/src/lib.rs
@@ -1009,7 +1009,7 @@ pub struct Context {
 impl Default for Context {
     fn default() -> Self {
         Context {
-            workunit_store: WorkunitStore::new(false, log::Level::Debug, true, true),
+            workunit_store: WorkunitStore::new(false, log::Level::Debug, true),
             build_id: String::default(),
             run_id: RunId(0),
             tail_tasks: TailTasks::new(),

--- a/src/rust/process_executor/src/main.rs
+++ b/src/rust/process_executor/src/main.rs
@@ -163,7 +163,7 @@ struct Opt {
 #[tokio::main]
 async fn main() -> Result<(), String> {
     env_logger::init();
-    let workunit_store = WorkunitStore::new(false, log::Level::Debug, true, true);
+    let workunit_store = WorkunitStore::new(false, log::Level::Debug, true);
     workunit_store.init_thread_state(None);
 
     let args = Opt::parse();

--- a/src/rust/workunit_store/src/lib.rs
+++ b/src/rust/workunit_store/src/lib.rs
@@ -391,7 +391,7 @@ pub struct WorkunitStore {
     max_level: Level,
     streaming_sender: UnboundedSender<StoreMsg>,
     streaming_enabled: Arc<AtomicBool>,
-    ui_sender: Option<UnboundedSender<StoreMsg>>,
+    ui_sender: UnboundedSender<StoreMsg>,
     streaming_workunit_data: Arc<Mutex<StreamingWorkunitData>>,
     heavy_hitters_data: Arc<Mutex<HeavyHittersData>>,
     metrics_data: Arc<MetricsData>,
@@ -579,16 +579,13 @@ impl WorkunitStore {
     ///
     /// Creates a WorkunitStore. Messages are only queued for `latest_workunits` once
     /// `streaming_consumers` is true or `enable_streaming_workunits` has been called (when a
-    /// polling consumer actually registers), and are only queued for
-    /// `heavy_hitters`/`straggling_workunits` when `ui_consumers` is true. The channels are
-    /// unbounded, so a session which queues messages that no consumer ever polls accumulates
-    /// them for its entire lifetime.
+    /// polling consumer actually registers). The channels are unbounded, so a session which
+    /// queues messages that no consumer ever polls accumulates them for its entire lifetime.
     ///
     pub fn new(
         log_starting_workunits: bool,
         max_level: Level,
         streaming_consumers: bool,
-        ui_consumers: bool,
     ) -> WorkunitStore {
         // NB: Although it would be nice not to have separate allocations per consumer, it is
         // difficult to use a channel like `tokio::sync::broadcast` due to that channel being bounded.
@@ -603,7 +600,7 @@ impl WorkunitStore {
             // installed.
             streaming_sender: sender1,
             streaming_enabled: Arc::new(AtomicBool::new(streaming_consumers)),
-            ui_sender: ui_consumers.then_some(sender2),
+            ui_sender: sender2,
             streaming_workunit_data: Arc::new(Mutex::new(StreamingWorkunitData::new(receiver1))),
             heavy_hitters_data: Arc::new(Mutex::new(HeavyHittersData::new(receiver2))),
             metrics_data: Arc::default(),
@@ -631,6 +628,15 @@ impl WorkunitStore {
     }
 
     ///
+    /// Drain queued messages into the heavy hitters graph without reporting anything: consumers
+    /// which report less frequently than they render should call this on every render to keep the
+    /// queue from growing.
+    ///
+    pub fn refresh_heavy_hitters(&self) {
+        self.heavy_hitters_data.lock().refresh_store()
+    }
+
+    ///
     /// Return visible workunits which have been running longer than the duration_threshold, sorted
     /// in ascending order by their duration.
     ///
@@ -654,21 +660,10 @@ impl WorkunitStore {
                 .send(msg)
                 .unwrap_or_else(|_| panic!("Receivers are static, and should always be present."));
         };
-        // Send a clone to the streaming sender if both consumers are enabled, and the owned value
-        // to the last enabled sender.
-        let streaming_sender = self
-            .streaming_enabled
-            .load(atomic::Ordering::Relaxed)
-            .then_some(&self.streaming_sender);
-        match (streaming_sender, self.ui_sender.as_ref()) {
-            (Some(sender1), Some(sender2)) => {
-                send_inner(sender1, msg.clone());
-                send_inner(sender2, msg);
-            }
-            (Some(sender1), None) => send_inner(sender1, msg),
-            (None, Some(sender2)) => send_inner(sender2, msg),
-            (None, None) => (),
+        if self.streaming_enabled.load(atomic::Ordering::Relaxed) {
+            send_inner(&self.streaming_sender, msg.clone());
         }
+        send_inner(&self.ui_sender, msg);
     }
 
     ///
@@ -829,7 +824,7 @@ impl WorkunitStore {
     }
 
     pub fn setup_for_tests() -> (WorkunitStore, RunningWorkunit) {
-        let store = WorkunitStore::new(false, Level::Trace, true, true);
+        let store = WorkunitStore::new(false, Level::Trace, true);
         store.init_thread_state(None);
         let workunit =
             store._start_workunit(SpanId(0), "testing", Level::Info, None, Option::default());

--- a/src/rust/workunit_store/src/tests.rs
+++ b/src/rust/workunit_store/src/tests.rs
@@ -50,6 +50,20 @@ fn straggling_workunits_basic() {
 }
 
 #[test]
+fn straggling_workunits_after_refresh() {
+    let ws = create_store(vec![wu_root(0), wu(1, 0)], vec![], vec![]);
+    ws.refresh_heavy_hitters();
+    ws.refresh_heavy_hitters();
+    assert_eq!(
+        vec!["1"],
+        ws.straggling_workunits(Duration::from_secs(0))
+            .into_iter()
+            .map(|(_, n)| n)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn straggling_workunits_blocked_leaf() {
     // Test that a blocked leaf does not cause its parents to be rendered.
     let ws = create_store(vec![wu_root(0)], vec![wu(1, 0)], vec![]);
@@ -90,7 +104,7 @@ async fn disabled_workunit_is_filtered() {
 #[tokio::test]
 async fn workunit_escalation_is_recorded() {
     // Create a store which will disable Debug level workunits.
-    let ws = WorkunitStore::new(true, Level::Info, true, true);
+    let ws = WorkunitStore::new(true, Level::Info, true);
     ws.init_thread_state(None);
 
     // Start a workunit at Debug (below the level of the store).
@@ -165,7 +179,7 @@ fn create_store(
         .iter()
         .map(|(_, span_id, _, _)| *span_id)
         .collect::<HashSet<_>>();
-    let ws = WorkunitStore::new(true, log::Level::Debug, true, true);
+    let ws = WorkunitStore::new(true, log::Level::Debug, true);
 
     // Collect and sort by SpanId.
     let mut all = started


### PR DESCRIPTION
Re-introduces the "Long running tasks ..." log in CI environments, which I accidentally nuked when disabling the workunit message queues that were "never" polled.

This change instead drains said queue regularly (to avoid garbage), and logs if there are indeed stragglers during CI runs, which reportedly some environments depend on for keep-alive, see https://github.com/pantsbuild/pants/pull/23604.

Closes https://github.com/pantsbuild/pants/issues/23603