### PR TITLE
Run pex on a suitable interpreter when resolving from a uv venv

### DIFF
--- a/docs/notes/2.34.x.md
+++ b/docs/notes/2.34.x.md
@@ -59,6 +59,8 @@ Support for creating multiplatform/foreign platform pexes when using the `uv` re
 
 Fixed a bug that caused `generate-lockfiles --sync` not to have its intended effect when using `uv` lockfiles.
 
+Fixed a bug that could cause tool execution to fail when resolving the tool from a `uv` lockfile.
+
 Required named indexes to be referenced explicitly in requirement sources when using the uv resolver, to match the pex resolver's behavior.
 
 Sidecar lockfile metadata files (`*.lock.metadata`, written when `[python].separate_lockfile_metadata_file` is enabled) now end with a trailing newline. The bundled tool metadata files have been updated accordingly, so regenerating them no longer produces a spurious diff.

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -806,6 +806,7 @@ async def build_pex(
         req_strings = ()
 
     venv_repos: list[VenvRepository] = []
+    python: PythonExecutable | None = None
     if requirements_setup.uv_lockfile is not None:
         if request.platforms:
             raise ValueError(
@@ -936,6 +937,7 @@ async def build_pex(
 
     pex_process = await setup_pex_cli_process(
         PexCliProcess(
+            interpreter=python,
             subcommand=(),
             extra_args=argv,
             additional_input_digest=merged_digest,

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -566,6 +566,7 @@ def test_build_pex_from_uv_lockfile_with_uv_platforms(rule_runner: RuleRunner) -
     lock = Lockfile("test.lock", url_description_of_origin="test uv lockfile", resolve_name="test")
     pex_data = create_pex_and_get_all_data(
         rule_runner,
+        pex_type=VenvPex,
         requirements=EntireLockfile(lock),
         interpreter_constraints=ic,
         layout=PexLayout.ZIPAPP,
@@ -577,10 +578,10 @@ def test_build_pex_from_uv_lockfile_with_uv_platforms(rule_runner: RuleRunner) -
     )
 
     speedup_files = [f for f in pex_data.files if "_speedups" in f]
-    assert any("linux" in f for f in speedup_files), (
+    assert any("cp312-cp312-manylinux" in f for f in speedup_files), (
         f"Expected linux markupsafe native extension; got: {speedup_files}"
     )
-    assert any("macosx" in f for f in speedup_files), (
+    assert any("cp312-cp312-macosx" in f for f in speedup_files), (
         f"Expected macosx markupsafe native extension; got: {speedup_files}"
     )
 


### PR DESCRIPTION
Otherwise, when building a venv pex, the interpreter may not
be compatible with the originating uv venv, and will fail.