### PR TITLE
Fix publish skip request hooks

### DIFF
--- a/docs/notes/2.32.x.md
+++ b/docs/notes/2.32.x.md
@@ -85,6 +85,8 @@ The `find-links` automatically injected by `pants.backend.plugin_development` is
 
 Fixed inverted logic when setting `noninteractive_process_output` to only log failures.
 
+Fixed the `publish` goal ignoring `skip_push` on `docker_image` and `helm_chart` targets, `skip_twine` on `python_distribution` targets, and the `[twine].skip` option, all of which had no effect on targets matched by the command line ([#23621](https://github.com/pantsbuild/pants/issues/23621)). The preemptive skip check those fields moved into was never invoked, because each backend spelled the `PublishFieldSet` hook `make_skip_request` rather than `check_skip_request`.
+
 ### Backends
 
 #### Docker

--- a/src/python/pants/backend/docker/goals/publish.py
+++ b/src/python/pants/backend/docker/goals/publish.py
@@ -7,7 +7,7 @@ import logging
 from collections import defaultdict
 from dataclasses import dataclass
 from itertools import chain
-from typing import DefaultDict, cast
+from typing import DefaultDict, cast, override
 
 from pants.backend.docker.goals.package_image import (
     DockerPackageFieldSet,
@@ -53,6 +53,7 @@ class PublishDockerImageFieldSet(PublishFieldSet, DockerPackageFieldSet):
 
     skip_push: DockerImageSkipPushField
 
+    @override
     def check_skip_request(
         self, package_fs: PackageFieldSet
     ) -> PublishDockerImageSkipRequest | None:

--- a/src/python/pants/backend/docker/goals/publish.py
+++ b/src/python/pants/backend/docker/goals/publish.py
@@ -53,7 +53,7 @@ class PublishDockerImageFieldSet(PublishFieldSet, DockerPackageFieldSet):
 
     skip_push: DockerImageSkipPushField
 
-    def make_skip_request(
+    def check_skip_request(
         self, package_fs: PackageFieldSet
     ) -> PublishDockerImageSkipRequest | None:
         return (

--- a/src/python/pants/backend/docker/goals/publish_test.py
+++ b/src/python/pants/backend/docker/goals/publish_test.py
@@ -331,12 +331,11 @@ def test_check_if_skip_push(
         if image_refs
         else None
     )
+    skip_request = publish_fs.check_skip_request(package_fs)
+    assert isinstance(skip_request, PublishDockerImageSkipRequest)
     result = run_rule_with_mocks(
         check_if_skip_push,
-        rule_args=[
-            PublishDockerImageSkipRequest(publish_fs=publish_fs, package_fs=package_fs),
-            docker_options,
-        ],
+        rule_args=[skip_request, docker_options],
         mock_calls=mock_calls,
     )
     assert result == expected

--- a/src/python/pants/backend/helm/goals/publish.py
+++ b/src/python/pants/backend/helm/goals/publish.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Iterable
 from dataclasses import dataclass
+from typing import override
 
 from pants.backend.helm.goals.package import BuiltHelmArtifact
 from pants.backend.helm.resolve.remotes import HelmRegistry
@@ -48,6 +49,7 @@ class HelmPublishFieldSet(HelmChartFieldSet, PublishFieldSet):
     repository: HelmChartRepositoryField
     skip_push: HelmSkipPushField
 
+    @override
     def check_skip_request(self, package_fs: PackageFieldSet) -> PublishHelmChartSkipRequest | None:
         return PublishHelmChartSkipRequest(publish_fs=self, package_fs=package_fs)
 

--- a/src/python/pants/backend/helm/goals/publish.py
+++ b/src/python/pants/backend/helm/goals/publish.py
@@ -48,7 +48,7 @@ class HelmPublishFieldSet(HelmChartFieldSet, PublishFieldSet):
     repository: HelmChartRepositoryField
     skip_push: HelmSkipPushField
 
-    def make_skip_request(self, package_fs: PackageFieldSet) -> PublishHelmChartSkipRequest | None:
+    def check_skip_request(self, package_fs: PackageFieldSet) -> PublishHelmChartSkipRequest | None:
         return PublishHelmChartSkipRequest(publish_fs=self, package_fs=package_fs)
 
     def get_output_data(self) -> PublishOutputData:

--- a/src/python/pants/backend/helm/goals/publish_test.py
+++ b/src/python/pants/backend/helm/goals/publish_test.py
@@ -209,12 +209,11 @@ def test_check_if_skip_push(
         if artifact_name
         else None
     )
+    skip_request = publish_fs.check_skip_request(package_fs)
+    assert isinstance(skip_request, PublishHelmChartSkipRequest)
     result = run_rule_with_mocks(
         check_if_skip_push,
-        rule_args=[
-            PublishHelmChartSkipRequest(publish_fs=publish_fs, package_fs=package_fs),
-            helm_subsystem,
-        ],
+        rule_args=[skip_request, helm_subsystem],
         mock_calls=mock_calls,
     )
     assert result == expected

--- a/src/python/pants/backend/python/goals/publish.py
+++ b/src/python/pants/backend/python/goals/publish.py
@@ -76,7 +76,7 @@ class PublishPythonPackageFieldSet(PublishFieldSet):
     repositories: PythonRepositoriesField
     skip_twine: SkipTwineUploadField
 
-    def make_skip_request(self, package_fs: PackageFieldSet) -> PythonDistCheckSkipRequest | None:
+    def check_skip_request(self, package_fs: PackageFieldSet) -> PythonDistCheckSkipRequest | None:
         return PythonDistCheckSkipRequest(publish_fs=self, package_fs=package_fs)
 
     def get_output_data(self) -> PublishOutputData:

--- a/src/python/pants/backend/python/goals/publish.py
+++ b/src/python/pants/backend/python/goals/publish.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from typing import override
 
 from pants.backend.python.subsystems.setuptools import PythonDistributionFieldSet
 from pants.backend.python.subsystems.twine import TwineSubsystem
@@ -76,6 +77,7 @@ class PublishPythonPackageFieldSet(PublishFieldSet):
     repositories: PythonRepositoriesField
     skip_twine: SkipTwineUploadField
 
+    @override
     def check_skip_request(self, package_fs: PackageFieldSet) -> PythonDistCheckSkipRequest | None:
         return PythonDistCheckSkipRequest(publish_fs=self, package_fs=package_fs)
 

--- a/src/python/pants/backend/python/goals/publish_test.py
+++ b/src/python/pants/backend/python/goals/publish_test.py
@@ -185,10 +185,10 @@ def test_check_if_skip_upload(
     rule_runner.set_options(["--twine-skip" if skip_twine_config else "--no-twine-skip"])
     rule_runner.write_files(project_files(skip_twine=skip_twine, repositories=repositories))
     tgt = rule_runner.get_target(Address("src", target_name="dist"))
-    request = PythonDistCheckSkipRequest(
-        publish_fs=PublishPythonPackageFieldSet.create(tgt),
-        package_fs=PythonDistributionFieldSet.create(tgt),
+    request = PublishPythonPackageFieldSet.create(tgt).check_skip_request(
+        PythonDistributionFieldSet.create(tgt)
     )
+    assert isinstance(request, PythonDistCheckSkipRequest)
     result = rule_runner.request(CheckSkipResult, [request])
     if expected:
         assert not result.skipped_packages


### PR DESCRIPTION
The name of the hook and the impls did not match.

Added typing.override decorations, seems like the perfect tool to ensure it doesnt happen again.

Closes https://github.com/pantsbuild/pants/issues/23621