### PR TITLE
Fix interactive processes hanging on terminal read

### DIFF
--- a/src/python/pants/engine/process_test.py
+++ b/src/python/pants/engine/process_test.py
@@ -313,6 +313,44 @@ def test_interactive_process_inputs(rule_runner: RuleRunner, run_in_workspace: b
         }
 
 
+def test_interactive_process_starts_new_session(rule_runner: RuleRunner) -> None:
+    # NB: `run_interactive_process()` expects an initialized workunit store, which only certain
+    # other engine operations take steps to initialize. This test otherwise has no engine setup
+    # to perform, so make an empty request with the side-effect of workunit initialization.
+    rule_runner.request(Digest, [CreateDigest([])])
+
+    # NB: Strictly speaking this is testing an implementation detail, because it's much more
+    # difficult to directly test the higher-level behavior we actually want: that interactive
+    # processes are able to read from stdin connected to a terminal without observing SIGTTIN.
+    #
+    # If a process is spawned in a background process group of a session associated with a
+    # controlling terminal, and the process attempts to read stdin from the controlling terminal,
+    # its entire process group will be signalled with SIGTTIN. By default, this stops every
+    # process in the group and appears as a hang.
+    #
+    # If instead the process is spawned in a new session, it still inherits file descriptors as
+    # normal, but as the process is necessarily no longer associated with the session of that
+    # controlling terminal it is also no longer subject to being signalled with SIGTTIN for reads
+    # on that terminal.
+    #
+    # `mock_console` isn't sufficient to recreate these conditions as its stdin is not tied to a
+    # controlling terminal, but we can at least ensure that interactive processes are spawned in
+    # a new session.
+    #
+    # `exec` preserves the spawned process's PID while `ps` reports its PID and session ID. The
+    # leader of a new session has a session ID equal to its PID.
+    process = InteractiveProcess(
+        argv=["/bin/bash", "-c", 'exec /bin/ps -o pid= -o sid= -p "$$"'],
+    )
+
+    with mock_console(rule_runner.options_bootstrapper) as (_, stdio_reader):
+        result = rule_runner.run_interactive_process(process)
+        assert result.exit_code == 0
+
+        pid, sid = map(int, stdio_reader.get_stdout().split())
+        assert pid == sid
+
+
 def test_interactive_process_rejects_invalid_run_in_workspace(rule_runner: RuleRunner) -> None:
     process = object.__new__(InteractiveProcess)
     object.__setattr__(process, "process", Process(["/bin/echo", "hello"], description="echo"))

--- a/src/rust/engine/src/intrinsics/interactive_process.rs
+++ b/src/rust/engine/src/intrinsics/interactive_process.rs
@@ -182,9 +182,11 @@ pub async fn interactive_process_inner(
         .try_clone_as_file()
         .map_err(|e| format!("Couldn't clone stderr: {e}"))?,
     ));
-  let mut subprocess =
-      ManagedChild::spawn(&mut command, Some(context.core.graceful_shutdown_timeout))
-        .map_err(|e| format!("Error executing interactive process: {e}"))?;
+  let mut subprocess = ManagedChild::spawn_in_new_session(
+    &mut command,
+    Some(context.core.graceful_shutdown_timeout),
+  )
+  .map_err(|e| format!("Error executing interactive process: {e}"))?;
   tokio::select! {
     _ = session.cancelled() => {
       // The Session was cancelled: attempt to kill the process group / process, and

--- a/src/rust/process_execution/children/src/lib.rs
+++ b/src/rust/process_execution/children/src/lib.rs
@@ -26,7 +26,37 @@ pub struct ManagedChild {
 }
 
 impl ManagedChild {
+    /// Spawn child as leader of a new process group.
     pub fn spawn(
+        command: &mut Command,
+        graceful_shutdown_timeout: Option<time::Duration>,
+    ) -> std::io::Result<Self> {
+        // Adjust the Command to create its own PGID as it starts, to make it safe to kill the PGID
+        // later.
+        command.process_group(0);
+
+        Self::spawn_inner(command, graceful_shutdown_timeout)
+    }
+
+    /// Spawn child as leader of a new process group in a new session.
+    ///
+    /// NB: Permits an interactive child to read terminal input. May be less efficient than `spawn`.
+    pub fn spawn_in_new_session(
+        command: &mut Command,
+        graceful_shutdown_timeout: Option<time::Duration>,
+    ) -> std::io::Result<Self> {
+        unsafe {
+            command.pre_exec(|| {
+                nix::unistd::setsid()
+                    .map(|_pgid| ())
+                    .map_err(|e| std::io::Error::other(format!("Could not create new session: {e}")))
+            });
+        };
+
+        Self::spawn_inner(command, graceful_shutdown_timeout)
+    }
+
+    fn spawn_inner(
         command: &mut Command,
         graceful_shutdown_timeout: Option<time::Duration>,
     ) -> std::io::Result<Self> {
@@ -34,10 +64,6 @@ impl ManagedChild {
         // mechanism:
         //   see https://docs.rs/tokio/1.14.0/tokio/process/struct.Command.html#method.kill_on_drop
         command.kill_on_drop(true);
-
-        // Adjust the Command to create its own PGID as it starts, to make it safe to kill the PGID
-        // later.
-        command.process_group(0);
 
         // Then spawn.
         let child = command.spawn()?;


### PR DESCRIPTION
PR #23466 changed the way processes were spawned through ManagedChild. Prior to that change, a spawned process would be created in a new process group, in a new session, but that mechanism precluded a more efficient process-spawning path. Ostensibly (per change history, local comments, test coverage), the spawning of the child in a new session was merely an implementation quirk of ensuring the child was spawned in a new process group, to make it safe to kill that child's process group later; the creation of the new session itself was incidental. Eliminating the constraint of also creating the child in a new session permitted the more efficient spawning path in #23466.

However, for spawned _interactive_ processes specifically there _is_ a dependency on spawning in a new session, as revealed by #23628: when an interactive process reasonably tries to read terminal input, and because it wasn't spawned in a new session but instead into a (new) background process group of the same session as the controlling terminal, it will be signalled with SIGTTIN and suspended.

This change preserves the "fast-path" spawning mechanism for non-interactive processes, but restores the spawning mechanism replaced in #23466 for just interactive processes.

Also adds a test to protect against regressing this behavior again.

Notice: An LLM assisted identifying the callpath through which interactive processes were ultimately spawned by ManagedChild, and wrote an initial skeleton for this change and for a unittest. This code was reviewed and edited by a human. All comments were written (or moved) by a human. Style and naming choices were made by a human.

Fixes #23628