### PR TITLE
go: keep the module download cache owner-writable so sandboxes are not leaked

### DIFF
--- a/docs/notes/2.34.x.md
+++ b/docs/notes/2.34.x.md
@@ -91,6 +91,8 @@ The new advanced option `[golang].third_party_target_granularity` controls how t
 
 Linked Go binaries and test binaries now record a Go toolchain build ID, as `go build` does. Without one the linker omits the Mach-O `LC_UUID` load command and the ELF GNU build-id note, and macOS 26 refuses to load a binary that declares a recent SDK and has no `LC_UUID`.
 
+Fixed a sandbox leak where Go module downloads left their extracted module cache read-only, so sandbox cleanup could not remove it. Download processes now pass `-modcacherw` so the sandboxes can be torn down.
+
 ### Plugin API changes
 
 `Target`, `TargetAdaptor`, `SourceBlock`, `SourceBlocks`, `TextBlock` and `Hunk` are now backed by native Rust implementations. They are still importable from their previous locations and their public constructors, attributes and methods are unchanged, but they are no longer Python dataclasses and they are built in `__new__` rather than `__init__`, so `dataclasses.is_dataclass`, `dataclasses.fields` and `dataclasses.replace` no longer apply to them. Defining subclasses in Python, and setting attributes on those subclasses, continues to work as before.

--- a/src/python/pants/backend/go/util_rules/sdk.py
+++ b/src/python/pants/backend/go/util_rules/sdk.py
@@ -36,6 +36,7 @@ class GoSdkProcess:
     working_dir: str | None
     output_files: tuple[str, ...]
     output_directories: tuple[str, ...]
+    allow_downloads: bool
     replace_sandbox_root_in_args: bool
 
     def __init__(
@@ -66,6 +67,7 @@ class GoSdkProcess:
         object.__setattr__(self, "working_dir", working_dir)
         object.__setattr__(self, "output_files", tuple(output_files))
         object.__setattr__(self, "output_directories", tuple(output_directories))
+        object.__setattr__(self, "allow_downloads", allow_downloads)
         object.__setattr__(self, "replace_sandbox_root_in_args", replace_sandbox_root_in_args)
 
 
@@ -141,6 +143,17 @@ async def setup_go_sdk_process(
         # GOTOOLCHAIN via `[golang].subprocess_env_vars` from accidentally re-enabling switching.
         "GOTOOLCHAIN": "local",
     }
+
+    if request.allow_downloads:
+        # Downloading a module extracts it into GOMODCACHE (which sits under the sandbox
+        # GOPATH). Go marks the extracted module directories read-only, so Pants' sandbox
+        # cleanup cannot remove them; the removal error is swallowed and every download
+        # silently leaks its whole sandbox. `-modcacherw` keeps the module cache
+        # owner-writable so the sandbox can be torn down. It is scoped to download-enabled
+        # processes through GOFLAGS rather than the shared SDK wrapper script, so the cache
+        # key of every other Go process is unaffected. Appending after the env merge above
+        # preserves a GOFLAGS supplied by the caller or via `[golang].subprocess_env_vars`.
+        env["GOFLAGS"] = f"{env.get('GOFLAGS', '')} -modcacherw".strip()
 
     immutable_input_digests: dict[str, Digest] = {}
 

--- a/src/python/pants/backend/go/util_rules/sdk_test.py
+++ b/src/python/pants/backend/go/util_rules/sdk_test.py
@@ -49,3 +49,72 @@ def test_gotoolchain_local_cannot_be_overridden(rule_runner: RuleRunner) -> None
         ],
     )
     assert process.env.get("GOTOOLCHAIN") == "local"
+
+
+def test_modcacherw_set_when_downloads_allowed(rule_runner: RuleRunner) -> None:
+    """A download-enabled process must pass `-modcacherw` so Go leaves the extracted module
+    cache owner-writable and Pants can tear the sandbox down instead of leaking it."""
+    process = rule_runner.request(
+        Process,
+        [GoSdkProcess(["mod", "download"], description="test: download", allow_downloads=True)],
+    )
+    assert "-modcacherw" in process.env.get("GOFLAGS", "").split()
+
+
+def test_modcacherw_absent_when_downloads_disabled(rule_runner: RuleRunner) -> None:
+    """A process that does not download must not add `-modcacherw`; it never extracts modules,
+    so there is nothing to leave writable, and GOPROXY is pinned off instead."""
+    process = rule_runner.request(
+        Process,
+        [GoSdkProcess(["version"], description="test: no download")],
+    )
+    assert "-modcacherw" not in process.env.get("GOFLAGS", "").split()
+    assert process.env.get("GOPROXY") == "off"
+
+
+def test_modcacherw_appends_to_existing_goflags(rule_runner: RuleRunner) -> None:
+    """`-modcacherw` must extend any caller-supplied GOFLAGS rather than replace it."""
+    process = rule_runner.request(
+        Process,
+        [
+            GoSdkProcess(
+                ["mod", "download"],
+                description="test: preserve GOFLAGS",
+                env=FrozenDict({"GOFLAGS": "-mod=readonly"}),
+                allow_downloads=True,
+            )
+        ],
+    )
+    goflags = process.env.get("GOFLAGS", "").split()
+    assert "-mod=readonly" in goflags
+    assert "-modcacherw" in goflags
+
+
+def test_modcacherw_appends_to_subsystem_goflags() -> None:
+    """`-modcacherw` must extend a GOFLAGS passed through `[golang].subprocess_env_vars` rather
+    than replace it.  The flag is appended after the subsystem env vars are merged into the
+    process env, so it must compose with them, not clobber them."""
+    rule_runner = RuleRunner(
+        rules=[
+            *sdk.rules(),
+            QueryRule(Process, [GoSdkProcess]),
+        ],
+    )
+    rule_runner.set_options(
+        ["--golang-subprocess-env-vars=['PATH', 'GOFLAGS']"],
+        env={"GOFLAGS": "-mod=readonly"},
+        env_inherit={"PATH"},
+    )
+    process = rule_runner.request(
+        Process,
+        [
+            GoSdkProcess(
+                ["mod", "download"],
+                description="test: subsystem GOFLAGS",
+                allow_downloads=True,
+            )
+        ],
+    )
+    goflags = process.env.get("GOFLAGS", "").split()
+    assert "-mod=readonly" in goflags
+    assert "-modcacherw" in goflags


### PR DESCRIPTION
Disclaimer: Like my previous Go PR, I'm still not primarily a golang developer. However, the fact that Golang doesn't work properly in Pants has been the bane of my existence for like 2 years now. The moment that Mythos/Fable dropped I immediately had it dig deeply into whether the whole road to proper-golang-in-pants could be opened up. So this is all by Claude Code with Fable 5 (xhigh), with review consults to GPT 5.6 (Sol). I've had it check and recheck, I ran many different roles over it, and I had it explain and re-explain it to me, and then I checked myself.

So, as much as I dislike AI slop and am worried about AI PR overload, I've done my very best to avoid exactly that while still using AI. I hope we can get this road unblocked.

The rest is Fable talking:

---


Go module download processes extract each module into GOMODCACHE with read-only permissions, which makes Pants' sandbox cleanup fail to remove them, so every download silently leaks its whole sandbox. This adds `-modcacherw` to the download-enabled Go processes so the extracted cache stays owner-writable and the sandbox can be torn down.

## The leak

A `go mod download` extracts the module archive into GOMODCACHE, which sits under the sandbox GOPATH. Go strips the write bits from the extracted module tree, so it is not owner-writable. When Pants cleans up the sandbox afterwards, `remove_dir_all` cannot delete those directories and the error is swallowed, so the extracted trees stay on disk after the sandbox should be gone. The leak repeats on every cold download and never gets reclaimed.

jgranstrom measured this directly while reviewing a separate change: about 700 leaked sandboxes and 2.1 GB per cold run, indefinitely. The observation is his; this PR is the isolated fix for it.

## The fix

`-modcacherw` tells Go to leave newly written module cache directories writable, so sandbox cleanup can remove them. It is scoped to the download-enabled processes, through `GOFLAGS`, rather than the shared SDK wrapper script. Editing the wrapper would change the input digest of every Go process and churn all of their cache keys; adding the flag through `GOFLAGS` touches only the download-enabled processes and leaves every other Go process's cache key unchanged. The flag is appended after the process env is merged, so a `GOFLAGS` supplied by a caller or via `[golang].subprocess_env_vars` is preserved rather than replaced.

## Tests

`sdk_test.py` gains four unit tests over the constructed process environment: `-modcacherw` is present when downloads are allowed, absent when they are not (so GOPROXY stays pinned `off`), and appended to a `GOFLAGS` supplied by the caller or by `[golang].subprocess_env_vars` rather than replacing it.

## Notes

This was split out of #23424, where the same flag rode alongside a persistent GOMODCACHE named cache. The named-cache part did not pay for itself on the benchmarks and is being dropped, but the writability fix stands on its own; it is the piece jgranstrom's review flagged as independently worth keeping. His "leak-free baseline" arm measured main plus `-modcacherw`, so the runtime effect of this change is already benchmarked.
