### PR TITLE
Add `[coursier].jvm_options` to support custom CAs and proxies

### DIFF
--- a/docs/notes/2.34.x.md
+++ b/docs/notes/2.34.x.md
@@ -51,6 +51,8 @@ Fixed the `buildTarget/scalacOptions` BSP response emitting scalac plugin (`-Xpl
 
 Fixed nailgun servers being left running after a `--no-pantsd` run exits.
 
+The new `[coursier].jvm_options` option passes extra JVM options to Coursier. Coursier is distributed as a GraalVM native image that bundles its own trust store and does not read `HTTP_PROXY`/`HTTPS_PROXY`, so a custom CA or proxy must be supplied as JVM system properties on Coursier's own command line — which was previously not possible, leaving Pants' JVM support unusable behind a TLS-inspecting proxy or in an environment without direct internet access. Values are automatically prefixed with `-J` if you omit it, and they apply to every Coursier invocation, including JDK provisioning.
+
 The Scala protobuf codegen backend (`pants.backend.codegen.protobuf.scala`) now honors `protobuf_sources`/`protobuf_source`'s `grpc=True` field: ScalaPB now generates `*Grpc.scala` service stubs, and the `scalapb-runtime-grpc` runtime is automatically inferred as a dependency, matching the existing behavior of the Java protobuf codegen backend. This is a behavior change for anyone using the Scala protobuf backend with `grpc=True` set on a `protobuf_sources` target: a `jvm_artifact` providing `com.thesamet.scalapb:scalapb-runtime-grpc_<scala-binary-version>` must now be resolvable, or dependency inference will fail. Callers remain responsible for declaring their own gRPC transport dependency (e.g. `grpc-netty-shaded`, `grpc-netty`, or `grpc-okhttp`), since that is a deployment choice not dictated by the generated code.
 
 #### Python

--- a/src/python/pants/jvm/resolve/coursier_setup.py
+++ b/src/python/pants/jvm/resolve/coursier_setup.py
@@ -82,7 +82,7 @@ COURSIER_FETCH_WRAPPER_SCRIPT = textwrap.dedent(  # noqa: PNT20
     shift
 
     working_dir="$(pwd)"
-    "$coursier_exe" fetch {repos_args} \
+    "$coursier_exe" {jvm_options_args} fetch {repos_args} \
         --json-output-file="$json_output_file" \
         "${{@//{coursier_working_directory}/$working_dir}}"
     {mkdir} -p classpath
@@ -176,6 +176,41 @@ class CoursierSubsystem(TemplatedExternalTool):
         ),
     )
 
+    jvm_options = StrListOption(
+        advanced=True,
+        help=softwrap(
+            """
+            Extra JVM options to pass to Coursier.
+
+            Coursier is distributed as a GraalVM native image. It bundles its own trust
+            store from build time and does not read the `HTTP_PROXY`/`HTTPS_PROXY`
+            environment variables, so a custom CA or proxy must be supplied as JVM system
+            properties on Coursier's own command line. Without this option there is no way
+            to do that, and Coursier fails to fetch artifacts and JDKs in environments
+            with a TLS-inspecting proxy or without direct internet access.
+
+            Each value is passed to Coursier prefixed with `-J`; the prefix is added
+            automatically if you omit it. For example, both
+            `-Djavax.net.ssl.trustStore=/etc/pki/java/cacerts` and
+            `-J-Djavax.net.ssl.trustStore=/etc/pki/java/cacerts` are passed to Coursier as
+            `-J-Djavax.net.ssl.trustStore=/etc/pki/java/cacerts`.
+
+            These options apply to every Coursier invocation, including JDK provisioning.
+            They are unrelated to `[jvm].global_options`, which applies to the JVM
+            processes Pants runs, not to Coursier itself.
+
+            See https://get-coursier.io/docs/other-proxy.
+            """
+        ),
+    )
+
+    @property
+    def normalized_jvm_options(self) -> tuple[str, ...]:
+        """`jvm_options` with the `-J` prefix Coursier requires, added where absent."""
+        return tuple(
+            option if option.startswith("-J") else f"-J{option}" for option in self.jvm_options
+        )
+
     def generate_exe(self, plat: Platform) -> str:
         tool_version = self.known_version(plat)
         url = (tool_version and tool_version.url_override) or self.generate_url(plat)
@@ -192,6 +227,7 @@ class Coursier:
     _digest: Digest
     repos: FrozenOrderedSet[str]
     jvm_index: str
+    jvm_options: tuple[str, ...]
     _append_only_caches: FrozenDict[str, str]
 
     bin_dir: ClassVar[str] = "__coursier"
@@ -203,10 +239,18 @@ class Coursier:
     working_directory_placeholder: ClassVar[str] = "___COURSIER_WORKING_DIRECTORY___"
 
     def args(self, args: Iterable[str], *, wrapper: Iterable[str] = ()) -> tuple[str, ...]:
+        # `jvm_options` must precede Coursier's subcommand, so it cannot simply be prepended
+        # to `args`. When a `wrapper` is used, the Coursier exe path is consumed by the
+        # wrapper script as a positional argument rather than being invoked directly here,
+        # so inserting the options at this point would shift the wrapper's own arguments.
+        # In that case the wrapper is responsible for passing them: they are templated into
+        # `COURSIER_FETCH_WRAPPER_SCRIPT` as `jvm_options_args`.
+        jvm_options = () if wrapper else self.jvm_options
         return (
             self.post_process_stderr,
             *wrapper,
             os.path.join(self.bin_dir, self.coursier.exe),
+            *jvm_options,
             *args,
         )
 
@@ -284,7 +328,9 @@ async def setup_coursier(
     repos_args = (
         " ".join(f"-r={shlex.quote(repo)}" for repo in coursier_subsystem.repos) + " --no-default"
     )
+    jvm_options = coursier_subsystem.normalized_jvm_options
     coursier_wrapper_script = COURSIER_FETCH_WRAPPER_SCRIPT.format(
+        jvm_options_args=" ".join(shlex.quote(option) for option in jvm_options),
         repos_args=repos_args,
         coursier_working_directory=Coursier.working_directory_placeholder,
         python_path=shlex.quote(python.path),
@@ -333,6 +379,7 @@ async def setup_coursier(
         ),
         repos=FrozenOrderedSet(coursier_subsystem.repos),
         jvm_index=coursier_subsystem.jvm_index,
+        jvm_options=jvm_options,
         _append_only_caches=python.APPEND_ONLY_CACHES,
     )
 

--- a/src/python/pants/jvm/resolve/coursier_setup_test.py
+++ b/src/python/pants/jvm/resolve/coursier_setup_test.py
@@ -1,0 +1,101 @@
+# Copyright 2026 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import pytest
+
+from pants.core.util_rules.external_tool import DownloadedExternalTool
+from pants.engine.fs import EMPTY_DIGEST
+from pants.jvm.resolve.coursier_setup import (
+    COURSIER_FETCH_WRAPPER_SCRIPT,
+    Coursier,
+    CoursierSubsystem,
+)
+from pants.testutil.option_util import create_subsystem
+from pants.util.frozendict import FrozenDict
+from pants.util.ordered_set import FrozenOrderedSet
+
+
+def make_coursier(jvm_options: tuple[str, ...] = ()) -> Coursier:
+    return Coursier(
+        coursier=DownloadedExternalTool(digest=EMPTY_DIGEST, exe="cs"),
+        _digest=EMPTY_DIGEST,
+        repos=FrozenOrderedSet(["https://repo1.maven.org/maven2"]),
+        jvm_index="",
+        jvm_options=jvm_options,
+        _append_only_caches=FrozenDict(),
+    )
+
+
+@pytest.mark.parametrize(
+    ("given", "expected"),
+    [
+        ([], ()),
+        # An explicit `-J` prefix is preserved.
+        (["-J-Dhttp.proxyHost=127.0.0.1"], ("-J-Dhttp.proxyHost=127.0.0.1",)),
+        # A missing `-J` prefix is added.
+        (["-Dhttp.proxyHost=127.0.0.1"], ("-J-Dhttp.proxyHost=127.0.0.1",)),
+        # Mixed input is normalized without ever doubling the prefix.
+        (["-Dfoo=1", "-J-Dbar=2"], ("-J-Dfoo=1", "-J-Dbar=2")),
+    ],
+)
+def test_normalized_jvm_options(given: list[str], expected: tuple[str, ...]) -> None:
+    subsystem = create_subsystem(CoursierSubsystem, jvm_options=given)
+    assert subsystem.normalized_jvm_options == expected
+
+
+def test_args_places_jvm_options_before_subcommand() -> None:
+    """Coursier only honors `-J` options that appear before its subcommand."""
+    coursier = make_coursier(("-J-Dhttp.proxyHost=127.0.0.1",))
+    args = coursier.args(["java-home", "--jvm", "temurin:1.17"])
+    exe_index = args.index(f"{Coursier.bin_dir}/cs")
+    assert args[exe_index + 1 :] == (
+        "-J-Dhttp.proxyHost=127.0.0.1",
+        "java-home",
+        "--jvm",
+        "temurin:1.17",
+    )
+
+
+def test_args_omits_jvm_options_when_wrapped() -> None:
+    """A wrapper script consumes the Coursier exe path as `$1`.
+
+    Inserting the JVM options here would shift the wrapper's own positional arguments, so
+    the wrapper receives them via `COURSIER_FETCH_WRAPPER_SCRIPT` instead.
+    """
+    coursier = make_coursier(("-J-Dhttp.proxyHost=127.0.0.1",))
+    args = coursier.args(["out.json"], wrapper=["/bin/bash", Coursier.fetch_wrapper_script])
+    assert "-J-Dhttp.proxyHost=127.0.0.1" not in args
+    # The exe path must stay the first argument the wrapper script sees.
+    assert args[args.index(Coursier.fetch_wrapper_script) + 1] == f"{Coursier.bin_dir}/cs"
+
+
+def test_args_unchanged_without_jvm_options() -> None:
+    coursier = make_coursier()
+    assert coursier.args(["java-home"]) == (
+        Coursier.post_process_stderr,
+        f"{Coursier.bin_dir}/cs",
+        "java-home",
+    )
+
+
+def _render_wrapper_script(jvm_options_args: str) -> str:
+    return COURSIER_FETCH_WRAPPER_SCRIPT.format(
+        jvm_options_args=jvm_options_args,
+        repos_args="--no-default",
+        coursier_working_directory="__CWD__",
+        python_path="/python",
+        coursier_bin_dir="__coursier",
+        mkdir="/bin/mkdir",
+    )
+
+
+def test_fetch_wrapper_script_places_jvm_options_before_fetch() -> None:
+    script = _render_wrapper_script("-J-Dhttp.proxyHost=127.0.0.1")
+    assert '"$coursier_exe" -J-Dhttp.proxyHost=127.0.0.1 fetch' in script
+
+
+def test_fetch_wrapper_script_without_jvm_options_still_calls_fetch() -> None:
+    script = _render_wrapper_script("")
+    assert "fetch --no-default" in script


### PR DESCRIPTION
Coursier ships as a GraalVM native image. It bundles its own trust store from build time and does not read the `HTTP_PROXY`/`HTTPS_PROXY` environment variables, so a custom CA or proxy has to be supplied as JVM system properties on Coursier's own command line. Pants offered no way to pass those, so any environment behind a TLS-inspecting proxy, or without direct internet access, could not use Pants' JVM support at all: Coursier fails to fetch Maven artifacts, nailgun, or JDKs.

`[jvm].global_options` does not help, as it only reaches the JVM processes Pants runs, not Coursier itself.

Add a `[coursier].jvm_options` option, injected at both places Coursier is invoked:

* `COURSIER_FETCH_WRAPPER_SCRIPT`, between `"$coursier_exe"` and `fetch`.
* `Coursier.args()`, between the exe path and the subcommand, which covers `java-home` and therefore JDK provisioning.

Coursier only honors `-J` options that precede its subcommand, so they cannot simply be appended to the existing args. `Coursier.args()` deliberately skips the injection when a `wrapper` is passed: there the exe path is consumed by the wrapper script as a positional argument, so inserting options at that point would shift the wrapper's own arguments. The fetch wrapper receives them via the template instead.

Values are prefixed with `-J` automatically when the caller omits it, so both `-Dfoo=bar` and `-J-Dfoo=bar` work.

Validated end-to-end by dogfooding it on this repo. In a container with no DNS resolver and egress only via an HTTP proxy, `./pants lint check` fails outright: Coursier dies with `UnknownHostException` fetching `ch.epfl.scala:scalafix-cli_2.13.12:0.11.1`. With `[coursier].jvm_options` set to the proxy properties -- written without the `-J` prefix, to exercise the normalization -- the same command completes, with ruff, flake8, autoflake, preamble, visibility and mypy all passing.

This PR was written primarily by Claude Code (Opus 5).

Closes #23391