### PR TITLE
go: fix test coverage on Go v1.25+ by registering via `testdeps`

### DIFF
--- a/docs/notes/2.34.x.md
+++ b/docs/notes/2.34.x.md
@@ -99,6 +99,10 @@ Linked Go binaries and test binaries now record a Go toolchain build ID, as `go 
 
 Dependency inference now resolves imports across local directory `replace` directives. When a `go.mod` replaces a required module with a path to another first-party module in the repo, imports of that module's packages are inferred automatically instead of having to be listed by hand in BUILD metadata. This is a no-op for modules without directory `replace` directives. See [#22097](https://github.com/pantsbuild/pants/issues/22097).
 
+Go test coverage now works on Go v1.25 and newer. Go v1.25 removed the `coverageredesign` GOEXPERIMENT along with the body of `testing.RegisterCover`, which is how Pants used to hand its coverage counters to the `testing` package; every `pants test --use-coverage` run against a Go v1.25+ toolchain failed with `testing: cannot use -test.coverprofile because test binary was not built with coverage enabled`. Pants now registers coverage through `testing/internal/testdeps` on those toolchains, the same way `cmd/go`'s own generated test main does, and writes the coverage profile in sorted file order so that `cover.out` is reproducible.
+
+Running `pants test --use-coverage` together with one of the `[go-test]` profiling options (for example `--go-test-block-profile`) no longer fails while rendering the coverage report, and a test binary which exits without writing a coverage profile is now reported as having no coverage data instead of raising `IndexError: tuple index out of range`.
+
 ### Plugin API changes
 
 `Target`, `TargetAdaptor`, `SourceBlock`, `SourceBlocks`, `TextBlock` and `Hunk` are now backed by native Rust implementations. They are still importable from their previous locations and their public constructors, attributes and methods are unchanged, but they are no longer Python dataclasses and they are built in `__new__` rather than `__init__`, so `dataclasses.is_dataclass`, `dataclasses.fields` and `dataclasses.replace` no longer apply to them. Defining subclasses in Python, and setting attributes on those subclasses, continues to work as before.

--- a/docs/notes/2.34.x.md
+++ b/docs/notes/2.34.x.md
@@ -103,6 +103,10 @@ Go test coverage now works on Go v1.25 and newer. Go v1.25 removed the `coverage
 
 Running `pants test --use-coverage` together with one of the `[go-test]` profiling options (for example `--go-test-block-profile`) no longer fails while rendering the coverage report, and a test binary which exits without writing a coverage profile is now reported as having no coverage data instead of raising `IndexError: tuple index out of range`.
 
+Go test coverage now follows `go test` when the race detector is enabled: the cover mode is forced to `atomic`, and `[go-test].cover_mode` is ignored for those packages. `set` and `count` instrumentation updates its counters without synchronization, so previously every covered function called from more than one goroutine made the race detector report a data race against the coverage counters themselves. `go test` refuses this combination outright (`-covermode must be "atomic", not "set", when -race is enabled`).
+
+`--go-test-cover-mode=atomic` now works for packages which do not already import `sync/atomic`. Atomic instrumentation rewrites the sources to call `sync/atomic.AddUint32`, but nothing added that package to the covered package's `importcfg`, so those packages failed to compile with `could not import sync/atomic`.
+
 ### Plugin API changes
 
 `Target`, `TargetAdaptor`, `SourceBlock`, `SourceBlocks`, `TextBlock` and `Hunk` are now backed by native Rust implementations. They are still importable from their previous locations and their public constructors, attributes and methods are unchanged, but they are no longer Python dataclasses and they are built in `__new__` rather than `__init__`, so `dataclasses.is_dataclass`, `dataclasses.fields` and `dataclasses.replace` no longer apply to them. Defining subclasses in Python, and setting attributes on those subclasses, continues to work as before.

--- a/src/python/pants/backend/go/conftest.py
+++ b/src/python/pants/backend/go/conftest.py
@@ -80,6 +80,19 @@ def _discover_go_binaries() -> list[tuple[str, tuple[int, int]]]:
     return go_binaries
 
 
+@pytest.fixture
+def go_binary_path() -> str:
+    """The `go` binary a test should use, defaulting to the newest one on `PATH`.
+
+    `pytest_generate_tests` parametrizes this fixture instead for tests marked with
+    `require_go_version_max`.
+    """
+    go_binaries = _discover_go_binaries()
+    if not go_binaries:
+        pytest.skip(reason="`go` not present on PATH")
+    return go_binaries[0][0]
+
+
 def pytest_generate_tests(metafunc):
     """Parametrize tests that require specific Go versions."""
     # Check if the test has the require_go_version_max marker.

--- a/src/python/pants/backend/go/conftest.py
+++ b/src/python/pants/backend/go/conftest.py
@@ -80,71 +80,48 @@ def _discover_go_binaries() -> list[tuple[str, tuple[int, int]]]:
     return go_binaries
 
 
-@pytest.fixture
-def go_binary_path() -> str:
-    """The `go` binary a test should use, defaulting to the newest one on `PATH`.
+# The Go version from which Pants registers coverage counters through
+# `testing/internal/testdeps` rather than `testing.RegisterCover`. Keep in sync with
+# `pants.backend.go.util_rules.coverage.registers_coverage_via_testdeps`.
+_TESTDEPS_COVERAGE_MIN_GO_VERSION = (1, 25)
 
-    `pytest_generate_tests` parametrizes this fixture instead for tests marked with
-    `require_go_version_max`.
+
+@lru_cache(None)
+def _go_binaries_per_coverage_mechanism() -> list[tuple[str, tuple[int, int]]]:
+    """The newest Go binary on `PATH` for each coverage registration mechanism Pants implements.
+
+    CI installs both a Go v1.25+ and a Go v1.24 toolchain precisely so that both mechanisms get
+    exercised. Where only one of the two is installed, only that one is returned.
     """
-    go_binaries = _discover_go_binaries()
-    if not go_binaries:
-        pytest.skip(reason="`go` not present on PATH")
-    return go_binaries[0][0]
+    selected = []
+    for uses_testdeps in (True, False):
+        for path, version in _discover_go_binaries():  # Newest first.
+            if (version >= _TESTDEPS_COVERAGE_MIN_GO_VERSION) is uses_testdeps:
+                selected.append((path, version))
+                break
+    return selected
 
 
 def pytest_generate_tests(metafunc):
-    """Parametrize tests that require specific Go versions."""
-    # Check if the test has the require_go_version_max marker.
-    marker = metafunc.definition.get_closest_marker("require_go_version_max")
-    if not marker:
+    """Run tests which pin a Go toolchain once per Go coverage registration mechanism."""
+    if "go_binary_path" not in metafunc.fixturenames:
         return
 
-    # Extract the maximum version from the marker.
-    if len(marker.args) < 2:
-        pytest.fail(
-            f"require_go_version_max marker requires 2 args (major, minor), got {marker.args}"
+    go_binaries = _go_binaries_per_coverage_mechanism()
+    if not go_binaries:
+        # Parametrize with None and mark to skip, so the test shows as skipped rather than
+        # uncollected. `pytest_runtest_setup` would skip it in any case.
+        metafunc.parametrize(
+            "go_binary_path",
+            [pytest.param(None, marks=pytest.mark.skip(reason="`go` not present on PATH"))],
+            ids=["no-go"],
         )
         return
 
-    max_major, max_minor = marker.args[0], marker.args[1]
-    max_version = (max_major, max_minor)
-
-    # Discover available Go binaries
-    available_go = _discover_go_binaries()
-
-    # Filter for compatible versions (<= max_version)
-    compatible_go = [(path, version) for path, version in available_go if version <= max_version]
-
-    # Parametrize the test if it accepts a `go_binary_path` fixture.
-    if "go_binary_path" in metafunc.fixturenames:
-        if compatible_go:
-            # Use the newest compatible version.
-            best_go_path, best_version = compatible_go[0]
-            metafunc.parametrize(
-                "go_binary_path",
-                [best_go_path],
-                ids=[f"go{best_version[0]}.{best_version[1]}"],
-            )
-        else:
-            # Parametrize with None and mark to skip, so the test shows as skipped rather than uncollected.
-            available_versions = [f"{v[0]}.{v[1]}" for _, v in available_go]
-            skip_msg = (
-                f"Test requires Go <= {max_major}.{max_minor}, but only found: "
-                f"{', '.join(available_versions) if available_versions else 'none'}"
-            )
-            metafunc.parametrize(
-                "go_binary_path",
-                [pytest.param(None, marks=pytest.mark.skip(reason=skip_msg))],
-                ids=["no-compatible-go"],
-            )
-
-
-def pytest_configure(config):
-    """Register custom markers."""
-    config.addinivalue_line(
-        "markers",
-        "require_go_version_max(major, minor): mark test to require Go version <= specified",
+    metafunc.parametrize(
+        "go_binary_path",
+        [path for path, _ in go_binaries],
+        ids=[f"go{major}.{minor}" for _, (major, minor) in go_binaries],
     )
 
 

--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -43,12 +43,14 @@ from pants.backend.go.util_rules.build_pkg_target import (
     setup_build_go_package_target_request,
 )
 from pants.backend.go.util_rules.coverage import (
+    COVERAGE_SETUP_TESTDEPS_IMPORTS,
     GenerateCoverageSetupCodeRequest,
     GenerateCoverageSetupCodeResult,
     GoCoverageConfig,
     GoCoverageData,
     GoCoverMode,
     generate_go_coverage_setup_code,
+    registers_coverage_via_testdeps,
 )
 from pants.backend.go.util_rules.first_party_pkg import (
     FirstPartyPkgAnalysis,
@@ -77,11 +79,19 @@ from pants.core.target_types import FileSourceField
 from pants.core.util_rules.env_vars import environment_vars_subset
 from pants.core.util_rules.source_files import SourceFilesRequest, determine_source_files
 from pants.engine.env_vars import EnvironmentVarsRequest
-from pants.engine.fs import EMPTY_FILE_DIGEST, AddPrefix, Digest, MergeDigests
+from pants.engine.fs import (
+    EMPTY_FILE_DIGEST,
+    AddPrefix,
+    Digest,
+    DigestSubset,
+    MergeDigests,
+    PathGlobs,
+)
 from pants.engine.internals.graph import resolve_targets
 from pants.engine.internals.native_engine import EMPTY_DIGEST, Snapshot
 from pants.engine.intrinsics import (
     add_prefix,
+    digest_subset_to_digest,
     digest_to_snapshot,
     execute_process_with_retry,
     merge_digests,
@@ -261,6 +271,7 @@ def _lift_build_requests_with_coverage(
 async def prepare_go_test_binary(
     request: PrepareGoTestBinaryRequest,
     analyzer: PackageAnalyzerSetup,
+    goroot: GoRoot,
 ) -> FalliblePrepareGoTestBinaryResult:
     go_mod_addr = await find_owning_go_mod(
         OwningGoModRequest(request.field_set.address), **implicitly()
@@ -502,9 +513,30 @@ async def prepare_go_test_binary(
                 packages=FrozenOrderedSet(coverage_metadata),
                 cover_mode=request.coverage.coverage_mode,  # type: ignore[union-attr] # gated on with_coverage
             ),
+            goroot,
         )
         coverage_setup_digest = coverage_setup_result.digest
         coverage_setup_files = [GenerateCoverageSetupCodeResult.PATH]
+
+        # The generated coverage setup code imports stdlib packages which `testmain.go` may not
+        # import. Only `testmain.go` is analyzed for imports, so those packages have to be added to
+        # the main package's direct dependencies explicitly or they will be missing from its
+        # `importcfg`. (Duplicate direct dependencies are de-duplicated by import path when the
+        # `importcfg` is built.)
+        if registers_coverage_via_testdeps(goroot):
+            extra_stdlib_build_requests = await concurrently(
+                setup_build_go_package_target_request_for_stdlib(
+                    BuildGoPackageRequestForStdlibRequest(
+                        import_path=stdlib_import_path,
+                        build_opts=build_opts,
+                    ),
+                    **implicitly(),
+                )
+                for stdlib_import_path in COVERAGE_SETUP_TESTDEPS_IMPORTS
+            )
+            for build_request in extra_stdlib_build_requests:
+                assert build_request.request is not None
+                main_direct_deps.append(build_request.request)
 
     testmain_input_digest = await merge_digests(
         MergeDigests([testmain.digest, coverage_setup_digest])
@@ -727,13 +759,23 @@ async def run_go_tests(
 
     coverage_data: GoCoverageData | None = None
     if test_subsystem.use_coverage:
-        coverage_data = GoCoverageData(
-            coverage_digest=results.last.output_digest,
-            import_path=test_binary.import_path,
-            sources_digest=test_binary.pkg_digest.digest,
-            sources_dir_path=test_binary.pkg_analysis.dir_path,
-            pkg_target_address=field_set.address,
+        # Subset the output digest down to the coverage profile: the digest may also hold the other
+        # profiles requested via `[go-test]` (e.g. `block.out`), which must not be mistaken for the
+        # coverage profile when the report is rendered.
+        #
+        # The profile may also be missing entirely - a `TestMain` which never calls `m.Run()` never
+        # writes one - in which case there is simply no coverage data to report.
+        coverage_profile_digest = await digest_subset_to_digest(
+            DigestSubset(results.last.output_digest, PathGlobs(["cover.out"]))
         )
+        if coverage_profile_digest != EMPTY_DIGEST:
+            coverage_data = GoCoverageData(
+                coverage_digest=coverage_profile_digest,
+                import_path=test_binary.import_path,
+                sources_digest=test_binary.pkg_digest.digest,
+                sources_dir_path=test_binary.pkg_analysis.dir_path,
+                pkg_target_address=field_set.address,
+            )
 
     output_files = [x for x in output_files if x != "cover.out"]
     extra_output: Snapshot | None = None

--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -318,12 +318,25 @@ async def prepare_go_test_binary(
     import_path = pkg_analysis.import_path
 
     with_coverage = False
+    cover_mode: GoCoverMode | None = None
     if request.coverage is not None:
         with_coverage = True
+        cover_mode = request.coverage.coverage_mode
+        # `go test` forces the cover mode to `atomic` when the race detector is enabled, and so must
+        # Pants: `set` and `count` instrumentation updates its counters without synchronization, so
+        # the race detector reports races on the coverage counters themselves rather than on the
+        # code under test. See `go help testflag`: "the default is set unless -race is enabled, in
+        # which case it is atomic".
+        #
+        # NB: this is resolved here rather than in `run_go_tests` because the race detector can be
+        # enabled per-target (`go_mod(race=...)`, `test_race`), so it is only known once the build
+        # options for this specific package have been resolved.
+        if build_opts.with_race_detector:
+            cover_mode = GoCoverMode.ATOMIC
         build_opts = dataclasses.replace(
             build_opts,
             coverage_config=GoCoverageConfig(
-                cover_mode=request.coverage.coverage_mode,
+                cover_mode=cover_mode,
                 import_path_include_patterns=request.coverage.coverage_packages,
             ),
         )
@@ -508,10 +521,11 @@ async def prepare_go_test_binary(
         coverage_metadata = [
             pkg.coverage_metadata for pkg in built_main_direct_deps if pkg.coverage_metadata
         ]
+        assert cover_mode is not None  # Gated on `with_coverage`.
         coverage_setup_result = await generate_go_coverage_setup_code(
             GenerateCoverageSetupCodeRequest(
                 packages=FrozenOrderedSet(coverage_metadata),
-                cover_mode=request.coverage.coverage_mode,  # type: ignore[union-attr] # gated on with_coverage
+                cover_mode=cover_mode,
             ),
             goroot,
         )

--- a/src/python/pants/backend/go/goals/test_test.py
+++ b/src/python/pants/backend/go/goals/test_test.py
@@ -24,11 +24,14 @@ from pants.backend.go.util_rules import (
     tests_analysis,
     third_party_pkg,
 )
+from pants.backend.go.util_rules.coverage import GoCoverageData
 from pants.backend.go.util_rules.sdk import GoSdkProcess
 from pants.core.goals.test import TestResult, get_filtered_environment
 from pants.core.target_types import FileTarget
 from pants.core.util_rules import source_files
 from pants.engine.addresses import Address
+from pants.engine.fs import DigestContents
+from pants.engine.internals.native_engine import Digest
 from pants.engine.process import ProcessResult
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
@@ -56,6 +59,7 @@ def rule_runner() -> RuleRunner:
             get_filtered_environment,
             QueryRule(TestResult, [GoTestRequest.Batch]),
             QueryRule(ProcessResult, [GoSdkProcess]),
+            QueryRule(DigestContents, (Digest,)),
         ],
         target_types=[GoModTarget, GoPackageTarget, FileTarget],
     )
@@ -755,3 +759,9 @@ def test_external_test_with_use_coverage(rule_runner: RuleRunner) -> None:
         TestResult, [GoTestRequest.Batch("", (GoTestFieldSet.create(tgt),), None)]
     )
     assert result.exit_code == 0
+
+    # An exit code of 0 is not enough: assert that a coverage profile was actually produced.
+    assert isinstance(result.coverage_data, GoCoverageData)
+    digest_contents = rule_runner.request(DigestContents, (result.coverage_data.coverage_digest,))
+    assert [file_content.path for file_content in digest_contents] == ["cover.out"]
+    assert digest_contents[0].content.decode().startswith("mode: set\n")

--- a/src/python/pants/backend/go/subsystems/gotest.py
+++ b/src/python/pants/backend/go/subsystems/gotest.py
@@ -55,6 +55,12 @@ class GoTestSubsystem(Subsystem):
               * `set`: bool: does this statement run?
               * `count`: int: how many times does this statement run?
               * `atomic`: int: count, but correct in multithreaded tests; significantly more expensive.
+
+            This option is ignored when the race detector is enabled for a package under test, in
+            which case `atomic` is always used: `set` and `count` update their counters without
+            synchronization, so the race detector would report races on the coverage counters
+            themselves. This mirrors `go test`, where "the default is set unless -race is enabled,
+            in which case it is atomic".
             """
         ),
     )

--- a/src/python/pants/backend/go/util_rules/BUILD
+++ b/src/python/pants/backend/go/util_rules/BUILD
@@ -6,6 +6,8 @@ python_tests(
     name="tests",
     timeout=120,
     overrides={
+        # Runs once per Go coverage registration mechanism, so once per installed toolchain.
+        "coverage_test.py": {"timeout": 300},
         "embed_integration_test.py": {"timeout": 240},
         "cgo_test.py": {"timeout": 240},
         "stdlib_archives_test.py": {"timeout": 240},

--- a/src/python/pants/backend/go/util_rules/BUILD
+++ b/src/python/pants/backend/go/util_rules/BUILD
@@ -6,8 +6,9 @@ python_tests(
     name="tests",
     timeout=120,
     overrides={
-        # Runs once per Go coverage registration mechanism, so once per installed toolchain.
-        "coverage_test.py": {"timeout": 300},
+        # Runs once per Go coverage registration mechanism, so once per installed toolchain, and
+        # the race detector cases rebuild the stdlib with race instrumentation.
+        "coverage_test.py": {"timeout": 600},
         "embed_integration_test.py": {"timeout": 240},
         "cgo_test.py": {"timeout": 240},
         "stdlib_archives_test.py": {"timeout": 240},

--- a/src/python/pants/backend/go/util_rules/build_pkg_target.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target.py
@@ -35,6 +35,10 @@ from pants.backend.go.util_rules.build_pkg_third_party import (
     setup_build_go_package_target_request_for_third_party,
 )
 from pants.backend.go.util_rules.cgo import CGoCompilerFlags
+from pants.backend.go.util_rules.coverage import (
+    SYNC_ATOMIC_IMPORT_PATH,
+    requires_sync_atomic_dependency,
+)
 from pants.backend.go.util_rules.embedcfg import EmbedConfig
 from pants.backend.go.util_rules.first_party_pkg import (
     FirstPartyPkgAnalysisRequest,
@@ -535,6 +539,20 @@ async def setup_build_go_package_target_request(
     if coverage_config:
         for pattern in coverage_config.import_path_include_patterns:
             with_coverage = with_coverage or match_simple_pattern(pattern)(import_path)
+
+    if requires_sync_atomic_dependency(with_coverage, coverage_config) and not any(
+        dep.import_path == SYNC_ATOMIC_IMPORT_PATH for dep in pkg_direct_dependencies
+    ):
+        maybe_sync_atomic_dep = await setup_build_go_package_target_request_for_stdlib(
+            BuildGoPackageRequestForStdlibRequest(
+                import_path=SYNC_ATOMIC_IMPORT_PATH,
+                build_opts=request.build_opts,
+            ),
+            **implicitly(),
+        )
+        if maybe_sync_atomic_dep.request is None:
+            return dataclasses.replace(maybe_sync_atomic_dep, dependency_failed=True)
+        pkg_direct_dependencies.append(maybe_sync_atomic_dep.request)
 
     result = BuildGoPackageRequest(
         digest=digest,

--- a/src/python/pants/backend/go/util_rules/build_pkg_third_party.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_third_party.py
@@ -23,6 +23,10 @@ from pants.backend.go.util_rules.build_pkg_stdlib import (
     BuildGoPackageRequestForStdlibRequest,
     setup_build_go_package_target_request_for_stdlib,
 )
+from pants.backend.go.util_rules.coverage import (
+    SYNC_ATOMIC_IMPORT_PATH,
+    requires_sync_atomic_dependency,
+)
 from pants.backend.go.util_rules.go_mod import GoModInfoRequest, determine_go_mod_info
 from pants.backend.go.util_rules.import_analysis import (
     GoStdLibPackagesRequest,
@@ -142,6 +146,20 @@ async def setup_build_go_package_target_request_for_third_party(
     if coverage_config:
         for pattern in coverage_config.import_path_include_patterns:
             with_coverage = with_coverage or match_simple_pattern(pattern)(request.import_path)
+
+    if requires_sync_atomic_dependency(with_coverage, coverage_config) and not any(
+        dep.import_path == SYNC_ATOMIC_IMPORT_PATH for dep in direct_dependencies
+    ):
+        maybe_sync_atomic_dep = await setup_build_go_package_target_request_for_stdlib(
+            BuildGoPackageRequestForStdlibRequest(
+                import_path=SYNC_ATOMIC_IMPORT_PATH,
+                build_opts=request.build_opts,
+            ),
+            **implicitly(),
+        )
+        if maybe_sync_atomic_dep.request is None:
+            return dataclasses.replace(maybe_sync_atomic_dep, dependency_failed=True)
+        direct_dependencies.append(maybe_sync_atomic_dep.request)
 
     result = BuildGoPackageRequest(
         digest=digest,

--- a/src/python/pants/backend/go/util_rules/coverage.py
+++ b/src/python/pants/backend/go/util_rules/coverage.py
@@ -10,6 +10,7 @@ from pathlib import PurePath
 
 import chevron
 
+from pants.backend.go.util_rules.goroot import GoRoot
 from pants.backend.go.util_rules.sdk import GoSdkProcess, GoSdkToolIDRequest, compute_go_tool_id
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.build_graph.address import Address
@@ -226,12 +227,47 @@ class GenerateCoverageSetupCodeResult:
     digest: Digest
 
 
+# The Go stdlib packages imported by the coverage setup code generated for Go v1.25+.
+#
+# `prepare_go_test_binary` must add these as direct dependencies of the synthetic main package:
+# the package analyzer only ever sees `testmain.go` (that is the sole output of the
+# `generate_testmain` process), so imports which appear only in `pants_cover_setup.go` would
+# otherwise never make it into the `importcfg` for the main package.
+COVERAGE_SETUP_TESTDEPS_IMPORTS: tuple[str, ...] = ("fmt", "io", "os", "sync/atomic")
+
+
+def registers_coverage_via_testdeps(goroot: GoRoot) -> bool:
+    """Whether the coverage setup code must register coverage through `testing/internal/testdeps`.
+
+    Pants instruments Go sources with the "legacy" coverage mechanism (`go tool cover -mode -var`),
+    which stores counters in exported package-level variables. Those counters used to be handed to
+    the `testing` package via `testing.RegisterCover`.
+
+    Go v1.20 replaced that mechanism with the "coverage redesign", under which `RegisterCover` is
+    ignored: `testing.CoverMode()` reads the state registered by `testing.MainStart` instead. Up to
+    Go v1.24 Pants avoided the problem by building everything with
+    `GOEXPERIMENT=nocoverageredesign` (see `sdk.py`), which restores the old implementation. Go
+    v1.25 removed that experiment, and with it `RegisterCover`'s body, so on Go v1.25+ the counters
+    have to be registered the way `cmd/go`'s own generated testmain does it - by pointing the
+    `testing/internal/testdeps` hooks at our own profile writer.
+    """
+    return goroot.is_compatible_version("1.25")
+
+
 COVERAGE_SETUP_CODE = """\
 package main
 
 import (
+{{#use_testdeps}}
+    "fmt"
+    "io"
+    "os"
+    "sync/atomic"
+{{/use_testdeps}}
     "testing"
-
+{{#use_testdeps}}
+    "testing/internal/testdeps"
+{{/use_testdeps}}
 {{#imports}}
     _cover{{i}} "{{import_path}}"
 {{/imports}}
@@ -240,6 +276,12 @@ import (
 var (
     coverCounters = make(map[string][]uint32)
     coverBlocks = make(map[string][]testing.CoverBlock)
+{{#use_testdeps}}
+    // Registration order of `coverCounters`. Iteration order of a Go map is randomized, so the
+    // coverage profile is written by walking this slice instead: `cover.out` ends up in a `Digest`
+    // which is materialized to `dist/`, and unstable output would mean an unstable cache key.
+    coverFileNames []string
+{{/use_testdeps}}
 )
 
 func coverRegisterFile(fileName string, counter []uint32, pos []uint32, numStmts []uint16) {
@@ -250,6 +292,9 @@ func coverRegisterFile(fileName string, counter []uint32, pos []uint32, numStmts
         // Already registered.
         return
     }
+{{#use_testdeps}}
+    coverFileNames = append(coverFileNames, fileName)
+{{/use_testdeps}}
     coverCounters[fileName] = counter
     block := make([]testing.CoverBlock, len(counter))
     for i := range counter {
@@ -269,14 +314,95 @@ func init() {
     coverRegisterFile("{{file_id}}", _cover{{i}}.{{cover_var}}.Count[:], _cover{{i}}.{{cover_var}}.Pos[:], _cover{{i}}.{{cover_var}}.NumStmt[:])
 {{/registrations}}
 }
+{{#use_testdeps}}
+
+// coverSnapshot backs `testing.Coverage()`. It reports the fraction of covered basic blocks,
+// matching what the `testing` package itself used to compute.
+func coverSnapshot() float64 {
+    var n, d int64
+    for _, fileName := range coverFileNames {
+        counters := coverCounters[fileName]
+        for i := range counters {
+            if atomic.LoadUint32(&counters[i]) > 0 {
+                n++
+            }
+            d++
+        }
+    }
+    if d == 0 {
+        return 0
+    }
+    return float64(n) / float64(d)
+}
+
+// coverWriteProfile writes the coverage profile in the "textfmt" format understood by
+// `go tool cover`. It is installed as `testdeps.CoverProcessTestDirFunc` and so is invoked by
+// `testing.M.Run` once the tests have finished.
+func coverWriteProfile(_ string, coverProfile string, coverMode string, coveredPackages string, w io.Writer, _ []string) (err error) {
+    var f *os.File
+    if coverProfile != "" {
+        f, err = os.Create(coverProfile)
+        if err != nil {
+            return err
+        }
+        defer func() {
+            if closeErr := f.Close(); err == nil {
+                err = closeErr
+            }
+        }()
+        if _, err = fmt.Fprintf(f, "mode: %s\\n", coverMode); err != nil {
+            return err
+        }
+    }
+
+    var active, total int64
+    for _, fileName := range coverFileNames {
+        counters := coverCounters[fileName]
+        blocks := coverBlocks[fileName]
+        for i := range counters {
+            stmts := int64(blocks[i].Stmts)
+            total += stmts
+            count := atomic.LoadUint32(&counters[i]) // For -mode=atomic.
+            if count > 0 {
+                active += stmts
+            }
+            if f == nil {
+                continue
+            }
+            if _, err = fmt.Fprintf(f, "%s:%d.%d,%d.%d %d %d\\n", fileName,
+                blocks[i].Line0, blocks[i].Col0,
+                blocks[i].Line1, blocks[i].Col1,
+                stmts,
+                count); err != nil {
+                return err
+            }
+        }
+    }
+
+    if total == 0 {
+        fmt.Fprintln(w, "coverage: [no statements]")
+        return nil
+    }
+    fmt.Fprintf(w, "coverage: %.1f%% of statements%s\\n", 100*float64(active)/float64(total), coveredPackages)
+    return nil
+}
+{{/use_testdeps}}
 
 func registerCover() {
+{{#use_testdeps}}
+    testdeps.CoverMode = "{{cover_mode}}"
+    testdeps.CoverSnapshotFunc = coverSnapshot
+    testdeps.CoverProcessTestDirFunc = coverWriteProfile
+    testdeps.CoverMarkProfileEmittedFunc = func(bool) {}
+{{/use_testdeps}}
+{{^use_testdeps}}
     testing.RegisterCover(testing.Cover{
         Mode: "{{cover_mode}}",
         Counters: coverCounters,
         Blocks: coverBlocks,
         CoveredPackages: "",
     })
+{{/use_testdeps}}
 }
 """
 
@@ -284,21 +410,32 @@ func registerCover() {
 @rule
 async def generate_go_coverage_setup_code(
     request: GenerateCoverageSetupCodeRequest,
+    goroot: GoRoot,
 ) -> GenerateCoverageSetupCodeResult:
+    # Sort the packages, and the per-file registrations within them, so that the generated code (and
+    # thus the order in which the coverage profile is written) does not depend on the order in which
+    # the packages happened to be built.
+    packages = sorted(request.packages, key=lambda pkg: pkg.import_path)
+    registrations = sorted(
+        (
+            (package_index, file_metadata)
+            for package_index, pkg in enumerate(packages)
+            for file_metadata in pkg.cover_file_metadatas
+        ),
+        key=lambda registration: registration[1].file_id,
+    )
     content = chevron.render(
         template=COVERAGE_SETUP_CODE,
         data={
-            "imports": [
-                {"i": i, "import_path": pkg.import_path} for i, pkg in enumerate(request.packages)
-            ],
+            "use_testdeps": registers_coverage_via_testdeps(goroot),
+            "imports": [{"i": i, "import_path": pkg.import_path} for i, pkg in enumerate(packages)],
             "registrations": [
                 {
-                    "i": i,
-                    "file_id": m.file_id,
-                    "cover_var": m.cover_var,
+                    "i": package_index,
+                    "file_id": file_metadata.file_id,
+                    "cover_var": file_metadata.cover_var,
                 }
-                for i, pkg in enumerate(request.packages)
-                for m in pkg.cover_file_metadatas
+                for package_index, file_metadata in registrations
             ],
             "cover_mode": request.cover_mode.value,
         },

--- a/src/python/pants/backend/go/util_rules/coverage.py
+++ b/src/python/pants/backend/go/util_rules/coverage.py
@@ -236,6 +236,29 @@ class GenerateCoverageSetupCodeResult:
 COVERAGE_SETUP_TESTDEPS_IMPORTS: tuple[str, ...] = ("fmt", "io", "os", "sync/atomic")
 
 
+# The import path `go tool cover -mode=atomic` injects into every covered package.
+SYNC_ATOMIC_IMPORT_PATH = "sync/atomic"
+
+
+def requires_sync_atomic_dependency(
+    with_coverage: bool, coverage_config: GoCoverageConfig | None
+) -> bool:
+    """Whether a package instrumented for coverage needs `sync/atomic` in its `importcfg`.
+
+    `go tool cover -mode=atomic` rewrites each covered statement to call
+    `sync/atomic.AddUint32`, adding an import the package's own sources never declared. Pants
+    builds each package's `importcfg` from its direct dependencies, so unless `sync/atomic` is
+    added explicitly the package fails to compile with "could not import sync/atomic". Packages
+    which happen to import `sync/atomic` already are unaffected, which is why this only breaks
+    some of them.
+    """
+    return (
+        with_coverage
+        and coverage_config is not None
+        and coverage_config.cover_mode == GoCoverMode.ATOMIC
+    )
+
+
 def registers_coverage_via_testdeps(goroot: GoRoot) -> bool:
     """Whether the coverage setup code must register coverage through `testing/internal/testdeps`.
 

--- a/src/python/pants/backend/go/util_rules/coverage_output.py
+++ b/src/python/pants/backend/go/util_rules/coverage_output.py
@@ -57,11 +57,23 @@ async def go_render_coverage_report(
         get_digest_contents(request.raw_report.coverage_digest),
     )
 
+    # `run_go_tests` guarantees that the digest holds exactly the coverage profile, but look the
+    # profile up by name rather than by position so that this cannot blow up with an `IndexError` if
+    # that ever stops being true.
+    raw_coverage_profile = next(
+        (
+            file_content.content
+            for file_content in digest_contents
+            if file_content.path == "cover.out"
+        ),
+        None,
+    )
+
     html_coverage_report: FilesystemCoverageReport | None = None
-    if go_test_subsystem.coverage_html:
+    if go_test_subsystem.coverage_html and raw_coverage_profile is not None:
         html_result = await render_go_coverage_profile_to_html(
             RenderGoCoverageProfileToHtmlRequest(
-                raw_coverage_profile=digest_contents[0].content,
+                raw_coverage_profile=raw_coverage_profile,
                 description_of_origin=f"Go package with import path `{request.raw_report.import_path}`",
                 sources_digest=request.raw_report.sources_digest,
                 sources_dir_path=request.raw_report.sources_dir_path,

--- a/src/python/pants/backend/go/util_rules/coverage_test.py
+++ b/src/python/pants/backend/go/util_rules/coverage_test.py
@@ -24,8 +24,9 @@ from pants.backend.go.util_rules import (
     tests_analysis,
     third_party_pkg,
 )
-from pants.backend.go.util_rules.coverage import GoCoverageData
+from pants.backend.go.util_rules.coverage import GoCoverageData, registers_coverage_via_testdeps
 from pants.backend.go.util_rules.coverage_output import GoCoverageDataCollection
+from pants.backend.go.util_rules.goroot import GoRoot
 from pants.build_graph.address import Address
 from pants.core.goals.test import (
     CoverageReport,
@@ -41,12 +42,6 @@ from pants.engine.internals.native_engine import Digest
 from pants.engine.rules import QueryRule
 from pants.engine.target import Target
 from pants.testutil.rule_runner import RuleRunner
-
-# Coverage tests require Go < 1.25 due to changes in coverage format.
-pytestmark = [
-    pytest.mark.require_go_version_max(1, 24),
-    pytest.mark.no_error_if_skipped,
-]
 
 
 @pytest.fixture
@@ -71,6 +66,7 @@ def rule_runner(go_binary_path: str) -> RuleRunner:
             QueryRule(TestResult, (GoTestRequest.Batch,)),
             QueryRule(CoverageReports, (GoCoverageDataCollection,)),
             QueryRule(DigestContents, (Digest,)),
+            QueryRule(GoRoot, ()),
         ],
         target_types=[GoModTarget, GoPackageTarget, FileTarget],
     )
@@ -234,3 +230,216 @@ def test_coverage_of_multiple_packages(rule_runner: RuleRunner) -> None:
     multi_cover_report = run_test(tgt)
     assert "foo/add.go" in multi_cover_report
     assert "foo/adder/add.go" in multi_cover_report
+
+
+def _run_test(rule_runner: RuleRunner, tgt: Target) -> TestResult:
+    return rule_runner.request(
+        TestResult, [GoTestRequest.Batch("", (GoTestFieldSet.create(tgt),), None)]
+    )
+
+
+def _coverage_profile(rule_runner: RuleRunner, coverage_data: GoCoverageData) -> str:
+    """Render the coverage reports and return the raw `cover.out` profile."""
+    coverage_reports = rule_runner.request(
+        CoverageReports, [GoCoverageDataCollection([coverage_data])]
+    )
+    go_report = next(
+        report
+        for report in coverage_reports.reports
+        if isinstance(report, FilesystemCoverageReport) and report.report_type == "go_cover"
+    )
+    digest_contents = rule_runner.request(DigestContents, (go_report.result_snapshot.digest,))
+    assert [fc.path for fc in digest_contents] == ["cover.out"]
+    return digest_contents[0].content.decode()
+
+
+def _covered_files(profile: str) -> list[str]:
+    """The file names in a profile, in the order in which they first appear."""
+    file_names: list[str] = []
+    for line in profile.splitlines()[1:]:  # Skip the `mode:` line.
+        file_name = line.split(":", 1)[0]
+        if file_name not in file_names:
+            file_names.append(file_name)
+    return file_names
+
+
+def test_coverage_with_test_main_calling_os_exit(rule_runner: RuleRunner) -> None:
+    """A `TestMain` which ends in `os.Exit(m.Run())` must still produce a coverage profile.
+
+    `os.Exit` skips everything after `m.Run()` in the generated test main, so coverage may only be
+    written from within `m.Run()` itself.
+    """
+    rule_runner.write_files(
+        {
+            "foo/BUILD": "go_mod(name='mod')\ngo_package()",
+            "foo/go.mod": "module foo",
+            "foo/add.go": textwrap.dedent(
+                """\
+                package foo
+                func add(x, y int) int {
+                  return x + y
+                }
+                """
+            ),
+            "foo/add_test.go": textwrap.dedent(
+                """\
+                package foo
+                import (
+                  "os"
+                  "testing"
+                )
+                func TestMain(m *testing.M) {
+                  os.Exit(m.Run())
+                }
+                func TestAdd(t *testing.T) {
+                  if add(2, 3) != 5 {
+                    t.Fail()
+                  }
+                }
+                """
+            ),
+        }
+    )
+    result = _run_test(rule_runner, rule_runner.get_target(Address("foo")))
+    assert result.exit_code == 0
+    assert result.coverage_data is not None
+    assert isinstance(result.coverage_data, GoCoverageData)
+
+    profile = _coverage_profile(rule_runner, result.coverage_data)
+    assert profile.startswith("mode: set\n")
+    assert _covered_files(profile) == ["foo/add.go"]
+    # `add` was called, so its block must have a non-zero execution count.
+    counts = [int(line.rsplit(" ", 1)[1]) for line in profile.splitlines()[1:]]
+    assert counts == [1]
+
+
+@pytest.mark.no_error_if_skipped
+def test_coverage_profile_is_deterministic(rule_runner: RuleRunner) -> None:
+    """The profile is written in sorted file order.
+
+    `cover.out` is materialized to `dist/`, so its contents must not depend on Go's randomized map
+    iteration order.
+    """
+    if not registers_coverage_via_testdeps(rule_runner.request(GoRoot, [])):
+        pytest.skip(
+            "Go < 1.25 writes the coverage profile itself, by iterating a map, so Pants cannot "
+            "make its contents deterministic."
+        )
+
+    sources = {
+        "foo/BUILD": "go_mod(name='mod')\ngo_package()",
+        "foo/go.mod": "module foo",
+        "foo/foo_test.go": textwrap.dedent(
+            """\
+            package foo
+            import "testing"
+            func TestAll(t *testing.T) {
+              if a()+b()+c()+d() != 4 {
+                t.Fail()
+              }
+            }
+            """
+        ),
+    }
+    for name in ("a", "b", "c", "d"):
+        sources[f"foo/{name}.go"] = textwrap.dedent(
+            f"""\
+            package foo
+            func {name}() int {{
+              return 1
+            }}
+            """
+        )
+    rule_runner.write_files(sources)
+
+    result = _run_test(rule_runner, rule_runner.get_target(Address("foo")))
+    assert result.exit_code == 0
+    assert isinstance(result.coverage_data, GoCoverageData)
+
+    covered_files = _covered_files(_coverage_profile(rule_runner, result.coverage_data))
+    assert covered_files == [f"foo/{name}.go" for name in ("a", "b", "c", "d")]
+
+
+def test_missing_coverage_profile_is_not_fatal(rule_runner: RuleRunner) -> None:
+    """A test binary which exits without running any tests writes no profile.
+
+    Pants must report that as "no coverage data" rather than crashing on the empty output.
+    """
+    rule_runner.write_files(
+        {
+            "foo/BUILD": "go_mod(name='mod')\ngo_package()",
+            "foo/go.mod": "module foo",
+            "foo/add.go": textwrap.dedent(
+                """\
+                package foo
+                func add(x, y int) int {
+                  return x + y
+                }
+                """
+            ),
+            "foo/add_test.go": textwrap.dedent(
+                """\
+                package foo
+                import (
+                  "os"
+                  "testing"
+                )
+                func TestMain(m *testing.M) {
+                  os.Exit(0)
+                }
+                func TestAdd(t *testing.T) {
+                  if add(2, 3) != 5 {
+                    t.Fail()
+                  }
+                }
+                """
+            ),
+        }
+    )
+    result = _run_test(rule_runner, rule_runner.get_target(Address("foo")))
+    assert result.exit_code == 0
+    assert result.coverage_data is None
+
+
+def test_coverage_with_other_profiles_enabled(rule_runner: RuleRunner) -> None:
+    """Other profiles land in the same output digest and must not be read as the cover profile."""
+    rule_runner.set_options(
+        [
+            "--test-use-coverage",
+            "--go-test-block-profile",
+        ],
+        env_inherit={"PATH"},
+    )
+    rule_runner.write_files(
+        {
+            "foo/BUILD": "go_mod(name='mod')\ngo_package()",
+            "foo/go.mod": "module foo",
+            "foo/add.go": textwrap.dedent(
+                """\
+                package foo
+                func add(x, y int) int {
+                  return x + y
+                }
+                """
+            ),
+            "foo/add_test.go": textwrap.dedent(
+                """\
+                package foo
+                import "testing"
+                func TestAdd(t *testing.T) {
+                  if add(2, 3) != 5 {
+                    t.Fail()
+                  }
+                }
+                """
+            ),
+        }
+    )
+    result = _run_test(rule_runner, rule_runner.get_target(Address("foo")))
+    assert result.exit_code == 0
+    assert result.extra_output is not None
+    assert "block.out" in result.extra_output.files
+    assert isinstance(result.coverage_data, GoCoverageData)
+
+    profile = _coverage_profile(rule_runner, result.coverage_data)
+    assert profile.startswith("mode: set\n")

--- a/src/python/pants/backend/go/util_rules/coverage_test.py
+++ b/src/python/pants/backend/go/util_rules/coverage_test.py
@@ -19,6 +19,7 @@ from pants.backend.go.util_rules import (
     coverage_output,
     first_party_pkg,
     go_mod,
+    implicit_linker_deps,
     link,
     sdk,
     tests_analysis,
@@ -56,6 +57,8 @@ def rule_runner(go_binary_path: str) -> RuleRunner:
             *coverage_output.rules(),
             *first_party_pkg.rules(),
             *go_mod.rules(),
+            # NB: required for `runtime/race`, which only reaches the linker as an implicit dep.
+            *implicit_linker_deps.rules(),
             *link.rules(),
             *sdk.rules(),
             *target_type_rules.rules(),
@@ -443,3 +446,110 @@ def test_coverage_with_other_profiles_enabled(rule_runner: RuleRunner) -> None:
 
     profile = _coverage_profile(rule_runner, result.coverage_data)
     assert profile.startswith("mode: set\n")
+
+
+def test_coverage_mode_atomic(rule_runner: RuleRunner) -> None:
+    """`--go-test-cover-mode=atomic` must work for a package that does not import `sync/atomic`.
+
+    `go tool cover -mode=atomic` rewrites the sources to call `sync/atomic.AddUint32`, so the
+    covered package needs `sync/atomic` in its `importcfg` even though its own sources never
+    imported it.
+    """
+    rule_runner.set_options(
+        [
+            "--test-use-coverage",
+            "--go-test-cover-mode=atomic",
+        ],
+        env_inherit={"PATH"},
+    )
+    rule_runner.write_files(
+        {
+            "foo/BUILD": "go_mod(name='mod')\ngo_package()",
+            "foo/go.mod": "module foo",
+            # NB: deliberately imports nothing, and `sync/atomic` least of all.
+            "foo/add.go": textwrap.dedent(
+                """\
+                package foo
+                func add(x, y int) int {
+                  return x + y
+                }
+                """
+            ),
+            "foo/add_test.go": textwrap.dedent(
+                """\
+                package foo
+                import "testing"
+                func TestAdd(t *testing.T) {
+                  if add(2, 3) != 5 {
+                    t.Fail()
+                  }
+                }
+                """
+            ),
+        }
+    )
+    result = _run_test(rule_runner, rule_runner.get_target(Address("foo")))
+    assert result.exit_code == 0
+    assert isinstance(result.coverage_data, GoCoverageData)
+
+    profile = _coverage_profile(rule_runner, result.coverage_data)
+    assert profile.startswith("mode: atomic\n")
+    assert _covered_files(profile) == ["foo/add.go"]
+
+
+def test_coverage_with_race_detector(rule_runner: RuleRunner) -> None:
+    """Coverage must not make the race detector fire on the coverage counters.
+
+    `set` and `count` instrumentation updates its counters without synchronization, so `go test`
+    forces `atomic` whenever `-race` is enabled. Pants must do the same, or every covered package
+    in a repo which enables the race detector reports races against itself.
+    """
+    rule_runner.write_files(
+        {
+            # NB: `race=True`, while `[go-test].cover_mode` is left at its `set` default.
+            "foo/BUILD": "go_mod(name='mod', race=True)\ngo_package()",
+            "foo/go.mod": "module foo",
+            "foo/add.go": textwrap.dedent(
+                """\
+                package foo
+                func add(x, y int) int {
+                  return x + y
+                }
+                """
+            ),
+            "foo/add_test.go": textwrap.dedent(
+                """\
+                package foo
+                import (
+                  "sync"
+                  "testing"
+                )
+                func TestAddConcurrently(t *testing.T) {
+                  var wg sync.WaitGroup
+                  for i := 0; i < 8; i++ {
+                    wg.Add(1)
+                    go func() {
+                      defer wg.Done()
+                      for j := 0; j < 200; j++ {
+                        if add(2, 3) != 5 {
+                          t.Error("bad sum")
+                        }
+                      }
+                    }()
+                  }
+                  wg.Wait()
+                }
+                """
+            ),
+        }
+    )
+    result = _run_test(rule_runner, rule_runner.get_target(Address("foo")))
+    assert b"DATA RACE" not in result.stdout_bytes
+    assert b"DATA RACE" not in result.stderr_bytes
+    assert result.exit_code == 0
+    assert isinstance(result.coverage_data, GoCoverageData)
+
+    # The race detector forces `atomic` even though `[go-test].cover_mode` is `set`.
+    profile = _coverage_profile(rule_runner, result.coverage_data)
+    assert profile.startswith("mode: atomic\n")
+    assert _covered_files(profile) == ["foo/add.go"]

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -429,6 +429,11 @@ def install_go() -> list[Step]:
             "with": {"go-version": go_version, "cache": False},
         }
 
+    # Both a Go v1.25+ and a Go v1.24 toolchain are installed on purpose: Pants registers Go
+    # coverage counters through `testing/internal/testdeps` from Go v1.25 and through
+    # `testing.RegisterCover` before it, and `src/python/pants/backend/go/conftest.py` runs the
+    # coverage tests once against each. Go tests which do not pin a toolchain use whichever `go`
+    # lands first on `PATH`, i.e. the one installed last.
     return [go_cfg(go_version) for go_version in ("1.25.3", "1.24.9")]
 
 


### PR DESCRIPTION
Closes #20689, and fixes the breakage tracked in #17951.

## The bug

With a Go v1.25 or newer toolchain, `pants test --use-coverage` fails on every Go package:

```
testing: cannot use -test.coverprofile because test binary was not built with coverage enabled
IndexError: tuple index out of range
```

Pants instruments sources with Go's legacy coverage mechanism (`go tool cover -mode=<m> -var=<v>`), which stores counters in exported package-level variables, and hands them to `testing` by generating a `registerCover()` that calls `testing.RegisterCover`.

Go v1.20's "coverage redesign" made `testing.CoverMode()` read state registered via `testing.MainStart` rather than anything `RegisterCover` writes. Up to v1.24 Pants worked around that by building everything with `GOEXPERIMENT=nocoverageredesign` (`sdk.py`), which restores the old implementation — so coverage genuinely worked there. Go v1.25 removed the experiment *and* gutted `RegisterCover` to an empty body, so `CoverMode()` is always `""` and `testing` aborts with exit 2.

## The fix

On Go v1.25+, the generated setup code registers coverage the way `cmd/go`'s own generated test main does — by pointing the exported `testing/internal/testdeps` hooks (`CoverMode`, `CoverSnapshotFunc`, `CoverProcessTestDirFunc`, `CoverMarkProfileEmittedFunc`) at a profile writer which emits textfmt from the counters Pants already collects.

Registering there, rather than writing the profile after `m.Run()`:

|  | write after `m.Run()` | `testdeps` |
| -- | -- | -- |
| `testing.CoverMode()` | still `""` → fatal guard still fires | non-empty → guard passes |
| `-test.coverprofile=cover.out` | must be removed; needs an env var or custom flag | unchanged |
| `TestMain` doing `os.Exit(m.Run())` | **profile silently lost** | written |
| `generate_testmain/main.go` | must restructure `main()` | **zero change** |
| `testing.Coverage()` | broken | works |

The `os.Exit` row is decisive: `os.Exit(m.Run())` is the conventional form of `TestMain`, and it skips everything after `m.Run()` in the generated main. Writing the profile there would ship silent 0% coverage for exactly those packages — trading a loud crash for a quiet wrong answer.

`generate_testmain` needs no change: `registerCover()` keeps its name and signature. Below v1.25 the legacy `RegisterCover` registration is retained unchanged — the `testdeps` hooks do not exist that far back (they are absent in 1.21.9 and 1.22.0), and `nocoverageredesign` still works there. The gate therefore sits at exactly the version where `sdk.py` already stops injecting the experiment.

`testing/internal/testdeps` is an internal path, but Pants drives `go tool compile` with a hand-built importcfg, so `cmd/go`'s internal-import check never runs — and `testmain.go` already imports it.

Two supporting changes:

* The generated setup file's imports are never analyzed — `generate_testmain` emits only `testmain.go` — so the stdlib packages the writer needs are added explicitly to the main package's direct dependencies.
* The profile is emitted in **sorted file order**. `cover.out` becomes a `Digest` materialized to `dist/`, and Go's map iteration order is randomized, so the previous output was neither reproducible nor stable as a cache key. (Below v1.25 Go writes the profile itself, from a map, so this only holds on the new path.)

## Also fixed: two bugs which predate this and affect Go v1.24 too

* With another `[go-test]` profile enabled (e.g. `--go-test-block-profile`) the test's output digest also held `block.out`, and `coverage_output.py` fed `digest_contents[0]` — a binary pprof profile — to the cover parser (`invalid cover mode specifier`).
* A test binary which writes no profile (a `TestMain` which never calls `m.Run()`) left an empty digest, and the unguarded index raised `IndexError: tuple index out of range`.

The coverage digest is now subset to `cover.out`, and coverage data is only reported when the profile exists.

## Tests

`coverage_test.py` drops `pytest.mark.require_go_version_max(1, 24)`, which by itself turns the existing tests red on a modern Go, and gains cases for the `os.Exit(m.Run())` `TestMain`, profile determinism, a missing profile, and coverage alongside another profile.

All are red on the unfixed tree — on Go 1.25 every one of them, and on Go 1.24 the last three (the two hardening bugs plus determinism). `test_external_test_with_use_coverage` now asserts that a profile was produced rather than only that the run exited 0.

The second commit makes CI exercise both mechanisms. CI already installs Go 1.25.3 and 1.24.9; tests which request the `go_binary_path` fixture are now parametrized over the newest `go` on `PATH` per mechanism, so `coverage_test.py` runs once against each rather than once against whichever landed first on `PATH`. That replaces the `require_go_version_max` marker added in #22810 solely to skip these tests on modern Go — nothing else used it, and they no longer need skipping.

Verified locally against Go 1.24.1, 1.25.9 and 1.26.4. The full `src/python/pants/backend/go::` suite passes on 1.24.1.

## Note for whoever reviews

Two pre-existing, unrelated failures block simply flipping CI's default Go to 1.25+, which is why this PR leaves the toolchain ordering alone:

* `build_pkg_test.py::test_build_invalid_pkg` asserts `go tool compile` exits 1; Go 1.25+ returns 2.
* `lint/vet/rules_integration_test.py::test_failing` depends on `go vet` wording that changed in Go 1.26.

A follow-up PR will handle `-race` correctness: `go help testflag` says cover mode defaults to `atomic` under `-race`, and Pants never applies that, so `set`/`count` instrumentation would have the race detector report a data race on the coverage counters themselves.


---

## Third commit: `-race` correctness

Found by running `pants test --use-coverage` over a repo whose modules set `go_mod(race=True)` — i.e. only reachable once the coverage fix above makes coverage work at all.

### `set`/`count` instrumentation races against the race detector

`go tool cover -mode=set` rewrites each covered statement to an unsynchronized `GoCover_x.Count[n] = 1`. Called from two goroutines, that is a data race on the counter, so the race detector reports the covered package against itself. One run over the repo in question produced **14,667 `DATA RACE` reports**, none of them on product code.

This is not a Pants-specific discovery. `go test` forces `atomic` under `-race`, and refuses the combination outright if you ask for it explicitly:

```console
$ go test -race -covermode=set ./...
-covermode must be "atomic", not "set", when -race is enabled
```

So Pants was building something `go test` will not let you request. Minimal reproduction, no Pants involved — a module with one pure function, instrumented with the same command Pants uses:

```console
$ go tool cover -mode=set -var=GoCover_repro_0 -o add.cover.go add.go
$ go test -race ./...
WARNING: DATA RACE
Write at 0x0001032422a0 by goroutine 11:
  repro.Add()
      add.go:3 +0x8c
Previous write at 0x0001032422a0 by goroutine 9:
  repro.Add()
      add.go:3 +0x8c
```

`Add` is `return x + y`. `add.go:3` is its `func` line, where the counter store was injected. Any covered function called from more than one goroutine produces this.

The cover mode is now resolved to `atomic` whenever the race detector is enabled for the package under test. That happens in `prepare_go_test_binary` rather than `run_go_tests`, because the race detector is set per-target (`go_mod(race=...)`, `test_race`) and is only known once that package's build options are resolved. The resolved mode is threaded into the generated coverage setup code too, so the profile header cannot disagree with the instrumentation.

NB: this silently overrides an explicit `[go-test].cover_mode=set`, matching `go test`'s default-path behaviour rather than its "explicitly asked, so error" behaviour. Happy to make it a hard error instead if you'd prefer to mirror `cmd/go` exactly.

### `atomic` mode fails to compile packages that don't import `sync/atomic`

Atomic instrumentation adds a `sync/atomic` import the package's own sources never declared, and Pants builds each `importcfg` from direct dependencies only:

```
could not import sync/atomic (open : no such file or directory)
```

Packages that already imported `sync/atomic` were unaffected, so this looked intermittent rather than simply broken. `sync/atomic` is now added as a direct dependency of any package instrumented in `atomic` mode — first-party and third-party alike.

Stdlib packages are deliberately excluded: a covered stdlib package that `sync/atomic` itself depends on would gain a dependency cycle, and `build_pkg_stdlib.py` already refuses to instrument `sync/atomic` under atomic mode for the same family of reasons.

### Tests

* `test_coverage_mode_atomic` — a package importing nothing at all; red today with the compile error above.
* `test_coverage_with_race_detector` — leaves `[go-test].cover_mode` at its `set` default, asserts the profile is `mode: atomic` and that no `DATA RACE` is reported. With the override reverted it fails with a race on a two-line pure function.

`coverage_test.py` also had to start registering `implicit_linker_deps.rules()`: without it `runtime/race` never reaches the linker, so the fixture could not link a race-enabled binary at all (`loadinternal: cannot find runtime/race`). That is part of why this went unnoticed — the coverage tests were structurally unable to exercise `-race`. Its timeout rises to 600s accordingly, since the race cases rebuild the stdlib with instrumentation (measured 216s warm; a cold run of only the two new cases exceeded 300s).
