### PR TITLE
feat(mypy): Support hierarchical mypy config discovery

### DIFF
--- a/docs/notes/2.34.x.md
+++ b/docs/notes/2.34.x.md
@@ -73,6 +73,8 @@ tightly than `or` in the spec](https://github.com/pex-tool/pex/releases/tag/v2.9
 
 The default version of `twine` in the bundled tool lockfile has been upgraded from `4.0.2` to `7.0.0`.  See <https://twine.readthedocs.io/en/stable/changelog.html> for more details.
 
+With `[mypy].config_discovery` enabled (the default), Pants now mirrors mypy's own config discovery behavior: each source file's nearest ancestor directory containing a `mypy.ini`, `.mypy.ini`, `pyproject.toml` (with a `[tool.mypy]` section), or `setup.cfg` (with a `[mypy]` section) is used, rather than only ever looking in the build root. Sources governed by different config files are partitioned into separate `mypy` invocations, and each partition's mypy incremental cache is isolated by config file to avoid cache thrashing.
+
 #### Shell
 
 #### Javascript

--- a/docs/notes/2.34.x.md
+++ b/docs/notes/2.34.x.md
@@ -73,8 +73,6 @@ tightly than `or` in the spec](https://github.com/pex-tool/pex/releases/tag/v2.9
 
 The default version of `twine` in the bundled tool lockfile has been upgraded from `4.0.2` to `7.0.0`.  See <https://twine.readthedocs.io/en/stable/changelog.html> for more details.
 
-With `[mypy].config_discovery` enabled (the default), Pants now mirrors mypy's own config discovery behavior: each source file's nearest ancestor directory containing a `mypy.ini`, `.mypy.ini`, `pyproject.toml` (with a `[tool.mypy]` section), or `setup.cfg` (with a `[mypy]` section) is used, rather than only ever looking in the build root. Sources governed by different config files are partitioned into separate `mypy` invocations, and each partition's mypy incremental cache is isolated by config file to avoid cache thrashing.
-
 #### Shell
 
 #### Javascript

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import dataclasses
 import os
 from collections import defaultdict
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from hashlib import sha256
 from textwrap import dedent  # noqa: PNT20
@@ -52,7 +52,6 @@ from pants.core.goals.check import (
     CheckSubsystem,
 )
 from pants.core.util_rules.config_files import (
-    GatheredPrioritizedConfigFilesByDirectories,
     GatherPrioritizedConfigFilesByDirectoriesRequest,
     OrphanFilepathConfigBehavior,
     gather_prioritized_config_files_by_workspace_dir,
@@ -70,6 +69,7 @@ from pants.engine.collection import Collection
 from pants.engine.fs import (
     EMPTY_DIGEST,
     CreateDigest,
+    Digest,
     DigestSubset,
     FileContent,
     MergeDigests,
@@ -291,8 +291,7 @@ async def mypy_typecheck_partition(
     if partition.resolve_description:
         mypy_cache_dir += f"/{partition.resolve_description}"
     if partition.config_file.path:
-        config_key = sha256(partition.config_file.path.encode()).hexdigest()[:12]
-        mypy_cache_dir += f"/{config_key}"
+        mypy_cache_dir += f"/{sha256(partition.config_file.path.encode()).hexdigest()}"
     run_cache_dir = ".tmp_cache/mypy_cache"
     argv = await _generate_argv(
         mypy,
@@ -457,14 +456,14 @@ async def mypy_typecheck_partition(
 
 
 async def _mypy_config_file_for_path(
-    config_path: str | None, gathered: GatheredPrioritizedConfigFilesByDirectories, mypy: MyPy
+    config_path: str | None, all_configs: Digest, mypy: MyPy
 ) -> MyPyConfigFile:
     if config_path is None:
         return MyPyConfigFile(
             EMPTY_DIGEST, None, mypy.check_and_warn_if_python_version_configured(None)
         )
     config_digest = await digest_subset_to_digest(
-        DigestSubset(gathered.snapshot.digest, PathGlobs([config_path]))
+        DigestSubset(all_configs, PathGlobs([config_path]))
     )
     digest_contents = await get_digest_contents(config_digest)
     config_content = digest_contents[0] if digest_contents else None
@@ -473,21 +472,19 @@ async def _mypy_config_file_for_path(
 
 
 async def _mypy_field_set_to_config_file(
-    field_sets: Iterable[MyPyFieldSet], mypy: MyPy
+    field_sets: Sequence[MyPyFieldSet], mypy: MyPy
 ) -> dict[MyPyFieldSet, MyPyConfigFile]:
     """Map each field set to the MyPyConfigFile that applies to it.
 
     If an explicit config is set, or config discovery is disabled, every field set shares the
     single repo-wide config (mirroring the pre-existing, non-hierarchical behavior). Otherwise,
-    Pants looks for the nearest ancestor mypy config file for each field set's source root, so
+    Pants looks for the nearest ancestor mypy config file for each field set's source file, so
     different parts of the repo can use different MyPy configs.
     """
-    field_sets = list(field_sets)
     if mypy.config or not mypy.config_discovery:
         config_file = await setup_mypy_config(**implicitly())
-        return {field_set: config_file for field_set in field_sets}
+        return dict.fromkeys(field_sets, config_file)
 
-    source_dirs = {os.path.dirname(field_set.sources.file_path) for field_set in field_sets}
     gathered = await gather_prioritized_config_files_by_workspace_dir(
         GatherPrioritizedConfigFilesByDirectoriesRequest(
             tool_name=mypy.options_scope,
@@ -498,23 +495,26 @@ async def _mypy_field_set_to_config_file(
         )
     )
 
-    config_paths = list(
-        {gathered.source_dir_to_config_file.get(source_dir) for source_dir in source_dirs}
-    )
-    config_files_by_path = dict(
+    # `None` for a field set whose source directory has no config file in any ancestor directory.
+    config_path_by_field_set = {
+        field_set: gathered.source_dir_to_config_file.get(
+            os.path.dirname(field_set.sources.file_path)
+        )
+        for field_set in field_sets
+    }
+    unique_config_paths = sorted(set(config_path_by_field_set.values()), key=lambda p: p or "")
+    config_file_by_path = dict(
         zip(
-            config_paths,
+            unique_config_paths,
             await concurrently(
-                _mypy_config_file_for_path(config_path, gathered, mypy)
-                for config_path in config_paths
+                _mypy_config_file_for_path(config_path, gathered.snapshot.digest, mypy)
+                for config_path in unique_config_paths
             ),
         )
     )
     return {
-        field_set: config_files_by_path[
-            gathered.source_dir_to_config_file.get(os.path.dirname(field_set.sources.file_path))
-        ]
-        for field_set in field_sets
+        field_set: config_file_by_path[config_path]
+        for field_set, config_path in config_path_by_field_set.items()
     }
 
 

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -495,7 +495,6 @@ async def _mypy_field_set_to_config_file(
         )
     )
 
-    # `None` for a field set whose source directory has no config file in any ancestor directory.
     config_path_by_field_set = {
         field_set: gathered.source_dir_to_config_file.get(
             os.path.dirname(field_set.sources.file_path)

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import dataclasses
+import os
+from collections import defaultdict
 from collections.abc import Iterable
 from dataclasses import dataclass
 from hashlib import sha256
@@ -13,11 +15,14 @@ import packaging
 
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.typecheck.mypy.subsystem import (
+    CONFIG_DISCOVERY_CONTENT_CHECKS,
+    CONFIG_DISCOVERY_FILENAMES,
     MyPy,
     MyPyCacheMode,
     MyPyConfigFile,
     MyPyFieldSet,
     MyPyFirstPartyPlugins,
+    setup_mypy_config,
 )
 from pants.backend.python.util_rules import pex_from_targets
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
@@ -46,6 +51,12 @@ from pants.core.goals.check import (
     CheckResults,
     CheckSubsystem,
 )
+from pants.core.util_rules.config_files import (
+    GatheredPrioritizedConfigFilesByDirectories,
+    GatherPrioritizedConfigFilesByDirectoriesRequest,
+    OrphanFilepathConfigBehavior,
+    gather_prioritized_config_files_by_workspace_dir,
+)
 from pants.core.util_rules.source_files import SourceFilesRequest, determine_source_files
 from pants.core.util_rules.system_binaries import (
     CpBinary,
@@ -56,9 +67,24 @@ from pants.core.util_rules.system_binaries import (
     ShBinary,
 )
 from pants.engine.collection import Collection
-from pants.engine.fs import CreateDigest, FileContent, MergeDigests, RemovePrefix
+from pants.engine.fs import (
+    EMPTY_DIGEST,
+    CreateDigest,
+    DigestSubset,
+    FileContent,
+    MergeDigests,
+    PathGlobs,
+    RemovePrefix,
+)
 from pants.engine.internals.graph import resolve_coarsened_targets as coarsened_targets_get
-from pants.engine.intrinsics import create_digest, execute_process, merge_digests, remove_prefix
+from pants.engine.intrinsics import (
+    create_digest,
+    digest_subset_to_digest,
+    execute_process,
+    get_digest_contents,
+    merge_digests,
+    remove_prefix,
+)
 from pants.engine.rules import collect_rules, concurrently, implicitly, rule
 from pants.engine.target import CoarsenedTargets, CoarsenedTargetsRequest
 from pants.engine.unions import UnionRule
@@ -74,10 +100,12 @@ class MyPyPartition:
     root_targets: CoarsenedTargets
     resolve_description: str | None
     interpreter_constraints: InterpreterConstraints
+    config_file: MyPyConfigFile
 
     def description(self) -> str:
         ics = str(sorted(str(c) for c in self.interpreter_constraints))
-        return f"{self.resolve_description}, {ics}" if self.resolve_description else ics
+        base = f"{self.resolve_description}, {ics}" if self.resolve_description else ics
+        return f"{base} ({self.config_file.path})" if self.config_file.path else base
 
 
 class MyPyPartitions(Collection[MyPyPartition]):
@@ -121,10 +149,11 @@ async def _generate_argv(
     venv_python: str,
     file_list_path: str,
     python_version: str | None,
+    config_path: str | None,
 ) -> tuple[str, ...]:
     args = [pex.pex.argv0, f"--python-executable={venv_python}", *mypy.args]
-    if mypy.config:
-        args.append(f"--config-file={mypy.config}")
+    if config_path:
+        args.append(f"--config-file={config_path}")
     if python_version:
         args.append(f"--python-version={python_version}")
 
@@ -161,7 +190,6 @@ def determine_python_files(files: Iterable[str]) -> tuple[str, ...]:
 @rule
 async def mypy_typecheck_partition(
     partition: MyPyPartition,
-    config_file: MyPyConfigFile,
     first_party_plugins: MyPyFirstPartyPlugins,
     build_root: BuildRoot,
     mypy: MyPy,
@@ -255,13 +283,16 @@ async def mypy_typecheck_partition(
         closure_sources_get, requirements_venv_pex_request, file_list_digest_request
     )
 
-    py_version = config_file.python_version_to_autoset(
+    py_version = partition.config_file.python_version_to_autoset(
         partition.interpreter_constraints, python_setup.interpreter_versions_universe
     )
     named_cache_dir = ".cache/mypy_cache"
     mypy_cache_dir = f"{named_cache_dir}/{sha256(build_root.path.encode()).hexdigest()}"
     if partition.resolve_description:
         mypy_cache_dir += f"/{partition.resolve_description}"
+    if partition.config_file.path:
+        config_key = sha256(partition.config_file.path.encode()).hexdigest()[:12]
+        mypy_cache_dir += f"/{config_key}"
     run_cache_dir = ".tmp_cache/mypy_cache"
     argv = await _generate_argv(
         mypy,
@@ -270,6 +301,7 @@ async def mypy_typecheck_partition(
         cache_dir=run_cache_dir,
         file_list_path=file_list_path,
         python_version=py_version,
+        config_path=partition.config_file.path,
     )
 
     mypy_command = " ".join(shell_quote(arg) for arg in argv)
@@ -371,7 +403,7 @@ async def mypy_typecheck_partition(
                 first_party_plugins.sources_digest,
                 closure_sources.source_files.snapshot.digest,
                 requirements_venv_pex.digest,
-                config_file.digest,
+                partition.config_file.digest,
                 script_runner_digest,
             ]
         )
@@ -424,6 +456,68 @@ async def mypy_typecheck_partition(
     )
 
 
+async def _mypy_config_file_for_path(
+    config_path: str | None, gathered: GatheredPrioritizedConfigFilesByDirectories, mypy: MyPy
+) -> MyPyConfigFile:
+    if config_path is None:
+        return MyPyConfigFile(
+            EMPTY_DIGEST, None, mypy.check_and_warn_if_python_version_configured(None)
+        )
+    config_digest = await digest_subset_to_digest(
+        DigestSubset(gathered.snapshot.digest, PathGlobs([config_path]))
+    )
+    digest_contents = await get_digest_contents(config_digest)
+    config_content = digest_contents[0] if digest_contents else None
+    python_version_configured = mypy.check_and_warn_if_python_version_configured(config_content)
+    return MyPyConfigFile(config_digest, config_path, python_version_configured)
+
+
+async def _mypy_field_set_to_config_file(
+    field_sets: Iterable[MyPyFieldSet], mypy: MyPy
+) -> dict[MyPyFieldSet, MyPyConfigFile]:
+    """Map each field set to the MyPyConfigFile that applies to it.
+
+    If an explicit config is set, or config discovery is disabled, every field set shares the
+    single repo-wide config (mirroring the pre-existing, non-hierarchical behavior). Otherwise,
+    Pants looks for the nearest ancestor mypy config file for each field set's source root, so
+    different parts of the repo can use different MyPy configs.
+    """
+    field_sets = list(field_sets)
+    if mypy.config or not mypy.config_discovery:
+        config_file = await setup_mypy_config(**implicitly())
+        return {field_set: config_file for field_set in field_sets}
+
+    source_dirs = {os.path.dirname(field_set.sources.file_path) for field_set in field_sets}
+    gathered = await gather_prioritized_config_files_by_workspace_dir(
+        GatherPrioritizedConfigFilesByDirectoriesRequest(
+            tool_name=mypy.options_scope,
+            candidate_conf_filenames=CONFIG_DISCOVERY_FILENAMES,
+            filepaths=tuple(field_set.sources.file_path for field_set in field_sets),
+            content_marker_by_filename=CONFIG_DISCOVERY_CONTENT_CHECKS,
+            orphan_filepath_behavior=OrphanFilepathConfigBehavior.IGNORE,
+        )
+    )
+
+    config_paths = list(
+        {gathered.source_dir_to_config_file.get(source_dir) for source_dir in source_dirs}
+    )
+    config_files_by_path = dict(
+        zip(
+            config_paths,
+            await concurrently(
+                _mypy_config_file_for_path(config_path, gathered, mypy)
+                for config_path in config_paths
+            ),
+        )
+    )
+    return {
+        field_set: config_files_by_path[
+            gathered.source_dir_to_config_file.get(os.path.dirname(field_set.sources.file_path))
+        ]
+        for field_set in field_sets
+    }
+
+
 @rule(desc="Determine if necessary to partition MyPy input", level=LogLevel.DEBUG)
 async def mypy_determine_partitions(
     request: MyPyRequest, mypy: MyPy, python_setup: PythonSetup
@@ -431,27 +525,41 @@ async def mypy_determine_partitions(
     resolve_and_interpreter_constraints_to_field_sets = (
         _partition_by_interpreter_constraints_and_resolve(request.field_sets, python_setup)
     )
-    coarsened_targets = await coarsened_targets_get(
-        CoarsenedTargetsRequest(field_set.address for field_set in request.field_sets),
-        **implicitly(),
+    coarsened_targets, field_set_to_config_file = await concurrently(
+        coarsened_targets_get(
+            CoarsenedTargetsRequest(field_set.address for field_set in request.field_sets),
+            **implicitly(),
+        ),
+        _mypy_field_set_to_config_file(request.field_sets, mypy),
     )
     coarsened_targets_by_address = coarsened_targets.by_address()
 
-    return MyPyPartitions(
-        MyPyPartition(
-            FrozenOrderedSet(field_sets),
-            CoarsenedTargets(
-                OrderedSet(
-                    coarsened_targets_by_address[field_set.address] for field_set in field_sets
+    partitions = []
+    for (resolve, interpreter_constraints), field_sets in sorted(
+        resolve_and_interpreter_constraints_to_field_sets.items()
+    ):
+        field_sets_by_config_file: dict[MyPyConfigFile, list[MyPyFieldSet]] = defaultdict(list)
+        for field_set in field_sets:
+            field_sets_by_config_file[field_set_to_config_file[field_set]].append(field_set)
+
+        for config_file, config_field_sets in sorted(
+            field_sets_by_config_file.items(), key=lambda item: item[0].path or ""
+        ):
+            partitions.append(
+                MyPyPartition(
+                    FrozenOrderedSet(config_field_sets),
+                    CoarsenedTargets(
+                        OrderedSet(
+                            coarsened_targets_by_address[field_set.address]
+                            for field_set in config_field_sets
+                        )
+                    ),
+                    resolve if len(python_setup.resolves) > 1 else None,
+                    interpreter_constraints or mypy.interpreter_constraints,
+                    config_file,
                 )
-            ),
-            resolve if len(python_setup.resolves) > 1 else None,
-            interpreter_constraints or mypy.interpreter_constraints,
-        )
-        for (resolve, interpreter_constraints), field_sets in sorted(
-            resolve_and_interpreter_constraints_to_field_sets.items()
-        )
-    )
+            )
+    return MyPyPartitions(partitions)
 
 
 @rule(desc="Typecheck using MyPy", level=LogLevel.DEBUG)

--- a/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
@@ -177,6 +177,88 @@ def test_config_file(
     assert f"{PACKAGE}/f.py:3" in result[0].stdout
 
 
+@pytest.mark.parametrize(
+    "config_filetype, config_header",
+    [
+        ("mypy.ini", "[mypy]"),
+        (".mypy.ini", "[mypy]"),
+        ("pyproject.toml", "[tool.mypy]"),
+        ("setup.cfg", "[mypy]"),
+    ],
+)
+def test_config_file_discovery_is_per_source_root(
+    rule_runner: PythonRuleRunner, config_filetype: str, config_header: str
+) -> None:
+    """Ensures all mypy config filetypes are discovered hierarchically."""
+    # TOML requires a lowercase boolean literal; other formats accept `True`.
+    bool_literal = "true" if config_filetype == "pyproject.toml" else "True"
+    rule_runner.write_files(
+        {
+            f"{PACKAGE}/strict/strict.py": NEEDS_CONFIG_FILE,
+            f"{PACKAGE}/strict/BUILD": "python_sources()",
+            f"{PACKAGE}/strict/{config_filetype}": (
+                f"{config_header}\ndisallow_any_expr = {bool_literal}\n"
+            ),
+            f"{PACKAGE}/lax/lax.py": NEEDS_CONFIG_FILE,
+            f"{PACKAGE}/lax/BUILD": "python_sources()",
+        }
+    )
+    strict_tgt = rule_runner.get_target(
+        Address(f"{PACKAGE}/strict", relative_file_path="strict.py")
+    )
+    lax_tgt = rule_runner.get_target(Address(f"{PACKAGE}/lax", relative_file_path="lax.py"))
+
+    partitions = rule_runner.request(
+        MyPyPartitions, [MyPyRequest(MyPyFieldSet.create(t) for t in (strict_tgt, lax_tgt))]
+    )
+    assert len(partitions) == 2
+
+    result = run_mypy(rule_runner, [strict_tgt, lax_tgt])
+    assert len(result) == 2
+    strict_result, lax_result = (
+        (result[0], result[1])
+        if f"{PACKAGE}/strict" in (result[0].partition_description or "")
+        else (result[1], result[0])
+    )
+    assert strict_result.exit_code == 1
+    assert f"{PACKAGE}/strict/strict.py:3" in strict_result.stdout
+    assert lax_result.exit_code == 0
+
+
+def test_config_file_discovery_prefers_nearest_ancestor(rule_runner: PythonRuleRunner) -> None:
+    """A closer ancestor config file wins, even over a farther ancestor with a higher-priority
+    filename (e.g. `mypy.ini` beats `setup.cfg` within a directory, but a directory's own
+    `setup.cfg` still beats an ancestor's `mypy.ini`)."""
+    rule_runner.write_files(
+        {
+            f"{PACKAGE}/mypy.ini": "[mypy]\ndisallow_any_expr = True\n",
+            f"{PACKAGE}/nested/setup.cfg": "[mypy]\n",
+            f"{PACKAGE}/nested/f.py": NEEDS_CONFIG_FILE,
+            f"{PACKAGE}/nested/BUILD": "python_sources()",
+            f"{PACKAGE}/other/f.py": NEEDS_CONFIG_FILE,
+            f"{PACKAGE}/other/BUILD": "python_sources()",
+        }
+    )
+    nested_tgt = rule_runner.get_target(Address(f"{PACKAGE}/nested", relative_file_path="f.py"))
+    other_tgt = rule_runner.get_target(Address(f"{PACKAGE}/other", relative_file_path="f.py"))
+
+    partitions = rule_runner.request(
+        MyPyPartitions, [MyPyRequest(MyPyFieldSet.create(t) for t in (nested_tgt, other_tgt))]
+    )
+    assert len(partitions) == 2
+
+    result = run_mypy(rule_runner, [nested_tgt, other_tgt])
+    assert len(result) == 2
+    nested_result, other_result = (
+        (result[0], result[1])
+        if f"{PACKAGE}/nested" in (result[0].partition_description or "")
+        else (result[1], result[0])
+    )
+    assert nested_result.exit_code == 0
+    assert other_result.exit_code == 1
+    assert f"{PACKAGE}/other/f.py:3" in other_result.stdout
+
+
 def test_passthrough_args(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {f"{PACKAGE}/f.py": NEEDS_CONFIG_FILE, f"{PACKAGE}/BUILD": "python_sources()"}

--- a/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
@@ -186,11 +186,10 @@ def test_config_file(
         ("setup.cfg", "[mypy]"),
     ],
 )
-def test_config_file_discovery_is_per_source_root(
+def test_config_file_discovery_is_per_source_dir(
     rule_runner: PythonRuleRunner, config_filetype: str, config_header: str
 ) -> None:
     """Ensures all mypy config filetypes are discovered hierarchically."""
-    # TOML requires a lowercase boolean literal; other formats accept `True`.
     bool_literal = "true" if config_filetype == "pyproject.toml" else "True"
     rule_runner.write_files(
         {
@@ -226,9 +225,11 @@ def test_config_file_discovery_is_per_source_root(
 
 
 def test_config_file_discovery_prefers_nearest_ancestor(rule_runner: PythonRuleRunner) -> None:
-    """A closer ancestor config file wins, even over a farther ancestor with a higher-priority
-    filename (e.g. `mypy.ini` beats `setup.cfg` within a directory, but a directory's own
-    `setup.cfg` still beats an ancestor's `mypy.ini`)."""
+    """
+    A closer ancestor config file wins, even over a farther ancestor with a higher-priority
+    filename (e.g. `mypy.ini` preferred over `setup.cfg` within a directory, but a directory's own
+    `setup.cfg` still takes precedence over an ancestor's `mypy.ini`).
+    """
     rule_runner.write_files(
         {
             f"{PACKAGE}/mypy.ini": "[mypy]\ndisallow_any_expr = True\n",

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -44,11 +44,21 @@ from pants.option.option_types import (
     TargetListOption,
 )
 from pants.util.docutil import doc_url
+from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet
 from pants.util.strutil import softwrap
 
 logger = logging.getLogger(__name__)
+
+# Candidate config filenames, in priority order (within a single directory, an earlier filename
+# wins over a later one; but a closer directory always wins over a farther one, regardless of
+# which candidate filename it has). Used for both single, repo-root-only discovery (via
+# `MyPy.config_request`) and per-source-root hierarchical discovery (see `mypy/rules.py`).
+CONFIG_DISCOVERY_FILENAMES = ("mypy.ini", ".mypy.ini", "pyproject.toml", "setup.cfg")
+CONFIG_DISCOVERY_CONTENT_CHECKS = FrozenDict(
+    {"pyproject.toml": b"[tool.mypy", "setup.cfg": b"[mypy"}
+)
 
 
 class MyPyCacheMode(StrEnum):
@@ -108,7 +118,12 @@ class MyPy(PythonToolBase):
         help=lambda cls: softwrap(
             f"""
             If true, Pants will include any relevant config files during runs
-            (`mypy.ini`, `.mypy.ini`, and `setup.cfg`).
+            (`mypy.ini`, `.mypy.ini`, `pyproject.toml`, and `setup.cfg`).
+
+            Pants looks for a config file in each source root and its ancestor directories. For a
+            given source root, Pants uses the config file in the nearest ancestor directory
+            (including the source root itself), following mypy's file-preference order if multiple
+            candidate config files exist in that directory.
 
             Use `[{cls.options_scope}].config` instead if your config is in a non-standard location.
             """
@@ -150,8 +165,12 @@ class MyPy(PythonToolBase):
             specified=self.config,
             specified_option_name=f"{self.options_scope}.config",
             discovery=self.config_discovery,
-            check_existence=["mypy.ini", ".mypy.ini"],
-            check_content={"setup.cfg": b"[mypy", "pyproject.toml": b"[tool.mypy"},
+            check_existence=[
+                filename
+                for filename in CONFIG_DISCOVERY_FILENAMES
+                if filename not in CONFIG_DISCOVERY_CONTENT_CHECKS
+            ],
+            check_content=CONFIG_DISCOVERY_CONTENT_CHECKS,
         )
 
     @property
@@ -207,6 +226,7 @@ class MyPy(PythonToolBase):
 @dataclass(frozen=True)
 class MyPyConfigFile:
     digest: Digest
+    path: str | None
     _python_version_configured: bool
 
     def python_version_to_autoset(
@@ -223,10 +243,13 @@ class MyPyConfigFile:
 async def setup_mypy_config(mypy: MyPy) -> MyPyConfigFile:
     config_files = await find_config_file(mypy.config_request)
     digest_contents = await get_digest_contents(config_files.snapshot.digest)
-    python_version_configured = mypy.check_and_warn_if_python_version_configured(
-        digest_contents[0] if digest_contents else None
+    config_content = digest_contents[0] if digest_contents else None
+    python_version_configured = mypy.check_and_warn_if_python_version_configured(config_content)
+    return MyPyConfigFile(
+        config_files.snapshot.digest,
+        config_content.path if config_content else None,
+        python_version_configured,
     )
-    return MyPyConfigFile(config_files.snapshot.digest, python_version_configured)
 
 
 # --------------------------------------------------------------------------------------

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -7,6 +7,7 @@ import logging
 from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import StrEnum
+from typing import Final
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.subsystems.setup import PythonSetup
@@ -55,8 +56,13 @@ logger = logging.getLogger(__name__)
 # wins over a later one; but a closer directory always wins over a farther one, regardless of
 # which candidate filename it has). Used for both single, repo-root-only discovery (via
 # `MyPy.config_request`) and per-source-root hierarchical discovery (see `mypy/rules.py`).
-CONFIG_DISCOVERY_FILENAMES = ("mypy.ini", ".mypy.ini", "pyproject.toml", "setup.cfg")
-CONFIG_DISCOVERY_CONTENT_CHECKS = FrozenDict(
+CONFIG_DISCOVERY_FILENAMES: Final[tuple[str, ...]] = (
+    "mypy.ini",
+    ".mypy.ini",
+    "pyproject.toml",
+    "setup.cfg",
+)
+CONFIG_DISCOVERY_CONTENT_CHECKS: Final[FrozenDict[str, bytes]] = FrozenDict(
     {"pyproject.toml": b"[tool.mypy", "setup.cfg": b"[mypy"}
 )
 
@@ -117,15 +123,15 @@ class MyPy(PythonToolBase):
         advanced=True,
         help=lambda cls: softwrap(
             f"""
-            If true, Pants will include any relevant config files during runs
+            If true, Pants will use any relevant config files during runs
             (`mypy.ini`, `.mypy.ini`, `pyproject.toml`, and `setup.cfg`).
 
-            Pants looks for a config file in each source root and its ancestor directories. For a
-            given source root, Pants uses the config file in the nearest ancestor directory
-            (including the source root itself), following mypy's file-preference order if multiple
-            candidate config files exist in that directory.
+            Pants looks for a config file in the directory of each source file and in that
+            directory's ancestors, using the nearest one found. If a directory holds more than one
+            candidate, Pants follows mypy's own file-preference order.
 
-            Use `[{cls.options_scope}].config` instead if your config is in a non-standard location.
+            Use `[{cls.options_scope}].config` instead if you have a singular mypy config and it
+            is defined in a non-standard location.
             """
         ),
     )

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -52,10 +52,7 @@ from pants.util.strutil import softwrap
 
 logger = logging.getLogger(__name__)
 
-# Candidate config filenames, in priority order (within a single directory, an earlier filename
-# wins over a later one; but a closer directory always wins over a farther one, regardless of
-# which candidate filename it has). Used for both single, repo-root-only discovery (via
-# `MyPy.config_request`) and per-source-root hierarchical discovery (see `mypy/rules.py`).
+# Candidate config filenames, in priority order
 CONFIG_DISCOVERY_FILENAMES: Final[tuple[str, ...]] = (
     "mypy.ini",
     ".mypy.ini",

--- a/src/python/pants/core/util_rules/config_files.py
+++ b/src/python/pants/core/util_rules/config_files.py
@@ -14,7 +14,10 @@ from pants.engine.fs import EMPTY_SNAPSHOT, PathGlobs, Snapshot
 from pants.engine.intrinsics import digest_to_snapshot, get_digest_contents
 from pants.engine.rules import collect_rules, implicitly, rule
 from pants.util.collections import ensure_str_list
-from pants.util.dirutil import find_nearest_ancestor_file
+from pants.util.dirutil import (
+    find_nearest_ancestor_file,
+    find_nearest_ancestor_file_by_priority_order,
+)
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.strutil import softwrap
@@ -154,6 +157,92 @@ async def gather_config_files_by_workspace_dir(
 
     return GatheredConfigFilesByDirectories(
         request.config_filename, config_files_snapshot, FrozenDict(source_dir_to_config_file)
+    )
+
+
+@dataclass(frozen=True)
+class GatheredPrioritizedConfigFilesByDirectories:
+    config_filenames: tuple[str, ...]
+    snapshot: Snapshot
+    source_dir_to_config_file: FrozenDict[str, str]
+
+
+@dataclass(frozen=True)
+class GatherPrioritizedConfigFilesByDirectoriesRequest:
+    """
+    Like `GatherConfigFilesByDirectoriesRequest`, but with multiple valid config filename
+    candidates, and a priority ordering of those filenames if multiple appear in a given directory.
+    `content_marker_by_filename` maps from config filename to a byte-string marker required for
+    the file to be considered a valid config (e.g. pyproject.toml might not have `[tool.mypy]`).
+    """
+
+    tool_name: str
+    candidate_conf_filenames: tuple[str, ...]
+    filepaths: tuple[str, ...]
+    content_marker_by_filename: FrozenDict[str, bytes] = FrozenDict()
+    orphan_filepath_behavior: OrphanFilepathConfigBehavior = OrphanFilepathConfigBehavior.ERROR
+
+
+@rule
+async def gather_prioritized_config_files_by_workspace_dir(
+    request: GatherPrioritizedConfigFilesByDirectoriesRequest,
+) -> GatheredPrioritizedConfigFilesByDirectories:
+    """
+    Like `gather_config_files_by_workspace_dir`, but supports multiple candidate config
+    filenames per directory, in priority order.
+    """
+
+    source_dirs = frozenset(os.path.dirname(path) for path in request.filepaths)
+    source_dirs_with_ancestors = {"", *source_dirs}
+    for source_dir in source_dirs:
+        ancestor = source_dir
+        while ancestor:
+            parent = os.path.dirname(ancestor)
+            if parent in source_dirs_with_ancestors:
+                break
+            source_dirs_with_ancestors.add(parent)
+            ancestor = parent
+
+    candidate_globs = [
+        os.path.join(dir, filename)
+        for dir in source_dirs_with_ancestors
+        for filename in request.candidate_conf_filenames
+    ]
+    candidate_digest_contents = await get_digest_contents(**implicitly(PathGlobs(candidate_globs)))
+    valid_files = tuple(
+        file_content.path
+        for file_content in candidate_digest_contents
+        if os.path.basename(file_content.path) not in request.content_marker_by_filename
+        or request.content_marker_by_filename[os.path.basename(file_content.path)]
+        in file_content.content
+    )
+
+    config_files_snapshot = await digest_to_snapshot(**implicitly(PathGlobs(valid_files)))
+    config_files_set = set(config_files_snapshot.files)
+    source_dir_to_config_file: dict[str, str] = {}
+    for source_dir in source_dirs:
+        config_file = find_nearest_ancestor_file_by_priority_order(
+            config_files_set, source_dir, request.candidate_conf_filenames
+        )
+        if config_file:
+            source_dir_to_config_file[source_dir] = config_file
+        else:
+            filenames = "`, `".join(request.candidate_conf_filenames)
+            msg = softwrap(
+                f"""
+                No {request.tool_name} file (one of `{filenames}`) found for
+                source directory '{source_dir}'.
+                """
+            )
+            if request.orphan_filepath_behavior == OrphanFilepathConfigBehavior.ERROR:
+                raise ValueError(msg)
+            elif request.orphan_filepath_behavior == OrphanFilepathConfigBehavior.WARN:
+                logger.warning(msg)
+
+    return GatheredPrioritizedConfigFilesByDirectories(
+        request.candidate_conf_filenames,
+        config_files_snapshot,
+        FrozenDict(source_dir_to_config_file),
     )
 
 

--- a/src/python/pants/core/util_rules/config_files.py
+++ b/src/python/pants/core/util_rules/config_files.py
@@ -14,10 +14,7 @@ from pants.engine.fs import EMPTY_SNAPSHOT, PathGlobs, Snapshot
 from pants.engine.intrinsics import digest_to_snapshot, get_digest_contents
 from pants.engine.rules import collect_rules, implicitly, rule
 from pants.util.collections import ensure_str_list
-from pants.util.dirutil import (
-    find_nearest_ancestor_file,
-    find_nearest_ancestor_file_by_priority_order,
-)
+from pants.util.dirutil import find_nearest_ancestor_file_by_priority_order
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.strutil import softwrap
@@ -101,6 +98,86 @@ class OrphanFilepathConfigBehavior(Enum):
 
 
 @dataclass(frozen=True)
+class GatheredPrioritizedConfigFilesByDirectories:
+    config_filenames: tuple[str, ...]
+    snapshot: Snapshot
+    source_dir_to_config_file: FrozenDict[str, str]
+
+
+@dataclass(frozen=True)
+class GatherPrioritizedConfigFilesByDirectoriesRequest:
+    """Like `GatherConfigFilesByDirectoriesRequest`, but with multiple valid config filename
+    candidates, and a priority ordering of those filenames if multiple appear in a given directory.
+
+    `content_marker_by_filename` maps from config filename to a byte-string marker required for the
+    file to be considered a valid config (e.g. `pyproject.toml` might not have `[tool.mypy]`).
+    """
+
+    tool_name: str
+    candidate_conf_filenames: tuple[str, ...]
+    filepaths: tuple[str, ...]
+    content_marker_by_filename: FrozenDict[str, bytes] = FrozenDict()
+    orphan_filepath_behavior: OrphanFilepathConfigBehavior = OrphanFilepathConfigBehavior.ERROR
+
+
+@rule
+async def gather_prioritized_config_files_by_workspace_dir(
+    request: GatherPrioritizedConfigFilesByDirectoriesRequest,
+) -> GatheredPrioritizedConfigFilesByDirectories:
+    """Gathers config files from the workspace and indexes them by the directories relative to
+    them, preferring the nearest ancestor directory and then `candidate_conf_filenames` order."""
+
+    source_dirs = frozenset(os.path.dirname(path) for path in request.filepaths)
+    source_dirs_with_ancestors = {"", *source_dirs}
+    for source_dir in source_dirs:
+        ancestor = os.path.dirname(source_dir)
+        while ancestor:
+            source_dirs_with_ancestors.add(ancestor)
+            ancestor = os.path.dirname(ancestor)
+
+    candidate_globs = [
+        os.path.join(dir, filename)
+        for dir in source_dirs_with_ancestors
+        for filename in request.candidate_conf_filenames
+    ]
+    candidate_digest_contents = await get_digest_contents(**implicitly(PathGlobs(candidate_globs)))
+    valid_files = tuple(
+        file_content.path
+        for file_content in candidate_digest_contents
+        if request.content_marker_by_filename.get(os.path.basename(file_content.path), b"")
+        in file_content.content
+    )
+
+    config_files_snapshot = await digest_to_snapshot(**implicitly(PathGlobs(valid_files)))
+    config_files_set = set(config_files_snapshot.files)
+    source_dir_to_config_file: dict[str, str] = {}
+    for source_dir in source_dirs:
+        config_file = find_nearest_ancestor_file_by_priority_order(
+            config_files_set, source_dir, request.candidate_conf_filenames
+        )
+        if config_file:
+            source_dir_to_config_file[source_dir] = config_file
+        else:
+            filenames = " or ".join(f"`{name}`" for name in request.candidate_conf_filenames)
+            msg = softwrap(
+                f"""
+                No {request.tool_name} file ({filenames}) found for
+                source directory '{source_dir}'.
+                """
+            )
+            if request.orphan_filepath_behavior == OrphanFilepathConfigBehavior.ERROR:
+                raise ValueError(msg)
+            elif request.orphan_filepath_behavior == OrphanFilepathConfigBehavior.WARN:
+                logger.warning(msg)
+
+    return GatheredPrioritizedConfigFilesByDirectories(
+        request.candidate_conf_filenames,
+        config_files_snapshot,
+        FrozenDict(source_dir_to_config_file),
+    )
+
+
+@dataclass(frozen=True)
 class GatheredConfigFilesByDirectories:
     config_filename: str
     snapshot: Snapshot
@@ -122,127 +199,16 @@ async def gather_config_files_by_workspace_dir(
     """Gathers config files from the workspace and indexes them by the directories relative to
     them."""
 
-    source_dirs = frozenset(os.path.dirname(path) for path in request.filepaths)
-    source_dirs_with_ancestors = {"", *source_dirs}
-    for source_dir in source_dirs:
-        source_dir_parts = source_dir.split(os.path.sep)
-        source_dir_parts.pop()
-        while source_dir_parts:
-            source_dirs_with_ancestors.add(os.path.sep.join(source_dir_parts))
-            source_dir_parts.pop()
-
-    config_file_globs = [
-        os.path.join(dir, request.config_filename) for dir in source_dirs_with_ancestors
-    ]
-    config_files_snapshot = await digest_to_snapshot(**implicitly(PathGlobs(config_file_globs)))
-    config_files_set = set(config_files_snapshot.files)
-    source_dir_to_config_file: dict[str, str] = {}
-    for source_dir in source_dirs:
-        config_file = find_nearest_ancestor_file(
-            config_files_set, source_dir, request.config_filename
+    gathered = await gather_prioritized_config_files_by_workspace_dir(
+        GatherPrioritizedConfigFilesByDirectoriesRequest(
+            tool_name=request.tool_name,
+            candidate_conf_filenames=(request.config_filename,),
+            filepaths=request.filepaths,
+            orphan_filepath_behavior=request.orphan_filepath_behavior,
         )
-        if config_file:
-            source_dir_to_config_file[source_dir] = config_file
-        else:
-            msg = softwrap(
-                f"""
-                No {request.tool_name} file (`{request.config_filename}`) found for
-                source directory '{source_dir}'.
-                """
-            )
-            if request.orphan_filepath_behavior == OrphanFilepathConfigBehavior.ERROR:
-                raise ValueError(msg)
-            elif request.orphan_filepath_behavior == OrphanFilepathConfigBehavior.WARN:
-                logger.warning(msg)
-
+    )
     return GatheredConfigFilesByDirectories(
-        request.config_filename, config_files_snapshot, FrozenDict(source_dir_to_config_file)
-    )
-
-
-@dataclass(frozen=True)
-class GatheredPrioritizedConfigFilesByDirectories:
-    config_filenames: tuple[str, ...]
-    snapshot: Snapshot
-    source_dir_to_config_file: FrozenDict[str, str]
-
-
-@dataclass(frozen=True)
-class GatherPrioritizedConfigFilesByDirectoriesRequest:
-    """
-    Like `GatherConfigFilesByDirectoriesRequest`, but with multiple valid config filename
-    candidates, and a priority ordering of those filenames if multiple appear in a given directory.
-    `content_marker_by_filename` maps from config filename to a byte-string marker required for
-    the file to be considered a valid config (e.g. pyproject.toml might not have `[tool.mypy]`).
-    """
-
-    tool_name: str
-    candidate_conf_filenames: tuple[str, ...]
-    filepaths: tuple[str, ...]
-    content_marker_by_filename: FrozenDict[str, bytes] = FrozenDict()
-    orphan_filepath_behavior: OrphanFilepathConfigBehavior = OrphanFilepathConfigBehavior.ERROR
-
-
-@rule
-async def gather_prioritized_config_files_by_workspace_dir(
-    request: GatherPrioritizedConfigFilesByDirectoriesRequest,
-) -> GatheredPrioritizedConfigFilesByDirectories:
-    """
-    Like `gather_config_files_by_workspace_dir`, but supports multiple candidate config
-    filenames per directory, in priority order.
-    """
-
-    source_dirs = frozenset(os.path.dirname(path) for path in request.filepaths)
-    source_dirs_with_ancestors = {"", *source_dirs}
-    for source_dir in source_dirs:
-        ancestor = source_dir
-        while ancestor:
-            parent = os.path.dirname(ancestor)
-            if parent in source_dirs_with_ancestors:
-                break
-            source_dirs_with_ancestors.add(parent)
-            ancestor = parent
-
-    candidate_globs = [
-        os.path.join(dir, filename)
-        for dir in source_dirs_with_ancestors
-        for filename in request.candidate_conf_filenames
-    ]
-    candidate_digest_contents = await get_digest_contents(**implicitly(PathGlobs(candidate_globs)))
-    valid_files = tuple(
-        file_content.path
-        for file_content in candidate_digest_contents
-        if os.path.basename(file_content.path) not in request.content_marker_by_filename
-        or request.content_marker_by_filename[os.path.basename(file_content.path)]
-        in file_content.content
-    )
-
-    config_files_snapshot = await digest_to_snapshot(**implicitly(PathGlobs(valid_files)))
-    config_files_set = set(config_files_snapshot.files)
-    source_dir_to_config_file: dict[str, str] = {}
-    for source_dir in source_dirs:
-        config_file = find_nearest_ancestor_file_by_priority_order(
-            config_files_set, source_dir, request.candidate_conf_filenames
-        )
-        if config_file:
-            source_dir_to_config_file[source_dir] = config_file
-        else:
-            filenames = "`, `".join(request.candidate_conf_filenames)
-            msg = softwrap(
-                f"""
-                No {request.tool_name} file (one of `{filenames}`) found for
-                source directory '{source_dir}'.
-                """
-            )
-            if request.orphan_filepath_behavior == OrphanFilepathConfigBehavior.ERROR:
-                raise ValueError(msg)
-            elif request.orphan_filepath_behavior == OrphanFilepathConfigBehavior.WARN:
-                logger.warning(msg)
-
-    return GatheredPrioritizedConfigFilesByDirectories(
-        request.candidate_conf_filenames,
-        config_files_snapshot,
-        FrozenDict(source_dir_to_config_file),
+        request.config_filename, gathered.snapshot, gathered.source_dir_to_config_file
     )
 
 

--- a/src/python/pants/core/util_rules/config_files_test.py
+++ b/src/python/pants/core/util_rules/config_files_test.py
@@ -11,10 +11,14 @@ from pants.core.util_rules.config_files import (
     ConfigFilesRequest,
     GatherConfigFilesByDirectoriesRequest,
     GatheredConfigFilesByDirectories,
+    GatheredPrioritizedConfigFilesByDirectories,
+    GatherPrioritizedConfigFilesByDirectoriesRequest,
+    OrphanFilepathConfigBehavior,
 )
 from pants.engine.fs import PathGlobs, Snapshot
 from pants.engine.internals.scheduler import ExecutionError
 from pants.testutil.rule_runner import QueryRule, RuleRunner
+from pants.util.frozendict import FrozenDict
 
 
 @pytest.fixture
@@ -24,6 +28,10 @@ def rule_runner() -> RuleRunner:
             *config_files.rules(),
             QueryRule(ConfigFiles, [ConfigFilesRequest]),
             QueryRule(GatheredConfigFilesByDirectories, [GatherConfigFilesByDirectoriesRequest]),
+            QueryRule(
+                GatheredPrioritizedConfigFilesByDirectories,
+                [GatherPrioritizedConfigFilesByDirectoriesRequest],
+            ),
         ]
     )
 
@@ -104,3 +112,74 @@ def test_gather_config_files(rule_runner: RuleRunner) -> None:
         ("hello", f"hello/{TEST_CONFIG_FILENAME}"),
         ("hello/world", f"hello/{TEST_CONFIG_FILENAME}"),
     ]
+
+
+CANDIDATE_CONF_FILENAMES = ("mypy.ini", ".mypy.ini", "pyproject.toml", "setup.cfg")
+CONTENT_MARKER_BY_FILENAME = FrozenDict({"pyproject.toml": b"[tool.mypy", "setup.cfg": b"[mypy"})
+
+
+def test_gather_prioritized_config_files(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "mypy.ini": "[mypy]",
+            "foo/bar/setup.cfg": "[mypy]",
+            "foo/bar/Foo.x": "",
+            "foo/bar/xyyzzy/Foo.x": "",
+            "foo/blah/Foo.x": "",
+            "hello/.mypy.ini": "[mypy]",
+            "hello/pyproject.toml": "[tool.other]",
+            "hello/Foo.x": "",
+            "hello/world/Foo.x": "",
+        }
+    )
+
+    snapshot = rule_runner.request(Snapshot, [PathGlobs(["**/*.x"])])
+    request = rule_runner.request(
+        GatheredPrioritizedConfigFilesByDirectories,
+        [
+            GatherPrioritizedConfigFilesByDirectoriesRequest(
+                tool_name="test",
+                candidate_conf_filenames=CANDIDATE_CONF_FILENAMES,
+                filepaths=snapshot.files,
+                content_marker_by_filename=CONTENT_MARKER_BY_FILENAME,
+            )
+        ],
+    )
+    assert sorted(request.source_dir_to_config_file.items()) == [
+        # Nearer ancestor config wins, even though `mypy.ini` outranks `setup.cfg` in priority.
+        ("foo/bar", "foo/bar/setup.cfg"),
+        ("foo/bar/xyyzzy", "foo/bar/setup.cfg"),
+        # No config in `foo/blah` or any of its ancestors besides the build root.
+        ("foo/blah", "mypy.ini"),
+        # `pyproject.toml` is present but lacks the `[tool.mypy]` marker, so `.mypy.ini` wins.
+        ("hello", "hello/.mypy.ini"),
+        ("hello/world", "hello/.mypy.ini"),
+    ]
+
+
+def test_gather_prioritized_config_files_orphan_behavior(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files({"foo/Foo.x": ""})
+    snapshot = rule_runner.request(Snapshot, [PathGlobs(["**/*.x"])])
+
+    def gather(
+        orphan_filepath_behavior: OrphanFilepathConfigBehavior,
+    ) -> GatheredPrioritizedConfigFilesByDirectories:
+        return rule_runner.request(
+            GatheredPrioritizedConfigFilesByDirectories,
+            [
+                GatherPrioritizedConfigFilesByDirectoriesRequest(
+                    tool_name="test",
+                    candidate_conf_filenames=CANDIDATE_CONF_FILENAMES,
+                    filepaths=snapshot.files,
+                    content_marker_by_filename=CONTENT_MARKER_BY_FILENAME,
+                    orphan_filepath_behavior=orphan_filepath_behavior,
+                )
+            ],
+        )
+
+    with pytest.raises(ExecutionError) as exc:
+        gather(OrphanFilepathConfigBehavior.ERROR)
+    assert "foo" in str(exc.value)
+
+    assert gather(OrphanFilepathConfigBehavior.WARN).source_dir_to_config_file == FrozenDict()
+    assert gather(OrphanFilepathConfigBehavior.IGNORE).source_dir_to_config_file == FrozenDict()

--- a/src/python/pants/util/dirutil.py
+++ b/src/python/pants/util/dirutil.py
@@ -444,24 +444,17 @@ def group_by_dir(paths: Iterable[str]) -> dict[str, set[str]]:
 
 def find_nearest_ancestor_file(files: set[str], dir: str, filename: str) -> str | None:
     """Given a filename return the nearest ancestor file of that name in the directory hierarchy."""
-    while True:
-        candidate_config_file_path = os.path.join(dir, filename)
-        if candidate_config_file_path in files:
-            return candidate_config_file_path
-
-        if dir == "":
-            return None
-        dir = os.path.dirname(dir)
+    return find_nearest_ancestor_file_by_priority_order(files, dir, (filename,))
 
 
 def find_nearest_ancestor_file_by_priority_order(
-    files: set[str], dir: str, candidate_filenames: Iterable[str]
+    files: set[str], dir: str, candidate_filenames: Sequence[str]
 ) -> str | None:
+    """Like `find_nearest_ancestor_file`, but with multiple candidate filenames.
+
+    A nearer ancestor directory always wins; within a single directory, the earliest of
+    `candidate_filenames` wins.
     """
-    Like `find_nearest_ancestor_file`, but checks multiple candidate filenames in order of priority
-    at each directory, returning the first match.
-    """
-    candidate_filenames = tuple(candidate_filenames)
     while True:
         for filename in candidate_filenames:
             candidate_config_file_path = os.path.join(dir, filename)

--- a/src/python/pants/util/dirutil.py
+++ b/src/python/pants/util/dirutil.py
@@ -452,3 +452,22 @@ def find_nearest_ancestor_file(files: set[str], dir: str, filename: str) -> str 
         if dir == "":
             return None
         dir = os.path.dirname(dir)
+
+
+def find_nearest_ancestor_file_by_priority_order(
+    files: set[str], dir: str, candidate_filenames: Iterable[str]
+) -> str | None:
+    """
+    Like `find_nearest_ancestor_file`, but checks multiple candidate filenames in order of priority
+    at each directory, returning the first match.
+    """
+    candidate_filenames = tuple(candidate_filenames)
+    while True:
+        for filename in candidate_filenames:
+            candidate_config_file_path = os.path.join(dir, filename)
+            if candidate_config_file_path in files:
+                return candidate_config_file_path
+
+        if dir == "":
+            return None
+        dir = os.path.dirname(dir)

--- a/src/python/pants/util/dirutil_test.py
+++ b/src/python/pants/util/dirutil_test.py
@@ -19,6 +19,7 @@ from pants.util.dirutil import (
     absolute_symlink,
     fast_relpath,
     find_nearest_ancestor_file,
+    find_nearest_ancestor_file_by_priority_order,
     group_by_dir,
     longest_dir_prefix,
     read_file,
@@ -496,3 +497,29 @@ def test_find_nearest_ancestor_file() -> None:
     assert find_nearest_ancestor_file(files2, "foo", "grok.conf") is None
     assert find_nearest_ancestor_file(files2, "foo/", "grok.conf") is None
     assert find_nearest_ancestor_file(files2, "", "grok.conf") is None
+
+
+def test_find_nearest_ancestor_file_by_priority_order() -> None:
+    candidates = ("mypy.ini", ".mypy.ini", "pyproject.toml", "setup.cfg")
+
+    # Within a single directory, the first candidate in priority order wins.
+    files = {"foo/bar/setup.cfg", "foo/bar/pyproject.toml", "foo/bar/.mypy.ini"}
+    assert (
+        find_nearest_ancestor_file_by_priority_order(files, "foo/bar", candidates)
+        == "foo/bar/.mypy.ini"
+    )
+
+    # A closer ancestor directory wins even if it only has a lower-priority filename than a
+    # farther ancestor.
+    files2 = {"mypy.ini", "foo/bar/setup.cfg"}
+    assert (
+        find_nearest_ancestor_file_by_priority_order(files2, "foo/bar", candidates)
+        == "foo/bar/setup.cfg"
+    )
+    assert find_nearest_ancestor_file_by_priority_order(files2, "foo", candidates) == "mypy.ini"
+    assert find_nearest_ancestor_file_by_priority_order(files2, "", candidates) == "mypy.ini"
+
+    # No candidate found anywhere in the ancestry.
+    files3 = {"hello/world/mypy.ini"}
+    assert find_nearest_ancestor_file_by_priority_order(files3, "foo/bar", candidates) is None
+    assert find_nearest_ancestor_file_by_priority_order(files3, "", candidates) is None


### PR DESCRIPTION
## What?
* Adds support for mypy's standard config discovery, as described [here](https://mypy.readthedocs.io/en/stable/config_file.html), and quoted below.
> If true, Pants will include any relevant config files during runs (mypy.ini, .mypy.ini, and setup.cfg).
Use [mypy].config instead if your config is in a non-standard location.

* Specifically, this adjusts the behavior when `[mypy].config_discovery = true` such that mypy configuration discovery uses the nearest ancestor mypy config discovered for the source(s) a `check` goal runs against.
    * Prior to this feature, the `[mypy].config_discovery = true` would exclusively search for a mypy config file in the repo root, while ignoring any + all other mypy configs.
    * This changes does NOT modify the behavior when `[mypy].config = "<path-to-config-file>"`, which remains mutually exclusive with `[mypy].config_discovery`.

## Why?
* The current `[mypy].config_discovery` option is not consistent with how mypy's "standard" discovery works. 
* A single mypy config for a multi-resolve monorepo can lead to problems, since not all mypy config options are scope-able to a particular module override (basically any config option noted as living in the `[global]` section of a mypy config).
    * example: the [plugins option](https://mypy.readthedocs.io/en/stable/config_file.html#confval-plugins).

## Relevant Issue(s)
closes https://github.com/pantsbuild/pants/issues/23533

## LLM Assistance Disclosure
I primarily used Claude Code for the implementation of this feature once I wrote the initial mypy partitioning component, with manual adjustment of most of the test cases, and manual removal of claude comments.