### PR TITLE
Named indexes must be referenced explicitly when using the uv resolver.

### DIFF
--- a/docs/notes/2.34.x.md
+++ b/docs/notes/2.34.x.md
@@ -59,6 +59,8 @@ Support for creating multiplatform/foreign platform pexes when using the `uv` re
 
 Fixed a bug that caused `generate-lockfiles --sync` not to have its intended effect when using `uv` lockfiles.
 
+Required named indexes to be referenced explicitly in requirement sources when using the uv resolver, to match the pex resolver's behavior.
+
 Interpreter constraints can now select a specific CPython ABI, to distinguish the free-threaded (no-GIL) build from the standard build. Qualify the interpreter type using either a PEP 508 extra, `CPython[free-threaded]` or `CPython[gil]`, or the equivalent `CPython+t` / `CPython-t` spellings. Both spellings are adopted from Pex. For example, `interpreter_constraints=["CPython[free-threaded]==3.14.*"]` matches only free-threaded 3.14 interpreters, while `CPython==3.14.*` continues to match either ABI.
 
 The default version of [Pex](https://github.com/pex-tool/pex) used by the Python backend has been upgraded to [`v2.98.4`](https://github.com/pex-tool/pex/releases/tag/v2.98.4). Of particular note for Pants users:

--- a/src/python/pants/backend/python/util_rules/pex_requirements.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements.py
@@ -431,6 +431,9 @@ def generate_uv_index_config(indexes: Iterable[str] | None, table_name: str) -> 
             lines.append(table_header)
             if name:
                 lines.append(f'name = "{name}"')
+                # All named indexes must be referenced explicitly in `sources`, to match the
+                # preexisting pex resolver behavior.
+                lines.append("explicit = true")
             lines.append(f'url = "{url}"')
             if is_default:
                 lines.append("default = true")

--- a/src/python/pants/backend/python/util_rules/pex_requirements_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements_test.py
@@ -516,9 +516,11 @@ def test_uv_config_indexes():
     assert indexes[0]["url"] == "https://primary.example.com/simple"
     assert "name" not in indexes[0]
     assert "default" not in indexes[0]
+    assert "explicit" not in indexes[0]
     assert indexes[1]["url"] == "https://secondary.example.com/simple"
     assert indexes[1].get("name") == "fallback"
     assert indexes[1]["default"] is True
+    assert indexes[1]["explicit"] is True
 
 
 def test_uv_config_find_links():


### PR DESCRIPTION
Matches the preexisting pex resolver behavior.