### PR TITLE
fix(golang): record a build ID when linking Go binaries

### DIFF
--- a/docs/notes/2.34.x.md
+++ b/docs/notes/2.34.x.md
@@ -87,6 +87,8 @@ Optimized third-party Go package compilation by materializing only the package's
 
 The new advanced option `[golang].third_party_target_granularity` controls how third-party targets are generated. The default `package` keeps one `go_third_party_package` target per third-party package; `module` instead generates one `go_third_party_module` target per module, matching how other backends model third-party dependencies, with transitive resolution owned by `go.mod`/`go.sum`. This dramatically reduces target count and dependency-resolution time on projects with large third-party modules.
 
+Linked Go binaries and test binaries now record a Go toolchain build ID, as `go build` does. Without one the linker omits the Mach-O `LC_UUID` load command and the ELF GNU build-id note, and macOS 26 refuses to load a binary that declares a recent SDK and has no `LC_UUID`.
+
 ### Plugin API changes
 
 `Target`, `TargetAdaptor`, `SourceBlock`, `SourceBlocks`, `TextBlock` and `Hunk` are now backed by native Rust implementations. They are still importable from their previous locations and their public constructors, attributes and methods are unchanged, but they are no longer Python dataclasses and they are built in `__new__` rather than `__init__`, so `dataclasses.is_dataclass`, `dataclasses.fields` and `dataclasses.replace` no longer apply to them. Defining subclasses in Python, and setting attributes on those subclasses, continues to work as before.

--- a/src/python/pants/backend/go/util_rules/link.py
+++ b/src/python/pants/backend/go/util_rules/link.py
@@ -2,13 +2,16 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from __future__ import annotations
 
+import hashlib
 import textwrap
+from collections.abc import Mapping
 from dataclasses import dataclass
 
 from pants.backend.go.subsystems.golang import GolangSubsystem
 from pants.backend.go.util_rules import import_config
 from pants.backend.go.util_rules.build_opts import GoBuildOptions
 from pants.backend.go.util_rules.cgo_binaries import CGoBinaryPathRequest, find_cgo_binary_path
+from pants.backend.go.util_rules.goroot import GoRoot
 from pants.backend.go.util_rules.import_config import ImportConfigRequest, generate_import_config
 from pants.backend.go.util_rules.link_defs import (
     ImplicitLinkerDependenciesHook,
@@ -84,11 +87,54 @@ async def setup_go_linker(
     return LinkerSetup(digest, extld_wrapper_path)
 
 
+def _compute_link_action_id(
+    request: LinkGoBinaryRequest,
+    goroot: GoRoot,
+    link_tool_id: str,
+    import_paths_to_pkg_a_files: Mapping[str, str],
+) -> str:
+    """Compute the Go toolchain build ID to record in the linked binary.
+
+    This computation is intended to capture similar values to the action ID computed by the `go`
+    tool for its own cache. For details, see `linkActionID` and `printLinkerConfig` in
+    https://github.com/golang/go/blob/master/src/cmd/go/internal/work/exec.go
+    """
+    h = hashlib.sha256()
+
+    # All Go action IDs have the full version (as returned by `runtime.Version()`) in the key.
+    # See https://github.com/golang/go/blob/master/src/cmd/go/internal/cache/hash.go#L32-L46
+    h.update(goroot.full_version.encode())
+
+    h.update(b"link\n")
+    h.update(f"goos {goroot.goos} goarch {goroot.goarch}\n".encode())
+    h.update(f"link {link_tool_id}\n".encode())
+    h.update(
+        f"race {request.build_opts.with_race_detector} msan {request.build_opts.with_msan} "
+        f"asan {request.build_opts.with_asan}\n".encode()
+    )
+    for flag in request.build_opts.linker_flags:
+        h.update(f"linkflag {flag}\n".encode())
+    h.update(f"out {request.output_filename}\n".encode())
+    for import_path, pkg_a_file in sorted(import_paths_to_pkg_a_files.items()):
+        h.update(f"packagefile {import_path}={pkg_a_file}\n".encode())
+    for archive in request.archives:
+        h.update(f"archive {archive}\n".encode())
+    if "GOEXPERIMENT" in goroot._raw_metadata:
+        h.update(f"GOEXPERIMENT={goroot._raw_metadata['GOEXPERIMENT']}\n".encode())
+
+    # Inputs are included in this hash since it feeds the link buildid that is recorded in the
+    # binary as its platform identity record. So it should distinguish different outputs.
+    h.update(f"inputs {request.input_digest.fingerprint}\n".encode())
+
+    return h.hexdigest()
+
+
 @rule
 async def link_go_binary(
     request: LinkGoBinaryRequest,
     linker_setup: LinkerSetup,
     union_membership: UnionMembership,
+    goroot: GoRoot,
 ) -> LinkedGoBinary:
     implict_linker_deps_hooks = union_membership.get(ImplicitLinkerDependenciesHook)
     implicit_linker_deps = await concurrently(
@@ -139,6 +185,13 @@ async def link_go_binary(
     maybe_msan_arg = ["-msan"] if request.build_opts.with_msan else []
     maybe_asan_arg = ["-asan"] if request.build_opts.with_asan else []
 
+    build_id = _compute_link_action_id(
+        request,
+        goroot,
+        link_tool_id.tool_id,
+        import_paths_to_pkg_a_files,
+    )
+
     result = await fallible_to_exec_result_or_raise(
         **implicitly(
             GoSdkProcess(
@@ -162,6 +215,8 @@ async def link_go_binary(
                     "-o",
                     request.output_filename,
                     "-buildmode=exe",  # seen in `go build -x` output
+                    "-buildid",
+                    build_id,
                     *request.build_opts.linker_flags,
                     *request.archives,
                 ),

--- a/src/python/pants/backend/go/util_rules/link_test.py
+++ b/src/python/pants/backend/go/util_rules/link_test.py
@@ -1,0 +1,201 @@
+# Copyright 2026 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from textwrap import dedent
+
+import pytest
+
+from pants.backend.go import target_type_rules
+from pants.backend.go.target_types import GoModTarget
+from pants.backend.go.util_rules import (
+    assembly,
+    build_opts,
+    build_pkg,
+    build_pkg_target,
+    first_party_pkg,
+    go_mod,
+    goroot,
+    implicit_linker_deps,
+    import_analysis,
+    link,
+    sdk,
+    third_party_pkg,
+)
+from pants.backend.go.util_rules.build_opts import GoBuildOptions
+from pants.backend.go.util_rules.build_pkg import (
+    BuildGoPackageRequest,
+    BuiltGoPackage,
+    MergeBuiltGoPackageArchivesRequest,
+    MergedGoPackageArchives,
+)
+from pants.backend.go.util_rules.link import LinkedGoBinary, LinkGoBinaryRequest
+from pants.backend.go.util_rules.sdk import GoSdkProcess
+from pants.engine.fs import Digest
+from pants.engine.process import Process, ProcessResult
+from pants.engine.rules import QueryRule
+from pants.testutil.rule_runner import RuleRunner
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    rule_runner = RuleRunner(
+        rules=[
+            *sdk.rules(),
+            *assembly.rules(),
+            *build_opts.rules(),
+            *build_pkg.rules(),
+            *build_pkg_target.rules(),
+            *import_analysis.rules(),
+            *go_mod.rules(),
+            *goroot.rules(),
+            *first_party_pkg.rules(),
+            *implicit_linker_deps.rules(),
+            *link.rules(),
+            *third_party_pkg.rules(),
+            *target_type_rules.rules(),
+            QueryRule(BuiltGoPackage, [BuildGoPackageRequest]),
+            QueryRule(MergedGoPackageArchives, [MergeBuiltGoPackageArchivesRequest]),
+            QueryRule(LinkedGoBinary, [LinkGoBinaryRequest]),
+            QueryRule(Process, [GoSdkProcess]),
+            QueryRule(ProcessResult, [Process]),
+        ],
+        target_types=[GoModTarget],
+    )
+    rule_runner.set_options([], env_inherit={"PATH"})
+    return rule_runner
+
+
+def _dep_package(rule_runner: RuleRunner) -> BuildGoPackageRequest:
+    return BuildGoPackageRequest(
+        import_path="example.com/dep",
+        pkg_name="dep",
+        dir_path="dep",
+        build_opts=GoBuildOptions(),
+        go_files=("dep.go",),
+        digest=rule_runner.make_snapshot(
+            {
+                "dep/dep.go": dedent(
+                    """\
+                    package dep
+
+                    func Greeting() string {
+                        return "hello"
+                    }
+                    """
+                )
+            }
+        ).digest,
+        s_files=(),
+        direct_dependencies=(),
+        minimum_go_version=None,
+    )
+
+
+def _link_main(
+    rule_runner: RuleRunner,
+    main_go: str,
+    direct_dependencies: tuple[BuildGoPackageRequest, ...] = (),
+) -> Digest:
+    built_package = rule_runner.request(
+        BuiltGoPackage,
+        [
+            BuildGoPackageRequest(
+                import_path="main",
+                pkg_name="main",
+                dir_path="",
+                build_opts=GoBuildOptions(),
+                go_files=("main.go",),
+                digest=rule_runner.make_snapshot({"main.go": main_go}).digest,
+                s_files=(),
+                direct_dependencies=direct_dependencies,
+                minimum_go_version=None,
+            )
+        ],
+    )
+    merged = rule_runner.request(
+        MergedGoPackageArchives, [MergeBuiltGoPackageArchivesRequest((built_package,))]
+    )
+    binary = rule_runner.request(
+        LinkedGoBinary,
+        [
+            LinkGoBinaryRequest(
+                input_digest=merged.digest,
+                archives=(built_package.pkg_archive_path,),
+                build_opts=GoBuildOptions(),
+                import_paths_to_pkg_a_files=merged.import_paths_to_pkg_a_files,
+                output_filename="./bin",
+                description="Link Go binary for test",
+            )
+        ],
+    )
+    return binary.digest
+
+
+def _build_id(rule_runner: RuleRunner, binary: Digest) -> str:
+    process = rule_runner.request(
+        Process,
+        [
+            GoSdkProcess(
+                ("tool", "buildid", "./bin"),
+                input_digest=binary,
+                description="Read the Go build ID from the linked binary",
+            )
+        ],
+    )
+    return rule_runner.request(ProcessResult, [process]).stdout.decode().strip()
+
+
+_STANDALONE = dedent(
+    """\
+    package main
+
+    func main() {
+        println("hello")
+    }
+    """
+)
+
+_USES_DEP = dedent(
+    """\
+    package main
+
+    import "example.com/dep"
+
+    func main() {
+        println(dep.Greeting())
+    }
+    """
+)
+
+_STANDALONE_ALTERED = dedent(
+    """\
+    package main
+
+    func main() {
+        println("goodbye")
+    }
+    """
+)
+
+
+def test_link_records_a_build_id(rule_runner: RuleRunner) -> None:
+    build_id = _build_id(rule_runner, _link_main(rule_runner, _STANDALONE))
+    assert build_id, "linked binary does not record a Go build ID"
+
+
+def test_build_id_distinguishes_binaries(rule_runner: RuleRunner) -> None:
+    standalone = _build_id(rule_runner, _link_main(rule_runner, _STANDALONE))
+    uses_dep = _build_id(
+        rule_runner, _link_main(rule_runner, _USES_DEP, (_dep_package(rule_runner),))
+    )
+    assert standalone and uses_dep, "linked binary does not record a Go build ID"
+    assert standalone != uses_dep
+
+
+def test_build_id_tracks_source_content(rule_runner: RuleRunner) -> None:
+    original = _build_id(rule_runner, _link_main(rule_runner, _STANDALONE))
+    altered = _build_id(rule_runner, _link_main(rule_runner, _STANDALONE_ALTERED))
+    assert original and altered, "linked binary does not record a Go build ID"
+    assert original != altered


### PR DESCRIPTION
## Problem

The Go backend doesn't pass a -buildid to `go tool link`. It does for `go tool compile`. Also go build effectively always provides one, it's conditional only on having the build cache enabled which is mandatory since 1.12.

This is causing some problems on macOS, as when go internally links, it only emits LC_UUID if there is a buildid (on 1.24+). The dyld loader on macOS started enforcing executables to have a LC_UUID for binaries built for SDK/OS 26. Without one on a binary built for that SDK version it cannot be executed on macOS 26.

This is somewhat narrow, as a pure go binary emits a hard coded SDK version 12, which is exempt from the enforcement. And when building with CGO the SDK version is the hosts (so can be in play), but if it's externally linked it gets an LC_UUID from that linker instead. When it does happen is when building a binary where the closure includes only internal CGO dependencies that are allowlisted by Go to be linked internally. This includes `runtime/cgo` and when using `race=True`. A binary built by pants in that case is not runnable on macOS 26.

An example case that this hits is depending on `testcontainers-go`, which depends on `ebitengine/purego`, which pulls in only `runtime/cgo`. This ends up on the path with an internal linker not emitting LC_UUID but emitting an SDK stamp of the host system that is affected by the enforcement. Running that binary fails with `dyld[317]: missing LC_UUID load command`.

Also more cosmetically it is a divergence from `go build` to omit a buildid, which some go tooling otherwise can use.

Worth noting is that Go does [fix the missing LC_UUID in some unreleased version](https://go-review.googlesource.com/c/go/+/751260/4/src/cmd/link/internal/ld/macho.go#854-860). But I think this fix is still valid since `go build` does provide a buildid to link still, and it also fixes the unpatched versions of Go.

## Fix

Produce a buildid similarly to what we do for compile. This also mimics the action ID in go, some similar omissions are on this hash as well, but as opposed to the compile one this one does include the input hash. The reason is that it is used to derive the platform identifiers where they are expected to be unique for a unique build. Conflicts on it can break various tooling that consumes that identifier, so its uniqueness is more strict on the linker side. 

It retains the reproducibility that you get from the Go backend already. I.e. if removing debug symbols `-g` CGO builds are still reproducible with the buildid. They aren't with -g enabled but that is true before this as well.

Adds buildid to the go linker, which adds LC_UUID to Mach-O on macOS and buildid note to ELF on Linux where internal linking previously omitted them, and makes externally linked binaries carry Go's value instead of the host linker's. Both parity with go build.

### Possible follow-up

A remaining divergence from go build is that the buildid itself is not based on output hash, in go they rewrite the buildid post-link. This could be done by pants also with `go tool buildid -w`, but it's mostly cosmetic so I didn't think it was worth adding that step for the fix. It would also need a slight format change. The platform identifiers are still input-derived in Go as well so they are already to parity.

## Verification

Added tests to make sure buildid is included in the linked binary. The tests fail without the fix.

Build go binaries that are pure-go, cgo-internal-only, cgo-external, all links and runs on both macOS and Linux, buildid present on both and LC_UUID on Mach-O and .note.gnu.build-id on ELF.

Notice: Claude used for verification harness, test generation, code drafting