### PR TITLE
go: honor `[go-test].force_race` and the `test_race`/`test_msan`/`test_asan` fields

### DIFF
--- a/docs/notes/2.34.x.md
+++ b/docs/notes/2.34.x.md
@@ -91,6 +91,8 @@ The new advanced option `[golang].third_party_target_granularity` controls how t
 
 Linked Go binaries and test binaries now record a Go toolchain build ID, as `go build` does. Without one the linker omits the Mach-O `LC_UUID` load command and the ELF GNU build-id note, and macOS 26 refuses to load a binary that declares a recent SDK and has no `LC_UUID`.
 
+Fixed `[go-test].force_race` and the `go_package` fields `test_race`, `test_msan` and `test_asan` being silently ignored. The `test` goal built its Go build options without requesting the test-specific fields, so the sanitizer settings never reached the test binary and only the owning `go_mod`'s `race` field had any effect.
+
 ### Plugin API changes
 
 `Target`, `TargetAdaptor`, `SourceBlock`, `SourceBlocks`, `TextBlock` and `Hunk` are now backed by native Rust implementations. They are still importable from their previous locations and their public constructors, attributes and methods are unchanged, but they are no longer Python dataclasses and they are built in `__new__` rather than `__init__`, so `dataclasses.is_dataclass`, `dataclasses.fields` and `dataclasses.replace` no longer apply to them. Defining subclasses in Python, and setting attributes on those subclasses, continues to work as before.

--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -270,7 +270,8 @@ async def prepare_go_test_binary(
             GoImportPathMappingRequest(go_mod_addr.address), **implicitly()
         ),
         go_extract_build_options_from_target(
-            GoBuildOptionsFromTargetRequest(request.field_set.address), **implicitly()
+            GoBuildOptionsFromTargetRequest(request.field_set.address, for_tests=True),
+            **implicitly(),
         ),
     )
 

--- a/src/python/pants/backend/go/goals/test_test.py
+++ b/src/python/pants/backend/go/goals/test_test.py
@@ -24,6 +24,8 @@ from pants.backend.go.util_rules import (
     tests_analysis,
     third_party_pkg,
 )
+from pants.backend.go.util_rules.build_opts import race_detector_supported
+from pants.backend.go.util_rules.goroot import GoRoot
 from pants.backend.go.util_rules.sdk import GoSdkProcess
 from pants.core.goals.test import TestResult, get_filtered_environment
 from pants.core.target_types import FileTarget
@@ -56,6 +58,7 @@ def rule_runner() -> RuleRunner:
             get_filtered_environment,
             QueryRule(TestResult, [GoTestRequest.Batch]),
             QueryRule(ProcessResult, [GoSdkProcess]),
+            QueryRule(GoRoot, []),
         ],
         target_types=[GoModTarget, GoPackageTarget, FileTarget],
     )
@@ -755,3 +758,85 @@ def test_external_test_with_use_coverage(rule_runner: RuleRunner) -> None:
         TestResult, [GoTestRequest.Batch("", (GoTestFieldSet.create(tgt),), None)]
     )
     assert result.exit_code == 0
+
+
+# A real unsynchronised write, which the race detector reports deterministically.
+# The `race` build constraint is deliberately NOT used as the probe: Pants sets
+# CGO_ENABLED and EXTRA_BUILD_TAGS when analysing a package but never the `race`
+# tag, so `//go:build race` files are not selected even when `-race` is passed to
+# the compiler.
+_RACE_PROBE_SOURCES = {
+    "foo/go.mod": "module foo\n",
+    "foo/race.go": textwrap.dedent(
+        """
+        package foo
+
+        import "sync"
+
+        func Racy() int {
+          total := 0
+          var wg sync.WaitGroup
+          for i := 0; i < 50; i++ {
+            wg.Add(1)
+            go func() {
+              defer wg.Done()
+              total++
+            }()
+          }
+          wg.Wait()
+          return total
+        }
+        """
+    ),
+    "foo/race_test.go": textwrap.dedent(
+        """
+        package foo
+
+        import "testing"
+
+        func TestRacy(t *testing.T) {
+          _ = Racy()
+        }
+        """
+    ),
+}
+
+
+def _run_race_probe(rule_runner: RuleRunner, build_file: str, options: list[str]) -> TestResult:
+    goroot = rule_runner.request(GoRoot, [])
+    if not race_detector_supported(goroot):
+        pytest.skip(f"race detector unsupported on {goroot.goos}/{goroot.goarch}")
+    rule_runner.set_options(options, env_inherit={"PATH"})
+    rule_runner.write_files({**_RACE_PROBE_SOURCES, "foo/BUILD": build_file})
+    tgt = rule_runner.get_target(Address("foo"))
+    return rule_runner.request(
+        TestResult, [GoTestRequest.Batch("", (GoTestFieldSet.create(tgt),), None)]
+    )
+
+
+def test_race_detector_enabled_by_force_race_option(rule_runner: RuleRunner) -> None:
+    """`[go-test].force_race` must reach the test binary.
+
+    Regression test: the `test` goal built its `GoBuildOptionsFromTargetRequest` without
+    `for_tests=True`, so the test-only fields were never consulted and this option was
+    silently ignored.
+    """
+    result = _run_race_probe(
+        rule_runner, "go_mod(name='mod')\ngo_package()", ["--go-test-force-race"]
+    )
+    assert result.exit_code != 0
+    assert b"DATA RACE" in result.stdout_bytes + result.stderr_bytes
+
+
+def test_race_detector_enabled_by_test_race_field(rule_runner: RuleRunner) -> None:
+    """`go_package(test_race=True)` must reach the test binary."""
+    result = _run_race_probe(rule_runner, "go_mod(name='mod')\ngo_package(test_race=True)", [])
+    assert result.exit_code != 0
+    assert b"DATA RACE" in result.stdout_bytes + result.stderr_bytes
+
+
+def test_race_detector_disabled_by_default(rule_runner: RuleRunner) -> None:
+    """Without either knob the race detector stays off and the race goes unreported."""
+    result = _run_race_probe(rule_runner, "go_mod(name='mod')\ngo_package()", [])
+    assert result.exit_code == 0
+    assert b"DATA RACE" not in result.stdout_bytes + result.stderr_bytes


### PR DESCRIPTION
`prepare_go_test_binary` builds its `GoBuildOptionsFromTargetRequest` without `for_tests=True`:

```python
go_extract_build_options_from_target(
    GoBuildOptionsFromTargetRequest(request.field_set.address), **implicitly()
),
```

`go_extract_build_options_from_target` only populates `test_target_fields` when that flag is set:

```python
if request.for_tests and GoTestBuildOptionsFieldSet.is_applicable(target):
    test_target_fields = GoTestBuildOptionsFieldSet.create(target)
```

and `test_target_fields` gates both the `[go-test].force_race` branch and the `go_package(test_race=...)` field (likewise `test_msan` / `test_asan`).

`go_package` also does not carry the non-test `race` / `cgo_enabled` fields, so `GoBuildOptionsFieldSet` does not apply to it either and that fallback misses as well. The net effect is that the only field the resolution chain can still reach is `race` on the owning `go_mod`, so **both documented ways to enable the race detector for a test are silently ignored** — tests keep passing while no longer detecting races.

Introduced in #17825, which split test-binary production from running it.

The existing coverage in `build_opts_test.py` passes `for_tests=True` explicitly, which is why it never caught the buggy caller.

## Fix

Pass `for_tests=True`. One line.

## Tests

Three tests in `test_test.py`, exercising `[go-test].force_race`, `go_package(test_race=True)`, and a default-off control so the probe cannot pass for the wrong reason.

They use a real unsynchronised write rather than a `//go:build race` file. That was my first attempt, and it does not work: package analysis passes `CGO_ENABLED` and `EXTRA_BUILD_TAGS` but never the `race` build tag, so `//go:build race` files are not selected even when `-race` does reach the compiler. That looks like a separate gap and I have deliberately left it alone here — happy to file it separately if it is not already known.

Verified red/green on macOS/arm64:

| | before | after |
|---|---|---|
| `test_race_detector_enabled_by_force_race_option` | fails (race unreported) | passes |
| `test_race_detector_enabled_by_test_race_field` | fails (race unreported) | passes |
| `test_race_detector_disabled_by_default` | passes | passes |

The tests skip on platforms where `race_detector_supported()` is false.

Note: `build_opts_test.py::test_runtime_check_enable_fields_work_as_expected[msan|asan]` and `test_test.py::test_external_test_with_use_coverage` already fail on my machine on an unmodified `main`, so they are unrelated to this change.

## LLM assistance notice
This PR was written primarily by Claude Code (Claude Opus 5).  I directed the scope and reviewed the result.