### PR TITLE
Key Go module downloads on `cgo_enabled`, not all of `GoBuildOptions`

### DIFF
--- a/docs/notes/2.34.x.md
+++ b/docs/notes/2.34.x.md
@@ -99,6 +99,8 @@ Linked Go binaries and test binaries now record a Go toolchain build ID, as `go 
 
 Dependency inference now resolves imports across local directory `replace` directives. When a `go.mod` replaces a required module with a path to another first-party module in the repo, imports of that module's packages are inferred automatically instead of having to be listed by hand in BUILD metadata. This is a no-op for modules without directory `replace` directives. See [#22097](https://github.com/pantsbuild/pants/issues/22097).
 
+Third-party module downloads are no longer duplicated across callers that differ only in build options which cannot affect them. Downloading and analyzing a module consults just `cgo_enabled` -- `go mod download` ignores build options entirely, and the package analyzer reads only `CGO_ENABLED` -- but the whole `GoBuildOptions` was part of the memoization key. Target generation passes default options while a compile resolves the real ones, so a repository building with e.g. `race=True` downloaded every third-party module twice per run.
+
 ### Plugin API changes
 
 `Target`, `TargetAdaptor`, `SourceBlock`, `SourceBlocks`, `TextBlock` and `Hunk` are now backed by native Rust implementations. They are still importable from their previous locations and their public constructors, attributes and methods are unchanged, but they are no longer Python dataclasses and they are built in `__new__` rather than `__init__`, so `dataclasses.is_dataclass`, `dataclasses.fields` and `dataclasses.replace` no longer apply to them. Defining subclasses in Python, and setting attributes on those subclasses, continues to work as before.

--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -585,6 +585,11 @@ async def generate_targets_from_go_mod(
             # TODO: There is a rule graph cycle in this rule if this rule tries to use GoBuildOptionsFromTargetRequest.
             # For now, just use a default set of options to facilitate analyzing third-party dependencies and
             # generating targets.
+            #
+            # NB: These defaults no longer cost an extra download of every module in the graph.
+            # `ModuleDownloadRequest` is keyed on `cgo_enabled` alone rather than the whole
+            # `GoBuildOptions`, so target generation and a compile resolving e.g. `race=True` share
+            # one memoized download. Only a caller that actually differs in `cgo_enabled` pays twice.
             build_opts=GoBuildOptions(),
         )
     )

--- a/src/python/pants/backend/go/util_rules/third_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/third_party_pkg.py
@@ -190,7 +190,7 @@ class ModuleDescriptors:
 @dataclass(frozen=True)
 class ModuleDownloadRequest:
     """Download and analyze a Go module, keyed by (name, version, minimum_go_version,
-    build_opts, go_sum_entries).
+    cgo_enabled, go_sum_entries).
 
     This enables cross-go.mod deduplication: if mod-a and mod-b both depend on
     grpc@v1.60.0 with the same go.sum entries, the download and analysis only
@@ -213,7 +213,13 @@ class ModuleDownloadRequest:
     name: str
     version: str
     minimum_go_version: str | None
-    build_opts: GoBuildOptions
+    # NB: Only `cgo_enabled` is carried here, rather than the whole `GoBuildOptions`. Downloading
+    # and analyzing a module is independent of every other build option -- `go mod download` does
+    # not consult them, and the package analyzer only reads `CGO_ENABLED`. Keying on the full
+    # options object meant that callers differing in an irrelevant field (e.g. target generation
+    # using defaults while a compile resolves `race=True`) each paid for their own download of
+    # every module in the graph.
+    cgo_enabled: bool
     go_sum_entries: tuple[str, ...]
 
 
@@ -526,9 +532,9 @@ async def download_and_analyze_module(
 ) -> AnalyzedThirdPartyModule:
     """Download and analyze a single Go module via a synthetic go.mod + go.sum.
 
-    Keyed by (name, version, minimum_go_version, build_opts, go_sum_entries),
+    Keyed by (name, version, minimum_go_version, cgo_enabled, go_sum_entries),
     which lets the Pants engine deduplicate identical module downloads across
-    go.mods.
+    go.mods and across callers using different build options.
 
     A synthetic go.mod + go.sum pair is written into the sandbox so that Go's
     normal checksum verification still runs -- the go.sum entries come straight
@@ -623,7 +629,7 @@ async def download_and_analyze_module(
                 },
                 description=f"Analyze metadata for Go third-party module: {request.name}@{request.version}",
                 level=LogLevel.DEBUG,
-                env={"CGO_ENABLED": "1" if request.build_opts.cgo_enabled else "0"},
+                env={"CGO_ENABLED": "1" if request.cgo_enabled else "0"},
             )
         )
     )
@@ -680,7 +686,7 @@ async def download_and_analyze_third_party_packages(
     # Parse the go.sum once into a dict for O(1) lookup per module.
     go_sum_index = _parse_go_sum(go_sum_content)
 
-    # The engine memoizes by (name, version, minimum_go_version, build_opts,
+    # The engine memoizes by (name, version, minimum_go_version, cgo_enabled,
     # go_sum_entries), so identical modules across go.mods are downloaded
     # once -- reducing downloads from O(N*M) to O(M).
     analyzed_modules = await concurrently(
@@ -689,7 +695,7 @@ async def download_and_analyze_third_party_packages(
                 name=mod.name,
                 version=mod.version,
                 minimum_go_version=mod.minimum_go_version,
-                build_opts=request.build_opts,
+                cgo_enabled=request.build_opts.cgo_enabled,
                 go_sum_entries=go_sum_index.get((mod.name, mod.version), ()),
             ),
             **implicitly(),

--- a/src/python/pants/backend/go/util_rules/third_party_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/third_party_pkg_test.py
@@ -27,6 +27,7 @@ from pants.backend.go.util_rules.third_party_pkg import (
     AllThirdPartyPackagesRequest,
     ModuleDescriptors,
     ModuleDescriptorsRequest,
+    ModuleDownloadRequest,
     ThirdPartyPkgAnalysis,
     ThirdPartyPkgAnalysisRequest,
     _extract_go_sum_entries_for_module,
@@ -620,7 +621,7 @@ UUID_GO_SUM = dedent(
 def test_cross_go_mod_dedup_produces_identical_results(rule_runner: RuleRunner) -> None:
     """Two go.mods depending on the same module@version produce byte-identical analyses.
 
-    The dedup path is keyed on (name, version, minimum_go_version, build_opts,
+    The dedup path is keyed on (name, version, minimum_go_version, cgo_enabled,
     go_sum_entries). go.sum entries are content-addressable, so two well-formed
     go.mods sharing a dep produce equal ModuleDownloadRequests -- the engine
     memoizes and both requests share a single download. The observable property
@@ -754,3 +755,69 @@ def test_gotoolchain_local_fail_fast(rule_runner: RuleRunner) -> None:
     )
     with engine_error(ProcessExecutionFailure, contains="go.mod requires go >= 1.99.0"):
         rule_runner.request(ModuleDescriptors, [ModuleDescriptorsRequest(digest, "")])
+
+
+def test_module_download_key_ignores_build_options_that_cannot_affect_it() -> None:
+    """Only `cgo_enabled` may split the module download/analysis cache key.
+
+    `go mod download` does not consult build options at all, and the package analyzer reads only
+    `CGO_ENABLED`. Carrying the whole `GoBuildOptions` meant callers that differed in an
+    irrelevant field each re-downloaded every module in the graph: target generation passes
+    `GoBuildOptions()` defaults (see the rule-graph-cycle TODO in `target_type_rules.py`) while a
+    compile resolves the real options, so a repo building with `race=True` paid exactly twice.
+    """
+
+    def key(build_opts: GoBuildOptions) -> ModuleDownloadRequest:
+        return ModuleDownloadRequest(
+            name="github.com/google/uuid",
+            version="v1.3.0",
+            minimum_go_version="1.16",
+            cgo_enabled=build_opts.cgo_enabled,
+            go_sum_entries=(),
+        )
+
+    # The case we actually hit: target generation's defaults vs. a compile with the race detector.
+    assert key(GoBuildOptions()) == key(GoBuildOptions(with_race_detector=True))
+
+    # Options that genuinely change nothing about the download must not split the key either.
+    assert key(GoBuildOptions()) == key(GoBuildOptions(with_msan=True))
+    assert key(GoBuildOptions()) == key(GoBuildOptions(compiler_flags=("-N",)))
+    assert key(GoBuildOptions()) == key(GoBuildOptions(linker_flags=("-s",)))
+
+    # `cgo_enabled` reaches the analyzer as CGO_ENABLED, so it must still split the key.
+    assert key(GoBuildOptions(cgo_enabled=True)) != key(GoBuildOptions(cgo_enabled=False))
+
+
+def test_race_detector_does_not_duplicate_module_downloads(rule_runner: RuleRunner) -> None:
+    """The same module requested with and without `race=True` shares one download.
+
+    This is the end-to-end form of the key narrowing: identical analysis digests imply both
+    requests resolved to the same engine-memoized `ModuleDownloadRequest`.
+    """
+    go_mod = dedent(
+        """\
+        module example.com/mod
+        go 1.16
+        require github.com/google/uuid v1.3.0
+        """
+    )
+    digest = set_up_go_mod(rule_runner, go_mod, UUID_GO_SUM)
+
+    def analyze(build_opts: GoBuildOptions) -> ThirdPartyPkgAnalysis:
+        result = rule_runner.request(
+            AllThirdPartyPackages,
+            [
+                AllThirdPartyPackagesRequest(
+                    Address("", target_name="mod"),
+                    digest,
+                    "go.mod",
+                    build_opts=build_opts,
+                )
+            ],
+        )
+        return result.import_paths_to_pkg_info["github.com/google/uuid"]
+
+    default = analyze(GoBuildOptions())
+    with_race = analyze(GoBuildOptions(with_race_detector=True))
+
+    assert default.digest == with_race.digest


### PR DESCRIPTION
`ModuleDownloadRequest` carries the whole `GoBuildOptions` in its memoization key, but downloading and analyzing a module barely depends on it: `go mod download` never consults build options, and the only consumer anywhere in `download_and_analyze_module` is `env={"CGO_ENABLED": ...}` for the package analyzer.

So callers differing only in a field that cannot affect the result each pay for their own download of every module in the graph. That is not hypothetical: target generation passes `GoBuildOptions()` defaults to dodge the rule-graph cycle noted in the TODO in `target_type_rules.py`, while a compile resolves the real options. A repository building with `race=True` therefore downloads every third-party module exactly twice per run.

Measured on a 32-`go_mod` production repo before this change: ~1,979 remote-cache AC lookups for 1,059 distinct modules.

## The change

Narrow the key to `cgo_enabled`. Both `GoBuildOptions.cgo_enabled` and `[golang].cgo_enabled` default to `True`, so the two keys collapse into one.

This also fixes the general N-way case — any two callers differing only in irrelevant options now share one download — which resolving the rule-graph cycle would not have done, since targets within a module can legitimately differ in build options.

The TODO is annotated rather than removed: the cycle still exists, it just no longer costs a duplicate download. Note that `expand_module_import_paths` (added by #23499) already passes the same defaults and comments that it matches target generation, so both sites share the single key.

## Tests

- `test_module_download_key_ignores_build_options_that_cannot_affect_it` pins the property directly: `race`, `msan`, and compiler/linker flags no longer split the key, while `cgo_enabled` still does.
- `test_race_detector_does_not_duplicate_module_downloads` is the end-to-end form — the same module analyzed with and without `race=True` yields identical digests, so both resolved to one memoized request.

## A note on verification

Lint, ruff, flake8 and mypy are clean on this branch. I was **not** able to run the Python test suite against `main` locally: every pytest invocation dies with SIGSEGV on my machine, including `src/python/pants/util/strutil_test.py`, and it reproduces on unmodified `main`, so it is unrelated to this change (2.34's free-threaded CPython default is my guess). The tests above were written and verified green against 2.33.x, where the same code applies cleanly. I would appreciate CI confirming them here.

No existing issue for this — happy to file one if you'd prefer it tracked separately.

## LLM assistance notice
This PR was written primarily by Claude Code (Claude Opus 5).  I directed the scope and reviewed the result.