### PR TITLE
Restart pantsd when `[GLOBAL].plugins` changes (Cherry-pick of #23650)

### DIFF
--- a/src/python/pants/option/bootstrap_options.py
+++ b/src/python/pants/option/bootstrap_options.py
@@ -819,6 +819,10 @@ class BootstrapOptions:
         ),
     )
     plugins = StrListOption(
+        # `pantsd` loads these onto its own `sys.path`, and `PluginResolver.resolve` constrains
+        # each resolve to what that `sys.path` already holds, so a changed value needs a new
+        # process rather than just a new scheduler (#23649).
+        daemon=True,
         advanced=True,
         help=softwrap(
             """

--- a/src/python/pants/option/global_options_test.py
+++ b/src/python/pants/option/global_options_test.py
@@ -17,6 +17,7 @@ from pants.option.bootstrap_options import DynamicRemoteOptions, ExecutionOption
 from pants.option.errors import OptionsError
 from pants.option.global_options import GlobalOptions
 from pants.option.options_bootstrapper import OptionsBootstrapper
+from pants.option.scope import GLOBAL_SCOPE
 from pants.testutil.option_util import create_dynamic_remote_options
 from pants.testutil.pytest_util import no_exception
 from pants.util.dirutil import safe_mkdir_for
@@ -143,6 +144,23 @@ def test_invalidation_globs() -> None:
     )
     for glob in globs:
         assert suffix not in glob
+
+
+def test_plugins_is_daemon_fingerprinted() -> None:
+    # A surviving `pantsd` constrains later plugin resolves to the versions already on its
+    # `sys.path`, so this option must invalidate the process itself (#23649).
+    ob = OptionsBootstrapper.create(
+        args=["--pants-config-files=[]", "--plugins=ansicolors==1.1.8"],
+        env={},
+        allow_pantsrc=False,
+    )
+    daemon_fingerprinted = {
+        name
+        for name, _, _ in ob.bootstrap_options.get_fingerprintable_for_scope(
+            GLOBAL_SCOPE, daemon_only=True
+        )
+    }
+    assert "plugins" in daemon_fingerprinted
 
 
 @pytest.mark.parametrize(

--- a/src/rust/pantsd/src/lib.rs
+++ b/src/rust/pantsd/src/lib.rs
@@ -333,6 +333,7 @@ pub fn fingerprinted_options(build_root: &BuildRoot) -> Result<Vec<Fingerprinted
         // FingerprintedOption::new(option_id!("log", "levels", "by", "target"), ...),
         FingerprintedOption::new(option_id!("log", "show", "rust", "3rdparty"), false),
         FingerprintedOption::new(option_id!("ignore", "warnings"), vec![]),
+        FingerprintedOption::new(option_id!("plugins"), vec![]),
         FingerprintedOption::new(
             option_id!("pants", "version"),
             include_str!("../../engine/VERSION"),


### PR DESCRIPTION
Fixes #23649.

`[GLOBAL].plugins` was not marked `daemon=True`, so changing it only reinitialized the scheduler. `pantsd` resolves plugins into its own process, and `PluginResolver.resolve` derives each resolve's constraints from that process's `sys.path`, so a surviving daemon keeps constraining later resolves to the versions it resolved first. Fingerprinting the option for the daemon replaces the process instead, so the next resolve starts from a clean `sys.path`.

### Validation

Built from source at 2.34.0.dev3 and run against the private monorepo where this was first hit, which pins `plugins = ["botocore==1.43.73"]`. Same repo, same sequence, bumping the pin to `botocore==1.43.74`, with only the patch differing.

Without the patch the daemon is reused (pid 2314187 on both runs) and the resolve fails:

```
pip: ERROR: ResolutionImpossible
pip:      The user requested botocore==1.43.74
pip:      The user requested (constraint) botocore==1.43.73
```

With the patch the daemon is replaced (pid 2320168 becomes 2320670) and the same run exits 0.

Supporting checks on that build:

- Repeating a value does not restart the daemon, so this does not over-invalidate.
- `pants test src/python/pants/pantsd/pantsd_integration_test.py` passes in 3m35s.
- `cargo test -p pantsd` passes, including `test_find_pantsd`, which launches a daemon and rediscovers it through `fingerprint_compute`.
- `pants test src/python/pants/option/global_options_test.py src/python/pants/option/options_bootstrapper_test.py` passes.

The Python and Rust option lists are asserted to match on every invocation, so the second commit is what lets the first one run at all. Further detail on the resolve chain is in the comment below.

### LLM assistance

Claude Code (Opus 5) did the code archaeology through `PluginResolver.resolve` and `PantsDaemonCore.prepare`, wrote the patch and the test, built the engine from source, and ran the validation above including the reverted-patch control. I hit the bug in our CI, pointed it at the failure, and reviewed the result.

