### PR TITLE
Remove dead reference to `terraform_modules` target generator

### DIFF
--- a/src/python/pants/backend/terraform/target_types.py
+++ b/src/python/pants/backend/terraform/target_types.py
@@ -53,8 +53,6 @@ class TerraformModuleTarget(Target):
         A single Terraform module corresponding to a directory.
 
         There must only be one `terraform_module` in a directory.
-
-        Use `terraform_modules` to generate `terraform_module` targets for less boilerplate.
         """
     )
 


### PR DESCRIPTION
`terraform_modules` target generator was removed in 2.12.

Fixes #23272.