### PR TITLE
fix(golang): memoize BuildGoPackageRequest.__eq__ over the shared dependency DAG

### DIFF
--- a/docs/notes/2.34.x.md
+++ b/docs/notes/2.34.x.md
@@ -106,6 +106,8 @@ Dependency inference now resolves imports across local directory `replace` direc
 
 Third-party module downloads are no longer duplicated across callers that differ only in build options which cannot affect them. Downloading and analyzing a module consults just `cgo_enabled` -- `go mod download` ignores build options entirely, and the package analyzer reads only `CGO_ENABLED` -- but the whole `GoBuildOptions` was part of the memoization key. Target generation passes default options while a compile resolves the real ones, so a repository building with e.g. `race=True` downloaded every third-party module twice per run.
 
+Comparing `BuildGoPackageRequest`s no longer enumerates the dependency DAG's root-to-leaf paths. `__eq__` recursed into `direct_dependencies` without memoization, costing one comparison per path rather than per node, which for third-party modules with wide generated package graphs is billions of operations for a single comparison. A long-lived daemon paid this whenever a `go.mod` or `go.sum` edit made those packages re-derive to an identical request.
+
 ### Plugin API changes
 
 `Target`, `TargetAdaptor`, `SourceBlock`, `SourceBlocks`, `TextBlock` and `Hunk` are now backed by native Rust implementations. They are still importable from their previous locations and their public constructors, attributes and methods are unchanged, but they are no longer Python dataclasses and they are built in `__new__` rather than `__init__`, so `dataclasses.is_dataclass`, `dataclasses.fields` and `dataclasses.replace` no longer apply to them. Defining subclasses in Python, and setting attributes on those subclasses, continues to work as before.

--- a/src/python/pants/backend/go/util_rules/build_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg.py
@@ -204,7 +204,14 @@ class BuildGoPackageRequest(EngineAwareParameter):
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
             return NotImplemented
-        return (
+        return self._eq_helper(other, set())
+
+    def _eq_helper(self, other: BuildGoPackageRequest, equal_items: set[tuple[int, int]]) -> bool:
+        key = (id(self), id(other))
+        if key[0] == key[1] or key in equal_items:
+            return True
+
+        is_eq = (
             self._hashcode == other._hashcode
             and self.import_path == other.import_path
             and self.pkg_name == other.pkg_name
@@ -229,9 +236,18 @@ class BuildGoPackageRequest(EngineAwareParameter):
             and self.pkg_specific_compiler_flags == other.pkg_specific_compiler_flags
             and self.pkg_specific_assembler_flags == other.pkg_specific_assembler_flags
             and self.is_stdlib == other.is_stdlib
-            # TODO: Use a recursive memoized __eq__ if this ever shows up in profiles.
-            and self.direct_dependencies == other.direct_dependencies
+            and len(self.direct_dependencies) == len(other.direct_dependencies)
+            and all(
+                l._eq_helper(r, equal_items)
+                for l, r in zip(self.direct_dependencies, other.direct_dependencies)
+            )
         )
+
+        # NB: We only track equal items because any non-equal item will cause the entire
+        # operation to shortcircuit.
+        if is_eq:
+            equal_items.add(key)
+        return is_eq
 
     def debug_hint(self) -> str | None:
         return self.import_path

--- a/src/python/pants/backend/go/util_rules/build_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_test.py
@@ -31,6 +31,7 @@ from pants.backend.go.util_rules.build_pkg import (
     _gather_transitive_prebuilt_object_files,
 )
 from pants.engine.fs import Snapshot
+from pants.engine.internals.native_engine import EMPTY_DIGEST
 from pants.engine.rules import QueryRule, rule
 from pants.testutil.rule_runner import RuleRunner
 from pants.util.frozendict import FrozenDict
@@ -570,3 +571,88 @@ def test_gather_transitive_prebuilt_object_files_depth2(syso_rule_runner: RuleRu
         f"grandchild/helper.syso missing from collected object_files={result.object_files!r}; "
         "BFS bug: _gather_transitive_prebuilt_object_files never visited the grandchild node"
     )
+
+
+def test_eq_is_linear_in_nodes_not_paths() -> None:
+    """`BuildGoPackageRequest`s form a structure-shared DAG, so comparing two equal-but-distinct
+    graphs must visit each pair of nodes once rather than once per path reaching it.
+
+    Real Go graphs make the difference enormous: `k8s.io/client-go/informers` aggregates 76
+    generated per-API-group informer packages, giving 5.5e9 paths over 61k nodes.
+    """
+
+    def req(import_path: str, deps: tuple[BuildGoPackageRequest, ...]) -> BuildGoPackageRequest:
+        return BuildGoPackageRequest(
+            import_path=import_path,
+            pkg_name=import_path,
+            digest=EMPTY_DIGEST,
+            dir_path=import_path,
+            build_opts=GoBuildOptions(),
+            go_files=("f.go",),
+            s_files=(),
+            direct_dependencies=deps,
+            minimum_go_version=None,
+        )
+
+    def fan_out(width: int, depth: int) -> BuildGoPackageRequest:
+        """Every node depends on every node of the level below."""
+        level = tuple(req(f"leaf{i}", ()) for i in range(width))
+        for d in range(depth):
+            level = tuple(req(f"n{d}_{i}", level) for i in range(width))
+        return req("root", level)
+
+    calls = 0
+
+    def counting(fn):
+        def wrapper(self, *args):
+            nonlocal calls
+            calls += 1
+            return fn(self, *args)
+
+        return wrapper
+
+    def graph_size(root: BuildGoPackageRequest) -> tuple[int, int]:
+        nodes, edges, stack = set(), 0, [root]
+        while stack:
+            node = stack.pop()
+            if id(node) in nodes:
+                continue
+            nodes.add(id(node))
+            edges += len(node.direct_dependencies)
+            stack.extend(node.direct_dependencies)
+        return len(nodes), edges
+
+    original_eq = BuildGoPackageRequest.__eq__
+    original_helper = getattr(BuildGoPackageRequest, "_eq_helper", None)
+    BuildGoPackageRequest.__eq__ = counting(original_eq)  # type: ignore[method-assign]
+    if original_helper is not None:
+        BuildGoPackageRequest._eq_helper = counting(original_helper)  # type: ignore[method-assign]
+    try:
+        a = fan_out(6, 6)
+        b = fan_out(6, 6)
+        assert a == b
+        # Each node entered once and each edge traversed once. Unmemoized recursion instead
+        # visits once per path reaching a node, which on this shape is 335,923 comparisons.
+        nodes, edges = graph_size(a)
+        assert calls <= nodes + edges, (
+            f"visited {calls} node pairs for a {nodes}-node, {edges}-edge graph"
+        )
+
+        # A difference anywhere must still be found, including when every hashcode collides so
+        # the `_hashcode` gate cannot short-circuit.
+        c = fan_out(6, 6)
+        for node in (a, c):
+            stack, seen = [node], set()
+            while stack:
+                n = stack.pop()
+                if id(n) in seen:
+                    continue
+                seen.add(id(n))
+                n._hashcode = 0
+                stack.extend(n.direct_dependencies)
+        c.direct_dependencies[0].direct_dependencies[0].pkg_name = "different"
+        assert a != c
+    finally:
+        BuildGoPackageRequest.__eq__ = original_eq  # type: ignore[method-assign]
+        if original_helper is not None:
+            BuildGoPackageRequest._eq_helper = original_helper  # type: ignore[method-assign]


### PR DESCRIPTION
# Problem

`BuildGoPackageRequest`s form a structure-shared DAG. `__eq__` recursed into `direct_dependencies` unmemoized, so a comparison cost one operation per path reaching a node instead of one per node.

This is pathological on certain dependencies that have wide import graphs. It affects daemon runs where the graph re-requests already warm packages, such as editing a `go.mod`. The effect can essentially stall the daemon for minutes to over an hour on a single pinned core. GIL and free-threaded affected equally.

# Solution

Uses the recursive memoized `_eq_helper` from `CoarsenedTarget`. A TODO was in place asking for this fix.

# Benchmarks

**Operations for one `==`**

| root | before | after |
| :--- | ---: | ---: |
| `k8s.io/client-go/tools/leaderelection` | 5,624,398,055 | 2,603 |
| `k8s.io/client-go/informers` | 5,531,793,337 | 2,579 |
| `cloud.google.com/go/spanner` | 916,761,390 | 2,201 |
| `cloud.google.com/go/pubsub/v2` | 59,729,324 | 990 |
| `google.golang.org/grpc` | 92,467 | 365 |
| `k8s.io/client-go/listers/apps/v1` | 36,836 | 349 |

Warm daemon, append a comment to `go.mod` and re-run `pants check` on a first-party package that imports an affected dep.

| dominant dep | before | after |
| :--- | ---: | ---: |
| `k8s.io/client-go` | >300s (killed) | 6.9s |
| `cloud.google.com/go/spanner` | >300s (killed) | 9.5s |
| `cloud.google.com/go/pubsub` | 164.3s | 7.1s |
| nothing changed (control) | 5.64s | 5.45s |

Notice: Claude used for benchmarking and test