### PR TITLE
Concurrent pantsd: Swap uncacheability for run-scoped results

### DIFF
--- a/src/rust/graph/src/entry.rs
+++ b/src/rust/graph/src/entry.rs
@@ -105,10 +105,12 @@ impl<N: Node> EntryResult<N> {
         }
     }
 
-    fn has_uncacheable_deps(&self) -> bool {
+    /// The Run which may consume this result, if it is confined to one.
+    fn uncacheable_run_id(&self) -> Option<RunId> {
         match self {
-            EntryResult::Uncacheable(_, _) | EntryResult::UncacheableDependencies(_, _) => true,
-            EntryResult::Clean(..) | EntryResult::Dirty(..) => false,
+            EntryResult::Uncacheable(_, run_id)
+            | EntryResult::UncacheableDependencies(_, run_id) => Some(*run_id),
+            EntryResult::Clean(..) | EntryResult::Dirty(..) => None,
         }
     }
 
@@ -165,10 +167,11 @@ impl<N: Node> AsRef<N::Item> for EntryResult<N> {
     }
 }
 
+/// A Node result, its Generation, and the Run it is confined to, if any.
 pub type NodeResult<N> = (
     Result<<N as Node>::Item, <N as Node>::Error>,
     Generation,
-    bool,
+    Option<RunId>,
 );
 
 #[derive(Debug)]
@@ -550,10 +553,19 @@ impl<N: Node> Entry<N> {
                 ..
             } => {
                 if let Some(receiver) = pending_value.receiver() {
+                    let entry = self.clone();
+                    let context = context.clone();
                     return async move {
-                        receiver.recv().await.unwrap_or_else(|| {
-                            (Err(N::Error::invalidated()), generation.next(), true)
-                        })
+                        let result = receiver.recv().await.unwrap_or_else(|| {
+                            (Err(N::Error::invalidated()), generation.next(), None)
+                        });
+                        match result {
+                            (Ok(_), _, Some(run_id)) if run_id != context.run_id() => {
+                                // We attached to another Run's attempt: re-enter for our own value.
+                                entry.get_node_result(&context, entry_id).await
+                            }
+                            result => result,
+                        }
                     }
                     .boxed();
                 }
@@ -567,7 +579,7 @@ impl<N: Node> Entry<N> {
                 return future::ready((
                     Ok(result.as_ref().clone()),
                     generation,
-                    result.has_uncacheable_deps(),
+                    result.uncacheable_run_id(),
                 ))
                 .boxed();
             }
@@ -644,7 +656,7 @@ impl<N: Node> Entry<N> {
             receiver
                 .recv()
                 .await
-                .unwrap_or_else(|| (Err(N::Error::invalidated()), generation.next(), true))
+                .unwrap_or_else(|| (Err(N::Error::invalidated()), generation.next(), None))
         }
         .boxed()
     }
@@ -732,7 +744,7 @@ impl<N: Node> Entry<N> {
                     previous_result.dirty();
                 }
                 generation = generation.next();
-                sender.send((Err(e), generation, true));
+                sender.send((Err(e), generation, Some(context.run_id())));
                 EntryState::NotStarted {
                     run_token,
                     generation,
@@ -751,7 +763,7 @@ impl<N: Node> Entry<N> {
                 sender.send((
                     Ok(next_result.as_ref().clone()),
                     generation,
-                    next_result.has_uncacheable_deps(),
+                    next_result.uncacheable_run_id(),
                 ));
                 EntryState::Completed {
                     result: next_result,
@@ -774,7 +786,7 @@ impl<N: Node> Entry<N> {
                 sender.send((
                     Ok(result.as_ref().clone()),
                     generation,
-                    result.has_uncacheable_deps(),
+                    result.uncacheable_run_id(),
                 ));
                 EntryState::Completed {
                     result,
@@ -937,7 +949,7 @@ impl<N: Node> Entry<N> {
                 let _ = pending_value.try_interrupt(NodeInterrupt::Aborted((
                     Err(err.clone()),
                     generation.next(),
-                    true,
+                    None,
                 )));
             };
         }

--- a/src/rust/graph/src/lib.rs
+++ b/src/rust/graph/src/lib.rs
@@ -547,7 +547,7 @@ impl<N: Node> Graph<N> {
         };
 
         if src_id.is_some()
-            && let Err(e) = context.dep_record(entry_id, generation, uncacheable)
+            && let Err(e) = context.dep_record(entry_id, generation, uncacheable.is_some())
         {
             return (Err(e), generation);
         }
@@ -653,7 +653,7 @@ impl<N: Node> Graph<N> {
                 // Cleaning succeeded.
                 //
                 // Return true if any dep was uncacheable.
-                Ok(uncacheable_deps.into_iter().any(|u| u))
+                Ok(uncacheable_deps.into_iter().any(|u| u.is_some()))
             }
             Err(()) => {
                 // Cleaning failed.

--- a/src/rust/graph/src/tests.rs
+++ b/src/rust/graph/src/tests.rs
@@ -12,6 +12,7 @@ use futures::future;
 use parking_lot::Mutex;
 use rand::RngExt;
 use task_executor::Executor;
+use tokio::sync::watch;
 use tokio::time::{error::Elapsed, sleep, timeout};
 
 use crate::context::Context;
@@ -462,6 +463,54 @@ async fn uncacheable_deps_is_cleaned_for_the_session() {
         Ok(vec![T(0, 0), T(1, 0), T(2, 0)])
     );
     assert_no_change_within_session(&context);
+}
+
+#[tokio::test]
+async fn uncacheable_node_reruns_for_concurrent_run() {
+    let _logger = env_logger::try_init();
+    let graph = empty_graph();
+
+    let mut uncacheable = HashSet::new();
+    uncacheable.insert(TNode::new(1));
+
+    // Run A blocks in the uncacheable node so run B observes its attempt in flight.
+    let (gate, mut entered, release) = TGate::new();
+    let context_a = {
+        let mut gates = HashMap::new();
+        gates.insert(TNode::new(1), gate);
+        graph.context(
+            TContext::new()
+                .with_uncacheable(uncacheable.clone())
+                .with_gates(gates),
+        )
+    };
+    let context_b = graph.context(TContext::new().with_uncacheable(uncacheable));
+
+    let graph_a = graph.clone();
+    let context_a2 = context_a.clone();
+    let fut_a = tokio::spawn(async move { graph_a.create(TNode::new(2), &context_a2).await });
+    entered.wait_for(|entered| *entered).await.unwrap();
+
+    let graph_b = graph.clone();
+    let context_b2 = context_b.clone();
+    let fut_b = tokio::spawn(async move { graph_b.create(TNode::new(2), &context_b2).await });
+    for _ in 0..10 {
+        tokio::task::yield_now().await;
+    }
+    // Yields are not synchronization: assert B is still pending, i.e. attached to A.
+    assert!(!fut_b.is_finished());
+    release.send(true).unwrap();
+
+    let expected = vec![T(0, 0), T(1, 0), T(2, 0)];
+    assert_eq!(fut_a.await.unwrap(), Ok(expected.clone()));
+    assert_eq!(fut_b.await.unwrap(), Ok(expected));
+
+    // B attached to A's attempt, but re-ran the uncacheable node rather than consuming it.
+    assert_eq!(
+        context_a.runs(),
+        vec![TNode::new(2), TNode::new(1), TNode::new(0)]
+    );
+    assert_eq!(context_b.runs(), vec![TNode::new(1)]);
 }
 
 #[tokio::test]
@@ -944,12 +993,38 @@ struct TContext {
     edges: Arc<HashMap<TNode, Vec<TNode>>>,
     delays_pre: Arc<HashMap<TNode, Duration>>,
     delays_post: Arc<HashMap<TNode, Duration>>,
+    gates: Arc<HashMap<TNode, TGate>>,
     // Nodes which should error when they run.
     errors: Arc<HashSet<TNode>>,
     non_restartable: Arc<HashSet<TNode>>,
     uncacheable: Arc<HashSet<TNode>>,
     aborts: Arc<Mutex<Vec<TNode>>>,
     runs: Arc<Mutex<Vec<TNode>>>,
+}
+
+///
+/// A gate for a TNode: when the node runs, it signals `entered` and then blocks until
+/// `release` becomes true.
+///
+struct TGate {
+    entered: watch::Sender<bool>,
+    release: watch::Receiver<bool>,
+}
+
+impl TGate {
+    /// Returns a TGate, a handle to await its entry, and a handle to release it.
+    fn new() -> (TGate, watch::Receiver<bool>, watch::Sender<bool>) {
+        let (entered_tx, entered_rx) = watch::channel(false);
+        let (release_tx, release_rx) = watch::channel(false);
+        (
+            TGate {
+                entered: entered_tx,
+                release: release_rx,
+            },
+            entered_rx,
+            release_tx,
+        )
+    }
 }
 
 impl TContext {
@@ -959,6 +1034,7 @@ impl TContext {
             edges: Arc::default(),
             delays_pre: Arc::default(),
             delays_post: Arc::default(),
+            gates: Arc::default(),
             errors: Arc::default(),
             non_restartable: Arc::default(),
             uncacheable: Arc::default(),
@@ -981,6 +1057,12 @@ impl TContext {
     /// Delays incurred after a node has requested its dependencies.
     fn with_delays_post(mut self, delays: HashMap<TNode, Duration>) -> TContext {
         self.delays_post = Arc::new(delays);
+        self
+    }
+
+    /// Gates awaited before a node requests its dependencies.
+    fn with_gates(mut self, gates: HashMap<TNode, TGate>) -> TContext {
+        self.gates = Arc::new(gates);
         self
     }
 
@@ -1030,6 +1112,11 @@ impl TContext {
     }
 
     async fn maybe_delay_pre(&self, node: &TNode) {
+        if let Some(gate) = self.gates.get(node) {
+            let _ = gate.entered.send(true);
+            let mut release = gate.release.clone();
+            release.wait_for(|released| *released).await.unwrap();
+        }
         if let Some(delay) = self.delays_pre.get(node) {
             sleep(*delay).await;
         }


### PR DESCRIPTION
NodeResult holds the producing RunId in place of an "uncacheable" bool. A Run that attaches to an in-flight attempt started by another Run re-enters get_node_result instead of taking that attempt's result.

Nothing can observe another Run's attempt under the pantsd concurrency lock, so this change is behaviour-preserving work.

See https://docs.google.com/document/d/1XEO55efGI8x91wGiVjmlFpUORJeQpZ2xF4zQoSE4TuY/edit?tab=t.0#heading=h.apz3211m77eg for design intent.