### PR TITLE
use official ubuntu 24.04 image for buildbarn remote execution integration test (Cherry-pick of #23622)

### DIFF
--- a/src/python/pants/engine/internals/buildbarn_integration_tests/config/docker-compose.images.yaml
+++ b/src/python/pants/engine/internals/buildbarn_integration_tests/config/docker-compose.images.yaml
@@ -17,4 +17,4 @@ services:
 
   execution-image:
     profiles: ["image_refs"]
-    image: ghcr.io/catthehacker/ubuntu:act-22.04@sha256:b3098f231fa07cf5c2423b0f2c2e7dacf85c0c508c7f27687febe30bab8cfd3e
+    image: ubuntu:24.04@sha256:561618e2c15bf2397621dd04f96926663a3b5616c189cf7e38db7e82f5c538ea


### PR DESCRIPTION
Use the official Ubuntu 24.04 image for the Buildbarn remote execution integration test.

AI disclosure: Used Codex to figure out the image pin.
