### PR TITLE
Concurrent pantsd: Reference-count live `Run`s in the graph

### DIFF
--- a/src/rust/engine/src/session.rs
+++ b/src/rust/engine/src/session.rs
@@ -13,7 +13,7 @@ use crate::python::{Failure, Value};
 
 use async_latch::AsyncLatch;
 use futures::future::{self, FutureExt};
-use graph::{Context, LastObserved};
+use graph::{Context, LastObserved, RunGuard};
 use log::warn;
 use parking_lot::Mutex;
 use pyo3::prelude::*;
@@ -87,6 +87,9 @@ struct SessionState {
     // entire Session, but in some cases (in particular, a `--loop`) the caller wants to retain the
     // same Session while still observing new values for uncacheable rules like Goals.
     run_id: AtomicU32,
+    // Keeps the current `run_id` live in the graph. Dropped (and swapped by `new_run_id`) so that
+    // the Run is retired for pruning once no holder remains.
+    run_guard: Mutex<RunGuard>,
     /// Tasks to await at the "tail" of the session.
     tail_tasks: TailTasks,
 }
@@ -177,6 +180,7 @@ impl Session {
         });
         core.sessions.add(&handle)?;
         let run_id = core.graph.generate_run_id();
+        let run_guard = core.graph.register_run(run_id);
         let preceding_graph_size = core.graph.len();
         Ok(Session {
             handle,
@@ -187,6 +191,7 @@ impl Session {
                 workunit_store,
                 session_values: Mutex::new(Value::new(session_values)),
                 run_id: AtomicU32::new(run_id.0),
+                run_guard: Mutex::new(run_guard),
                 tail_tasks: TailTasks::new(),
             }),
         })
@@ -296,10 +301,14 @@ impl Session {
     }
 
     pub fn new_run_id(&self) {
-        self.state.run_id.store(
-            self.state.core.graph.generate_run_id().0,
-            atomic::Ordering::SeqCst,
-        );
+        let new_run_id = self.state.core.graph.generate_run_id();
+        let new_run_guard = self.state.core.graph.register_run(new_run_id);
+        self.state
+            .run_id
+            .store(new_run_id.0, atomic::Ordering::SeqCst);
+        // Dropping the previous guard retires the previous Run only once any in-flight holder
+        // (e.g. Contexts from work that outlives the run switch) has also dropped it.
+        *self.state.run_guard.lock() = new_run_guard;
     }
 
     pub async fn with_console_ui_disabled<T>(&self, f: impl Future<Output = T>) -> T {

--- a/src/rust/graph/src/context.rs
+++ b/src/rust/graph/src/context.rs
@@ -3,20 +3,21 @@
 
 use std::ops::Deref;
 use std::sync::Arc;
-use std::sync::atomic::{self, AtomicU32, AtomicUsize};
+use std::sync::atomic::AtomicUsize;
 
 use parking_lot::Mutex;
 use workunit_store::RunId;
 
-use crate::Graph;
 use crate::entry::Generation;
 use crate::node::{CompoundNode, EntryId, Node, NodeError};
+use crate::{Graph, RunGuard};
 
 struct InnerContext<N: Node + Send> {
     context: N::Context,
-    run_id: AtomicU32,
+    run_id: RunId,
     stats: Stats,
     graph: Graph<N>,
+    _run_guard: RunGuard,
 }
 
 #[derive(Clone, Default)]
@@ -39,15 +40,21 @@ pub struct Context<N: Node + Send> {
 }
 
 impl<N: Node + Send> Context<N> {
-    pub(crate) fn new(graph: Graph<N>, context: N::Context, run_id: RunId) -> Self {
+    pub(crate) fn new(
+        graph: Graph<N>,
+        context: N::Context,
+        run_id: RunId,
+        run_guard: RunGuard,
+    ) -> Self {
         Self {
             entry_id: None,
             dep_state: Arc::default(),
             inner: Arc::new(InnerContext {
                 context,
-                run_id: AtomicU32::new(run_id.0),
+                run_id,
                 stats: Stats::default(),
                 graph,
+                _run_guard: run_guard,
             }),
         }
     }
@@ -71,14 +78,7 @@ impl<N: Node + Send> Context<N> {
     }
 
     pub fn run_id(&self) -> RunId {
-        RunId(self.inner.run_id.load(atomic::Ordering::SeqCst))
-    }
-
-    pub fn new_run_id(&self) {
-        self.inner.run_id.store(
-            self.inner.graph.generate_run_id().0,
-            atomic::Ordering::SeqCst,
-        );
+        self.inner.run_id
     }
 
     pub fn context(&self) -> &N::Context {

--- a/src/rust/graph/src/lib.rs
+++ b/src/rust/graph/src/lib.rs
@@ -59,6 +59,11 @@ impl LiveRuns {
             run_id,
         }
     }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.0.lock().len()
+    }
 }
 
 ///
@@ -458,6 +463,11 @@ impl<N: Node> Graph<N> {
         let run_id = inner.run_id_generator;
         inner.run_id_generator += 1;
         RunId(run_id)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn live_runs_len(&self) -> usize {
+        self.inner.lock().live_runs.len()
     }
 
     ///

--- a/src/rust/graph/src/lib.rs
+++ b/src/rust/graph/src/lib.rs
@@ -41,10 +41,51 @@ pub struct InvalidationResult {
 
 type Nodes<N> = HashMap<N, EntryId>;
 
+///
+/// The set of Runs which are currently live.
+///
+/// Membership is reference counted: each holder of a Run registers with `register`, receiving a
+/// `RunGuard` which deregisters the Run when the last holder drops it. A Run therefore stays live
+/// exactly while some holder can still refer to it, and can never be leaked.
+///
+#[derive(Debug, Default)]
+pub(crate) struct LiveRuns(Mutex<HashMap<RunId, usize>>);
+
+impl LiveRuns {
+    fn register(self: &Arc<Self>, run_id: RunId) -> RunGuard {
+        *self.0.lock().entry(run_id).or_insert(0) += 1;
+        RunGuard {
+            live_runs: self.clone(),
+            run_id,
+        }
+    }
+}
+
+///
+/// A holder's registration of a live Run. Dropping the last guard for a Run deregisters it.
+///
+pub struct RunGuard {
+    live_runs: Arc<LiveRuns>,
+    run_id: RunId,
+}
+
+impl Drop for RunGuard {
+    fn drop(&mut self) {
+        let mut live = self.live_runs.0.lock();
+        if let Some(count) = live.get_mut(&self.run_id) {
+            *count -= 1;
+            if *count == 0 {
+                live.remove(&self.run_id);
+            }
+        }
+    }
+}
+
 struct InnerGraph<N: Node> {
     nodes: Nodes<N>,
     pg: PGraph<N>,
     run_id_generator: u32,
+    live_runs: Arc<LiveRuns>,
 }
 
 impl<N: Node> InnerGraph<N> {
@@ -382,6 +423,7 @@ impl<N: Node> Graph<N> {
             nodes: HashMap::default(),
             pg: DiGraph::new(),
             run_id_generator: 0,
+            live_runs: Arc::new(LiveRuns::default()),
         }));
         let _join = executor.native_spawn(Self::cycle_check_task(Arc::downgrade(&inner)));
 
@@ -397,12 +439,20 @@ impl<N: Node> Graph<N> {
         self.context_with_run_id(context, self.generate_run_id())
     }
 
-    /// Create a Context wrapping an opaque Node::Context type.
+    /// Create a Context wrapping an opaque Node::Context type. The returned Context holds a
+    /// registration for the RunId which is released when its last clone drops.
     pub fn context_with_run_id(&self, context: N::Context, run_id: RunId) -> Context<N> {
-        Context::new(self.clone(), context, run_id)
+        let run_guard = self.register_run(run_id);
+        Context::new(self.clone(), context, run_id, run_guard)
     }
 
-    /// Generate a unique RunId for this Graph which can be reused in `context_with_run_id`.
+    /// Register a holder of the given RunId, keeping it live until the returned guard drops.
+    pub fn register_run(&self, run_id: RunId) -> RunGuard {
+        self.inner.lock().live_runs.register(run_id)
+    }
+
+    /// Generate a unique RunId for this Graph which can be registered via `register_run` or
+    /// `context_with_run_id`.
     pub fn generate_run_id(&self) -> RunId {
         let mut inner = self.inner.lock();
         let run_id = inner.run_id_generator;

--- a/src/rust/graph/src/tests.rs
+++ b/src/rust/graph/src/tests.rs
@@ -465,6 +465,26 @@ async fn uncacheable_deps_is_cleaned_for_the_session() {
 }
 
 #[tokio::test]
+async fn live_runs_released_when_last_holder_drops() {
+    let _logger = env_logger::try_init();
+    let graph = empty_graph();
+
+    let context_a = graph.context(TContext::new());
+    let context_b = graph.context(TContext::new());
+    assert_eq!(graph.live_runs_len(), 2);
+
+    let context_a2 = context_a.clone();
+    drop(context_a);
+    assert_eq!(graph.live_runs_len(), 2);
+
+    drop(context_a2);
+    assert_eq!(graph.live_runs_len(), 1);
+
+    drop(context_b);
+    assert_eq!(graph.live_runs_len(), 0);
+}
+
+#[tokio::test]
 async fn dirtied_uncacheable_deps_node_re_runs() {
     let _logger = env_logger::try_init();
     let graph = empty_graph();


### PR DESCRIPTION
Adds a `LiveRun`s set to the graph. Holders register through `register_run` and get back a `RunGuard`, so a `RunId` stays live while something can still refer to it. A `Context` holds one for its own run, and a `Session` holds one for its current run, swapping it in `new_run_id`.

This is in preparation for an `Entry` to hold per run state that should be cleaned.

This change is behaviour-preserving work.

See https://docs.google.com/document/d/1XEO55efGI8x91wGiVjmlFpUORJeQpZ2xF4zQoSE4TuY/edit?tab=t.0#heading=h.apz3211m77eg for design intent.