### PR TITLE
Condition chmod on file not already being executable.

### DIFF
--- a/docs/notes/2.34.x.md
+++ b/docs/notes/2.34.x.md
@@ -33,6 +33,8 @@ Published Pants binaries are now compiled with a new `dist` Cargo profile that e
 
 Pants option config files are now parsed as TOML 1.1 rather than TOML 1.0. This covers `pants.toml` and any other file named by `[GLOBAL].pants_config_files`, the rcfiles named by `[GLOBAL].pantsrc_files` (`/etc/pantsrc`, `~/.pants.rc` and `.pants.rc` by default), and `.toml` files referenced by `@fromfile` option values. Inline tables may now span multiple lines and end with a trailing comma, strings may use the `\e` and `\xHH` escapes, and times may omit their seconds. TOML 1.1 only adds syntax to TOML 1.0, so existing files continue to parse unchanged. TOML files read by backends, such as `pyproject.toml`, are unaffected.
 
+Conditioned a previously unconditional 'chmod' of a file in the unpacked pants code.  This allows users to use a read-only venv.
+
 ### Goals
 
 ### Backends

--- a/src/python/pants/engine/embedded_binary.py
+++ b/src/python/pants/engine/embedded_binary.py
@@ -16,7 +16,7 @@ def get_embedded_binary(binary_name: str) -> str | None:
     with importlib.resources.as_file(
         importlib.resources.files("pants.bin").joinpath(binary_name)
     ) as bin_path:
-        if os.path.isfile(bin_path):
+        if os.path.isfile(bin_path) and not os.access(bin_path, os.X_OK):
             os.chmod(bin_path, 0o755)
             return str(bin_path)
     return None

--- a/src/python/pants/engine/embedded_binary.py
+++ b/src/python/pants/engine/embedded_binary.py
@@ -16,7 +16,8 @@ def get_embedded_binary(binary_name: str) -> str | None:
     with importlib.resources.as_file(
         importlib.resources.files("pants.bin").joinpath(binary_name)
     ) as bin_path:
-        if os.path.isfile(bin_path) and not os.access(bin_path, os.X_OK):
-            os.chmod(bin_path, 0o755)
+        if os.path.isfile(bin_path):
+            if not os.access(bin_path, os.X_OK):
+                os.chmod(bin_path, 0o755)
             return str(bin_path)
     return None


### PR DESCRIPTION
This allows Pants to run out of a read-only area for a multi-user installation.