### PR TITLE
Return a Result from `get_digest` instead of panicking

### DIFF
--- a/docs/notes/2.34.x.md
+++ b/docs/notes/2.34.x.md
@@ -35,6 +35,8 @@ Pants option config files are now parsed as TOML 1.1 rather than TOML 1.0. This 
 
 Conditioned a previously unconditional 'chmod' of a file in the unpacked pants code.  This allows users to use a read-only venv.
 
+Fixed a crash when computing a process's cache key. `get_digest` returned a tuple and unwrapped the fallible `make_execute_request`, so any error inside it aborted the process rather than surfacing as an error. Both callers are on the cache-key path, so a transient failure while storing a process's wrapper script could take down an entire run with a panic and a "Please set RUST_BACKTRACE=1 ... and then file a bug" message.
+
 ### Goals
 
 ### Backends

--- a/src/rust/process_execution/pe_nailgun/src/nailgun_pool.rs
+++ b/src/rust/process_execution/pe_nailgun/src/nailgun_pool.rs
@@ -451,7 +451,7 @@ struct NailgunProcessFingerprint {
 impl NailgunProcessFingerprint {
     pub async fn new(name: String, nailgun_req: &Process, store: &Store) -> Result<Self, String> {
         let (nailgun_req_digest, _command_digest) =
-            process_execution::get_digest(nailgun_req, None, None, store, None).await;
+            process_execution::get_digest(nailgun_req, None, None, store, None).await?;
         Ok(NailgunProcessFingerprint {
             name,
             fingerprint: nailgun_req_digest.hash,

--- a/src/rust/process_execution/src/cache.rs
+++ b/src/rust/process_execution/src/cache.rs
@@ -86,7 +86,7 @@ impl crate::CommandRunner for CommandRunner {
             &self.file_store,
             None,
         )
-        .await;
+        .await?;
 
         let key = CacheKey {
             digest: Some(action_digest.into()),

--- a/src/rust/process_execution/src/lib.rs
+++ b/src/rust/process_execution/src/lib.rs
@@ -1089,7 +1089,7 @@ pub async fn get_digest(
     process_cache_namespace: Option<String>,
     store: &Store,
     append_only_caches_base_path: Option<&str>,
-) -> (Digest, Digest) {
+) -> Result<(Digest, Digest), String> {
     let EntireExecuteRequest {
         execute_request,
         action,
@@ -1101,13 +1101,12 @@ pub async fn get_digest(
         store,
         append_only_caches_base_path,
     )
-    .await
-    .unwrap();
+    .await?;
 
-    (
-        execute_request.action_digest.unwrap().try_into().unwrap(),
-        action.command_digest.unwrap().try_into().unwrap(),
-    )
+    Ok((
+        require_digest(execute_request.action_digest.as_ref())?,
+        require_digest(action.command_digest.as_ref())?,
+    ))
 }
 
 pub fn digest<T: prost::Message>(message: &T) -> Result<Digest, String> {

--- a/src/rust/process_execution/src/tests.rs
+++ b/src/rust/process_execution/src/tests.rs
@@ -18,8 +18,8 @@ use workunit_store::RunId;
 
 use crate::{
     CacheName, Platform, Process, ProcessExecutionEnvironment, ProcessExecutionStrategy,
-    ProcessResultMetadata, ProcessResultSource, extract_output_files, local::KeepSandboxes,
-    maybe_make_wrapper_script,
+    ProcessResultMetadata, ProcessResultSource, extract_output_files, get_digest,
+    local::KeepSandboxes, maybe_make_wrapper_script,
 };
 
 #[test]
@@ -370,4 +370,30 @@ async fn wrapper_script_supports_sandbox_root_replacements_in_environmenbt() {
         .await
         .unwrap();
     assert_eq!(content, "xyzzy\n");
+}
+
+// `get_digest` used to `.unwrap()` the `make_execute_request` result, so any failure inside it --
+// including the transient "Failed to store wrapper script for remote execution" seen when a
+// GOSUMDB fetch dies mid-run -- aborted the whole process instead of surfacing an error. Both of
+// its callers are on the cache-key path, so a network blip could take down an entire run.
+#[tokio::test]
+async fn get_digest_propagates_errors_instead_of_panicking() {
+    let store_dir = TempDir::new().unwrap();
+    let store = store::Store::local_only(task_executor::Executor::new(), store_dir.path()).unwrap();
+
+    let mut process = Process::new(vec!["/bin/echo".to_owned()]);
+    process.append_only_caches.insert(
+        CacheName::new("test_cache".into()).unwrap(),
+        RelativePath::new("foo").unwrap(),
+    );
+
+    // A NUL byte in the caches base path makes `quote_path` (and so `make_execute_request`) fail.
+    // The path is only ever shell-quoted into the wrapper script, so nothing validates it earlier.
+    let result = get_digest(&process, None, None, &store, Some("/tmp/ba\0d")).await;
+
+    let err = result.expect_err("get_digest should return an error rather than panicking");
+    assert!(
+        err.contains("nul byte"),
+        "expected the make_execute_request failure to be propagated, got: {err}"
+    );
 }

--- a/src/rust/process_execution/src/tests.rs
+++ b/src/rust/process_execution/src/tests.rs
@@ -372,10 +372,6 @@ async fn wrapper_script_supports_sandbox_root_replacements_in_environmenbt() {
     assert_eq!(content, "xyzzy\n");
 }
 
-// `get_digest` used to `.unwrap()` the `make_execute_request` result, so any failure inside it --
-// including the transient "Failed to store wrapper script for remote execution" seen when a
-// GOSUMDB fetch dies mid-run -- aborted the whole process instead of surfacing an error. Both of
-// its callers are on the cache-key path, so a network blip could take down an entire run.
 #[tokio::test]
 async fn get_digest_propagates_errors_instead_of_panicking() {
     let store_dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Background

Fix a panic in `process_execution::get_digest` caused by blindly unwrapping a `Result` by instead propagating the error upward.

Both callers are on the cache-key path (`cache.rs`, `nailgun_pool.rs`), so a transient failure took down the whole run rather than surfacing as an error.

## LLM assistance notice

This PR was written primarily by Claude Code (Claude Opus 5). I directed the scope and reviewed the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)