### PR TITLE
upgrade to Rust v1.98.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,7 +45,7 @@ jobs:
     - name: Install Rust toolchain
       run: |
         # Set the default toolchain. Installs the toolchain if it is not already installed.
-        rustup default 1.97.1
+        rustup default 1.98.0
         cargo version
     - name: Expose Pythons
       run: |
@@ -184,7 +184,7 @@ jobs:
     - name: Install Rust toolchain
       run: |
         # Set the default toolchain. Installs the toolchain if it is not already installed.
-        rustup default 1.97.1
+        rustup default 1.98.0
         cargo version
     - name: Expose Pythons
       run: |
@@ -345,7 +345,7 @@ jobs:
       with:
         key: macOS14-ARM64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
         path: |
-          ~/.rustup/toolchains/1.97.1-*
+          ~/.rustup/toolchains/1.98.0-*
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo
@@ -490,7 +490,7 @@ jobs:
     - name: Install Rust toolchain
       run: |
         # Set the default toolchain. Installs the toolchain if it is not already installed.
-        rustup default 1.97.1
+        rustup default 1.98.0
         cargo version
     - name: Expose Pythons
       run: |
@@ -629,7 +629,7 @@ jobs:
     - name: Install Rust toolchain
       run: |
         # Set the default toolchain. Installs the toolchain if it is not already installed.
-        rustup default 1.97.1
+        rustup default 1.98.0
         cargo version
     - name: Expose Pythons
       run: |
@@ -805,7 +805,7 @@ jobs:
       with:
         key: macOS14-ARM64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
         path: |
-          ~/.rustup/toolchains/1.97.1-*
+          ~/.rustup/toolchains/1.98.0-*
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo
@@ -954,7 +954,7 @@ jobs:
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
         path: |
-          ~/.rustup/toolchains/1.97.1-*
+          ~/.rustup/toolchains/1.98.0-*
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -62,7 +62,7 @@ jobs:
       with:
         key: Linux-ARM64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
         path: |
-          ~/.rustup/toolchains/1.97.1-*
+          ~/.rustup/toolchains/1.98.0-*
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo
@@ -174,7 +174,7 @@ jobs:
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
         path: |
-          ~/.rustup/toolchains/1.97.1-*
+          ~/.rustup/toolchains/1.98.0-*
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo
@@ -292,7 +292,7 @@ jobs:
       with:
         key: macOS14-ARM64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
         path: |
-          ~/.rustup/toolchains/1.97.1-*
+          ~/.rustup/toolchains/1.98.0-*
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo
@@ -394,7 +394,7 @@ jobs:
     - name: Install Rust toolchain
       run: |
         # Set the default toolchain. Installs the toolchain if it is not already installed.
-        rustup default 1.97.1
+        rustup default 1.98.0
         cargo version
     - name: Expose Pythons
       run: |
@@ -484,7 +484,7 @@ jobs:
     - name: Install Rust toolchain
       run: |
         # Set the default toolchain. Installs the toolchain if it is not already installed.
-        rustup default 1.97.1
+        rustup default 1.98.0
         cargo version
     - name: Expose Pythons
       run: |
@@ -596,7 +596,7 @@ jobs:
       with:
         key: macOS14-ARM64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
         path: |
-          ~/.rustup/toolchains/1.97.1-*
+          ~/.rustup/toolchains/1.98.0-*
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo
@@ -692,7 +692,7 @@ jobs:
     - name: Install Rust toolchain
       run: |
         # Set the default toolchain. Installs the toolchain if it is not already installed.
-        rustup default 1.97.1
+        rustup default 1.98.0
         cargo version
     - name: Expose Pythons
       run: |
@@ -782,7 +782,7 @@ jobs:
     - name: Install Rust toolchain
       run: |
         # Set the default toolchain. Installs the toolchain if it is not already installed.
-        rustup default 1.97.1
+        rustup default 1.98.0
         cargo version
     - name: Expose Pythons
       run: |
@@ -894,7 +894,7 @@ jobs:
       with:
         key: macOS14-ARM64-rustup-${{ hashFiles('src/rust/rust-toolchain') }}-v2
         path: |
-          ~/.rustup/toolchains/1.97.1-*
+          ~/.rustup/toolchains/1.98.0-*
           ~/.rustup/update-hashes
           ~/.rustup/settings.toml
     - name: Cache Cargo

--- a/src/rust/rust-toolchain
+++ b/src/rust/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.97.1"
+channel = "1.98.0"
 profile = "minimal"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Upgrade to [Rust v1.98.0](https://blog.rust-lang.org/2026/08/20/Rust-1.98.0/).